### PR TITLE
refactor: add private access control to lock isolated values

### DIFF
--- a/.github/workflows/conventional-commits-lint.js
+++ b/.github/workflows/conventional-commits-lint.js
@@ -16,6 +16,7 @@ const ALLOWED_CONVENTIONAL_COMMIT_PREFIXES = [
   "chore",
   "style",
   "test",
+  "refactor",
 ];
 
 const object = process.argv[2];

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -53,7 +53,7 @@ public final class PostgrestClient: Sendable {
     }
   }
 
-  let _configuration: LockIsolated<Configuration>
+  private let _configuration: LockIsolated<Configuration>
   public var configuration: Configuration { _configuration.value }
 
   /// Creates a PostgREST client with the specified configuration.

--- a/Sources/Realtime/V2/CallbackManager.swift
+++ b/Sources/Realtime/V2/CallbackManager.swift
@@ -16,7 +16,7 @@ final class CallbackManager: @unchecked Sendable {
     var callbacks: [RealtimeCallback] = []
   }
 
-  let mutableState = LockIsolated(MutableState())
+  private let mutableState = LockIsolated(MutableState())
 
   @discardableResult
   func addBroadcastCallback(

--- a/Sources/Realtime/V2/CallbackManager.swift
+++ b/Sources/Realtime/V2/CallbackManager.swift
@@ -18,6 +18,14 @@ final class CallbackManager: @unchecked Sendable {
 
   private let mutableState = LockIsolated(MutableState())
 
+  var serverChanges: [PostgresJoinConfig] {
+    mutableState.serverChanges
+  }
+
+  var callbacks: [RealtimeCallback] {
+    mutableState.callbacks
+  }
+
   @discardableResult
   func addBroadcastCallback(
     event: String,

--- a/Sources/Realtime/V2/WebSocketClient.swift
+++ b/Sources/Realtime/V2/WebSocketClient.swift
@@ -42,7 +42,7 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
     var stream: SocketStream?
   }
 
-  let mutableState = LockIsolated(MutableState())
+  private let mutableState = LockIsolated(MutableState())
 
   init(config: RealtimeClientV2.Configuration) {
     realtimeURL = config.realtimeWebSocketURL

--- a/Sources/_Helpers/EventEmitter.swift
+++ b/Sources/_Helpers/EventEmitter.swift
@@ -30,7 +30,7 @@ public final class ObservationToken: Sendable {
 package final class EventEmitter<Event: Sendable>: Sendable {
   public typealias Listener = @Sendable (Event) -> Void
 
-  let listeners = LockIsolated<[ObjectIdentifier: Listener]>([:])
+  private let listeners = LockIsolated<[ObjectIdentifier: Listener]>([:])
   public let lastEvent: LockIsolated<Event>
 
   let emitsLastEventWhenAttaching: Bool

--- a/Tests/RealtimeTests/CallbackManagerTests.swift
+++ b/Tests/RealtimeTests/CallbackManagerTests.swift
@@ -36,14 +36,14 @@ final class CallbackManagerTests: XCTestCase {
 
     XCTAssertEqual(callbackManager.addPresenceCallback { _ in }, 3)
 
-    XCTAssertEqual(callbackManager.mutableState.value.callbacks.count, 3)
+    XCTAssertEqual(callbackManager.callbacks.count, 3)
 
     callbackManager.removeCallback(id: 2)
     callbackManager.removeCallback(id: 3)
 
-    XCTAssertEqual(callbackManager.mutableState.value.callbacks.count, 1)
+    XCTAssertEqual(callbackManager.callbacks.count, 1)
     XCTAssertFalse(
-      callbackManager.mutableState.value.callbacks
+      callbackManager.callbacks
         .contains(where: { $0.id == 2 || $0.id == 3 })
     )
   }
@@ -62,7 +62,7 @@ final class CallbackManagerTests: XCTestCase {
 
     callbackManager.setServerChanges(changes: changes)
 
-    XCTAssertEqual(callbackManager.mutableState.value.serverChanges, changes)
+    XCTAssertEqual(callbackManager.serverChanges, changes)
   }
 
   func testTriggerPostgresChanges() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

LockIsolated values should be private to avoid misusage.