### PR TITLE
feat(auth): add support for multiple auth instances

### DIFF
--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -9,9 +9,11 @@ import Foundation
 import Helpers
 
 public struct AuthAdmin: Sendable {
-  var configuration: AuthClient.Configuration { Current.configuration }
-  var api: APIClient { Current.api }
-  var encoder: JSONEncoder { Current.encoder }
+  let clientID: AuthClientID
+
+  var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
+  var api: APIClient { Dependencies[clientID].api }
+  var encoder: JSONEncoder { Dependencies[clientID].encoder }
 
   /// Delete a user. Requires `service_role` key.
   /// - Parameter id: The id of the user you want to delete.

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -13,7 +13,7 @@ import Helpers
 typealias AuthClientID = UUID
 
 public final class AuthClient: Sendable {
-  private let clientID = AuthClientID()
+  let clientID = AuthClientID()
 
   private var api: APIClient { Dependencies[clientID].api }
   var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
@@ -51,6 +51,7 @@ public final class AuthClient: Sendable {
   public var mfa: AuthMFA {
     AuthMFA(clientID: clientID)
   }
+
   /// Namespace for the GoTrue admin methods.
   /// - Warning: This methods requires `service_role` key, be careful to never expose `service_role`
   /// key in the client.

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -10,15 +10,19 @@ import Helpers
   import FoundationNetworking
 #endif
 
+typealias AuthClientID = UUID
+
 public final class AuthClient: Sendable {
-  private var api: APIClient { Current.api }
-  var configuration: AuthClient.Configuration { Current.configuration }
-  private var codeVerifierStorage: CodeVerifierStorage { Current.codeVerifierStorage }
-  private var date: @Sendable () -> Date { Current.date }
-  private var sessionManager: SessionManager { Current.sessionManager }
-  private var eventEmitter: AuthStateChangeEventEmitter { Current.eventEmitter }
-  private var logger: (any SupabaseLogger)? { Current.configuration.logger }
-  private var storage: any AuthLocalStorage { Current.configuration.localStorage }
+  private let clientID = AuthClientID()
+
+  private var api: APIClient { Dependencies[clientID].api }
+  var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
+  private var codeVerifierStorage: CodeVerifierStorage { Dependencies[clientID].codeVerifierStorage }
+  private var date: @Sendable () -> Date { Dependencies[clientID].date }
+  private var sessionManager: SessionManager { Dependencies[clientID].sessionManager }
+  private var eventEmitter: AuthStateChangeEventEmitter { Dependencies[clientID].eventEmitter }
+  private var logger: (any SupabaseLogger)? { Dependencies[clientID].configuration.logger }
+  private var sessionStorage: SessionStorage { Dependencies[clientID].sessionStorage }
 
   /// Returns the session, refreshing it if necessary.
   ///
@@ -33,31 +37,38 @@ public final class AuthClient: Sendable {
   ///
   /// The session returned by this property may be expired. Use ``session`` for a session that is guaranteed to be valid.
   public var currentSession: Session? {
-    try? storage.getSession()
+    try? sessionStorage.get()
   }
 
   /// Returns the current user, if any.
   ///
   /// The user returned by this property may be outdated. Use ``user(jwt:)`` method to get an up-to-date user instance.
   public var currentUser: User? {
-    try? storage.getSession()?.user
+    try? sessionStorage.get()?.user
   }
 
   /// Namespace for accessing multi-factor authentication API.
-  public let mfa = AuthMFA()
+  public var mfa: AuthMFA {
+    AuthMFA(clientID: clientID)
+  }
   /// Namespace for the GoTrue admin methods.
   /// - Warning: This methods requires `service_role` key, be careful to never expose `service_role`
   /// key in the client.
-  public let admin = AuthAdmin()
+  public var admin: AuthAdmin {
+    AuthAdmin(clientID: clientID)
+  }
 
   /// Initializes a AuthClient with a specific configuration.
   ///
   /// - Parameters:
   ///   - configuration: The client configuration.
   public init(configuration: Configuration) {
-    Current = Dependencies(
+    Dependencies[clientID] = Dependencies(
       configuration: configuration,
-      http: HTTPClient(configuration: configuration)
+      http: HTTPClient(configuration: configuration),
+      api: APIClient(clientID: clientID),
+      sessionStorage: .live(clientID: clientID),
+      sessionManager: .live(clientID: clientID)
     )
   }
 
@@ -1046,7 +1057,7 @@ public final class AuthClient: Sendable {
       scopes: scopes,
       redirectTo: redirectTo,
       queryParams: queryParams,
-      launchURL: { Current.urlOpener.open($0) }
+      launchURL: { Dependencies[clientID].urlOpener.open($0) }
     )
   }
 

--- a/Sources/Auth/AuthMFA.swift
+++ b/Sources/Auth/AuthMFA.swift
@@ -3,12 +3,14 @@ import Helpers
 
 /// Contains the full multi-factor authentication API.
 public struct AuthMFA: Sendable {
-  var configuration: AuthClient.Configuration { Current.configuration }
-  var api: APIClient { Current.api }
-  var encoder: JSONEncoder { Current.encoder }
-  var decoder: JSONDecoder { Current.decoder }
-  var sessionManager: SessionManager { Current.sessionManager }
-  var eventEmitter: AuthStateChangeEventEmitter { Current.eventEmitter }
+  let clientID: AuthClientID
+
+  var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
+  var api: APIClient { Dependencies[clientID].api }
+  var encoder: JSONEncoder { Dependencies[clientID].encoder }
+  var decoder: JSONDecoder { Dependencies[clientID].decoder }
+  var sessionManager: SessionManager { Dependencies[clientID].sessionManager }
+  var eventEmitter: AuthStateChangeEventEmitter { Dependencies[clientID].eventEmitter }
 
   /// Starts the enrollment process for a new Multi-Factor Authentication (MFA) factor. This method
   /// creates a new `unverified` factor.

--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -21,12 +21,14 @@ extension HTTPClient {
 }
 
 struct APIClient: Sendable {
+  let clientID: AuthClientID
+
   var configuration: AuthClient.Configuration {
-    Current.configuration
+    Dependencies[clientID].configuration
   }
 
   var http: any HTTPClientType {
-    Current.http
+    Dependencies[clientID].http
   }
 
   func execute(_ request: HTTPRequest) async throws -> HTTPResponse {
@@ -62,7 +64,7 @@ struct APIClient: Sendable {
   @discardableResult
   func authorizedExecute(_ request: HTTPRequest) async throws -> HTTPResponse {
     var sessionManager: SessionManager {
-      Current.sessionManager
+      Dependencies[clientID].sessionManager
     }
 
     let session = try await sessionManager.session()

--- a/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
+++ b/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
@@ -1,0 +1,46 @@
+//
+//  AuthClientMultipleInstancesTests.swift
+//
+//
+//  Created by Guilherme Souza on 05/07/24.
+//
+
+@testable import Auth
+import TestHelpers
+import XCTest
+
+final class AuthClientMultipleInstancesTests: XCTestCase {
+  func testMultipleAuthClientInstances() {
+    let url = URL(string: "http://localhost:54321/auth")!
+
+    let client1Storage = InMemoryLocalStorage()
+    let client2Storage = InMemoryLocalStorage()
+
+    let client1 = AuthClient(
+      configuration: AuthClient.Configuration(
+        url: url,
+        localStorage: client1Storage,
+        logger: nil
+      )
+    )
+
+    let client2 = AuthClient(
+      configuration: AuthClient.Configuration(
+        url: url,
+        localStorage: client2Storage,
+        logger: nil
+      )
+    )
+
+    XCTAssertNotEqual(client1.clientID, client2.clientID)
+
+    XCTAssertIdentical(
+      Dependencies[client1.clientID].configuration.localStorage as? InMemoryLocalStorage,
+      client1Storage
+    )
+    XCTAssertIdentical(
+      Dependencies[client2.clientID].configuration.localStorage as? InMemoryLocalStorage,
+      client2Storage
+    )
+  }
+}

--- a/Tests/AuthTests/MockHelpers.swift
+++ b/Tests/AuthTests/MockHelpers.swift
@@ -21,6 +21,9 @@ extension Dependencies {
       localStorage: InMemoryLocalStorage(),
       logger: nil
     ),
-    http: HTTPClientMock()
+    http: HTTPClientMock(),
+    api: APIClient(clientID: AuthClientID()),
+    sessionStorage: SessionStorage.live(clientID: AuthClientID()),
+    sessionManager: SessionManager.live(clientID: AuthClientID())
   )
 }

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -18,14 +18,6 @@ import XCTest
 struct UnimplementedError: Error {}
 
 final class RequestsTests: XCTestCase {
-  var storage: InMemoryLocalStorage!
-
-  override func setUp() {
-    super.setUp()
-
-    storage = InMemoryLocalStorage()
-  }
-
   func testSignUpWithEmailAndPassword() async {
     let sut = makeSUT()
 
@@ -155,7 +147,7 @@ final class RequestsTests: XCTestCase {
 
       let currentDate = Date()
 
-      Current.date = { currentDate }
+      Dependencies[sut.clientID].date = { currentDate }
 
       let url = URL(
         string:
@@ -193,9 +185,8 @@ final class RequestsTests: XCTestCase {
   }
 
   func testSetSessionWithAFutureExpirationDate() async throws {
-    try storage.storeSession(.validSession)
-
     let sut = makeSUT()
+    try Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     let accessToken =
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjo0ODUyMTYzNTkzLCJzdWIiOiJmMzNkM2VjOS1hMmVlLTQ3YzQtODBlMS01YmQ5MTlmM2Q4YjgiLCJlbWFpbCI6ImhpQGJpbmFyeXNjcmFwaW5nLmNvIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6e30sInJvbGUiOiJhdXRoZW50aWNhdGVkIn0.UiEhoahP9GNrBKw_OHBWyqYudtoIlZGkrjs7Qa8hU7I"
@@ -217,9 +208,8 @@ final class RequestsTests: XCTestCase {
   }
 
   func testSignOut() async throws {
-    try storage.storeSession(.validSession)
-
     let sut = makeSUT()
+    try Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
       try await sut.signOut()
@@ -227,9 +217,8 @@ final class RequestsTests: XCTestCase {
   }
 
   func testSignOutWithLocalScope() async throws {
-    try storage.storeSession(.validSession)
-
     let sut = makeSUT()
+    try Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
       try await sut.signOut(scope: .local)
@@ -237,9 +226,9 @@ final class RequestsTests: XCTestCase {
   }
 
   func testSignOutWithOthersScope() async throws {
-    try storage.storeSession(.validSession)
-
     let sut = makeSUT()
+
+    try Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
       try await sut.signOut(scope: .others)
@@ -276,7 +265,7 @@ final class RequestsTests: XCTestCase {
   func testUpdateUser() async throws {
     let sut = makeSUT()
 
-    try storage.storeSession(.validSession)
+    try Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
       try await sut.update(
@@ -339,7 +328,7 @@ final class RequestsTests: XCTestCase {
   func testReauthenticate() async throws {
     let sut = makeSUT()
 
-    try storage.storeSession(.validSession)
+    try Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
       try await sut.reauthenticate()
@@ -349,7 +338,7 @@ final class RequestsTests: XCTestCase {
   func testUnlinkIdentity() async throws {
     let sut = makeSUT()
 
-    try storage.storeSession(.validSession)
+    try Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
       try await sut.unlinkIdentity(
@@ -405,7 +394,7 @@ final class RequestsTests: XCTestCase {
   func testGetLinkIdentityURL() async throws {
     let sut = makeSUT()
 
-    try storage.storeSession(.validSession)
+    try Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
       _ = try await sut.getLinkIdentityURL(
@@ -441,7 +430,7 @@ final class RequestsTests: XCTestCase {
       url: clientURL,
       headers: ["Apikey": "dummy.api.key", "X-Client-Info": "gotrue-swift/x.y.z"],
       flowType: flowType,
-      localStorage: storage,
+      localStorage: InMemoryLocalStorage(),
       logger: nil,
       encoder: encoder,
       fetch: { request in


### PR DESCRIPTION
## What kind of change does this PR introduce?

Close https://github.com/supabase/supabase-swift/issues/441

## What is the current behavior?

`Auth` uses a singleton dependency, so all client instances use the same set of dependencies, this makes it impossible to use multiple auth instances properly.

## What is the new behavior?

`AuthClient` has a unique identifier, now used to index an instance of the `Dependencies` struct. Each `AuthClient` has its own `Dependencies`.