### PR TITLE
fix(auth): mark identities last_sign_in_at field as optional

### DIFF
--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -223,9 +223,9 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
   public var userId: UUID
   public var identityData: [String: AnyJSON]?
   public var provider: String
-  public var createdAt: Date
-  public var lastSignInAt: Date
-  public var updatedAt: Date
+  public var createdAt: Date?
+  public var lastSignInAt: Date?
+  public var updatedAt: Date?
 
   public init(
     id: String,
@@ -233,9 +233,9 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
     userId: UUID,
     identityData: [String: AnyJSON],
     provider: String,
-    createdAt: Date,
-    lastSignInAt: Date,
-    updatedAt: Date
+    createdAt: Date?,
+    lastSignInAt: Date?,
+    updatedAt: Date?
   ) {
     self.id = id
     self.identityId = identityId
@@ -267,9 +267,9 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
     userId = try container.decode(UUID.self, forKey: .userId)
     identityData = try container.decodeIfPresent([String: AnyJSON].self, forKey: .identityData)
     provider = try container.decode(String.self, forKey: .provider)
-    createdAt = try container.decode(Date.self, forKey: .createdAt)
-    lastSignInAt = try container.decode(Date.self, forKey: .lastSignInAt)
-    updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+    lastSignInAt = try container.decodeIfPresent(Date.self, forKey: .lastSignInAt)
+    updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
   }
 
   public func encode(to encoder: any Encoder) throws {
@@ -280,9 +280,9 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
     try container.encode(userId, forKey: .userId)
     try container.encodeIfPresent(identityData, forKey: .identityData)
     try container.encode(provider, forKey: .provider)
-    try container.encode(createdAt, forKey: .createdAt)
-    try container.encode(lastSignInAt, forKey: .lastSignInAt)
-    try container.encode(updatedAt, forKey: .updatedAt)
+    try container.encodeIfPresent(createdAt, forKey: .createdAt)
+    try container.encodeIfPresent(lastSignInAt, forKey: .lastSignInAt)
+    try container.encodeIfPresent(updatedAt, forKey: .updatedAt)
   }
 }
 

--- a/Tests/AuthTests/Resources/user.json
+++ b/Tests/AuthTests/Resources/user.json
@@ -26,6 +26,17 @@
       "last_sign_in_at": "2022-04-09T11:23:45Z",
       "created_at": "2022-04-09T11:23:45.899924Z",
       "updated_at": "2022-04-09T11:23:45.899926Z"
+    },
+    {
+      "id": "6c69f399-be1b-467a-9c53-d3753abdd2df",
+      "user_id": "6c69f399-be1b-467a-9c53-d3753abdd2df",
+      "identity_id": "6c69f399-be1b-467a-9c53-d3753abdd2df",
+      "identity_data": {
+        "sub": "6c69f399-be1b-467a-9c53-d3753abdd2df"
+      },
+      "provider": "github",
+      "created_at": "2022-04-09T11:23:45.899924Z",
+      "updated_at": "2022-04-09T11:23:45.899926Z"
     }
   ],
   "created_at": "2022-04-09T11:23:45.874827Z",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #482 

`last_sign_in_at` field is marked as required but should be optional.