### PR TITLE
feat(auth): add support for error codes and refactor `AuthError`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,7 @@ let package = Package(
       dependencies: [
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "Helpers",
         "Auth",

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -800,7 +800,7 @@ public final class AuthClient: Sendable {
           headers: [.init(name: "Authorization", value: "Bearer \(accessToken)")]
         )
       )
-    } catch let AuthError.api(_, _, _, response) where ![404, 403, 401].contains(response.statusCode) {
+    } catch let AuthError.api(_, _, _, response) where [404, 403, 401].contains(response.statusCode) {
       // ignore 404s since user might not exist anymore
       // ignore 401s, and 403s since an invalid or expired JWT should sign out the current session.
     }

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -449,7 +449,11 @@ public final class AuthClient: Sendable {
 
   /// Log in an existing user by exchanging an Auth Code issued during the PKCE flow.
   public func exchangeCodeForSession(authCode: String) async throws -> Session {
-    let codeVerifier = codeVerifierStorage.get() ?? ""
+    let codeVerifier = codeVerifierStorage.get()
+
+    if codeVerifier == nil {
+      logger?.error("code verifier not found, a code verifier should exist when calling this method.")
+    }
 
     let session: Session = try await api.execute(
       .init(

--- a/Sources/Auth/AuthError.swift
+++ b/Sources/Auth/AuthError.swift
@@ -18,86 +18,86 @@ public struct ErrorCode: Decodable, RawRepresentable, Sendable, Hashable {
 // on the server).
 extension ErrorCode {
   /// ErrorCodeUnknown should not be used directly, it only indicates a failure in the error handling system in such a way that an error code was not assigned properly.
-  public static let Unknown = ErrorCode("unknown")
+  public static let unknown = ErrorCode("unknown")
 
   /// ErrorCodeUnexpectedFailure signals an unexpected failure such as a 500 Internal Server Error.
-  public static let UnexpectedFailure = ErrorCode("unexpected_failure")
+  public static let unexpectedFailure = ErrorCode("unexpected_failure")
 
-  public static let ValidationFailed = ErrorCode("validation_failed")
-  public static let BadJSON = ErrorCode("bad_json")
-  public static let EmailExists = ErrorCode("email_exists")
-  public static let PhoneExists = ErrorCode("phone_exists")
-  public static let BadJWT = ErrorCode("bad_jwt")
-  public static let NotAdmin = ErrorCode("not_admin")
-  public static let NoAuthorization = ErrorCode("no_authorization")
-  public static let UserNotFound = ErrorCode("user_not_found")
-  public static let SessionNotFound = ErrorCode("session_not_found")
-  public static let FlowStateNotFound = ErrorCode("flow_state_not_found")
-  public static let FlowStateExpired = ErrorCode("flow_state_expired")
-  public static let SignupDisabled = ErrorCode("signup_disabled")
-  public static let UserBanned = ErrorCode("user_banned")
-  public static let ProviderEmailNeedsVerification = ErrorCode("provider_email_needs_verification")
-  public static let InviteNotFound = ErrorCode("invite_not_found")
-  public static let BadOAuthState = ErrorCode("bad_oauth_state")
-  public static let BadOAuthCallback = ErrorCode("bad_oauth_callback")
-  public static let OAuthProviderNotSupported = ErrorCode("oauth_provider_not_supported")
-  public static let UnexpectedAudience = ErrorCode("unexpected_audience")
-  public static let SingleIdentityNotDeletable = ErrorCode("single_identity_not_deletable")
-  public static let EmailConflictIdentityNotDeletable = ErrorCode("email_conflict_identity_not_deletable")
-  public static let IdentityAlreadyExists = ErrorCode("identity_already_exists")
-  public static let EmailProviderDisabled = ErrorCode("email_provider_disabled")
-  public static let PhoneProviderDisabled = ErrorCode("phone_provider_disabled")
-  public static let TooManyEnrolledMFAFactors = ErrorCode("too_many_enrolled_mfa_factors")
-  public static let MFAFactorNameConflict = ErrorCode("mfa_factor_name_conflict")
-  public static let MFAFactorNotFound = ErrorCode("mfa_factor_not_found")
-  public static let MFAIPAddressMismatch = ErrorCode("mfa_ip_address_mismatch")
-  public static let MFAChallengeExpired = ErrorCode("mfa_challenge_expired")
-  public static let MFAVerificationFailed = ErrorCode("mfa_verification_failed")
-  public static let MFAVerificationRejected = ErrorCode("mfa_verification_rejected")
-  public static let InsufficientAAL = ErrorCode("insufficient_aal")
-  public static let CaptchaFailed = ErrorCode("captcha_failed")
-  public static let SAMLProviderDisabled = ErrorCode("saml_provider_disabled")
-  public static let ManualLinkingDisabled = ErrorCode("manual_linking_disabled")
-  public static let SMSSendFailed = ErrorCode("sms_send_failed")
-  public static let EmailNotConfirmed = ErrorCode("email_not_confirmed")
-  public static let PhoneNotConfirmed = ErrorCode("phone_not_confirmed")
-  public static let SAMLRelayStateNotFound = ErrorCode("saml_relay_state_not_found")
-  public static let SAMLRelayStateExpired = ErrorCode("saml_relay_state_expired")
-  public static let SAMLIdPNotFound = ErrorCode("saml_idp_not_found")
-  public static let SAMLAssertionNoUserID = ErrorCode("saml_assertion_no_user_id")
-  public static let SAMLAssertionNoEmail = ErrorCode("saml_assertion_no_email")
-  public static let UserAlreadyExists = ErrorCode("user_already_exists")
-  public static let SSOProviderNotFound = ErrorCode("sso_provider_not_found")
-  public static let SAMLMetadataFetchFailed = ErrorCode("saml_metadata_fetch_failed")
-  public static let SAMLIdPAlreadyExists = ErrorCode("saml_idp_already_exists")
-  public static let SSODomainAlreadyExists = ErrorCode("sso_domain_already_exists")
-  public static let SAMLEntityIDMismatch = ErrorCode("saml_entity_id_mismatch")
-  public static let Conflict = ErrorCode("conflict")
-  public static let ProviderDisabled = ErrorCode("provider_disabled")
-  public static let UserSSOManaged = ErrorCode("user_sso_managed")
-  public static let ReauthenticationNeeded = ErrorCode("reauthentication_needed")
-  public static let SamePassword = ErrorCode("same_password")
-  public static let ReauthenticationNotValid = ErrorCode("reauthentication_not_valid")
-  public static let OTPExpired = ErrorCode("otp_expired")
-  public static let OTPDisabled = ErrorCode("otp_disabled")
-  public static let IdentityNotFound = ErrorCode("identity_not_found")
-  public static let WeakPassword = ErrorCode("weak_password")
-  public static let OverRequestRateLimit = ErrorCode("over_request_rate_limit")
-  public static let OverEmailSendRateLimit = ErrorCode("over_email_send_rate_limit")
-  public static let OverSMSSendRateLimit = ErrorCode("over_sms_send_rate_limit")
-  public static let odeVerifier = ErrorCode("bad_code_verifier")
-  public static let AnonymousProviderDisabled = ErrorCode("anonymous_provider_disabled")
-  public static let HookTimeout = ErrorCode("hook_timeout")
-  public static let HookTimeoutAfterRetry = ErrorCode("hook_timeout_after_retry")
-  public static let HookPayloadOverSizeLimit = ErrorCode("hook_payload_over_size_limit")
-  public static let RequestTimeout = ErrorCode("request_timeout")
-  public static let MFAPhoneEnrollDisabled = ErrorCode("mfa_phone_enroll_not_enabled")
-  public static let MFAPhoneVerifyDisabled = ErrorCode("mfa_phone_verify_not_enabled")
-  public static let MFATOTPEnrollDisabled = ErrorCode("mfa_totp_enroll_not_enabled")
-  public static let MFATOTPVerifyDisabled = ErrorCode("mfa_totp_verify_not_enabled")
-  public static let MFAVerifiedFactorExists = ErrorCode("mfa_verified_factor_exists")
+  public static let validationFailed = ErrorCode("validation_failed")
+  public static let badJSON = ErrorCode("bad_json")
+  public static let emailExists = ErrorCode("email_exists")
+  public static let phoneExists = ErrorCode("phone_exists")
+  public static let badJWT = ErrorCode("bad_jwt")
+  public static let notAdmin = ErrorCode("not_admin")
+  public static let noAuthorization = ErrorCode("no_authorization")
+  public static let userNotFound = ErrorCode("user_not_found")
+  public static let sessionNotFound = ErrorCode("session_not_found")
+  public static let flowStateNotFound = ErrorCode("flow_state_not_found")
+  public static let flowStateExpired = ErrorCode("flow_state_expired")
+  public static let signupDisabled = ErrorCode("signup_disabled")
+  public static let userBanned = ErrorCode("user_banned")
+  public static let providerEmailNeedsVerification = ErrorCode("provider_email_needs_verification")
+  public static let inviteNotFound = ErrorCode("invite_not_found")
+  public static let badOAuthState = ErrorCode("bad_oauth_state")
+  public static let badOAuthCallback = ErrorCode("bad_oauth_callback")
+  public static let oauthProviderNotSupported = ErrorCode("oauth_provider_not_supported")
+  public static let unexpectedAudience = ErrorCode("unexpected_audience")
+  public static let singleIdentityNotDeletable = ErrorCode("single_identity_not_deletable")
+  public static let emailConflictIdentityNotDeletable = ErrorCode("email_conflict_identity_not_deletable")
+  public static let identityAlreadyExists = ErrorCode("identity_already_exists")
+  public static let emailProviderDisabled = ErrorCode("email_provider_disabled")
+  public static let phoneProviderDisabled = ErrorCode("phone_provider_disabled")
+  public static let tooManyEnrolledMFAFactors = ErrorCode("too_many_enrolled_mfa_factors")
+  public static let mfaFactorNameConflict = ErrorCode("mfa_factor_name_conflict")
+  public static let mfaFactorNotFound = ErrorCode("mfa_factor_not_found")
+  public static let mfaIPAddressMismatch = ErrorCode("mfa_ip_address_mismatch")
+  public static let mfaChallengeExpired = ErrorCode("mfa_challenge_expired")
+  public static let mfaVerificationFailed = ErrorCode("mfa_verification_failed")
+  public static let mfaVerificationRejected = ErrorCode("mfa_verification_rejected")
+  public static let insufficientAAL = ErrorCode("insufficient_aal")
+  public static let captchaFailed = ErrorCode("captcha_failed")
+  public static let samlProviderDisabled = ErrorCode("saml_provider_disabled")
+  public static let manualLinkingDisabled = ErrorCode("manual_linking_disabled")
+  public static let smsSendFailed = ErrorCode("sms_send_failed")
+  public static let emailNotConfirmed = ErrorCode("email_not_confirmed")
+  public static let phoneNotConfirmed = ErrorCode("phone_not_confirmed")
+  public static let samlRelayStateNotFound = ErrorCode("saml_relay_state_not_found")
+  public static let samlRelayStateExpired = ErrorCode("saml_relay_state_expired")
+  public static let samlIdPNotFound = ErrorCode("saml_idp_not_found")
+  public static let samlAssertionNoUserID = ErrorCode("saml_assertion_no_user_id")
+  public static let samlAssertionNoEmail = ErrorCode("saml_assertion_no_email")
+  public static let userAlreadyExists = ErrorCode("user_already_exists")
+  public static let ssoProviderNotFound = ErrorCode("sso_provider_not_found")
+  public static let samlMetadataFetchFailed = ErrorCode("saml_metadata_fetch_failed")
+  public static let samlIdPAlreadyExists = ErrorCode("saml_idp_already_exists")
+  public static let ssoDomainAlreadyExists = ErrorCode("sso_domain_already_exists")
+  public static let samlEntityIDMismatch = ErrorCode("saml_entity_id_mismatch")
+  public static let conflict = ErrorCode("conflict")
+  public static let providerDisabled = ErrorCode("provider_disabled")
+  public static let userSSOManaged = ErrorCode("user_sso_managed")
+  public static let reauthenticationNeeded = ErrorCode("reauthentication_needed")
+  public static let samePassword = ErrorCode("same_password")
+  public static let reauthenticationNotValid = ErrorCode("reauthentication_not_valid")
+  public static let otpExpired = ErrorCode("otp_expired")
+  public static let otpDisabled = ErrorCode("otp_disabled")
+  public static let identityNotFound = ErrorCode("identity_not_found")
+  public static let weakPassword = ErrorCode("weak_password")
+  public static let overRequestRateLimit = ErrorCode("over_request_rate_limit")
+  public static let overEmailSendRateLimit = ErrorCode("over_email_send_rate_limit")
+  public static let overSMSSendRateLimit = ErrorCode("over_sms_send_rate_limit")
+  public static let badCodeVerifier = ErrorCode("bad_code_verifier")
+  public static let anonymousProviderDisabled = ErrorCode("anonymous_provider_disabled")
+  public static let hookTimeout = ErrorCode("hook_timeout")
+  public static let hookTimeoutAfterRetry = ErrorCode("hook_timeout_after_retry")
+  public static let hookPayloadOverSizeLimit = ErrorCode("hook_payload_over_size_limit")
+  public static let requestTimeout = ErrorCode("request_timeout")
+  public static let mfaPhoneEnrollDisabled = ErrorCode("mfa_phone_enroll_not_enabled")
+  public static let mfaPhoneVerifyDisabled = ErrorCode("mfa_phone_verify_not_enabled")
+  public static let mfaTOTPEnrollDisabled = ErrorCode("mfa_totp_enroll_not_enabled")
+  public static let mfaTOTPVerifyDisabled = ErrorCode("mfa_totp_verify_not_enabled")
+  public static let mfaVerifiedFactorExists = ErrorCode("mfa_verified_factor_exists")
   // #nosec G101 -- Not a secret value.
-  public static let InvalidCredentials = ErrorCode("invalid_credentials")
+  public static let invalidCredentials = ErrorCode("invalid_credentials")
 }
 
 public enum AuthError: LocalizedError {
@@ -175,7 +175,7 @@ public enum AuthError: LocalizedError {
 
     return .api(
       message: message,
-      errorCode: .Unknown,
+      errorCode: .unknown,
       underlyingData: (try? AuthClient.Configuration.jsonEncoder.encode(error)) ?? Data(),
       underlyingResponse: HTTPURLResponse(
         url: URL(string: "http://localhost")!,
@@ -249,17 +249,17 @@ public enum AuthError: LocalizedError {
 
   public var errorCode: ErrorCode {
     switch self {
-    case .sessionMissing: .SessionNotFound
-    case .weakPassword: .WeakPassword
+    case .sessionMissing: .sessionNotFound
+    case .weakPassword: .weakPassword
     case let .api(_, errorCode, _, _): errorCode
-    case .pkceGrantCodeExchange, .implicitGrantRedirect: .Unknown
+    case .pkceGrantCodeExchange, .implicitGrantRedirect: .unknown
     // Deprecated cases
-    case .missingExpClaim, .malformedJWT, .invalidRedirectScheme, .missingURL: .Unknown
+    case .missingExpClaim, .malformedJWT, .invalidRedirectScheme, .missingURL: .unknown
     }
   }
 
   public var errorDescription: String? {
-    if errorCode == .Unknown {
+    if errorCode == .unknown {
       message
     } else {
       "\(errorCode.rawValue): \(message)"

--- a/Sources/Auth/AuthError.swift
+++ b/Sources/Auth/AuthError.swift
@@ -224,15 +224,25 @@ public enum AuthError: LocalizedError {
     public var weakPassword: WeakPassword?
   }
 
+  /// Error thrown when a session is required to proceed, but none was found, either thrown by the client, or returned by the server.
   case sessionMissing
+
+  /// Error thrown when password is deemed weak, check associated reasons to know why.
   case weakPassword(message: String, reasons: [String])
+
+  /// Error thrown by API when an error occurs, check `errorCode` to know more,
+  /// or use `underlyingData` or `underlyingResponse` for access to the response which originated this error.
   case api(
     message: String,
     errorCode: ErrorCode,
     underlyingData: Data,
     underlyingResponse: HTTPURLResponse
   )
+
+  /// Error thrown when an error happens during PKCE grant flow.
   case pkceGrantCodeExchange(message: String, error: String? = nil, code: String? = nil)
+
+  /// Error thrown when an error happens during implicit grant flow.
   case implicitGrantRedirect(message: String)
 
   public var message: String {

--- a/Sources/Auth/AuthError.swift
+++ b/Sources/Auth/AuthError.swift
@@ -104,7 +104,7 @@ extension ErrorCode {
   public static let invalidCredentials = ErrorCode("invalid_credentials")
 }
 
-public enum AuthError: LocalizedError {
+public enum AuthError: LocalizedError, Equatable {
   @available(
     *,
     deprecated,
@@ -274,5 +274,10 @@ public enum AuthError: LocalizedError {
 
   public var errorDescription: String? {
     message
+  }
+
+  public static func ~= (lhs: AuthError, rhs: any Error) -> Bool {
+    guard let rhs = rhs as? AuthError else { return false }
+    return lhs == rhs
   }
 }

--- a/Sources/Auth/AuthError.swift
+++ b/Sources/Auth/AuthError.swift
@@ -1,74 +1,149 @@
 import Foundation
 
-public enum AuthError: LocalizedError, Sendable, Equatable {
-  case missingExpClaim
-  case malformedJWT
-  case sessionNotFound
-  case api(APIError)
+/// An error code thrown by the server.
+public struct ErrorCode: Decodable, RawRepresentable, Sendable, Hashable {
+  public var rawValue: String
 
-  /// Error thrown during PKCE flow.
-  case pkce(PKCEFailureReason)
-
-  case invalidImplicitGrantFlowURL
-  case missingURL
-  case invalidRedirectScheme
-
-  /// An error returned by the API.
-  public struct APIError: Error, Decodable, Sendable, Equatable {
-    /// A basic message describing the problem with the request. Usually missing if
-    /// ``AuthError/APIError/error`` is present.
-    public var msg: String?
-
-    /// The HTTP status code. Usually missing if ``AuthError/APIError/error`` is present.
-    public var code: Int?
-
-    /// Certain responses will contain this property with the provided values.
-    ///
-    /// Usually one of these:
-    ///   - `invalid_request`
-    ///   - `unauthorized_client`
-    ///   - `access_denied`
-    ///   - `server_error`
-    ///   - `temporarily_unavailable`
-    ///   - `unsupported_otp_type`
-    public var error: String?
-
-    /// Certain responses that have an ``AuthError/APIError/error`` property may have this property
-    /// which describes the error.
-    public var errorDescription: String?
-
-    /// Only returned when signing up if the password used is too weak. Inspect the
-    /// ``WeakPassword/reasons`` and ``AuthError/APIError/msg`` property to identify the causes.
-    public var weakPassword: WeakPassword?
+  public init(rawValue: String) {
+    self.rawValue = rawValue
   }
 
-  public enum PKCEFailureReason: Sendable {
-    /// Code verifier not found in the URL.
-    case codeVerifierNotFound
-
-    /// Not a valid PKCE flow URL.
-    case invalidPKCEFlowURL
-  }
-
-  public var errorDescription: String? {
-    switch self {
-    case let .api(error): error.errorDescription ?? error.msg ?? error.error
-    case .missingExpClaim: "Missing expiration claim in the access token."
-    case .malformedJWT: "A malformed JWT received."
-    case .sessionNotFound: "Unable to get a valid session."
-    case let .pkce(reason): reason.errorDescription
-    case .invalidImplicitGrantFlowURL: "Not a valid implicit grant flow url."
-    case .missingURL: "Missing URL."
-    case .invalidRedirectScheme: "Invalid redirect scheme."
-    }
+  public init(_ rawValue: String) {
+    self.init(rawValue: rawValue)
   }
 }
 
-extension AuthError.PKCEFailureReason {
-  var errorDescription: String {
-    switch self {
-    case .codeVerifierNotFound: "A code verifier wasn't found in PKCE flow."
-    case .invalidPKCEFlowURL: "Not a valid PKCE flow url."
-    }
-  }
+// Known error codes. Note that the server may also return other error codes
+// not included in this list (if the client library is older than the version
+// on the server).
+extension ErrorCode {
+  /// ErrorCodeUnknown should not be used directly, it only indicates a failure in the error handling system in such a way that an error code was not assigned properly.
+  public static let Unknown = ErrorCode("unknown")
+
+  /// ErrorCodeUnexpectedFailure signals an unexpected failure such as a 500 Internal Server Error.
+  public static let UnexpectedFailure = ErrorCode("unexpected_failure")
+
+  public static let ValidationFailed = ErrorCode("validation_failed")
+  public static let BadJSON = ErrorCode("bad_json")
+  public static let EmailExists = ErrorCode("email_exists")
+  public static let PhoneExists = ErrorCode("phone_exists")
+  public static let BadJWT = ErrorCode("bad_jwt")
+  public static let NotAdmin = ErrorCode("not_admin")
+  public static let NoAuthorization = ErrorCode("no_authorization")
+  public static let UserNotFound = ErrorCode("user_not_found")
+  public static let SessionNotFound = ErrorCode("session_not_found")
+  public static let FlowStateNotFound = ErrorCode("flow_state_not_found")
+  public static let FlowStateExpired = ErrorCode("flow_state_expired")
+  public static let SignupDisabled = ErrorCode("signup_disabled")
+  public static let UserBanned = ErrorCode("user_banned")
+  public static let ProviderEmailNeedsVerification = ErrorCode("provider_email_needs_verification")
+  public static let InviteNotFound = ErrorCode("invite_not_found")
+  public static let BadOAuthState = ErrorCode("bad_oauth_state")
+  public static let BadOAuthCallback = ErrorCode("bad_oauth_callback")
+  public static let OAuthProviderNotSupported = ErrorCode("oauth_provider_not_supported")
+  public static let UnexpectedAudience = ErrorCode("unexpected_audience")
+  public static let SingleIdentityNotDeletable = ErrorCode("single_identity_not_deletable")
+  public static let EmailConflictIdentityNotDeletable = ErrorCode("email_conflict_identity_not_deletable")
+  public static let IdentityAlreadyExists = ErrorCode("identity_already_exists")
+  public static let EmailProviderDisabled = ErrorCode("email_provider_disabled")
+  public static let PhoneProviderDisabled = ErrorCode("phone_provider_disabled")
+  public static let TooManyEnrolledMFAFactors = ErrorCode("too_many_enrolled_mfa_factors")
+  public static let MFAFactorNameConflict = ErrorCode("mfa_factor_name_conflict")
+  public static let MFAFactorNotFound = ErrorCode("mfa_factor_not_found")
+  public static let MFAIPAddressMismatch = ErrorCode("mfa_ip_address_mismatch")
+  public static let MFAChallengeExpired = ErrorCode("mfa_challenge_expired")
+  public static let MFAVerificationFailed = ErrorCode("mfa_verification_failed")
+  public static let MFAVerificationRejected = ErrorCode("mfa_verification_rejected")
+  public static let InsufficientAAL = ErrorCode("insufficient_aal")
+  public static let CaptchaFailed = ErrorCode("captcha_failed")
+  public static let SAMLProviderDisabled = ErrorCode("saml_provider_disabled")
+  public static let ManualLinkingDisabled = ErrorCode("manual_linking_disabled")
+  public static let SMSSendFailed = ErrorCode("sms_send_failed")
+  public static let EmailNotConfirmed = ErrorCode("email_not_confirmed")
+  public static let PhoneNotConfirmed = ErrorCode("phone_not_confirmed")
+  public static let SAMLRelayStateNotFound = ErrorCode("saml_relay_state_not_found")
+  public static let SAMLRelayStateExpired = ErrorCode("saml_relay_state_expired")
+  public static let SAMLIdPNotFound = ErrorCode("saml_idp_not_found")
+  public static let SAMLAssertionNoUserID = ErrorCode("saml_assertion_no_user_id")
+  public static let SAMLAssertionNoEmail = ErrorCode("saml_assertion_no_email")
+  public static let UserAlreadyExists = ErrorCode("user_already_exists")
+  public static let SSOProviderNotFound = ErrorCode("sso_provider_not_found")
+  public static let SAMLMetadataFetchFailed = ErrorCode("saml_metadata_fetch_failed")
+  public static let SAMLIdPAlreadyExists = ErrorCode("saml_idp_already_exists")
+  public static let SSODomainAlreadyExists = ErrorCode("sso_domain_already_exists")
+  public static let SAMLEntityIDMismatch = ErrorCode("saml_entity_id_mismatch")
+  public static let Conflict = ErrorCode("conflict")
+  public static let ProviderDisabled = ErrorCode("provider_disabled")
+  public static let UserSSOManaged = ErrorCode("user_sso_managed")
+  public static let ReauthenticationNeeded = ErrorCode("reauthentication_needed")
+  public static let SamePassword = ErrorCode("same_password")
+  public static let ReauthenticationNotValid = ErrorCode("reauthentication_not_valid")
+  public static let OTPExpired = ErrorCode("otp_expired")
+  public static let OTPDisabled = ErrorCode("otp_disabled")
+  public static let IdentityNotFound = ErrorCode("identity_not_found")
+  public static let WeakPassword = ErrorCode("weak_password")
+  public static let OverRequestRateLimit = ErrorCode("over_request_rate_limit")
+  public static let OverEmailSendRateLimit = ErrorCode("over_email_send_rate_limit")
+  public static let OverSMSSendRateLimit = ErrorCode("over_sms_send_rate_limit")
+  public static let odeVerifier = ErrorCode("bad_code_verifier")
+  public static let AnonymousProviderDisabled = ErrorCode("anonymous_provider_disabled")
+  public static let HookTimeout = ErrorCode("hook_timeout")
+  public static let HookTimeoutAfterRetry = ErrorCode("hook_timeout_after_retry")
+  public static let HookPayloadOverSizeLimit = ErrorCode("hook_payload_over_size_limit")
+  public static let RequestTimeout = ErrorCode("request_timeout")
+  public static let MFAPhoneEnrollDisabled = ErrorCode("mfa_phone_enroll_not_enabled")
+  public static let MFAPhoneVerifyDisabled = ErrorCode("mfa_phone_verify_not_enabled")
+  public static let MFATOTPEnrollDisabled = ErrorCode("mfa_totp_enroll_not_enabled")
+  public static let MFATOTPVerifyDisabled = ErrorCode("mfa_totp_verify_not_enabled")
+  public static let MFAVerifiedFactorExists = ErrorCode("mfa_verified_factor_exists")
+  // #nosec G101 -- Not a secret value.
+  public static let InvalidCredentials = ErrorCode("invalid_credentials")
+}
+
+/// Represents an error thrown by Auth, either by the client or the server.
+public protocol SupabaseAuthError: LocalizedError {
+  var message: String { get }
+  var errorCode: ErrorCode { get }
+}
+
+public struct SupabaseAuthSessionMissingError: SupabaseAuthError {
+  public let errorCode: ErrorCode = .SessionNotFound
+
+  public let message: String = "Auth session missing."
+}
+
+/// Error thrown on certain methods when the password used is deemed weak.
+/// Inspect the reasons to identify what password strength rules are inadequate.
+public struct SupabaseAuthWeakPasswordError: SupabaseAuthError {
+  public let errorCode: ErrorCode = .WeakPassword
+
+  public let message: String
+  public let reasons: [String]
+}
+
+public struct SupabaseAuthAPIError: SupabaseAuthError {
+  public let message: String
+  public let errorCode: ErrorCode
+
+  /// The Data response for the underlysing request which caused this error to be thrown.
+  public let underlyngData: Data
+
+  /// The response for the underlysing request which caused this error to be thrown.
+  public let underlyingResponse: HTTPURLResponse
+
+  /// The HTTP status code for the response which caused this error to be thrown.
+  public var status: Int { underlyingResponse.statusCode }
+}
+
+public struct SupabaseAuthPKCEGrantCodeExchangeError: SupabaseAuthError {
+  public let errorCode: ErrorCode = .Unknown
+
+  public let message: String
+  public let error: String?
+  public let code: String?
+}
+
+public struct SupabaseAuthImplicitGrantRedirectError: SupabaseAuthError {
+  public let errorCode: ErrorCode = .Unknown
+  public var message: String
 }

--- a/Sources/Auth/AuthError.swift
+++ b/Sources/Auth/AuthError.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
 /// An error code thrown by the server.
 public struct ErrorCode: Decodable, RawRepresentable, Sendable, Hashable {
   public var rawValue: String
@@ -259,10 +263,6 @@ public enum AuthError: LocalizedError {
   }
 
   public var errorDescription: String? {
-    if errorCode == .unknown {
-      message
-    } else {
-      "\(errorCode.rawValue): \(message)"
-    }
+    message
   }
 }

--- a/Sources/Auth/AuthMFA.swift
+++ b/Sources/Auth/AuthMFA.swift
@@ -129,7 +129,7 @@ public struct AuthMFA: Sendable {
 
       var currentLevel: AuthenticatorAssuranceLevels?
 
-      if let aal = payload["aal"] as? AuthenticatorAssuranceLevels {
+      if let aal = payload?["aal"] as? AuthenticatorAssuranceLevels {
         currentLevel = aal
       }
 
@@ -142,7 +142,7 @@ public struct AuthMFA: Sendable {
 
       var currentAuthenticationMethods: [AMREntry] = []
 
-      if let amr = payload["amr"] as? [Any] {
+      if let amr = payload?["amr"] as? [Any] {
         currentAuthenticationMethods = amr.compactMap(AMREntry.init(value:))
       }
 
@@ -151,7 +151,7 @@ public struct AuthMFA: Sendable {
         nextLevel: nextLevel,
         currentAuthenticationMethods: currentAuthenticationMethods
       )
-    } catch AuthError.sessionNotFound {
+    } catch is SupabaseAuthSessionMissingError {
       return AuthMFAGetAuthenticatorAssuranceLevelResponse(
         currentLevel: nil,
         nextLevel: nil,

--- a/Sources/Auth/AuthMFA.swift
+++ b/Sources/Auth/AuthMFA.swift
@@ -151,14 +151,12 @@ public struct AuthMFA: Sendable {
         nextLevel: nextLevel,
         currentAuthenticationMethods: currentAuthenticationMethods
       )
-    } catch is SupabaseAuthSessionMissingError {
+    } catch AuthError.sessionMissing {
       return AuthMFAGetAuthenticatorAssuranceLevelResponse(
         currentLevel: nil,
         nextLevel: nil,
         currentAuthenticationMethods: []
       )
-    } catch {
-      throw error
     }
   }
 }

--- a/Sources/Auth/Deprecated.swift
+++ b/Sources/Auth/Deprecated.swift
@@ -24,8 +24,8 @@ public typealias GoTrueLocalStorage = AuthLocalStorage
 @available(*, deprecated, renamed: "AuthMetaSecurity")
 public typealias GoTrueMetaSecurity = AuthMetaSecurity
 
-@available(*, deprecated, renamed: "AuthError")
-public typealias GoTrueError = AuthError
+// @available(*, deprecated, renamed: "AuthError")
+// public typealias GoTrueError = AuthError
 
 extension JSONEncoder {
   @available(

--- a/Sources/Auth/Deprecated.swift
+++ b/Sources/Auth/Deprecated.swift
@@ -24,8 +24,8 @@ public typealias GoTrueLocalStorage = AuthLocalStorage
 @available(*, deprecated, renamed: "AuthMetaSecurity")
 public typealias GoTrueMetaSecurity = AuthMetaSecurity
 
-// @available(*, deprecated, renamed: "AuthError")
-// public typealias GoTrueError = AuthError
+@available(*, deprecated, renamed: "AuthError")
+public typealias GoTrueError = AuthError
 
 extension JSONEncoder {
   @available(

--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -107,7 +107,10 @@ struct APIClient: Sendable {
 
   private func parseResponseAPIVersion(_ response: HTTPResponse) -> Date? {
     guard let apiVersion = response.headers[API_VERSION_HEADER_NAME] else { return nil }
-    return ISO8601DateFormatter().date(from: "\(apiVersion)T00:00:00.0Z")
+
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.date(from: "\(apiVersion)T00:00:00.0Z")
   }
 }
 

--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -35,27 +35,14 @@ struct APIClient: Sendable {
     var request = request
     request.headers = HTTPHeaders(configuration.headers).merged(with: request.headers)
 
+    if request.headers[API_VERSION_HEADER_NAME] == nil {
+      request.headers[API_VERSION_HEADER_NAME] = API_VERSIONS[._20240101]!.name.rawValue
+    }
+
     let response = try await http.send(request)
 
-    guard (200 ..< 300).contains(response.statusCode) else {
-      if let apiError = try? configuration.decoder.decode(
-        AuthError.APIError.self,
-        from: response.data
-      ) {
-        throw AuthError.api(apiError)
-      }
-
-      /// There are some GoTrue endpoints that can return a `PostgrestError`, for example the
-      /// ``AuthAdmin/deleteUser(id:shouldSoftDelete:)`` that could return an error in case the
-      /// user is referenced by other schemas.
-      if let postgrestError = try? configuration.decoder.decode(
-        PostgrestError.self,
-        from: response.data
-      ) {
-        throw postgrestError
-      }
-
-      throw HTTPError(data: response.data, response: response.underlyingResponse)
+    guard 200 ..< 300 ~= response.statusCode else {
+      throw handleError(response: response)
     }
 
     return response
@@ -73,5 +60,72 @@ struct APIClient: Sendable {
     request.headers["Authorization"] = "Bearer \(session.accessToken)"
 
     return try await execute(request)
+  }
+
+  func handleError(response: HTTPResponse) -> any SupabaseAuthError {
+    guard let error = try? response.decoded(
+      as: _RawAPIErrorResponse.self,
+      decoder: configuration.decoder
+    ) else {
+      return SupabaseAuthAPIError(
+        message: "Unexpected error",
+        errorCode: .UnexpectedFailure,
+        underlyngData: response.data,
+        underlyingResponse: response.underlyingResponse
+      )
+    }
+
+    let responseAPIVersion = parseResponseAPIVersion(response)
+
+    let errorCode: ErrorCode? = if let responseAPIVersion, responseAPIVersion >= API_VERSIONS[._20240101]!.timestamp, let code = error.code {
+      ErrorCode(code)
+    } else {
+      error.errorCode
+    }
+
+    if errorCode == nil, let weakPassword = error.weakPassword {
+      return SupabaseAuthWeakPasswordError(
+        message: error._getErrorMessage(),
+        reasons: weakPassword.reasons ?? []
+      )
+    } else if errorCode == .WeakPassword {
+      return SupabaseAuthWeakPasswordError(
+        message: error._getErrorMessage(),
+        reasons: error.weakPassword?.reasons ?? []
+      )
+    } else if errorCode == .SessionNotFound {
+      return SupabaseAuthSessionMissingError()
+    } else {
+      return SupabaseAuthAPIError(
+        message: error._getErrorMessage(),
+        errorCode: errorCode ?? .Unknown,
+        underlyngData: response.data,
+        underlyingResponse: response.underlyingResponse
+      )
+    }
+  }
+
+  private func parseResponseAPIVersion(_ response: HTTPResponse) -> Date? {
+    guard let apiVersion = response.headers[API_VERSION_HEADER_NAME] else { return nil }
+    return ISO8601DateFormatter().date(from: "\(apiVersion)T00:00:00.0Z")
+  }
+}
+
+// Struct for mapping all fields possibly returned by API.
+struct _RawAPIErrorResponse: Decodable {
+  let msg: String?
+  let message: String?
+  let errorDescription: String?
+  let error: String?
+  let code: String?
+  let errorCode: ErrorCode?
+  let weakPassword: _WeakPassword?
+
+  struct _WeakPassword: Decodable {
+    let reasons: [String]?
+  }
+
+  func _getErrorMessage() -> String {
+    msg ?? message ?? errorDescription ?? error ?? "Unknown"
   }
 }

--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -69,7 +69,7 @@ struct APIClient: Sendable {
     ) else {
       return .api(
         message: "Unexpected error",
-        errorCode: .UnexpectedFailure,
+        errorCode: .unexpectedFailure,
         underlyingData: response.data,
         underlyingResponse: response.underlyingResponse
       )
@@ -88,17 +88,17 @@ struct APIClient: Sendable {
         message: error._getErrorMessage(),
         reasons: weakPassword.reasons ?? []
       )
-    } else if errorCode == .WeakPassword {
+    } else if errorCode == .weakPassword {
       return .weakPassword(
         message: error._getErrorMessage(),
         reasons: error.weakPassword?.reasons ?? []
       )
-    } else if errorCode == .SessionNotFound {
+    } else if errorCode == .sessionNotFound {
       return .sessionMissing
     } else {
       return .api(
         message: error._getErrorMessage(),
-        errorCode: errorCode ?? .Unknown,
+        errorCode: errorCode ?? .unknown,
         underlyingData: response.data,
         underlyingResponse: response.underlyingResponse
       )

--- a/Sources/Auth/Internal/Contants.swift
+++ b/Sources/Auth/Internal/Contants.swift
@@ -9,3 +9,24 @@ import Foundation
 
 let EXPIRY_MARGIN: TimeInterval = 30
 let STORAGE_KEY = "supabase.auth.token"
+
+let API_VERSION_HEADER_NAME = "X-Supabase-Api-Version"
+let API_VERSIONS: [APIVersion.Name: APIVersion] = [
+  ._20240101: ._20240101,
+]
+
+struct APIVersion {
+  let timestamp: Date
+  let name: Name
+
+  enum Name: String {
+    case _20240101 = "2024-01-01"
+  }
+}
+
+extension APIVersion {
+  static let _20240101 = APIVersion(
+    timestamp: ISO8601DateFormatter().date(from: "\(Name._20240101)T00:00:00.0Z")!,
+    name: ._20240101
+  )
+}

--- a/Sources/Auth/Internal/Contants.swift
+++ b/Sources/Auth/Internal/Contants.swift
@@ -22,11 +22,17 @@ struct APIVersion {
   enum Name: String {
     case _20240101 = "2024-01-01"
   }
+
+  static func date(for name: Name) -> Date {
+    let formattar = ISO8601DateFormatter()
+    formattar.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formattar.date(from: "\(name.rawValue)T00:00:00.0Z")!
+  }
 }
 
 extension APIVersion {
   static let _20240101 = APIVersion(
-    timestamp: ISO8601DateFormatter().date(from: "\(Name._20240101)T00:00:00.0Z")!,
+    timestamp: APIVersion.date(for: ._20240101),
     name: ._20240101
   )
 }

--- a/Sources/Auth/Internal/Helpers.swift
+++ b/Sources/Auth/Internal/Helpers.swift
@@ -40,19 +40,19 @@ private func extractParams(from fragment: String) -> [URLQueryItem] {
       }
 }
 
-func decode(jwt: String) throws -> [String: Any] {
+func decode(jwt: String) throws -> [String: Any]? {
   let parts = jwt.split(separator: ".")
   guard parts.count == 3 else {
-    throw AuthError.malformedJWT
+    return nil
   }
 
   let payload = String(parts[1])
   guard let data = base64URLDecode(payload) else {
-    throw AuthError.malformedJWT
+    return nil
   }
   let json = try JSONSerialization.jsonObject(with: data, options: [])
   guard let decodedPayload = json as? [String: Any] else {
-    throw AuthError.malformedJWT
+    return nil
   }
   return decodedPayload
 }

--- a/Sources/Auth/Internal/SessionManager.swift
+++ b/Sources/Auth/Internal/SessionManager.swift
@@ -40,7 +40,7 @@ private actor LiveSessionManager {
   func session() async throws -> Session {
     try await trace(using: logger) {
       guard let currentSession = try sessionStorage.get() else {
-        throw SupabaseAuthSessionMissingError()
+        throw AuthError.sessionMissing
       }
 
       if !currentSession.isExpired {

--- a/Sources/Auth/Internal/SessionManager.swift
+++ b/Sources/Auth/Internal/SessionManager.swift
@@ -40,7 +40,7 @@ private actor LiveSessionManager {
   func session() async throws -> Session {
     try await trace(using: logger) {
       guard let currentSession = try sessionStorage.get() else {
-        throw AuthError.sessionNotFound
+        throw SupabaseAuthSessionMissingError()
       }
 
       if !currentSession.isExpired {

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -9,6 +9,7 @@
 import ConcurrencyExtras
 import CustomDump
 @testable import Helpers
+import InlineSnapshotTesting
 import TestHelpers
 import XCTest
 
@@ -93,9 +94,16 @@ final class AuthClientTests: XCTestCase {
 
     do {
       _ = try await sut.session
-    } catch AuthError.sessionNotFound {
     } catch {
-      XCTFail("Unexpected error.")
+      assertInlineSnapshot(of: error, as: .dump) {
+        """
+        ▿ SupabaseAuthSessionMissingError
+          ▿ errorCode: ErrorCode
+            - rawValue: "session_not_found"
+          - message: "Auth session missing."
+
+        """
+      }
     }
 
     let events = await eventsTask.value.map(\.event)
@@ -117,7 +125,12 @@ final class AuthClientTests: XCTestCase {
 
   func testSignOutShouldRemoveSessionIfUserIsNotFound() async throws {
     sut = makeSUT { _ in
-      throw AuthError.api(AuthError.APIError(code: 404))
+      throw SupabaseAuthAPIError(
+        message: "",
+        errorCode: .Unknown,
+        underlyngData: Data(),
+        underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+      )
     }
 
     let validSession = Session.validSession
@@ -129,12 +142,7 @@ final class AuthClientTests: XCTestCase {
 
     await Task.megaYield()
 
-    do {
-      try await sut.signOut()
-    } catch AuthError.api {
-    } catch {
-      XCTFail("Unexpected error: \(error)")
-    }
+    try await sut.signOut()
 
     let events = await eventsTask.value.map(\.event)
     let sessions = await eventsTask.value.map(\.session)
@@ -148,7 +156,12 @@ final class AuthClientTests: XCTestCase {
 
   func testSignOutShouldRemoveSessionIfJWTIsInvalid() async throws {
     sut = makeSUT { _ in
-      throw AuthError.api(AuthError.APIError(code: 401))
+      throw SupabaseAuthAPIError(
+        message: "",
+        errorCode: .InvalidCredentials,
+        underlyngData: Data(),
+        underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+      )
     }
 
     let validSession = Session.validSession
@@ -160,12 +173,7 @@ final class AuthClientTests: XCTestCase {
 
     await Task.megaYield()
 
-    do {
-      try await sut.signOut()
-    } catch AuthError.api {
-    } catch {
-      XCTFail("Unexpected error: \(error)")
-    }
+    try await sut.signOut()
 
     let events = await eventsTask.value.map(\.event)
     let sessions = await eventsTask.value.map(\.session)
@@ -179,7 +187,12 @@ final class AuthClientTests: XCTestCase {
 
   func testSignOutShouldRemoveSessionIf403Returned() async throws {
     sut = makeSUT { _ in
-      throw AuthError.api(AuthError.APIError(code: 403))
+      throw SupabaseAuthAPIError(
+        message: "",
+        errorCode: .InvalidCredentials,
+        underlyngData: Data(),
+        underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+      )
     }
 
     let validSession = Session.validSession
@@ -191,12 +204,7 @@ final class AuthClientTests: XCTestCase {
 
     await Task.megaYield()
 
-    do {
-      try await sut.signOut()
-    } catch AuthError.api {
-    } catch {
-      XCTFail("Unexpected error: \(error)")
-    }
+    try await sut.signOut()
 
     let events = await eventsTask.value.map(\.event)
     let sessions = await eventsTask.value.map(\.session)
@@ -251,25 +259,6 @@ final class AuthClientTests: XCTestCase {
     let events = await eventsTask.value.map(\.event)
 
     XCTAssertEqual(events, [.initialSession, .signedIn])
-  }
-
-  func testSignInWithOAuthWithInvalidRedirecTo() async {
-    let sut = makeSUT()
-
-    do {
-      try await sut.signInWithOAuth(
-        provider: .google,
-        redirectTo: nil,
-        launchFlow: { _ in
-          XCTFail("Should not call launchFlow.")
-          return URL(string: "https://supabase.com")!
-        }
-      )
-    } catch let error as AuthError {
-      XCTAssertEqual(error, .invalidRedirectScheme)
-    } catch {
-      XCTFail("Unexcpted error: \(error)")
-    }
   }
 
   func testGetLinkIdentityURL() async throws {

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -97,10 +97,7 @@ final class AuthClientTests: XCTestCase {
     } catch {
       assertInlineSnapshot(of: error, as: .dump) {
         """
-        ▿ SupabaseAuthSessionMissingError
-          ▿ errorCode: ErrorCode
-            - rawValue: "session_not_found"
-          - message: "Auth session missing."
+        - AuthError.sessionMissing
 
         """
       }
@@ -125,10 +122,10 @@ final class AuthClientTests: XCTestCase {
 
   func testSignOutShouldRemoveSessionIfUserIsNotFound() async throws {
     sut = makeSUT { _ in
-      throw SupabaseAuthAPIError(
+      throw AuthError.api(
         message: "",
         errorCode: .Unknown,
-        underlyngData: Data(),
+        underlyingData: Data(),
         underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 404, httpVersion: nil, headerFields: nil)!
       )
     }
@@ -156,10 +153,10 @@ final class AuthClientTests: XCTestCase {
 
   func testSignOutShouldRemoveSessionIfJWTIsInvalid() async throws {
     sut = makeSUT { _ in
-      throw SupabaseAuthAPIError(
+      throw AuthError.api(
         message: "",
         errorCode: .InvalidCredentials,
-        underlyngData: Data(),
+        underlyingData: Data(),
         underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 401, httpVersion: nil, headerFields: nil)!
       )
     }
@@ -187,10 +184,10 @@ final class AuthClientTests: XCTestCase {
 
   func testSignOutShouldRemoveSessionIf403Returned() async throws {
     sut = makeSUT { _ in
-      throw SupabaseAuthAPIError(
+      throw AuthError.api(
         message: "",
         errorCode: .InvalidCredentials,
-        underlyngData: Data(),
+        underlyingData: Data(),
         underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 403, httpVersion: nil, headerFields: nil)!
       )
     }

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -124,7 +124,7 @@ final class AuthClientTests: XCTestCase {
     sut = makeSUT { _ in
       throw AuthError.api(
         message: "",
-        errorCode: .Unknown,
+        errorCode: .unknown,
         underlyingData: Data(),
         underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 404, httpVersion: nil, headerFields: nil)!
       )
@@ -155,7 +155,7 @@ final class AuthClientTests: XCTestCase {
     sut = makeSUT { _ in
       throw AuthError.api(
         message: "",
-        errorCode: .InvalidCredentials,
+        errorCode: .invalidCredentials,
         underlyingData: Data(),
         underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 401, httpVersion: nil, headerFields: nil)!
       )
@@ -186,7 +186,7 @@ final class AuthClientTests: XCTestCase {
     sut = makeSUT { _ in
       throw AuthError.api(
         message: "",
-        errorCode: .InvalidCredentials,
+        errorCode: .invalidCredentials,
         underlyingData: Data(),
         underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 403, httpVersion: nil, headerFields: nil)!
       )

--- a/Tests/AuthTests/AuthErrorTests.swift
+++ b/Tests/AuthTests/AuthErrorTests.swift
@@ -11,28 +11,28 @@ import XCTest
 final class AuthErrorTests: XCTestCase {
   func testErrors() {
     let sessionMissing = AuthError.sessionMissing
-    XCTAssertEqual(sessionMissing.errorCode, .SessionNotFound)
+    XCTAssertEqual(sessionMissing.errorCode, .sessionNotFound)
     XCTAssertEqual(sessionMissing.message, "Auth session missing.")
 
     let weakPassword = AuthError.weakPassword(message: "Weak password", reasons: [])
-    XCTAssertEqual(weakPassword.errorCode, .WeakPassword)
+    XCTAssertEqual(weakPassword.errorCode, .weakPassword)
     XCTAssertEqual(weakPassword.message, "Weak password")
 
     let api = AuthError.api(
       message: "API Error",
-      errorCode: .EmailConflictIdentityNotDeletable,
+      errorCode: .emailConflictIdentityNotDeletable,
       underlyingData: Data(),
       underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
     )
-    XCTAssertEqual(api.errorCode, .EmailConflictIdentityNotDeletable)
+    XCTAssertEqual(api.errorCode, .emailConflictIdentityNotDeletable)
     XCTAssertEqual(api.message, "API Error")
 
     let pkceGrantCodeExchange = AuthError.pkceGrantCodeExchange(message: "PKCE failure", error: nil, code: nil)
-    XCTAssertEqual(pkceGrantCodeExchange.errorCode, .Unknown)
+    XCTAssertEqual(pkceGrantCodeExchange.errorCode, .unknown)
     XCTAssertEqual(pkceGrantCodeExchange.message, "PKCE failure")
 
     let implicitGrantRedirect = AuthError.implicitGrantRedirect(message: "Implicit grant failure")
-    XCTAssertEqual(implicitGrantRedirect.errorCode, .Unknown)
+    XCTAssertEqual(implicitGrantRedirect.errorCode, .unknown)
     XCTAssertEqual(implicitGrantRedirect.message, "Implicit grant failure")
   }
 }

--- a/Tests/AuthTests/AuthErrorTests.swift
+++ b/Tests/AuthTests/AuthErrorTests.swift
@@ -8,6 +8,10 @@
 @testable import Auth
 import XCTest
 
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
 final class AuthErrorTests: XCTestCase {
   func testErrors() {
     let sessionMissing = AuthError.sessionMissing

--- a/Tests/AuthTests/AuthErrorTests.swift
+++ b/Tests/AuthTests/AuthErrorTests.swift
@@ -1,0 +1,38 @@
+//
+//  AuthErrorTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 29/08/24.
+//
+
+@testable import Auth
+import XCTest
+
+final class AuthErrorTests: XCTestCase {
+  func testErrors() {
+    let sessionMissing = AuthError.sessionMissing
+    XCTAssertEqual(sessionMissing.errorCode, .SessionNotFound)
+    XCTAssertEqual(sessionMissing.message, "Auth session missing.")
+
+    let weakPassword = AuthError.weakPassword(message: "Weak password", reasons: [])
+    XCTAssertEqual(weakPassword.errorCode, .WeakPassword)
+    XCTAssertEqual(weakPassword.message, "Weak password")
+
+    let api = AuthError.api(
+      message: "API Error",
+      errorCode: .EmailConflictIdentityNotDeletable,
+      underlyingData: Data(),
+      underlyingResponse: HTTPURLResponse(url: URL(string: "http://localhost")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+    )
+    XCTAssertEqual(api.errorCode, .EmailConflictIdentityNotDeletable)
+    XCTAssertEqual(api.message, "API Error")
+
+    let pkceGrantCodeExchange = AuthError.pkceGrantCodeExchange(message: "PKCE failure", error: nil, code: nil)
+    XCTAssertEqual(pkceGrantCodeExchange.errorCode, .Unknown)
+    XCTAssertEqual(pkceGrantCodeExchange.message, "PKCE failure")
+
+    let implicitGrantRedirect = AuthError.implicitGrantRedirect(message: "Implicit grant failure")
+    XCTAssertEqual(implicitGrantRedirect.errorCode, .Unknown)
+    XCTAssertEqual(implicitGrantRedirect.message, "Implicit grant failure")
+  }
+}

--- a/Tests/AuthTests/JWTTests.swift
+++ b/Tests/AuthTests/JWTTests.swift
@@ -7,7 +7,7 @@ final class JWTTests: XCTestCase {
     let token =
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoxNjQ4NjQwMDIxLCJzdWIiOiJmMzNkM2VjOS1hMmVlLTQ3YzQtODBlMS01YmQ5MTlmM2Q4YjgiLCJlbWFpbCI6ImhpQGJpbmFyeXNjcmFwaW5nLmNvIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6e30sInJvbGUiOiJhdXRoZW50aWNhdGVkIn0.CGr5zNE5Yltlbn_3Ms2cjSLs_AW9RKM3lxh7cTQrg0w"
     let jwt = try decode(jwt: token)
-    let exp = try XCTUnwrap(jwt["exp"] as? TimeInterval)
+    let exp = try XCTUnwrap(jwt?["exp"] as? TimeInterval)
     XCTAssertEqual(exp, 1648640021)
   }
 }

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -7,6 +7,7 @@
 
 @testable import Auth
 import Helpers
+import InlineSnapshotTesting
 import SnapshotTesting
 import TestHelpers
 import XCTest
@@ -177,10 +178,16 @@ final class RequestsTests: XCTestCase {
 
     do {
       _ = try await sut.session(from: url)
-    } catch let error as URLError {
-      XCTAssertEqual(error.code, .badURL)
     } catch {
-      XCTFail("Unexpected error thrown: \(error.localizedDescription)")
+      assertInlineSnapshot(of: error, as: .dump) {
+        """
+        ▿ SupabaseAuthImplicitGrantRedirectError
+          ▿ errorCode: ErrorCode
+            - rawValue: "unknown"
+          - message: "No session defined in URL"
+
+        """
+      }
     }
   }
 

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -181,10 +181,9 @@ final class RequestsTests: XCTestCase {
     } catch {
       assertInlineSnapshot(of: error, as: .dump) {
         """
-        ▿ SupabaseAuthImplicitGrantRedirectError
-          ▿ errorCode: ErrorCode
-            - rawValue: "unknown"
-          - message: "No session defined in URL"
+        ▿ AuthError
+          ▿ implicitGrantRedirect: (1 element)
+            - message: "No session defined in URL"
 
         """
       }

--- a/Tests/AuthTests/SessionManagerTests.swift
+++ b/Tests/AuthTests/SessionManagerTests.swift
@@ -12,6 +12,7 @@ import Helpers
 import TestHelpers
 import XCTest
 import XCTestDynamicOverlay
+import InlineSnapshotTesting
 
 final class SessionManagerTests: XCTestCase {
   var http: HTTPClientMock!
@@ -45,10 +46,17 @@ final class SessionManagerTests: XCTestCase {
   func testSession_shouldFailWithSessionNotFound() async {
     do {
       _ = try await sut.session()
-      XCTFail("Expected a \(AuthError.sessionNotFound) failure")
-    } catch AuthError.sessionNotFound {
+      XCTFail("Expected a \(SupabaseAuthSessionMissingError()) failure")
     } catch {
-      XCTFail("Unexpected error \(error)")
+      assertInlineSnapshot(of: error, as: .dump) {
+        """
+        ▿ SupabaseAuthSessionMissingError
+          ▿ errorCode: ErrorCode
+            - rawValue: "session_not_found"
+          - message: "Auth session missing."
+
+        """
+      }
     }
   }
 

--- a/Tests/AuthTests/SessionManagerTests.swift
+++ b/Tests/AuthTests/SessionManagerTests.swift
@@ -9,10 +9,10 @@
 import ConcurrencyExtras
 import CustomDump
 import Helpers
+import InlineSnapshotTesting
 import TestHelpers
 import XCTest
 import XCTestDynamicOverlay
-import InlineSnapshotTesting
 
 final class SessionManagerTests: XCTestCase {
   var http: HTTPClientMock!
@@ -46,14 +46,11 @@ final class SessionManagerTests: XCTestCase {
   func testSession_shouldFailWithSessionNotFound() async {
     do {
       _ = try await sut.session()
-      XCTFail("Expected a \(SupabaseAuthSessionMissingError()) failure")
+      XCTFail("Expected a \(AuthError.sessionMissing) failure")
     } catch {
       assertInlineSnapshot(of: error, as: .dump) {
         """
-        ▿ SupabaseAuthSessionMissingError
-          ▿ errorCode: ErrorCode
-            - rawValue: "session_not_found"
-          - message: "Auth session missing."
+        - AuthError.sessionMissing
 
         """
       }

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testDeleteUser.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testDeleteUser.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"should_soft_delete\":false}" \
 	"http://localhost:54321/auth/v1/admin/users/E621E1F8-C36C-495A-93FC-0C247A3E6E5F"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testGetLinkIdentityURL.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testGetLinkIdentityURL.1.txt
@@ -2,4 +2,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/user/identities/authorize?extra_key=extra_value&provider=github&redirect_to=https://supabase.com&scopes=user:email&skip_http_redirect=true"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAChallenge.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAChallenge.1.txt
@@ -3,4 +3,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/factors/123/challenge"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAChallengePhone.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAChallengePhone.1.txt
@@ -4,5 +4,6 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"channel\":\"whatsapp\"}" \
 	"http://localhost:54321/auth/v1/factors/123/challenge"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAEnrollLegacy.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAEnrollLegacy.1.txt
@@ -4,5 +4,6 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"factor_type\":\"totp\",\"friendly_name\":\"test\",\"issuer\":\"supabase.com\"}" \
 	"http://localhost:54321/auth/v1/factors"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAEnrollPhone.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAEnrollPhone.1.txt
@@ -4,5 +4,6 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"factor_type\":\"phone\",\"friendly_name\":\"test\",\"phone\":\"+1 202-918-2132\"}" \
 	"http://localhost:54321/auth/v1/factors"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAEnrollTotp.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAEnrollTotp.1.txt
@@ -4,5 +4,6 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"factor_type\":\"totp\",\"friendly_name\":\"test\",\"issuer\":\"supabase.com\"}" \
 	"http://localhost:54321/auth/v1/factors"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAUnenroll.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAUnenroll.1.txt
@@ -3,4 +3,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/factors/123"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAVerify.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testMFAVerify.1.txt
@@ -4,5 +4,6 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"challenge_id\":\"123\",\"code\":\"123456\",\"factor_id\":\"123\"}" \
 	"http://localhost:54321/auth/v1/factors/123/verify"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testReauthenticate.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testReauthenticate.1.txt
@@ -2,4 +2,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/reauthenticate"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testRefreshSession.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testRefreshSession.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"refresh_token\":\"refresh-token\"}" \
 	"http://localhost:54321/auth/v1/token?grant_type=refresh_token"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testResendEmail.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testResendEmail.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"email\":\"example@mail.com\",\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"type\":\"email_change\"}" \
 	"http://localhost:54321/auth/v1/resend?redirect_to=https://supabase.com"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testResendPhone.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testResendPhone.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"phone\":\"+1 202-918-2132\",\"type\":\"phone_change\"}" \
 	"http://localhost:54321/auth/v1/resend"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testResetPasswordForEmail.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testResetPasswordForEmail.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"email\":\"example@mail.com\",\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"}}" \
 	"http://localhost:54321/auth/v1/recover?redirect_to=https://supabase.com"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSessionFromURL.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSessionFromURL.1.txt
@@ -2,4 +2,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/user"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSetSessionWithAExpiredToken.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSetSessionWithAExpiredToken.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"refresh_token\":\"dummy-refresh-token\"}" \
 	"http://localhost:54321/auth/v1/token?grant_type=refresh_token"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSetSessionWithAFutureExpirationDate.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSetSessionWithAFutureExpirationDate.1.txt
@@ -2,4 +2,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjo0ODUyMTYzNTkzLCJzdWIiOiJmMzNkM2VjOS1hMmVlLTQ3YzQtODBlMS01YmQ5MTlmM2Q4YjgiLCJlbWFpbCI6ImhpQGJpbmFyeXNjcmFwaW5nLmNvIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6e30sInJvbGUiOiJhdXRoZW50aWNhdGVkIn0.UiEhoahP9GNrBKw_OHBWyqYudtoIlZGkrjs7Qa8hU7I" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/user"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInAnonymously.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInAnonymously.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"data\":{\"custom_key\":\"custom_value\"},\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"}}" \
 	"http://localhost:54321/auth/v1/signup"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithEmailAndPassword.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithEmailAndPassword.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"email\":\"example@mail.com\",\"gotrue_meta_security\":{\"captcha_token\":\"dummy-captcha\"},\"password\":\"the.pass\"}" \
 	"http://localhost:54321/auth/v1/token?grant_type=password"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithIdToken.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithIdToken.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"access_token\":\"access-token\",\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"id_token\":\"id-token\",\"nonce\":\"nonce\",\"provider\":\"apple\"}" \
 	"http://localhost:54321/auth/v1/token?grant_type=id_token"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithOTPUsingEmail.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithOTPUsingEmail.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"create_user\":true,\"data\":{\"custom_key\":\"custom_value\"},\"email\":\"example@mail.com\",\"gotrue_meta_security\":{\"captcha_token\":\"dummy-captcha\"}}" \
 	"http://localhost:54321/auth/v1/otp?redirect_to=https://supabase.com"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithOTPUsingPhone.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithOTPUsingPhone.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"channel\":\"sms\",\"create_user\":true,\"data\":{\"custom_key\":\"custom_value\"},\"gotrue_meta_security\":{\"captcha_token\":\"dummy-captcha\"},\"phone\":\"+1 202-918-2132\"}" \
 	"http://localhost:54321/auth/v1/otp"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithPhoneAndPassword.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithPhoneAndPassword.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"gotrue_meta_security\":{\"captcha_token\":\"dummy-captcha\"},\"password\":\"the.pass\",\"phone\":\"+1 202-918-2132\"}" \
 	"http://localhost:54321/auth/v1/token?grant_type=password"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithSSOUsingDomain.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithSSOUsingDomain.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"domain\":\"supabase.com\",\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"redirect_to\":\"https:\/\/supabase.com\"}" \
 	"http://localhost:54321/auth/v1/sso"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithSSOUsingProviderId.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignInWithSSOUsingProviderId.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"provider_id\":\"E621E1F8-C36C-495A-93FC-0C247A3E6E5F\",\"redirect_to\":\"https:\/\/supabase.com\"}" \
 	"http://localhost:54321/auth/v1/sso"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignOut.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignOut.1.txt
@@ -3,4 +3,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/logout?scope=global"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignOutWithLocalScope.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignOutWithLocalScope.1.txt
@@ -3,4 +3,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/logout?scope=local"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignOutWithOthersScope.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignOutWithOthersScope.1.txt
@@ -3,4 +3,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/logout?scope=others"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignUpWithEmailAndPassword.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignUpWithEmailAndPassword.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"data\":{\"custom_key\":\"custom_value\"},\"email\":\"example@mail.com\",\"gotrue_meta_security\":{\"captcha_token\":\"dummy-captcha\"},\"password\":\"the.pass\"}" \
 	"http://localhost:54321/auth/v1/signup?redirect_to=https://supabase.com"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testSignUpWithPhoneAndPassword.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testSignUpWithPhoneAndPassword.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"data\":{\"custom_key\":\"custom_value\"},\"gotrue_meta_security\":{\"captcha_token\":\"dummy-captcha\"},\"password\":\"the.pass\",\"phone\":\"+1 202-918-2132\"}" \
 	"http://localhost:54321/auth/v1/signup"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testUnlinkIdentity.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testUnlinkIdentity.1.txt
@@ -3,4 +3,5 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	"http://localhost:54321/auth/v1/user/identities/E621E1F8-C36C-495A-93FC-0C247A3E6E5F"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testUpdateUser.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testUpdateUser.1.txt
@@ -4,5 +4,6 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"data\":{\"custom_key\":\"custom_value\"},\"email\":\"example@mail.com\",\"email_change_token\":\"123456\",\"nonce\":\"abcdef\",\"password\":\"another.pass\",\"phone\":\"+1 202-918-2132\"}" \
 	"http://localhost:54321/auth/v1/user"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testVerifyOTPUsingEmail.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testVerifyOTPUsingEmail.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"email\":\"example@mail.com\",\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"token\":\"123456\",\"type\":\"magiclink\"}" \
 	"http://localhost:54321/auth/v1/verify?redirect_to=https://supabase.com"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testVerifyOTPUsingPhone.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testVerifyOTPUsingPhone.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"phone\":\"+1 202-918-2132\",\"token\":\"123456\",\"type\":\"sms\"}" \
 	"http://localhost:54321/auth/v1/verify"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testVerifyOTPUsingTokenHash.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testVerifyOTPUsingTokenHash.1.txt
@@ -3,5 +3,6 @@ curl \
 	--header "Apikey: dummy.api.key" \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"token_hash\":\"abc-def\",\"type\":\"email\"}" \
 	"http://localhost:54321/auth/v1/verify"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR includes some changes on Auth error system, I tried my best to keep it compatible and without breaking changes.

If you see anything that could be a breaking change, please let me know.

## What is the new behavior?

### Error codes

Introduce `ErrorCode` type as a raw representable string, added static properties for each of the known error codes. Since error codes are raw representable strings, if an unknown error code is returned, decoding is going to work fine.

### Deprecated errors

- `missingExpClaim` error deprecated, it is never thrown now, but I kept it for retro-compatibility 
- `malformedJWT` error deprecated, it is never thrown now, but I kept  it for retro-compatibility 
- `sessionNotFound` error deprecated, use `sessionMissing` instead
- `pkce(_:)` error deprecated, use `pkceGrantCodeExchange` instead
- `invalidImplicitGrantFlowURL` error deprecated, use `implicitGrantRedirect` instead
- `missingURL` error deprecated, it is never thrown, but I kept it for retro-compatibility
- `api(_:)` error deprecated, use `api(message:errorCode:underlyingData:underlyingResponse:)` instead

### Added errors

- `sessionMissing` thrown when a session is required to proceed, but none was found, either thrown by the client, or returned by the server.
- `weakPassword` thrown when password is deemed weak, check associated reasons to know why.
- `api(message:errorCode:underlyingData:underlyingResponse:)` thrown by API when an error occurs, check `errorCode` to know more, or use `underlyingData` or `underlyingResponse` for access to the response which originated this error.
- `pkceGrantCodeExchange` thrown when an error happens during PKCE grant flow.
- `implicitGrantRedirect` thrown when an error happens during implicit grant flow.