### PR TITLE
fix(storage): headers overridden

### DIFF
--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -31,7 +31,7 @@ public class StorageApi: @unchecked Sendable {
   @discardableResult
   func execute(_ request: HTTPRequest) async throws -> HTTPResponse {
     var request = request
-    request.headers.merge(with: HTTPHeaders(configuration.headers))
+    request.headers = HTTPHeaders(configuration.headers).merged(with: request.headers)
 
     let response = try await http.send(request)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The same issue fixed in https://github.com/supabase/supabase-swift/pull/379 but for `storage`.