### PR TITLE
Update RealtimeChannelV2.swift

### DIFF
--- a/Sources/Realtime/V2/RealtimeChannelV2.swift
+++ b/Sources/Realtime/V2/RealtimeChannelV2.swift
@@ -357,6 +357,7 @@ public final class RealtimeChannelV2: Sendable {
 
           await socket.removeChannel(self)
           logger?.debug("Unsubscribed from channel \(message.topic)")
+          status = .unsubscribed
         }
 
       case .error:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds missing `.unsubscribed` status change

## What is the current behavior?

Once `.unsubscribing` from a channel occurs, `.unsubscribed` never gets set (leaving `.unsubscribing` indefinitely as the status)

## What is the new behavior?

Status is changed to `.unsubscribed` 
