### PR TITLE
feat(functions): add experimental invoke with streamed responses

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -164,7 +164,8 @@ public actor FunctionsClient {
   /// - Returns: A stream of Data.
   ///
   /// - Warning: Experimental method.
-  public func _invoke(
+  /// - Note: This method doesn't use the same underlying `URLSession` as the remaining methods in the library.
+  public func _invokeWithStreamedResponse(
     _ functionName: String,
     options invokeOptions: FunctionInvokeOptions = .init()
   ) -> AsyncThrowingStream<Data, any Error> {

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -71,6 +71,7 @@ public final class SupabaseClient: @unchecked Sendable {
     url: functionsURL,
     headers: defaultHeaders,
     region: options.functions.region,
+    logger: options.global.logger,
     fetch: fetchWithAuth
   )
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Close https://github.com/supabase/supabase-swift/issues/252

Add experimental method to invoke function with streamed responses

## Why is it sill experimental?

To implement the streamed responses, we need to set up a custom `URLSession` for setting its `delegate` property, which means that it doesn't use the `customFetch` that is provided to the `functions` package and all other `sub-packages`.

I prefer keeping it `Experimental` until we try to refactor the code so that all requests uses the same `URLSession` instance.