### PR TITLE
feat(auth): add `getLinkIdentityURL`

### DIFF
--- a/Examples/supabase/config.toml
+++ b/Examples/supabase/config.toml
@@ -53,6 +53,7 @@ jwt_expiry = 3600
 enable_signup = true
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = true
+enable_anonymous_sign_ins = true
 
 [auth.email]
 # Allow/disallow new user signups via email to your project.

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -717,3 +717,8 @@ public struct SSOResponse: Codable, Hashable, Sendable {
   /// identity provider's authentication flow.
   public let url: URL
 }
+
+public struct OAuthResponse: Codable, Hashable, Sendable {
+  public let provider: Provider
+  public let url: URL
+}

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -406,6 +406,21 @@ final class RequestsTests: XCTestCase {
     }
   }
 
+  func testGetLinkIdentityURL() async {
+    sessionManager.session = { @Sendable _ in .validSession }
+
+    let sut = makeSUT()
+
+    await assert {
+      _ = try await sut.getLinkIdentityURL(
+        provider: .github,
+        scopes: "user:email",
+        redirectTo: URL(string: "https://supabase.com"),
+        queryParams: [("extra_key", "extra_value")]
+      )
+    }
+  }
+
   private func assert(_ block: () async throws -> Void) async {
     do {
       try await block()

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testGetLinkIdentityURL.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testGetLinkIdentityURL.1.txt
@@ -1,0 +1,5 @@
+curl \
+	--header "Apikey: dummy.api.key" \
+	--header "Authorization: Bearer accesstoken" \
+	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	"http://localhost:54321/auth/v1/user/identities/authorize?extra_key=extra_value&provider=github&redirect_to=https://supabase.com&scopes=user:email&skip_http_redirect=true"


### PR DESCRIPTION
## What kind of change does this PR introduce?

- We had a `_getURLForLinkIdentity` experimental method for implementing manual identity linking.
- This PR drops the experimental flag, and rename the method to `getLinkIdentityURL` to be aligned with Flutter.