### PR TITLE
feat(realtime): add closure based methods

### DIFF
--- a/Sources/Realtime/RealtimeChannel+AsyncAwait.swift
+++ b/Sources/Realtime/RealtimeChannel+AsyncAwait.swift
@@ -101,4 +101,25 @@ extension RealtimeChannelV2 {
     }
     return stream
   }
+
+  /// Listen for broadcast messages sent by other clients within the same channel under a specific `event`.
+  public func broadcastStream(event: String) -> AsyncStream<JSONObject> {
+    let (stream, continuation) = AsyncStream<JSONObject>.makeStream()
+
+    let subscription = onBroadcast(event: event) {
+      continuation.yield($0)
+    }
+
+    continuation.onTermination = { _ in
+      subscription.cancel()
+    }
+
+    return stream
+  }
+
+  /// Listen for broadcast messages sent by other clients within the same channel under a specific `event`.
+  @available(*, deprecated, renamed: "broadcastStream(event:)")
+  public func broadcast(event: String) -> AsyncStream<JSONObject> {
+    broadcastStream(event: event)
+  }
 }

--- a/Sources/Realtime/RealtimeChannel+AsyncAwait.swift
+++ b/Sources/Realtime/RealtimeChannel+AsyncAwait.swift
@@ -1,0 +1,104 @@
+//
+//  RealtimeChannel+AsyncAwait.swift
+//
+//
+//  Created by Guilherme Souza on 17/04/24.
+//
+
+import Foundation
+
+extension RealtimeChannelV2 {
+  /// Listen for clients joining / leaving the channel using presences.
+  public func presenceChange() -> AsyncStream<any PresenceAction> {
+    let (stream, continuation) = AsyncStream<any PresenceAction>.makeStream()
+
+    let subscription = onPresenceChange {
+      continuation.yield($0)
+    }
+
+    continuation.onTermination = { _ in
+      subscription.cancel()
+    }
+
+    return stream
+  }
+
+  /// Listen for postgres changes in a channel.
+  public func postgresChange(
+    _: InsertAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil
+  ) -> AsyncStream<InsertAction> {
+    postgresChange(event: .insert, schema: schema, table: table, filter: filter)
+      .compactMap { $0.wrappedAction as? InsertAction }
+      .eraseToStream()
+  }
+
+  /// Listen for postgres changes in a channel.
+  public func postgresChange(
+    _: UpdateAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil
+  ) -> AsyncStream<UpdateAction> {
+    postgresChange(event: .update, schema: schema, table: table, filter: filter)
+      .compactMap { $0.wrappedAction as? UpdateAction }
+      .eraseToStream()
+  }
+
+  /// Listen for postgres changes in a channel.
+  public func postgresChange(
+    _: DeleteAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil
+  ) -> AsyncStream<DeleteAction> {
+    postgresChange(event: .delete, schema: schema, table: table, filter: filter)
+      .compactMap { $0.wrappedAction as? DeleteAction }
+      .eraseToStream()
+  }
+
+  /// Listen for postgres changes in a channel.
+  public func postgresChange(
+    _: SelectAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil
+  ) -> AsyncStream<SelectAction> {
+    postgresChange(event: .select, schema: schema, table: table, filter: filter)
+      .compactMap { $0.wrappedAction as? SelectAction }
+      .eraseToStream()
+  }
+
+  /// Listen for postgres changes in a channel.
+  public func postgresChange(
+    _: AnyAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil
+  ) -> AsyncStream<AnyAction> {
+    postgresChange(event: .all, schema: schema, table: table, filter: filter)
+  }
+
+  private func postgresChange(
+    event: PostgresChangeEvent,
+    schema: String,
+    table: String?,
+    filter: String?
+  ) -> AsyncStream<AnyAction> {
+    let (stream, continuation) = AsyncStream<AnyAction>.makeStream()
+    let subscription = _onPostgresChange(
+      event: event,
+      schema: schema,
+      table: table,
+      filter: filter
+    ) {
+      continuation.yield($0)
+    }
+    continuation.onTermination = { _ in
+      subscription.cancel()
+    }
+    return stream
+  }
+}

