### PR TITLE
fix(realtime): handle timeout when subscribing to channel

### DIFF
--- a/Sources/Realtime/V2/PushV2.swift
+++ b/Sources/Realtime/V2/PushV2.swift
@@ -30,9 +30,10 @@ actor PushV2 {
           }
         }
       } catch is TimeoutError {
+        channel?.logger?.debug("Push timed out.")
         return .timeout
       } catch {
-        channel?.logger?.error("error sending Push: \(error)")
+        channel?.logger?.error("Error sending push: \(error)")
         return .error
       }
     }

--- a/Sources/Realtime/V2/PushV2.swift
+++ b/Sources/Realtime/V2/PushV2.swift
@@ -23,8 +23,17 @@ actor PushV2 {
     await channel?.socket?.push(message)
 
     if channel?.config.broadcast.acknowledgeBroadcasts == true {
-      return await withCheckedContinuation {
-        receivedContinuation = $0
+      do {
+        return try await withTimeout(interval: channel?.socket?.config.timeoutInterval ?? 10) {
+          await withCheckedContinuation {
+            self.receivedContinuation = $0
+          }
+        }
+      } catch is TimeoutError {
+        return .timeout
+      } catch {
+        channel?.logger?.error("error sending Push: \(error)")
+        return .error
       }
     }
 

--- a/Sources/Realtime/V2/PushV2.swift
+++ b/Sources/Realtime/V2/PushV2.swift
@@ -24,7 +24,7 @@ actor PushV2 {
 
     if channel?.config.broadcast.acknowledgeBroadcasts == true {
       do {
-        return try await withTimeout(interval: channel?.socket?.config.timeoutInterval ?? 10) {
+        return try await withTimeout(interval: channel?.socket?.options.timeoutInterval ?? 10) {
           await withCheckedContinuation {
             self.receivedContinuation = $0
           }

--- a/Sources/Realtime/V2/RealtimeChannelV2.swift
+++ b/Sources/Realtime/V2/RealtimeChannelV2.swift
@@ -109,7 +109,7 @@ public actor RealtimeChannelV2 {
     )
 
     do {
-      try await withTimeout(interval: socket?.config.timeoutInterval ?? 10) { [self] in
+      try await withTimeout(interval: socket?.options.timeoutInterval ?? 10) { [self] in
         _ = await statusChange.first { @Sendable in $0 == .subscribed }
       }
     } catch {

--- a/Sources/Realtime/V2/RealtimeChannelV2.swift
+++ b/Sources/Realtime/V2/RealtimeChannelV2.swift
@@ -108,7 +108,18 @@ public actor RealtimeChannelV2 {
       )
     )
 
-    _ = await statusChange.first { @Sendable in $0 == .subscribed }
+    do {
+      try await withTimeout(interval: socket?.config.timeoutInterval ?? 10) { [self] in
+        _ = await statusChange.first { @Sendable in $0 == .subscribed }
+      }
+    } catch {
+      if error is TimeoutError {
+        logger?.debug("subscribe timed out.")
+        await subscribe()
+      } else {
+        logger?.error("subscribe failed: \(error)")
+      }
+    }
   }
 
   public func unsubscribe() async {

--- a/Sources/_Helpers/Task+withTimeout.swift
+++ b/Sources/_Helpers/Task+withTimeout.swift
@@ -1,0 +1,39 @@
+//
+//  Task+withTimeout.swift
+//
+//
+//  Created by Guilherme Souza on 19/04/24.
+//
+
+import Foundation
+
+@discardableResult
+package func withTimeout<R: Sendable>(
+  interval: TimeInterval,
+  @_inheritActorContext operation: @escaping @Sendable () async throws -> R
+) async throws -> R {
+  try await withThrowingTaskGroup(of: R.self) { group in
+    defer {
+      group.cancelAll()
+    }
+
+    let deadline = Date(timeIntervalSinceNow: interval)
+
+    group.addTask {
+      try await operation()
+    }
+
+    group.addTask {
+      let interval = deadline.timeIntervalSinceNow
+      if interval > 0 {
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC * UInt64(interval))
+      }
+      try Task.checkCancellation()
+      throw TimeoutError()
+    }
+
+    return try await group.next()!
+  }
+}
+
+package struct TimeoutError: Error, Hashable {}

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -226,51 +226,6 @@ final class RealtimeTests: XCTestCase {
     }
   }
 
-  func testChannelSubscribe_timeout() async throws {
-    let channel = await sut.channel("test")
-    await connectSocketAndWait()
-
-    Task {
-      await channel.subscribe()
-    }
-
-    await Task.megaYield()
-
-    try? await Task.sleep(nanoseconds: NSEC_PER_SEC * 2)
-
-    let joinMessages = ws.sentMessages.value.filter { $0.event == "phx_join" }
-
-    XCTAssertNoDifference(
-      joinMessages,
-      [
-        RealtimeMessageV2(
-          joinRef: "1",
-          ref: "1",
-          topic: "realtime:test",
-          event: "phx_join",
-          payload: try JSONObject(
-            RealtimeJoinPayload(
-              config: RealtimeJoinConfig(),
-              accessToken: apiKey
-            )
-          )
-        ),
-        RealtimeMessageV2(
-          joinRef: "3",
-          ref: "3",
-          topic: "realtime:test",
-          event: "phx_join",
-          payload: try JSONObject(
-            RealtimeJoinPayload(
-              config: RealtimeJoinConfig(),
-              accessToken: apiKey
-            )
-          )
-        ),
-      ]
-    )
-  }
-
   private func connectSocketAndWait() async {
     let connection = Task {
       await sut.connect()

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -33,139 +33,114 @@ final class RealtimeTests: XCTestCase {
     )
   }
 
-  func testBehavior_Closure() async {
-    let channel = await sut.channel("public:messages")
-    _ = await channel.onPostgresChange(InsertAction.self, table: "messages") { _ in }
-    _ = await channel.onPostgresChange(UpdateAction.self, table: "messages") { _ in }
-    _ = await channel.onPostgresChange(DeleteAction.self, table: "messages") { _ in }
+  func testBehavior() async throws {
+    try await withTimeout(interval: 2) { [self] in
+      let channel = await sut.channel("public:messages")
+      _ = await channel.postgresChange(InsertAction.self, table: "messages")
+      _ = await channel.postgresChange(UpdateAction.self, table: "messages")
+      _ = await channel.postgresChange(DeleteAction.self, table: "messages")
 
-    let statusChange = await sut.statusChange
+      let statusChange = await sut.statusChange
 
-    await connectSocketAndWait()
+      await connectSocketAndWait()
 
-    let status = await statusChange.prefix(3).collect()
-    XCTAssertEqual(status, [.disconnected, .connecting, .connected])
+      let status = await statusChange.prefix(3).collect()
+      XCTAssertEqual(status, [.disconnected, .connecting, .connected])
 
-    let messageTask = await sut.messageTask
-    XCTAssertNotNil(messageTask)
+      let messageTask = await sut.messageTask
+      XCTAssertNotNil(messageTask)
 
-    let heartbeatTask = await sut.heartbeatTask
-    XCTAssertNotNil(heartbeatTask)
+      let heartbeatTask = await sut.heartbeatTask
+      XCTAssertNotNil(heartbeatTask)
 
-    let subscription = Task {
-      await channel.subscribe()
+      let subscription = Task {
+        await channel.subscribe()
+      }
+      await Task.megaYield()
+      ws.mockReceive(.messagesSubscribed)
+
+      // Wait until channel subscribed
+      await subscription.value
+
+      XCTAssertNoDifference(ws.sentMessages.value, [.subscribeToMessages])
     }
-    await Task.megaYield()
-    ws.mockReceive(.messagesSubscribed)
-
-    // Wait until channel subscribed
-    await subscription.value
-
-    XCTAssertNoDifference(ws.sentMessages.value, [.subscribeToMessages])
-  }
-
-  func testBehavior_AsyncAwait() async {
-    let channel = await sut.channel("public:messages")
-    _ = await channel.postgresChange(InsertAction.self, table: "messages")
-    _ = await channel.postgresChange(UpdateAction.self, table: "messages")
-    _ = await channel.postgresChange(DeleteAction.self, table: "messages")
-
-    let statusChange = await sut.statusChange
-
-    await connectSocketAndWait()
-
-    let status = await statusChange.prefix(3).collect()
-    XCTAssertEqual(status, [.disconnected, .connecting, .connected])
-
-    let messageTask = await sut.messageTask
-    XCTAssertNotNil(messageTask)
-
-    let heartbeatTask = await sut.heartbeatTask
-    XCTAssertNotNil(heartbeatTask)
-
-    let subscription = Task {
-      await channel.subscribe()
-    }
-    await Task.megaYield()
-    ws.mockReceive(.messagesSubscribed)
-
-    // Wait until channel subscribed
-    await subscription.value
-
-    XCTAssertNoDifference(ws.sentMessages.value, [.subscribeToMessages])
   }
 
   func testHeartbeat() async throws {
-    let expectation = expectation(description: "heartbeat")
-    expectation.expectedFulfillmentCount = 2
+    try await withTimeout(interval: 4) { [self] in
+      let expectation = expectation(description: "heartbeat")
+      expectation.expectedFulfillmentCount = 2
 
-    ws.on { message in
-      if message.event == "heartbeat" {
-        expectation.fulfill()
-        return RealtimeMessageV2(
-          joinRef: message.joinRef,
-          ref: message.ref,
-          topic: "phoenix",
-          event: "phx_reply",
-          payload: [
-            "response": [:],
-            "status": "ok",
-          ]
-        )
+      ws.on { message in
+        if message.event == "heartbeat" {
+          expectation.fulfill()
+          return RealtimeMessageV2(
+            joinRef: message.joinRef,
+            ref: message.ref,
+            topic: "phoenix",
+            event: "phx_reply",
+            payload: [
+              "response": [:],
+              "status": "ok",
+            ]
+          )
+        }
+
+        return nil
       }
 
-      return nil
+      await connectSocketAndWait()
+
+      await fulfillment(of: [expectation], timeout: 3)
     }
-
-    await connectSocketAndWait()
-
-    await fulfillment(of: [expectation], timeout: 3)
   }
 
   func testHeartbeat_whenNoResponse_shouldReconnect() async throws {
-    let sentHeartbeatExpectation = expectation(description: "sentHeartbeat")
+    try await withTimeout(interval: 6) { [self] in
+      let sentHeartbeatExpectation = expectation(description: "sentHeartbeat")
 
-    ws.on {
-      if $0.event == "heartbeat" {
-        sentHeartbeatExpectation.fulfill()
+      ws.on {
+        if $0.event == "heartbeat" {
+          sentHeartbeatExpectation.fulfill()
+        }
+
+        return nil
       }
 
-      return nil
-    }
+      let statuses = LockIsolated<[RealtimeClientV2.Status]>([])
 
-    let statuses = LockIsolated<[RealtimeClientV2.Status]>([])
-
-    Task {
-      for await status in await sut.statusChange {
-        statuses.withValue {
-          $0.append(status)
+      Task {
+        for await status in await sut.statusChange {
+          statuses.withValue {
+            $0.append(status)
+          }
         }
       }
+      await Task.megaYield()
+      await connectSocketAndWait()
+
+      await fulfillment(of: [sentHeartbeatExpectation], timeout: 2)
+
+      let pendingHeartbeatRef = await sut.pendingHeartbeatRef
+      XCTAssertNotNil(pendingHeartbeatRef)
+
+      // Wait until next heartbeat
+      try await Task.sleep(nanoseconds: NSEC_PER_SEC * 2)
+
+      // Wait for reconnect delay
+      try await Task.sleep(nanoseconds: NSEC_PER_SEC * 1)
+
+      XCTAssertEqual(
+        statuses.value,
+        [
+          .disconnected,
+          .connecting,
+          .connected,
+          .disconnected,
+          .connecting,
+        ]
+      )
     }
-    await Task.megaYield()
-    await connectSocketAndWait()
-
-    await fulfillment(of: [sentHeartbeatExpectation], timeout: 2)
-
-    let pendingHeartbeatRef = await sut.pendingHeartbeatRef
-    XCTAssertNotNil(pendingHeartbeatRef)
-
-    // Wait until next heartbeat
-    try await Task.sleep(nanoseconds: NSEC_PER_SEC * 2)
-
-    // Wait for reconnect delay
-    try await Task.sleep(nanoseconds: NSEC_PER_SEC * 1)
-
-    XCTAssertEqual(
-      statuses.value,
-      [
-        .disconnected,
-        .connecting,
-        .connected,
-        .disconnected,
-        .connecting,
-      ]
-    )
   }
 
   private func connectSocketAndWait() async {

--- a/Tests/_HelpersTests/WithTimeoutTests.swift
+++ b/Tests/_HelpersTests/WithTimeoutTests.swift
@@ -1,0 +1,34 @@
+//
+//  WithTimeoutTests.swift
+//
+//
+//  Created by Guilherme Souza on 19/04/24.
+//
+
+import _Helpers
+import Foundation
+import XCTest
+
+final class WithTimeoutTests: XCTestCase {
+  func testWithTimeout() async {
+    do {
+      try await withTimeout(interval: 0.25) {
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+      }
+      XCTFail("Task should timeout.")
+    } catch {
+      XCTAssertTrue(error is TimeoutError)
+    }
+
+    do {
+      let answer = try await withTimeout(interval: 1.25) {
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+        return 42
+      }
+
+      XCTAssertEqual(answer, 42)
+    } catch {
+      XCTFail("Should not throw error: \(error)")
+    }
+  }
+}

--- a/supabase-swift.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/supabase-swift.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -37,15 +37,6 @@
       }
     },
     {
-      "identity" : "keychainaccess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kishikawakatsumi/KeychainAccess",
-      "state" : {
-        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
-        "version" : "4.2.2"
-      }
-    },
-    {
       "identity" : "svgview",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/exyte/SVGView",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

`channel.subscribe()` currently doesn't handle timeout, if for some reason channel doesn't receive a reply back, if blocks forever.

## What is the new behavior?

- `channel.subscribe()` retries the subscription in case of timeout.
- timeout is configured through Configuration object when initializing client.

## Additional context

I'll handle retry limits on a future PR, so it doesn't keep retrying forever.
