### PR TITLE
fix(auth): expose KeychainLocalStorage with default init params

### DIFF
--- a/Sources/Auth/Storage/AuthLocalStorage.swift
+++ b/Sources/Auth/Storage/AuthLocalStorage.swift
@@ -8,12 +8,8 @@ public protocol AuthLocalStorage: Sendable {
 
 extension AuthClient.Configuration {
   #if !os(Linux) && !os(Windows)
-    public static let defaultLocalStorage: any AuthLocalStorage = KeychainLocalStorage(
-      service: "supabase.gotrue.swift",
-      accessGroup: nil
-    )
+    public static let defaultLocalStorage: any AuthLocalStorage = KeychainLocalStorage()
   #elseif os(Windows)
-    public static let defaultLocalStorage: any AuthLocalStorage =
-      WinCredLocalStorage(service: "supabase.gotrue.swift")
+    public static let defaultLocalStorage: any AuthLocalStorage = WinCredLocalStorage()
   #endif
 }

--- a/Sources/Auth/Storage/KeychainLocalStorage.swift
+++ b/Sources/Auth/Storage/KeychainLocalStorage.swift
@@ -1,10 +1,11 @@
 #if !os(Windows) && !os(Linux)
   import Foundation
 
+  /// ``AuthLocalStorage`` implementation using Keychain. This is the default local storage used by the library.
   public struct KeychainLocalStorage: AuthLocalStorage {
     private let keychain: Keychain
 
-    public init(service: String, accessGroup: String?) {
+    public init(service: String = "supabase.gotrue.swift", accessGroup: String? = nil) {
       keychain = Keychain(service: service, accessGroup: accessGroup)
     }
 

--- a/Sources/Auth/Storage/WinCredLocalStorage.swift
+++ b/Sources/Auth/Storage/WinCredLocalStorage.swift
@@ -13,7 +13,7 @@
     private let credentialType: DWORD
     private let credentialPersistence: DWORD
 
-    public init(service: String) {
+    public init(service: String = "supabase.gotrue.swift") {
       self.service = service
       credentialType = DWORD(CRED_TYPE_GENERIC)
       credentialPersistence = DWORD(CRED_PERSIST_LOCAL_MACHINE)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

When one needs to provide a custom instance of `KeychainLocalStorage` just to pass in an `access group`, one most pass in also the `service` value, usually you don't care about `service` value and wants to just use the default one.

## What is the new behavior?

Add a default value to the `service` param, so one can pass just an `access group` and keep the default `service` value.

## Additional context

https://github.com/supabase/supabase-swift/issues/516#issuecomment-2324533015