### PR TITLE
feat: add third-party auth support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -137,6 +137,7 @@ let package = Package(
       name: "Supabase",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "Auth",
         "Functions",
         "PostgREST",

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -60,6 +60,12 @@ public struct SupabaseClientOptions: Sendable {
     /// Set to `true` if you want to automatically refresh the token before expiring.
     public let autoRefreshToken: Bool
 
+    /// Optional function for using a third-party authentication system with Supabase. The function should return an access token or ID token (JWT) by obtaining it from the third-party auth client library.
+    /// Note that this function may be called concurrently and many times. Use memoization and locking techniques if this is not supported by the client libraries.
+    /// When set, the `auth` namespace of the Supabase client cannot be used.
+    /// Create another client if you wish to use Supabase Auth and third-party authentications concurrently in the same application.
+    public let accessToken: (@Sendable () async throws -> String)?
+
     public init(
       storage: any AuthLocalStorage,
       redirectToURL: URL? = nil,
@@ -67,7 +73,8 @@ public struct SupabaseClientOptions: Sendable {
       flowType: AuthFlowType = AuthClient.Configuration.defaultFlowType,
       encoder: JSONEncoder = AuthClient.Configuration.jsonEncoder,
       decoder: JSONDecoder = AuthClient.Configuration.jsonDecoder,
-      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken
+      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+      accessToken: (@Sendable () async throws -> String)? = nil
     ) {
       self.storage = storage
       self.redirectToURL = redirectToURL
@@ -76,6 +83,7 @@ public struct SupabaseClientOptions: Sendable {
       self.encoder = encoder
       self.decoder = decoder
       self.autoRefreshToken = autoRefreshToken
+      self.accessToken = accessToken
     }
   }
 
@@ -154,7 +162,8 @@ extension SupabaseClientOptions.AuthOptions {
       flowType: AuthFlowType = AuthClient.Configuration.defaultFlowType,
       encoder: JSONEncoder = AuthClient.Configuration.jsonEncoder,
       decoder: JSONDecoder = AuthClient.Configuration.jsonDecoder,
-      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken
+      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+      accessToken: (@Sendable () async throws -> String)? = nil
     ) {
       self.init(
         storage: AuthClient.Configuration.defaultLocalStorage,
@@ -163,7 +172,8 @@ extension SupabaseClientOptions.AuthOptions {
         flowType: flowType,
         encoder: encoder,
         decoder: decoder,
-        autoRefreshToken: autoRefreshToken
+        autoRefreshToken: autoRefreshToken,
+        accessToken: accessToken
       )
     }
   #endif

--- a/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "7cc8037abb258fd1406effe711922c8d309c2e7a93147bfe68753fd05392a24a",
   "pins" : [
     {
       "identity" : "appauth-ios",
@@ -65,6 +64,24 @@
       }
     },
     {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "46072478ca365fe48370993833cb22de9b41567f",
+        "version" : "3.5.2"
+      }
+    },
+    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
@@ -80,6 +97,15 @@
       "state" : {
         "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
         "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
+        "version" : "1.17.2"
       }
     },
     {
@@ -110,5 +136,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -100,11 +100,14 @@ final class SupabaseClientTests: XCTestCase {
   #endif
 
   func testClientInitWithCustomAccessToken() async {
+    let localStorage = AuthLocalStorageMock()
+
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,
       supabaseKey: "ANON_KEY",
       options: .init(
         auth: .init(
+          storage: localStorage,
           accessToken: { "jwt" }
         )
       )

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -1,6 +1,7 @@
 @testable import Auth
 import CustomDump
 @testable import Functions
+import IssueReporting
 @testable import Realtime
 @testable import Supabase
 import XCTest
@@ -118,13 +119,8 @@ final class SupabaseClientTests: XCTestCase {
       "should not listen for internal auth events when using 3p authentication"
     )
 
-    overridedPreconditionHandler.setValue { _, message, _, _ in
-      XCTAssertEqual(
-        message(),
-        "Supabase Client is configured with the auth.accessToken option, accessing supabase.auth is not possible."
-      )
+    withExpectedIssue {
+      _ = client.auth
     }
-
-    _ = client.auth
   }
 }

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -119,8 +119,11 @@ final class SupabaseClientTests: XCTestCase {
       "should not listen for internal auth events when using 3p authentication"
     )
 
-    withExpectedIssue {
-      _ = client.auth
-    }
+    #if canImport(Darwin)
+      // withExpectedIssue is unavailable on non-Darwin platform.
+      withExpectedIssue {
+        _ = client.auth
+      }
+    #endif
   }
 }


### PR DESCRIPTION
Adds support for the accessToken option on the Supabase client which can be used to provide a third-party authentication (e.g. Auth0, Clerk, Firebase Auth, ...) access token or ID token to be used instead of Supabase Auth.

When set, `supabase.auth.xyz` cannot be used and an error will be thrown.

See https://github.com/supabase/supabase-js/pull/1004 for more information.