### PR TITLE
Provide a means of synchronously invalidating local session data

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -778,6 +778,11 @@ public final class AuthClient: Sendable {
     return session
   }
 
+  /// Provides a synchronous means of instantly invalidating the current local session.
+  public func invalidateCurrentSession() {
+    try? sessionStorage.delete()
+  }
+
   /// Signs out the current user, if there is a logged in user.
   ///
   /// If using ``SignOutScope/others`` scope, no ``AuthChangeEvent/signedOut`` event is fired.


### PR DESCRIPTION
When re-installing an app, I want previous session data that was persisting in the keychain to be deleted as well. I'm not sure this is the best approach, but it allows for a synchronous removal of any existing session data.