### PR TITLE
fix(auth): prevent from requesting login keychain password os macOS

### DIFF
--- a/Sources/Auth/Internal/Keychain.swift
+++ b/Sources/Auth/Internal/Keychain.swift
@@ -67,6 +67,11 @@
         query[kSecAttrAccessGroup as String] = accessGroup
       }
 
+      // this is highly recommended for all keychain operations and makes the
+      // macOS keychain item behave like an iOS keychain item
+      // https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain
+      query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
+
       return query
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR aligns the behavior of KeychainLocalStorage on iOS and macOS. 

## What is the current behavior?

When one app save an item in KeychainLocalStorage with an access group on macOS, another app/extension with the same access group would not be able to access the item without the user having to enter their login keychain password. On iOS this would work without user having to enter any passwords.

## What is the new behavior?

Both on iOS and macOS apps/extensions are able to access keychain items with the shared access group correctly without the user having to enter their password.