--- a/Sources/Realtime/V2/PushV2.swift
+++ b/Sources/Realtime/V2/PushV2.swift
@@ -20,28 +20,15 @@ actor PushV2 {
   }
 
   func send() async -> PushStatus {
-    do {
-      try await channel?.socket?.ws.send(message)
+    await channel?.socket?.push(message)
 
-      if channel?.config.broadcast.acknowledgeBroadcasts == true {
-        return await withCheckedContinuation {
-          receivedContinuation = $0
-        }
+    if channel?.config.broadcast.acknowledgeBroadcasts == true {
+      return await withCheckedContinuation {
+        receivedContinuation = $0
       }
-
-      return .ok
-    } catch {
-      await channel?.socket?.config.logger?.debug(
-        """
-        Failed to send message:
-        \(message)
-
-        Error:
-        \(error)
-        """
-      )
-      return .error
     }
+
+    return .ok
   }
 
   func didReceive(status: PushStatus) {

--- a/Sources/Realtime/V2/RealtimeChannelV2.swift
+++ b/Sources/Realtime/V2/RealtimeChannelV2.swift
@@ -15,6 +15,8 @@ public struct RealtimeChannelConfig: Sendable {
 }
 
 public actor RealtimeChannelV2 {
+  public typealias Subscription = ObservationToken
+
   public enum Status: Sendable {
     case unsubscribed
     case subscribing
@@ -340,93 +342,84 @@ public actor RealtimeChannelV2 {
   }
 
   /// Listen for clients joining / leaving the channel using presences.
-  public func presenceChange() -> AsyncStream<any PresenceAction> {
-    let (stream, continuation) = AsyncStream<any PresenceAction>.makeStream()
-
-    let id = callbackManager.addPresenceCallback {
-      continuation.yield($0)
-    }
-
-    let logger = logger
-
-    continuation.onTermination = { [weak callbackManager] _ in
+  public func onPresenceChange(
+    _ callback: @escaping @Sendable (any PresenceAction) -> Void
+  ) -> Subscription {
+    let id = callbackManager.addPresenceCallback(callback: callback)
+    return Subscription { [weak callbackManager, logger] in
       logger?.debug("Removing presence callback with id: \(id)")
       callbackManager?.removeCallback(id: id)
     }
-
-    return stream
   }
 
   /// Listen for postgres changes in a channel.
-  public func postgresChange(
+  public func onPostgresChange(
     _: InsertAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil
-  ) -> AsyncStream<InsertAction> {
-    postgresChange(event: .insert, schema: schema, table: table, filter: filter)
-      .compactMap { $0.wrappedAction as? InsertAction }
-      .eraseToStream()
+    filter: String? = nil,
+    callback: @escaping @Sendable (InsertAction) -> Void
+  ) -> Subscription {
+    _onPostgresChange(
+      event: .insert,
+      schema: schema,
+      table: table,
+      filter: filter
+    ) {
+      guard case let .insert(action) = $0 else { return }
+      callback(action)
+    }
   }
 
   /// Listen for postgres changes in a channel.
-  public func postgresChange(
+  public func onPostgresChange(
     _: UpdateAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil
-  ) -> AsyncStream<UpdateAction> {
-    postgresChange(event: .update, schema: schema, table: table, filter: filter)
-      .compactMap { $0.wrappedAction as? UpdateAction }
-      .eraseToStream()
+    filter: String? = nil,
+    callback: @escaping @Sendable (UpdateAction) -> Void
+  ) -> Subscription {
+    _onPostgresChange(
+      event: .update,
+      schema: schema,
+      table: table,
+      filter: filter
+    ) {
+      guard case let .update(action) = $0 else { return }
+      callback(action)
+    }
   }
 
   /// Listen for postgres changes in a channel.
-  public func postgresChange(
+  public func onPostgresChange(
     _: DeleteAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil
-  ) -> AsyncStream<DeleteAction> {
-    postgresChange(event: .delete, schema: schema, table: table, filter: filter)
-      .compactMap { $0.wrappedAction as? DeleteAction }
-      .eraseToStream()
+    filter: String? = nil,
+    callback: @escaping @Sendable (DeleteAction) -> Void
+  ) -> Subscription {
+    _onPostgresChange(
+      event: .delete,
+      schema: schema,
+      table: table,
+      filter: filter
+    ) {
+      guard case let .delete(action) = $0 else { return }
+      callback(action)
+    }
   }
 
-  /// Listen for postgres changes in a channel.
-  public func postgresChange(
-    _: SelectAction.Type,
-    schema: String = "public",
-    table: String? = nil,
-    filter: String? = nil
-  ) -> AsyncStream<SelectAction> {
-    postgresChange(event: .select, schema: schema, table: table, filter: filter)
-      .compactMap { $0.wrappedAction as? SelectAction }
-      .eraseToStream()
-  }
-
-  /// Listen for postgres changes in a channel.
-  public func postgresChange(
-    _: AnyAction.Type,
-    schema: String = "public",
-    table: String? = nil,
-    filter: String? = nil
-  ) -> AsyncStream<AnyAction> {
-    postgresChange(event: .all, schema: schema, table: table, filter: filter)
-  }
-
-  private func postgresChange(
+  func _onPostgresChange(
     event: PostgresChangeEvent,
     schema: String,
     table: String?,
-    filter: String?
-  ) -> AsyncStream<AnyAction> {
+    filter: String?,
+    callback: @escaping @Sendable (AnyAction) -> Void
+  ) -> Subscription {
     precondition(
       status != .subscribed,
       "You cannot call postgresChange after joining the channel"
     )
-
-    let (stream, continuation) = AsyncStream<AnyAction>.makeStream()
 
     let config = PostgresJoinConfig(
       event: event,
@@ -437,18 +430,11 @@ public actor RealtimeChannelV2 {
 
     clientChanges.append(config)
 
-    let id = callbackManager.addPostgresCallback(filter: config) { action in
-      continuation.yield(action)
-    }
-
-    let logger = logger
-
-    continuation.onTermination = { [weak callbackManager] _ in
+    let id = callbackManager.addPostgresCallback(filter: config, callback: callback)
+    return Subscription { [weak callbackManager, logger] in
       logger?.debug("Removing postgres callback with id: \(id)")
       callbackManager?.removeCallback(id: id)
     }
-
-    return stream
   }
 
   /// Listen for broadcast messages sent by other clients within the same channel under a specific

--- a/Sources/_Helpers/EventEmitter.swift
+++ b/Sources/_Helpers/EventEmitter.swift
@@ -12,7 +12,7 @@ public final class ObservationToken: Sendable {
   let _onCancel = LockIsolated((@Sendable () -> Void)?.none)
 
   package init(_ onCancel: (@Sendable () -> Void)? = nil) {
-    self._onCancel.setValue(onCancel)
+    _onCancel.setValue(onCancel)
   }
 
   @available(*, deprecated, renamed: "cancel")

--- a/Sources/_Helpers/EventEmitter.swift
+++ b/Sources/_Helpers/EventEmitter.swift
@@ -9,10 +9,19 @@ import ConcurrencyExtras
 import Foundation
 
 public final class ObservationToken: Sendable {
-  let _onRemove = LockIsolated((@Sendable () -> Void)?.none)
+  let _onCancel = LockIsolated((@Sendable () -> Void)?.none)
 
+  package init(_ onCancel: (@Sendable () -> Void)? = nil) {
+    self._onCancel.setValue(onCancel)
+  }
+
+  @available(*, deprecated, renamed: "cancel")
   public func remove() {
-    _onRemove.withValue {
+    cancel()
+  }
+
+  public func cancel() {
+    _onCancel.withValue {
       if $0 == nil {
         return
       }
@@ -23,7 +32,7 @@ public final class ObservationToken: Sendable {
   }
 
   deinit {
-    remove()
+    cancel()
   }
 }
 
@@ -53,7 +62,7 @@ package final class EventEmitter<Event: Sendable>: Sendable {
     let token = ObservationToken()
     let key = ObjectIdentifier(token)
 
-    token._onRemove.setValue { [weak self] in
+    token._onCancel.setValue { [weak self] in
       self?.listeners.withValue {
         $0[key] = nil
       }
@@ -86,7 +95,7 @@ package final class EventEmitter<Event: Sendable>: Sendable {
       }
 
       continuation.onTermination = { _ in
-        token.remove()
+        token.cancel()
       }
     }
   }

--- a/Tests/_HelpersTests/ObservationTokenTests.swift
+++ b/Tests/_HelpersTests/ObservationTokenTests.swift
@@ -15,14 +15,14 @@ final class ObservationTokenTests: XCTestCase {
     let handle = ObservationToken()
 
     let onRemoveCallCount = LockIsolated(0)
-    handle._onRemove.setValue {
+    handle._onCancel.setValue {
       onRemoveCallCount.withValue {
         $0 += 1
       }
     }
 
-    handle.remove()
-    handle.remove()
+    handle.cancel()
+    handle.cancel()
 
     XCTAssertEqual(onRemoveCallCount.value, 1)
   }
@@ -31,7 +31,7 @@ final class ObservationTokenTests: XCTestCase {
     var handle: ObservationToken? = ObservationToken()
 
     let onRemoveCallCount = LockIsolated(0)
-    handle?._onRemove.setValue {
+    handle?._onCancel.setValue {
       onRemoveCallCount.withValue {
         $0 += 1
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add closure based methods for RealtimeChannel:

## Current behavior
Library currently exposes only methods that returns an `AsyncStream` to be used in Swift Concurrency model.

## New behavior
This PR add closure based methods `onPostgresChange`, `onBroadcast`, and `onPresenceChange`