### PR TITLE
fix(realtime): add missing `onPostgresChange` overload

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -120,6 +120,8 @@ let package = Package(
       name: "RealtimeTests",
       dependencies: [
         .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
         "PostgREST",
         "Realtime",
         "TestHelpers",

--- a/Sources/Realtime/PhoenixTransport.swift
+++ b/Sources/Realtime/PhoenixTransport.swift
@@ -200,8 +200,8 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
     session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
     var request = URLRequest(url: url)
 
-    headers.forEach { (key: String, value: Any) in
-      guard let value = value as? String else { return }
+    for (key, value) in headers {
+      guard let value = value as? String else { continue }
       request.addValue(value, forHTTPHeaderField: key)
     }
 

--- a/Sources/Realtime/V2/RealtimeChannelV2.swift
+++ b/Sources/Realtime/V2/RealtimeChannelV2.swift
@@ -86,7 +86,7 @@ public final class RealtimeChannelV2: Sendable {
   let logger: (any SupabaseLogger)?
   let socket: Socket
 
-  private let callbackManager = CallbackManager()
+  let callbackManager = CallbackManager()
   private let statusEventEmitter = EventEmitter<Status>(initialEvent: .unsubscribed)
 
   public private(set) var status: Status {
@@ -481,7 +481,7 @@ public final class RealtimeChannelV2: Sendable {
     callback: @escaping @Sendable (AnyAction) -> Void
   ) -> Subscription {
     _onPostgresChange(
-      event: .insert,
+      event: .all,
       schema: schema,
       table: table,
       filter: filter

--- a/Sources/Realtime/V2/RealtimeChannelV2.swift
+++ b/Sources/Realtime/V2/RealtimeChannelV2.swift
@@ -474,6 +474,24 @@ public final class RealtimeChannelV2: Sendable {
 
   /// Listen for postgres changes in a channel.
   public func onPostgresChange(
+    _: AnyAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil,
+    callback: @escaping @Sendable (AnyAction) -> Void
+  ) -> Subscription {
+    _onPostgresChange(
+      event: .insert,
+      schema: schema,
+      table: table,
+      filter: filter
+    ) {
+      callback($0)
+    }
+  }
+
+  /// Listen for postgres changes in a channel.
+  public func onPostgresChange(
     _: InsertAction.Type,
     schema: String = "public",
     table: String? = nil,

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -13,7 +13,7 @@ import XCTestDynamicOverlay
 final class RealtimeChannelTests: XCTestCase {
   var sut: RealtimeChannelV2!
 
-  func test() {
+  func testOnPostgresChange() {
     sut = RealtimeChannelV2(
       topic: "topic",
       config: RealtimeChannelConfig(
@@ -30,7 +30,7 @@ final class RealtimeChannelTests: XCTestCase {
     sut.onPostgresChange(UpdateAction.self) { _ in }.store(in: &subscriptions)
     sut.onPostgresChange(DeleteAction.self) { _ in }.store(in: &subscriptions)
 
-    assertInlineSnapshot(of: sut.callbackManager.callbacks, as: .dump, record: true) {
+    assertInlineSnapshot(of: sut.callbackManager.callbacks, as: .dump) {
       """
       ▿ 4 elements
         ▿ RealtimeCallback

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -1,0 +1,102 @@
+//
+//  RealtimeChannelTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 09/09/24.
+//
+
+import InlineSnapshotTesting
+@testable import Realtime
+import XCTest
+import XCTestDynamicOverlay
+
+final class RealtimeChannelTests: XCTestCase {
+  var sut: RealtimeChannelV2!
+
+  func test() {
+    sut = RealtimeChannelV2(
+      topic: "topic",
+      config: RealtimeChannelConfig(
+        broadcast: BroadcastJoinConfig(),
+        presence: PresenceJoinConfig(),
+        isPrivate: false
+      ),
+      socket: .mock,
+      logger: nil
+    )
+    var subscriptions = Set<RealtimeChannelV2.Subscription>()
+    sut.onPostgresChange(AnyAction.self) { _ in }.store(in: &subscriptions)
+    sut.onPostgresChange(InsertAction.self) { _ in }.store(in: &subscriptions)
+    sut.onPostgresChange(UpdateAction.self) { _ in }.store(in: &subscriptions)
+    sut.onPostgresChange(DeleteAction.self) { _ in }.store(in: &subscriptions)
+
+    assertInlineSnapshot(of: sut.callbackManager.callbacks, as: .dump, record: true) {
+      """
+      ▿ 4 elements
+        ▿ RealtimeCallback
+          ▿ postgres: PostgresCallback
+            - callback: (Function)
+            ▿ filter: PostgresJoinConfig
+              ▿ event: Optional<PostgresChangeEvent>
+                - some: PostgresChangeEvent.all
+              - filter: Optional<String>.none
+              - id: 0
+              - schema: "public"
+              - table: Optional<String>.none
+            - id: 1
+        ▿ RealtimeCallback
+          ▿ postgres: PostgresCallback
+            - callback: (Function)
+            ▿ filter: PostgresJoinConfig
+              ▿ event: Optional<PostgresChangeEvent>
+                - some: PostgresChangeEvent.insert
+              - filter: Optional<String>.none
+              - id: 0
+              - schema: "public"
+              - table: Optional<String>.none
+            - id: 2
+        ▿ RealtimeCallback
+          ▿ postgres: PostgresCallback
+            - callback: (Function)
+            ▿ filter: PostgresJoinConfig
+              ▿ event: Optional<PostgresChangeEvent>
+                - some: PostgresChangeEvent.update
+              - filter: Optional<String>.none
+              - id: 0
+              - schema: "public"
+              - table: Optional<String>.none
+            - id: 3
+        ▿ RealtimeCallback
+          ▿ postgres: PostgresCallback
+            - callback: (Function)
+            ▿ filter: PostgresJoinConfig
+              ▿ event: Optional<PostgresChangeEvent>
+                - some: PostgresChangeEvent.delete
+              - filter: Optional<String>.none
+              - id: 0
+              - schema: "public"
+              - table: Optional<String>.none
+            - id: 4
+
+      """
+    }
+  }
+}
+
+extension Socket {
+  static var mock: Socket {
+    Socket(
+      broadcastURL: unimplemented(),
+      status: unimplemented(),
+      options: unimplemented(),
+      accessToken: unimplemented(),
+      apiKey: unimplemented(),
+      makeRef: unimplemented(),
+      connect: unimplemented(),
+      addChannel: unimplemented(),
+      removeChannel: unimplemented(),
+      push: unimplemented(),
+      httpSend: unimplemented()
+    )
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a missing overload of the `onPostgresChange` method for listening for all changes.