### PR TITLE
fix: manually percent encode query items to allow values with + sign

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "Sources/Auth/**"
-      - "Tests/Auth/**"
+      - "Tests/AuthTests/**"
       - ".github/workflows/auth.yml"
   push:
     branches:
       - main
     paths:
       - "Sources/Auth/**"
-      - "Tests/Auth/**"
+      - "Tests/AuthTests/**"
       - ".github/workflows/auth.yml"
 
 concurrency:

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "Sources/Functions/**"
-      - "Tests/Functions/**"
+      - "Tests/FunctionsTests/**"
       - ".github/workflows/functions.yml"
   push:
     branches:
       - main
     paths:
       - "Sources/Functions/**"
-      - "Tests/Functions/**"
+      - "Tests/FunctionsTests/**"
       - ".github/workflows/functions.yml"
 
 concurrency:

--- a/.github/workflows/postgrest.yml
+++ b/.github/workflows/postgrest.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "Sources/PostgREST/**"
-      - "Tests/PostgREST/**"
+      - "Tests/PostgRESTTests/**"
       - ".github/workflows/postgrest.yml"
   push:
     branches:
       - main
     paths:
       - "Sources/PostgREST/**"
-      - "Tests/PostgREST/**"
+      - "Tests/PostgRESTTests/**"
       - ".github/workflows/postgrest.yml"
 
 concurrency:

--- a/.github/workflows/realtime.yml
+++ b/.github/workflows/realtime.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "Sources/Realtime/**"
-      - "Tests/Realtime/**"
+      - "Tests/RealtimeTests/**"
       - ".github/workflows/realtime.yml"
   push:
     branches:
       - main
     paths:
       - "Sources/Realtime/**"
-      - "Tests/Realtime/**"
+      - "Tests/RealtimeTests/**"
       - ".github/workflows/realtime.yml"
 
 concurrency:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "Sources/Storage/**"
-      - "Tests/Storage/**"
+      - "Tests/StorageTests/**"
       - ".github/workflows/storage.yml"
   push:
     branches:
       - main
     paths:
       - "Sources/Storage/**"
-      - "Tests/Storage/**"
+      - "Tests/StorageTests/**"
       - ".github/workflows/storage.yml"
 
 concurrency:

--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "Sources/Supabase/**"
-      - "Tests/Supabase/**"
+      - "Tests/SupabaseTests/**"
       - ".github/workflows/supabase.yml"
   push:
     branches:
       - main
     paths:
       - "Sources/Supabase/**"
-      - "Tests/Supabase/**"
+      - "Tests/SupabaseTests/**"
       - ".github/workflows/supabase.yml"
 
 concurrency:

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -206,6 +206,11 @@ final class BuildURLRequestTests: XCTestCase {
           .select()
           .containedBy("userMetadata", value: ["age": 18])
       },
+      TestCase(name: "filter starting with non-alphanumeric") { client in
+        client.from("users")
+          .select()
+          .eq("to", value: "+16505555555")
+      },
     ]
 
     for testCase in testCases {

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.filter-starting-with-non-alphanumeric.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.filter-starting-with-non-alphanumeric.txt
@@ -1,0 +1,5 @@
+curl \
+	--header "Accept: application/json" \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: postgrest-swift/x.y.z" \
+	"https://example.supabase.co/users?select=*&to=eq.+16505555555"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase/supabase-swift/issues/401

## What is the current behavior?

Can't include query values that contain any of the characters `:#[]@!$&'()*+,;=`, this had been fixed before, but got lost on some PRs ago.

## What is the new behavior?

Manually escape the query items, and don't use the default escaping logic from Foundation.

## Additional context

Add any other context or screenshots.
