### PR TITLE
fix(storage): getSignedURLs method using wrong encoder

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -219,11 +219,13 @@ public class StorageFileApi: StorageApi {
       let paths: [String]
     }
 
+    let encoder = JSONEncoder()
+
     let response = try await execute(
       Request(
         path: "/object/sign/\(bucketId)",
         method: .post,
-        body: configuration.encoder.encode(
+        body: encoder.encode(
           Params(expiresIn: expiresIn, paths: paths)
         )
       )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase-swift/issues/351

`getSignedURLs` was using the default encoder which encodes keys as `snake_case` by default. But this endpoint requires `lowerCamelCase` keys.