### PR TITLE
chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+
+root = true
+
+[*]
+ident_style = space
+ident_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+


### PR DESCRIPTION
Xcode 16 added support for `.editorconfig` standard.