### PR TITLE
feat(postgrest): use `Date` when filtering columns

### DIFF
--- a/Sources/PostgREST/URLQueryRepresentable.swift
+++ b/Sources/PostgREST/URLQueryRepresentable.swift
@@ -27,6 +27,14 @@ extension UUID: URLQueryRepresentable {
   public var queryValue: String { uuidString }
 }
 
+extension Date: URLQueryRepresentable {
+  public var queryValue: String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: self)
+  }
+}
+
 extension Array: URLQueryRepresentable where Element: URLQueryRepresentable {
   public var queryValue: String {
     "{\(map(\.queryValue).joined(separator: ","))}"

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -222,6 +222,11 @@ final class BuildURLRequestTests: XCTestCase {
           .select()
           .eq("to", value: "+16505555555")
       },
+      TestCase(name: "filter using Date") { client in
+        client.from("users")
+          .select()
+          .gt("created_at", value: Date(timeIntervalSince1970: 0))
+      },
     ]
 
     for testCase in testCases {

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.filter-using-Date.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.filter-using-Date.txt
@@ -1,0 +1,5 @@
+curl \
+	--header "Accept: application/json" \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: postgrest-swift/x.y.z" \
+	"https://example.supabase.co/users?created_at=gt.1970-01-01T00:00:00.000Z&select=*"


### PR DESCRIPTION
## What kind of change does this PR introduce?
When using filters on `Timestampz` typed columns, the `Date.now.description` declaration only works for users with time in 24-hour format and not for those using 12-hour one. 
This pull request makes using filters simpler and less error-prone when manipulating the `Date` type.

## What is the current behavior?
In order to use filters with `Date` type, we need to have a custom logic in order to make it works properly.

## What is the new behavior?
When using a filter, the `Date.now` (or `Date()`) works by the book without having to implement a custom logic.

## Additional context
If my change doesn't work on other Date/Time types, please let me know. I would be happy to make this works for everyone and every Date/Time type