### PR TITLE
fix(functions): invoke with custom http method

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -131,7 +131,7 @@ public actor FunctionsClient {
   ) async throws -> Response {
     var request = Request(
       path: functionName,
-      method: .post,
+      method: invokeOptions.method?.httpMethod ?? .post,
       headers: invokeOptions.headers.merging(headers) { invoke, _ in invoke },
       body: invokeOptions.body
     )

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -1,3 +1,4 @@
+import _Helpers
 import Foundation
 
 /// An error type representing various errors that can occur while invoking functions.
@@ -87,6 +88,16 @@ public struct FunctionInvokeOptions: Sendable {
     case put = "PUT"
     case patch = "PATCH"
     case delete = "DELETE"
+
+    var httpMethod: Request.Method {
+      switch self {
+      case .get: .get
+      case .post: .post
+      case .put: .put
+      case .patch: .patch
+      case .delete: .delete
+      }
+    }
   }
 }
 

--- a/Tests/FunctionsTests/FunctionsClientTests.swift
+++ b/Tests/FunctionsTests/FunctionsClientTests.swift
@@ -57,6 +57,23 @@ final class FunctionsClientTests: XCTestCase {
     )
   }
 
+  func testInvokeWithCustomMethod() async throws {
+    let url = URL(string: "http://localhost:5432/functions/v1/hello_world")!
+    let _request = ActorIsolated(URLRequest?.none)
+
+    let sut = FunctionsClient(url: self.url, headers: ["Apikey": apiKey]) { request in
+      await _request.setValue(request)
+      return (
+        Data(), HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+      )
+    }
+
+    try await sut.invoke("hello_world", options: .init(method: .get))
+    let request = await _request.value
+
+    XCTAssertEqual(request?.httpMethod, "GET")
+  }
+
   func testInvokeWithRegionDefinedInClient() async {
     let sut = FunctionsClient(url: url, region: .caCentral1) {
       let region = $0.value(forHTTPHeaderField: "x-region")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase/supabase-swift/pull/346#discussion_r1592835376
Fix https://github.com/supabase/supabase-swift/issues/362

## What is the current behavior?

https://github.com/supabase/supabase-swift/pull/346 introduced a regression where it doesn't allow to invoke a function with a custom HTTP method anymore
