### PR TITLE
fix(postgrest): update parameter of `is` filter to allow only `Bool` or `nil`

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -699,13 +699,13 @@ public final class AuthClient: Sendable {
   /// - Parameter scope: Specifies which sessions should be logged out.
   public func signOut(scope: SignOutScope = .global) async throws {
     guard let accessToken = currentSession?.accessToken else {
-        configuration.logger?.warning("signOut called without a session")
-        return
+      configuration.logger?.warning("signOut called without a session")
+      return
     }
 
     if scope != .others {
-        await sessionManager.remove()
-        eventEmitter.emit(.signedOut, session: nil)
+      await sessionManager.remove()
+      eventEmitter.emit(.signedOut, session: nil)
     }
 
     do {
@@ -713,7 +713,7 @@ public final class AuthClient: Sendable {
         .init(
           url: configuration.url.appendingPathComponent("logout"),
           method: .post,
-          query: [URLQueryItem(name: "scope", value: scope.rawValue)], 
+          query: [URLQueryItem(name: "scope", value: scope.rawValue)],
           headers: [.init(name: "Authorization", value: "Bearer \(accessToken)")]
         )
       )
@@ -936,10 +936,10 @@ public final class AuthClient: Sendable {
         url: configuration.url.appendingPathComponent("user"),
         method: .put,
         query: [
-            (redirectTo ?? configuration.redirectToURL).map { URLQueryItem(
-                name: "redirect_to",
-                value: $0.absoluteString
-            ) },
+          (redirectTo ?? configuration.redirectToURL).map { URLQueryItem(
+            name: "redirect_to",
+            value: $0.absoluteString
+          ) },
         ].compactMap { $0 },
         body: configuration.encoder.encode(user)
       )

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -254,7 +254,7 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder {
   ///   - value: The value to filter with
   public func `is`(
     _ column: String,
-    value: any URLQueryRepresentable
+    value: Bool?
   ) -> PostgrestFilterBuilder {
     let queryValue = value.queryValue
     mutableState.withValue {

--- a/Tests/IntegrationTests/Potsgrest/PostgrestFilterTests.swift
+++ b/Tests/IntegrationTests/Potsgrest/PostgrestFilterTests.swift
@@ -288,7 +288,7 @@ final class PostgrestFilterTests: XCTestCase {
   }
 
   func testIs() async throws {
-    let res = try await client.from("users").select("data").is("data", value: AnyJSON.null)
+    let res = try await client.from("users").select("data").is("data", value: nil)
       .execute()
       .value as AnyJSON
 
@@ -556,7 +556,7 @@ final class PostgrestFilterTests: XCTestCase {
     let res = try await client.from("users")
       .select()
       .eq("username", value: "supabot")
-      .is("data", value: AnyJSON.null)
+      .is("data", value: nil)
       .overlaps("age_range", value: "[1,2)")
       .eq("status", value: "ONLINE")
       .textSearch("catchphrase", query: "cat")

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -169,7 +169,7 @@ final class BuildURLRequestTests: XCTestCase {
       TestCase(name: "query if nil value") { client in
         client.from("users")
           .select()
-          .is("email", value: String?.none)
+          .is("email", value: nil)
       },
       TestCase(name: "likeAllOf") { client in
         client.from("users")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

Currently any type can be passed to the `is` filter.

## What is the new behavior?

Only `true`, `false`, or `nil` are allowed.

## Additional context

https://github.com/supabase/supabase-flutter/pull/920