### PR TITLE
test(integration): compare email instead of newEmail

### DIFF
--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -220,7 +220,7 @@ final class AuthClientIntegrationTests: XCTestCase {
       let email = mockEmail()
       let user = try await authClient.update(user: UserAttributes(email: email))
 
-      XCTAssertEqual(user.newEmail, email)
+      XCTAssertEqual(user.email, email)
     }
   }
 


### PR DESCRIPTION
Test integration project doesn't require email confirmation anymore due send email limitation