### PR TITLE
fix(postgrest): race condition when setting fetchOptions and execute method call

### DIFF
--- a/Sources/_Helpers/Request.swift
+++ b/Sources/_Helpers/Request.swift
@@ -186,7 +186,7 @@ package struct Response: Sendable {
   package let data: Data
   package let response: HTTPURLResponse
 
-  public var statusCode: Int {
+  package var statusCode: Int {
     response.statusCode
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a bug which could lead to a race condition when executing the request on Postgrest.

## What is the current behavior?

Lock was being acquired first for updating the fetchOptions and then inside the `execute` method for executing the request, this could lead to the `execute` method to use the wrong fetch options.

## What is the new behavior?

Move assignment of `fetchOptions` inside `execute` method, on a single lock acquisition.