### PR TITLE
refactor(realtime): drop actor from RealtimeChannel and RealtimeClient

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -106,7 +106,9 @@ public final class AuthClient: Sendable {
   /// - Parameters:
   ///   - email: User's email address.
   ///   - password: Password for the user.
-  ///   - data: User's metadata.
+  ///   - data: Custom data object to store additional user metadata.
+  ///   - redirectTo: The redirect URL embedded in the email link, defaults to ``Configuration/redirectToURL`` if not provided.
+  ///   - captchaToken: Optional captcha token for securing this endpoint.
   @discardableResult
   public func signUp(
     email: String,
@@ -145,7 +147,8 @@ public final class AuthClient: Sendable {
   /// - Parameters:
   ///   - phone: User's phone number with international prefix.
   ///   - password: Password for the user.
-  ///   - data: User's metadata.
+  ///   - data: Custom data object to store additional user metadata.
+  ///   - captchaToken: Optional captcha token for securing this endpoint.
   @discardableResult
   public func signUp(
     phone: String,
@@ -184,6 +187,10 @@ public final class AuthClient: Sendable {
   }
 
   /// Log in an existing user with an email and password.
+  /// - Parameters:
+  ///   - email: User's email address.
+  ///   - password: User's password.
+  ///   - captchaToken: Optional captcha token for securing this endpoint.
   @discardableResult
   public func signIn(
     email: String,
@@ -207,6 +214,10 @@ public final class AuthClient: Sendable {
   }
 
   /// Log in an existing user with a phone and password.
+  /// - Parameters:
+  ///   - email: User's phone number.
+  ///   - password: User's password.
+  ///   - captchaToken: Optional captcha token for securing this endpoint.
   @discardableResult
   public func signIn(
     phone: String,
@@ -333,8 +344,7 @@ public final class AuthClient: Sendable {
   ///   - data: User's metadata.
   ///   - captchaToken: Captcha verification token.
   ///
-  /// - Note: You need to configure a WhatsApp sender on Twillo if you are using phone sign in with
-  /// the `whatsapp` channel.
+  /// - Note: You need to configure a WhatsApp sender on Twillo if you are using phone sign in with the `whatsapp` channel.
   public func signInWithOTP(
     phone: String,
     channel: MessagingChannel = .sms,
@@ -362,8 +372,7 @@ public final class AuthClient: Sendable {
   /// Attempts a single-sign on using an enterprise Identity Provider.
   /// - Parameters:
   ///   - domain: The email domain to use for signing in.
-  ///   - redirectTo: The URL to redirect the user to after they sign in with the third-party
-  /// provider.
+  ///   - redirectTo: The URL to redirect the user to after they sign in with the third-party provider.
   ///   - captchaToken: The captcha token to be used for captcha verification.
   /// - Returns: A URL that you can use to initiate the provider's authentication flow.
   public func signInWithSSO(

--- a/Sources/Realtime/V2/PushV2.swift
+++ b/Sources/Realtime/V2/PushV2.swift
@@ -20,11 +20,11 @@ actor PushV2 {
   }
 
   func send() async -> PushStatus {
-    await channel?.socket?.push(message)
+    await channel?.socket.push(message)
 
     if channel?.config.broadcast.acknowledgeBroadcasts == true {
       do {
-        return try await withTimeout(interval: channel?.socket?.options.timeoutInterval ?? 10) {
+        return try await withTimeout(interval: channel?.socket.options().timeoutInterval ?? 10) {
           await withCheckedContinuation {
             self.receivedContinuation = $0
           }

--- a/Tests/IntegrationTests/RealtimeIntegrationTests.swift
+++ b/Tests/IntegrationTests/RealtimeIntegrationTests.swift
@@ -40,14 +40,14 @@ final class RealtimeIntegrationTests: XCTestCase {
     let expectation = expectation(description: "receivedBroadcastMessages")
     expectation.expectedFulfillmentCount = 3
 
-    let channel = await realtime.channel("integration") {
+    let channel = realtime.channel("integration") {
       $0.broadcast.receiveOwnBroadcasts = true
     }
 
     let receivedMessages = LockIsolated<[JSONObject]>([])
 
     Task {
-      for await message in await channel.broadcastStream(event: "test") {
+      for await message in channel.broadcastStream(event: "test") {
         receivedMessages.withValue {
           $0.append(message)
         }
@@ -101,7 +101,7 @@ final class RealtimeIntegrationTests: XCTestCase {
   }
 
   func testPresence() async throws {
-    let channel = await realtime.channel("integration") {
+    let channel = realtime.channel("integration") {
       $0.broadcast.receiveOwnBroadcasts = true
     }
 
@@ -111,7 +111,7 @@ final class RealtimeIntegrationTests: XCTestCase {
     let receivedPresenceChanges = LockIsolated<[any PresenceAction]>([])
 
     Task {
-      for await presence in await channel.presenceChange() {
+      for await presence in channel.presenceChange() {
         receivedPresenceChanges.withValue {
           $0.append(presence)
         }
@@ -161,7 +161,7 @@ final class RealtimeIntegrationTests: XCTestCase {
 
   // FIXME: Test getting stuck
 //  func testPostgresChanges() async throws {
-//    let channel = await realtime.channel("db-changes")
+//    let channel = realtime.channel("db-changes")
 //
 //    let receivedInsertActions = Task {
 //      await channel.postgresChange(InsertAction.self, schema: "public").prefix(1).collect()

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -37,6 +37,7 @@ final class RealtimeTests: XCTestCase {
 
   override func tearDown() {
     sut.disconnect()
+  
     super.tearDown()
   }
 

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -35,30 +35,29 @@ final class RealtimeTests: XCTestCase {
     )
   }
 
-  override func tearDown() async throws {
-    await sut.disconnect()
-
-    try await super.tearDown()
+  override func tearDown() {
+    sut.disconnect()
+    super.tearDown()
   }
 
   func testBehavior() async throws {
     try await withTimeout(interval: 2) { [self] in
-      let channel = await sut.channel("public:messages")
-      _ = await channel.postgresChange(InsertAction.self, table: "messages")
-      _ = await channel.postgresChange(UpdateAction.self, table: "messages")
-      _ = await channel.postgresChange(DeleteAction.self, table: "messages")
+      let channel = sut.channel("public:messages")
+      _ = channel.postgresChange(InsertAction.self, table: "messages")
+      _ = channel.postgresChange(UpdateAction.self, table: "messages")
+      _ = channel.postgresChange(DeleteAction.self, table: "messages")
 
-      let statusChange = await sut.statusChange
+      let statusChange = sut.statusChange
 
       await connectSocketAndWait()
 
       let status = await statusChange.prefix(3).collect()
       XCTAssertEqual(status, [.disconnected, .connecting, .connected])
 
-      let messageTask = await sut.messageTask
+      let messageTask = sut.mutableState.messageTask
       XCTAssertNotNil(messageTask)
 
-      let heartbeatTask = await sut.heartbeatTask
+      let heartbeatTask = sut.mutableState.heartbeatTask
       XCTAssertNotNil(heartbeatTask)
 
       let subscription = Task {
@@ -75,7 +74,7 @@ final class RealtimeTests: XCTestCase {
   }
 
   func testSubscribeTimeout() async throws {
-    let channel = await sut.channel("public:messages")
+    let channel = sut.channel("public:messages")
     let joinEventCount = LockIsolated(0)
 
     ws.on { message in
@@ -130,8 +129,8 @@ final class RealtimeTests: XCTestCase {
         )
       ),
       RealtimeMessageV2(
-        joinRef: "3",
-        ref: "3",
+        joinRef: "2",
+        ref: "2",
         topic: "realtime:public:messages",
         event: "phx_join",
         payload: JSONObject(
@@ -193,7 +192,7 @@ final class RealtimeTests: XCTestCase {
       let statuses = LockIsolated<[RealtimeClientV2.Status]>([])
 
       Task {
-        for await status in await sut.statusChange {
+        for await status in sut.statusChange {
           statuses.withValue {
             $0.append(status)
           }
@@ -204,7 +203,7 @@ final class RealtimeTests: XCTestCase {
 
       await fulfillment(of: [sentHeartbeatExpectation], timeout: 2)
 
-      let pendingHeartbeatRef = await sut.pendingHeartbeatRef
+      let pendingHeartbeatRef = sut.mutableState.pendingHeartbeatRef
       XCTAssertNotNil(pendingHeartbeatRef)
 
       // Wait until next heartbeat

--- a/Tests/RealtimeTests/_PushTests.swift
+++ b/Tests/RealtimeTests/_PushTests.swift
@@ -40,7 +40,7 @@ final class _PushTests: XCTestCase {
         broadcast: .init(acknowledgeBroadcasts: false),
         presence: .init()
       ),
-      socket: socket,
+      socket: Socket(client: socket),
       logger: nil
     )
     let push = PushV2(

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -72,10 +72,10 @@ final class SupabaseClientTests: XCTestCase {
 
     XCTAssertEqual(client.functions.region, "ap-northeast-1")
 
-    let realtimeURL = await client.realtimeV2.url
+    let realtimeURL = client.realtimeV2.url
     XCTAssertEqual(realtimeURL.absoluteString, "https://project-ref.supabase.co/realtime/v1")
 
-    let realtimeOptions = await client.realtimeV2.options
+    let realtimeOptions = client.realtimeV2.options
     let expectedRealtimeHeader = client.defaultHeaders.merged(with: ["custom_realtime_header_key": "custom_realtime_header_value"])
     XCTAssertNoDifference(realtimeOptions.headers, expectedRealtimeHeader)
     XCTAssertIdentical(realtimeOptions.logger as? Logger, logger)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make `RealtimeChannelV2` and `RealtimeClientV2` classes instead of actor, and add protect mutable state using a `LockIsolated`.

This makes the call side to not require to be on an async context.

```diff
- let channel = await client.channel("messages")
+ let channel = client.channel("messages")
```

Note this is not a breaking change, the compiler would only emit a warning stating that the `await` isn't required.