### PR TITLE
fix(auth): verify otp using token hash

### DIFF
--- a/Examples/Examples/Profile/ProfileView.swift
+++ b/Examples/Examples/Profile/ProfileView.swift
@@ -19,7 +19,8 @@ struct ProfileView: View {
     NavigationStack {
       List {
         if let user,
-           let json = try? AnyJSON(user) {
+           let json = try? AnyJSON(user)
+        {
           Section {
             AnyJSONView(value: json)
           }

--- a/Examples/Examples/Profile/UpdateProfileView.swift
+++ b/Examples/Examples/Profile/UpdateProfileView.swift
@@ -5,8 +5,8 @@
 //  Created by Guilherme Souza on 14/05/24.
 //
 
-import SwiftUI
 import Supabase
+import SwiftUI
 
 struct UpdateProfileView: View {
   let user: User
@@ -93,7 +93,7 @@ struct UpdateProfileView: View {
   }
 
   @MainActor
-  private func verifyTapped() async { 
+  private func verifyTapped() async {
     do {
       try await supabase.auth.verifyOTP(phone: phone, token: otp, type: .phoneChange)
     } catch {

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -862,6 +862,25 @@ public final class AuthClient: Sendable {
     )
   }
 
+  /// Log in an user given a token hash received via email.
+  @discardableResult
+  public func verifyOTP(
+    tokenHash: String,
+    type: EmailOTPType
+  ) async throws -> AuthResponse {
+    try await _verifyOTP(
+      request: .init(
+        url: configuration.url.appendingPathComponent("verify"),
+        method: .post,
+        body: configuration.encoder.encode(
+          VerifyOTPParams.tokenHash(
+            VerifyTokenHashParams(tokenHash: tokenHash, type: type)
+          )
+        )
+      )
+    )
+  }
+
   private func _verifyOTP(request: HTTPRequest) async throws -> AuthResponse {
     let response = try await api.execute(request).decoded(
       as: AuthResponse.self,

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -371,6 +371,7 @@ struct OTPParams: Codable, Hashable, Sendable {
 enum VerifyOTPParams: Encodable {
   case email(VerifyEmailOTPParams)
   case mobile(VerifyMobileOTPParams)
+  case tokenHash(VerifyTokenHashParams)
 
   func encode(to encoder: any Encoder) throws {
     var container = encoder.singleValueContainer()
@@ -378,6 +379,8 @@ enum VerifyOTPParams: Encodable {
     case let .email(value):
       try container.encode(value)
     case let .mobile(value):
+      try container.encode(value)
+    case let .tokenHash(value):
       try container.encode(value)
     }
   }
@@ -388,6 +391,11 @@ struct VerifyEmailOTPParams: Encodable, Hashable, Sendable {
   var token: String
   var type: EmailOTPType
   var gotrueMetaSecurity: AuthMetaSecurity?
+}
+
+struct VerifyTokenHashParams: Encodable, Hashable, Sendable {
+  var tokenHash: String
+  var type: EmailOTPType
 }
 
 struct VerifyMobileOTPParams: Encodable, Hashable {

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -273,6 +273,17 @@ final class RequestsTests: XCTestCase {
     }
   }
 
+  func testVerifyOTPUsingTokenHash() async {
+    let sut = makeSUT()
+
+    await assert {
+      try await sut.verifyOTP(
+        tokenHash: "abc-def",
+        type: .email
+      )
+    }
+  }
+
   func testUpdateUser() async throws {
     let sut = makeSUT()
 

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testVerifyOTPUsingTokenHash.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testVerifyOTPUsingTokenHash.1.txt
@@ -1,0 +1,7 @@
+curl \
+	--request POST \
+	--header "Apikey: dummy.api.key" \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--data "{\"token_hash\":\"abc-def\",\"type\":\"email\"}" \
+	"http://localhost:54321/auth/v1/verify"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase/supabase-swift/issues/446

## What is the current behavior?

`verifyOTP` using token hash method is missing from library but present on documentatino.

## What is the new behavior?

Add `verifyOTP` using token hash.

## Additional context

Add any other context or screenshots.
