### PR TITLE
fix: race condition when accessing SupabaseClient

### DIFF
--- a/Sources/Supabase/Deprecated.swift
+++ b/Sources/Supabase/Deprecated.swift
@@ -1,0 +1,26 @@
+//
+//  Deprecated.swift
+//
+//
+//  Created by Guilherme Souza on 15/05/24.
+//
+
+import Foundation
+
+extension SupabaseClient {
+  /// Database client for Supabase.
+  @available(
+    *,
+    deprecated,
+    message: "Direct access to database is deprecated, please use one of the available methods such as, SupabaseClient.from(_:), SupabaseClient.rpc(_:params:), or SupabaseClient.schema(_:)."
+  )
+  public var database: PostgrestClient {
+    rest
+  }
+
+  /// Realtime client for Supabase
+  @available(*, deprecated, message: "Use realtimeV2")
+  public var realtime: RealtimeClient {
+    _realtime.value
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

I wasn't able to reproduce it, but I have an assumption that these changes may fix the following crashes.

Fix https://github.com/supabase/supabase-swift/issues/239
Fix https://github.com/supabase/supabase-swift/issues/385

## What is the current behavior?

Inner clients from SupabaseClient were defined as `lazy var`, but `lazy var` isn't thread-safe in Swift, this was probably causing some crashes when accessed from different threads.

We also relied on it to mark the `SupabaseClient` class as `@unchecked Sendable`.

## What is the new behavior?

Moved inner clients to a `LockIsolated` and made `SupabaseClient` conform to `Sendable`.
