### PR TITLE
fix(postgrest): avoid duplicated columns and prefer fields

### DIFF
--- a/Sources/Helpers/HTTP/HTTPRequest.swift
+++ b/Sources/Helpers/HTTP/HTTPRequest.swift
@@ -68,3 +68,13 @@ package enum HTTPMethod: String, Sendable {
   case patch = "PATCH"
   case options = "OPTIONS"
 }
+
+extension [URLQueryItem] {
+  package mutating func appendOrUpdate(_ queryItem: URLQueryItem) {
+    if let index = firstIndex(where: { $0.name == queryItem.name }) {
+      self[index] = queryItem
+    } else {
+      self.append(queryItem)
+    }
+  }
+}

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -27,7 +27,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
       }
       .joined(separator: "")
 
-      $0.request.query.append(URLQueryItem(name: "select", value: cleanedColumns))
+      $0.request.query.appendOrUpdate(URLQueryItem(name: "select", value: cleanedColumns))
 
       if let count {
         $0.request.headers["Prefer"] = "count=\(count.rawValue)"
@@ -73,7 +73,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
       {
         let allKeys = jsonObject.flatMap(\.keys)
         let uniqueKeys = Set(allKeys).sorted()
-        $0.request.query.append(URLQueryItem(
+        $0.request.query.appendOrUpdate(URLQueryItem(
           name: "columns",
           value: uniqueKeys.joined(separator: ",")
         ))
@@ -108,7 +108,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
         "return=\(returning.rawValue)",
       ]
       if let onConflict {
-        $0.request.query.append(URLQueryItem(name: "on_conflict", value: onConflict))
+        $0.request.query.appendOrUpdate(URLQueryItem(name: "on_conflict", value: onConflict))
       }
       $0.request.body = try configuration.encoder.encode(values)
       if let count {
@@ -126,7 +126,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
       {
         let allKeys = jsonObject.flatMap(\.keys)
         let uniqueKeys = Set(allKeys).sorted()
-        $0.request.query.append(URLQueryItem(
+        $0.request.query.appendOrUpdate(URLQueryItem(
           name: "columns",
           value: uniqueKeys.joined(separator: ",")
         ))

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -141,6 +141,17 @@ final class BuildURLRequestTests: XCTestCase {
             ]
           )
       },
+      TestCase(name: "select after bulk upsert") { client in
+        try client.from("users")
+          .upsert(
+            [
+              User(email: "johndoe@supabase.io"),
+              User(email: "johndoe2@supabase.io"),
+            ],
+            onConflict: "username"
+          )
+          .select()
+      },
       TestCase(name: "test upsert ignoring duplicates") { client in
         try client.from("users")
           .upsert(User(email: "johndoe@supabase.io"), ignoreDuplicates: true)

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.select-after-bulk-upsert.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.select-after-bulk-upsert.txt
@@ -1,0 +1,8 @@
+curl \
+	--request POST \
+	--header "Accept: application/json" \
+	--header "Content-Type: application/json" \
+	--header "Prefer: resolution=merge-duplicates,return=representation" \
+	--header "X-Client-Info: postgrest-swift/x.y.z" \
+	--data "[{\"email\":\"johndoe@supabase.io\"},{\"email\":\"johndoe2@supabase.io\"}]" \
+	"https://example.supabase.co/users?columns=email&on_conflict=username&select=*"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When chaining a `select` after a `upsert` call, the `prefer` header gets duplicated.

## What is the new behavior?

Avoid duplicated header fields