### PR TITLE
fix(storage): list method using wrong encoder

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -320,6 +320,8 @@ public class StorageFileApi: StorageApi {
     path: String? = nil,
     options: SearchOptions? = nil
   ) async throws -> [FileObject] {
+    let encoder = JSONEncoder()
+    
     var options = options ?? DEFAULT_SEARCH_OPTIONS
     options.prefix = path ?? ""
 
@@ -327,7 +329,7 @@ public class StorageFileApi: StorageApi {
       HTTPRequest(
         url: configuration.url.appendingPathComponent("object/list/\(bucketId)"),
         method: .post,
-        body: configuration.encoder.encode(options)
+        body: encoder.encode(options)
       )
     )
     .decoded(decoder: configuration.decoder)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

`list` methods is sending a request to API storage with **snake_case** instead of **lowerCamelCase** for `SortBy` option

## What is the new behavior?

Using a regular encoder to send the correct key, so now the key `sortBy` sent works.
