### PR TITLE
fix(auth): header being overridden

### DIFF
--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -23,7 +23,7 @@ struct APIClient: Sendable {
 
   func execute(_ request: HTTPRequest) async throws -> HTTPResponse {
     var request = request
-    request.headers.merge(with: HTTPHeaders(configuration.headers))
+    request.headers = HTTPHeaders(configuration.headers).merged(with: request.headers)
 
     let response = try await http.send(request)
 


### PR DESCRIPTION
I noticed that auth calls like `updateUser` would fail due to a wrong JWT token. The cause for this was, that the `execute` method would override the `Authentication` header to the anon key. I changed the call, such that the `execute` method does not override existing headers.