### PR TITLE
fix(realtime): send access token to realtime on initial session

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -354,7 +354,7 @@ public final class SupabaseClient: Sendable {
 
   private func handleTokenChanged(event: AuthChangeEvent, session: Session?) async {
     let accessToken = mutableState.withValue {
-      if event == .tokenRefreshed || event == .signedIn, $0.changedAccessToken != session?.accessToken {
+      if event == .initialSession || event == .tokenRefreshed || event == .signedIn, $0.changedAccessToken != session?.accessToken {
         $0.changedAccessToken = session?.accessToken
         return session?.accessToken
       } else if event == .signedOut {

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -353,16 +353,18 @@ public final class SupabaseClient: Sendable {
   }
 
   private func handleTokenChanged(event: AuthChangeEvent, session: Session?) async {
-    let accessToken = mutableState.withValue {
-      if event == .initialSession || event == .tokenRefreshed || event == .signedIn, $0.changedAccessToken != session?.accessToken {
+    let accessToken: String? = mutableState.withValue {
+      if [.initialSession, .signedIn, .tokenRefreshed].contains(event), $0.changedAccessToken != session?.accessToken {
         $0.changedAccessToken = session?.accessToken
-        return session?.accessToken
-      } else if event == .signedOut {
+        return session?.accessToken ?? supabaseKey
+      }
+
+      if event == .signedOut {
         $0.changedAccessToken = nil
         return supabaseKey
-      } else {
-        return nil
       }
+
+      return nil
     }
 
     realtime.setAuth(accessToken)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #438 

## What is the current behavior?

When `initialSession` event occurs, access token isn't sent to realtime

## What is the new behavior?

Send accessToken also when `initialSession` event happens.