### PR TITLE
fix(auth): extract both query and fragment from URL

### DIFF
--- a/Sources/Auth/Internal/Helpers.swift
+++ b/Sources/Auth/Internal/Helpers.swift
@@ -1,29 +1,30 @@
 import Foundation
 
-struct Params: Hashable {
-  var name: String
-  var value: String
-}
-
-func extractParams(from url: URL) -> [Params] {
+/// Extracts parameters encoded in the URL both in the query and fragment.
+func extractParams(from url: URL) -> [String: String] {
   guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-    return []
+    return [:]
   }
+
+  var result: [String: String] = [:]
 
   if let fragment = components.fragment {
-    return extractParams(from: fragment)
-  }
-
-  if let queryItems = components.queryItems {
-    return queryItems.map {
-      Params(name: $0.name, value: $0.value ?? "")
+    let items = extractParams(from: fragment)
+    for item in items {
+      result[item.name] = item.value
     }
   }
 
-  return []
+  if let items = components.queryItems {
+    for item in items {
+      result[item.name] = item.value
+    }
+  }
+
+  return result
 }
 
-func extractParams(from fragment: String) -> [Params] {
+private func extractParams(from fragment: String) -> [URLQueryItem] {
   let components =
     fragment
       .split(separator: "&")
@@ -33,7 +34,7 @@ func extractParams(from fragment: String) -> [Params] {
     components
       .compactMap {
         $0.count == 2
-          ? Params(name: String($0[0]), value: String($0[1]))
+          ? URLQueryItem(name: String($0[0]), value: String($0[1]))
           : nil
       }
 }

--- a/Tests/AuthTests/ExtractParamsTests.swift
+++ b/Tests/AuthTests/ExtractParamsTests.swift
@@ -13,13 +13,20 @@ final class ExtractParamsTests: XCTestCase {
     let code = UUID().uuidString
     let url = URL(string: "io.supabase.flutterquickstart://login-callback/?code=\(code)")!
     let params = extractParams(from: url)
-    XCTAssertEqual(params, [Params(name: "code", value: code)])
+    XCTAssertEqual(params, ["code": code])
   }
 
   func testExtractParamsInFragment() {
     let code = UUID().uuidString
     let url = URL(string: "io.supabase.flutterquickstart://login-callback/#code=\(code)")!
     let params = extractParams(from: url)
-    XCTAssertEqual(params, [Params(name: "code", value: code)])
+    XCTAssertEqual(params, ["code": code])
+  }
+
+  func testExtractParamsInBothFragmentAndQuery() {
+    let code = UUID().uuidString
+    let url = URL(string: "io.supabase.flutterquickstart://login-callback/?code=\(code)#message=abc")!
+    let params = extractParams(from: url)
+    XCTAssertEqual(params, ["code": code, "message": "abc"])
   }
 }

--- a/Tests/AuthTests/ExtractParamsTests.swift
+++ b/Tests/AuthTests/ExtractParamsTests.swift
@@ -29,4 +29,10 @@ final class ExtractParamsTests: XCTestCase {
     let params = extractParams(from: url)
     XCTAssertEqual(params, ["code": code, "message": "abc"])
   }
+
+  func testExtractParamsQueryTakesPrecedence() {
+    let url = URL(string: "io.supabase.flutterquickstart://login-callback/?code=123#code=abc")!
+    let params = extractParams(from: url)
+    XCTAssertEqual(params, ["code": "123"])
+  }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase/supabase-swift/issues/364

## What is the current behavior?

Params extraction logic was extracting only the fragment OR the query

## What is the new behavior?

Params extraction logic now extracts both from the fragment and query if both exist.