### PR TITLE
fix: concurrency warnings pre swift 6 support

### DIFF
--- a/Sources/Auth/Defaults.swift
+++ b/Sources/Auth/Defaults.swift
@@ -9,25 +9,13 @@ import Foundation
 import Helpers
 
 extension AuthClient.Configuration {
-  private static let dateFormatterWithFractionalSeconds = { () -> ISO8601DateFormatter in
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return formatter
-  }()
-
-  private static let dateFormatter = { () -> ISO8601DateFormatter in
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
-    return formatter
-  }()
-
   /// The default JSONEncoder instance used by the ``AuthClient``.
   public static let jsonEncoder: JSONEncoder = {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
     encoder.dateEncodingStrategy = .custom { date, encoder in
       var container = encoder.singleValueContainer()
-      let string = dateFormatterWithFractionalSeconds.string(from: date)
+      let string = DateFormatter.iso8601.string(from: date)
       try container.encode(string)
     }
     return encoder
@@ -41,7 +29,7 @@ extension AuthClient.Configuration {
       let container = try decoder.singleValueContainer()
       let string = try container.decode(String.self)
 
-      let supportedFormatters = [dateFormatterWithFractionalSeconds, dateFormatter]
+      let supportedFormatters: [DateFormatter] = [.iso8601, .iso8601_noMilliseconds]
 
       for formatter in supportedFormatters {
         if let date = formatter.date(from: string) {

--- a/Sources/Helpers/SupabaseLogger.swift
+++ b/Sources/Helpers/SupabaseLogger.swift
@@ -55,7 +55,7 @@ public struct SupabaseLogMessage: Codable, CustomStringConvertible, Sendable {
   }
 
   public var description: String {
-    let date = iso8601Formatter.string(from: Date(timeIntervalSince1970: timestamp))
+    let date = DateFormatter.iso8601_noMilliseconds.string(from: Date(timeIntervalSince1970: timestamp))
     let file = fileID.split(separator: ".", maxSplits: 1).first.map(String.init) ?? fileID
     var description = "\(date) [\(level)] [\(system)] [\(file).\(function):\(line)] \(message)"
     if !additionalContext.isEmpty {
@@ -64,12 +64,6 @@ public struct SupabaseLogMessage: Codable, CustomStringConvertible, Sendable {
     return description
   }
 }
-
-private let iso8601Formatter: ISO8601DateFormatter = {
-  let formatter = ISO8601DateFormatter()
-  formatter.formatOptions = [.withInternetDateTime]
-  return formatter
-}()
 
 public protocol SupabaseLogger: Sendable {
   func log(message: SupabaseLogMessage)

--- a/Sources/PostgREST/Defaults.swift
+++ b/Sources/PostgREST/Defaults.swift
@@ -11,17 +11,9 @@ import Helpers
 let version = Helpers.version
 
 extension PostgrestClient.Configuration {
-  private static let supportedDateFormatters: [ISO8601DateFormatter] = [
-    { () -> ISO8601DateFormatter in
-      let formatter = ISO8601DateFormatter()
-      formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-      return formatter
-    }(),
-    { () -> ISO8601DateFormatter in
-      let formatter = ISO8601DateFormatter()
-      formatter.formatOptions = [.withInternetDateTime]
-      return formatter
-    }(),
+  private static let supportedDateFormatters: [DateFormatter] = [
+    .iso8601,
+    .iso8601_noMilliseconds,
   ]
 
   /// The default `JSONDecoder` instance for ``PostgrestClient`` responses.


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is part of the Swift 6 mode support, some concurrency warnings will become errors when Swift 6 is enabled.

This PR fixes a couple of concurrency warnings, by not using the `ISO8601DateFormatter`, which isn't `Sendable` in favor of the `DateFormatter`, which is `Sendable` and is already being used on some places