### PR TITLE
fix(auth): auth event emitter being shared among clients

### DIFF
--- a/Sources/Auth/Internal/CodeVerifierStorage.swift
+++ b/Sources/Auth/Internal/CodeVerifierStorage.swift
@@ -8,12 +8,12 @@ struct CodeVerifierStorage: Sendable {
 }
 
 extension CodeVerifierStorage {
-  static let live: Self = {
+  static var live: Self {
     let code = LockIsolated(String?.none)
 
     return Self(
       get: { code.value },
       set: { code.setValue($0) }
     )
-  }()
+  }
 }

--- a/Sources/Auth/Internal/Dependencies.swift
+++ b/Sources/Auth/Internal/Dependencies.swift
@@ -9,7 +9,7 @@ struct Dependencies: Sendable {
   var sessionStorage: SessionStorage
   var sessionManager: SessionManager
 
-  var eventEmitter: AuthStateChangeEventEmitter = .shared
+  var eventEmitter = AuthStateChangeEventEmitter()
   var date: @Sendable () -> Date = { Date() }
   var codeVerifierStorage = CodeVerifierStorage.live
   var urlOpener: URLOpener = .live

--- a/Sources/Auth/Internal/EventEmitter.swift
+++ b/Sources/Auth/Internal/EventEmitter.swift
@@ -3,9 +3,7 @@ import Foundation
 import Helpers
 
 struct AuthStateChangeEventEmitter {
-  static let shared = AuthStateChangeEventEmitter(emitter: .init(initialEvent: nil, emitsLastEventWhenAttaching: false))
-
-  let emitter: EventEmitter<(AuthChangeEvent, Session?)?>
+  var emitter = EventEmitter<(AuthChangeEvent, Session?)?>(initialEvent: nil, emitsLastEventWhenAttaching: false)
 
   func attach(_ listener: @escaping AuthStateChangeListener) -> ObservationToken {
     emitter.attach { event in


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix issue brought on https://github.com/supabase/supabase-swift/pull/445#discussion_r1714098710

## What is the current behavior?

When having multiple auth instances, the AuthStateChangeEventEmitter gets shared between auth instances

## What is the new behavior?

Each auth instance has its own AuthStateChangeEventEmitter instance