### PR TITLE
feat(storage): fill content-type based on file extension

### DIFF
--- a/Sources/Storage/Helpers.swift
+++ b/Sources/Storage/Helpers.swift
@@ -5,29 +5,42 @@
 //  Created by Guilherme Souza on 22/05/24.
 //
 
-import CoreServices
 import Foundation
-import UniformTypeIdentifiers
 
-func mimeTypeForExtension(_ fileExtension: String) -> String {
-  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, visionOS 1.0, *) {
-    return UTType(filenameExtension: fileExtension)?.preferredMIMEType ?? "application/octet-stream"
-  } else {
-    guard
-      let type = UTTypeCreatePreferredIdentifierForTag(
-        kUTTagClassFilenameExtension,
-        fileExtension as NSString,
-        nil
-      )?.takeUnretainedValue(),
-      let mimeType = UTTypeCopyPreferredTagWithClass(
-        type,
-        kUTTagClassMIMEType
-      )?.takeUnretainedValue()
-    else { return "application/octet-stream" }
+#if canImport(CoreServices)
+  import CoreServices
+#endif
 
-    return mimeType as String
+#if canImport(UniformTypeIdentifiers)
+  import UniformTypeIdentifiers
+#endif
+
+#if os(Linux) || os(Windows)
+  /// On Linux or Windows this method always returns `application/octet-stream`.
+  func mimeTypeForExtension(_: String) -> String {
+    "application/octet-stream"
   }
-}
+#else
+  func mimeTypeForExtension(_ fileExtension: String) -> String {
+    if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, visionOS 1.0, *) {
+      return UTType(filenameExtension: fileExtension)?.preferredMIMEType ?? "application/octet-stream"
+    } else {
+      guard
+        let type = UTTypeCreatePreferredIdentifierForTag(
+          kUTTagClassFilenameExtension,
+          fileExtension as NSString,
+          nil
+        )?.takeUnretainedValue(),
+        let mimeType = UTTypeCopyPreferredTagWithClass(
+          type,
+          kUTTagClassMIMEType
+        )?.takeUnretainedValue()
+      else { return "application/octet-stream" }
+
+      return mimeType as String
+    }
+  }
+#endif
 
 extension String {
   var pathExtension: String {

--- a/Sources/Storage/Helpers.swift
+++ b/Sources/Storage/Helpers.swift
@@ -1,0 +1,40 @@
+//
+//  Helpers.swift
+//
+//
+//  Created by Guilherme Souza on 22/05/24.
+//
+
+import CoreServices
+import Foundation
+import UniformTypeIdentifiers
+
+func mimeTypeForExtension(_ fileExtension: String) -> String {
+  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, visionOS 1.0, *) {
+    return UTType(filenameExtension: fileExtension)?.preferredMIMEType ?? "application/octet-stream"
+  } else {
+    guard
+      let type = UTTypeCreatePreferredIdentifierForTag(
+        kUTTagClassFilenameExtension,
+        fileExtension as NSString,
+        nil
+      )?.takeUnretainedValue(),
+      let mimeType = UTTypeCopyPreferredTagWithClass(
+        type,
+        kUTTagClassMIMEType
+      )?.takeUnretainedValue()
+    else { return "application/octet-stream" }
+
+    return mimeType as String
+  }
+}
+
+extension String {
+  var pathExtension: String {
+    (self as NSString).pathExtension
+  }
+
+  var fileName: String {
+    (self as NSString).lastPathComponent
+  }
+}

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -38,14 +38,14 @@ public class StorageFileApi: StorageApi {
     file: Data,
     options: FileOptions
   ) async throws -> FileUploadResponse {
-    let contentType = options.contentType
+    let contentType = options.contentType ?? mimeTypeForExtension(path.pathExtension)
     var headers = HTTPHeaders([
       "x-upsert": "\(options.upsert)",
     ])
 
     headers["duplex"] = options.duplex
 
-    let fileName = fileName(fromPath: path)
+    let fileName = path.fileName
 
     let form = FormData()
     form.append(
@@ -472,13 +472,13 @@ public class StorageFileApi: StorageApi {
     file: Data,
     options: FileOptions = FileOptions()
   ) async throws -> SignedURLUploadResponse {
-    let contentType = options.contentType
+    let contentType = options.contentType ?? mimeTypeForExtension(path.pathExtension)
     var headers = HTTPHeaders([
       "x-upsert": "\(options.upsert)",
     ])
     headers["duplex"] = options.duplex
 
-    let fileName = fileName(fromPath: path)
+    let fileName = path.fileName
 
     let form = FormData()
     form.append(file: File(
@@ -508,8 +508,4 @@ public class StorageFileApi: StorageApi {
 
     return SignedURLUploadResponse(path: path, fullPath: fullPath)
   }
-}
-
-private func fileName(fromPath path: String) -> String {
-  (path as NSString).lastPathComponent
 }

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -44,9 +44,8 @@ public struct FileOptions: Sendable {
   /// in the `Cache-Control: max-age=<seconds>` header. Defaults to 3600 seconds.
   public var cacheControl: String
 
-  /// The `Content-Type` header value. Should be specified if using a `fileBody` that is neither
-  /// `Blob` nor `File` nor `FormData`, otherwise will default to `text/plain;charset=UTF-8`.
-  public var contentType: String
+  /// The `Content-Type` header value.
+  public var contentType: String?
 
   /// When upsert is set to true, the file is overwritten if it exists. When set to false, an error
   /// is thrown if the object already exists. Defaults to false.
@@ -59,7 +58,7 @@ public struct FileOptions: Sendable {
 
   public init(
     cacheControl: String = "3600",
-    contentType: String = "text/plain;charset=UTF-8",
+    contentType: String? = nil,
     upsert: Bool = false,
     duplex: String? = nil
   ) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Developer must specify the content-type manually

## What is the new behavior?

Use `UTType` from Apple framework for getting the MIME type based on a file extension, ie `.jpg -> image/jpeg`.

Note: not all file extensions are supported, so it defaults to `application/octet-stream`