### PR TITLE
fix: Swift 6 warnings related to `@_unsafeInheritExecutor` attribute

### DIFF
--- a/Sources/Helpers/SupabaseLogger.swift
+++ b/Sources/Helpers/SupabaseLogger.swift
@@ -171,23 +171,45 @@ extension SupabaseLogger {
   }
 }
 
-@inlinable
-@discardableResult
-package func trace<R: Sendable>(
-  using logger: (any SupabaseLogger)?,
-  _ operation: () async throws -> R,
-  isolation _: isolated (any Actor)? = #isolation,
-  fileID: StaticString = #fileID,
-  function: StaticString = #function,
-  line: UInt = #line
-) async rethrows -> R {
-  logger?.debug("begin", fileID: fileID, function: function, line: line)
-  defer { logger?.debug("end", fileID: fileID, function: function, line: line) }
+#if compiler(>=6.0)
+  @inlinable
+  @discardableResult
+  package func trace<R: Sendable>(
+    using logger: (any SupabaseLogger)?,
+    _ operation: () async throws -> R,
+    isolation _: isolated (any Actor)? = #isolation,
+    fileID: StaticString = #fileID,
+    function: StaticString = #function,
+    line: UInt = #line
+  ) async rethrows -> R {
+    logger?.debug("begin", fileID: fileID, function: function, line: line)
+    defer { logger?.debug("end", fileID: fileID, function: function, line: line) }
 
-  do {
-    return try await operation()
-  } catch {
-    logger?.debug("error: \(error)", fileID: fileID, function: function, line: line)
-    throw error
+    do {
+      return try await operation()
+    } catch {
+      logger?.debug("error: \(error)", fileID: fileID, function: function, line: line)
+      throw error
+    }
   }
-}
+#else
+  @inlinable
+  @discardableResult
+  package func trace<R: Sendable>(
+    using logger: (any SupabaseLogger)?,
+    _ operation: () async throws -> R,
+    fileID: StaticString = #fileID,
+    function: StaticString = #function,
+    line: UInt = #line
+  ) async rethrows -> R {
+    logger?.debug("begin", fileID: fileID, function: function, line: line)
+    defer { logger?.debug("end", fileID: fileID, function: function, line: line) }
+
+    do {
+      return try await operation()
+    } catch {
+      logger?.debug("error: \(error)", fileID: fileID, function: function, line: line)
+      throw error
+    }
+  }
+#endif

--- a/Sources/Helpers/SupabaseLogger.swift
+++ b/Sources/Helpers/SupabaseLogger.swift
@@ -173,10 +173,10 @@ extension SupabaseLogger {
 
 @inlinable
 @discardableResult
-@_unsafeInheritExecutor
-package func trace<R>(
+package func trace<R: Sendable>(
   using logger: (any SupabaseLogger)?,
-  @_inheritActorContext _ operation: @Sendable () async throws -> R,
+  _ operation: () async throws -> R,
+  isolation _: isolated (any Actor)? = #isolation,
   fileID: StaticString = #fileID,
   function: StaticString = #function,
   line: UInt = #line

--- a/Sources/Helpers/SupabaseLogger.swift
+++ b/Sources/Helpers/SupabaseLogger.swift
@@ -193,6 +193,7 @@ extension SupabaseLogger {
     }
   }
 #else
+  @_unsafeInheritExecutor
   @inlinable
   @discardableResult
   package func trace<R: Sendable>(

--- a/Sources/Helpers/TaskLocalHelpers.swift
+++ b/Sources/Helpers/TaskLocalHelpers.swift
@@ -7,22 +7,42 @@
 
 import Foundation
 
-extension TaskLocal where Value == JSONObject {
-  @discardableResult
-  @inlinable package final func withValue<R>(
-    merging valueDuringOperation: Value,
-    operation: () async throws -> R,
-    isolation: isolated (any Actor)? = #isolation,
-    file: String = #fileID,
-    line: UInt = #line
-  ) async rethrows -> R {
-    let currentValue = wrappedValue
-    return try await withValue(
-      currentValue.merging(valueDuringOperation) { _, new in new },
-      operation: operation,
-      isolation: isolation,
-      file: file,
-      line: line
-    )
+#if compiler(>=6.0)
+  extension TaskLocal where Value == JSONObject {
+    @discardableResult
+    @inlinable package final func withValue<R>(
+      merging valueDuringOperation: Value,
+      operation: () async throws -> R,
+      isolation: isolated (any Actor)? = #isolation,
+      file: String = #fileID,
+      line: UInt = #line
+    ) async rethrows -> R {
+      let currentValue = wrappedValue
+      return try await withValue(
+        currentValue.merging(valueDuringOperation) { _, new in new },
+        operation: operation,
+        isolation: isolation,
+        file: file,
+        line: line
+      )
+    }
   }
-}
+#else
+  extension TaskLocal where Value == JSONObject {
+    @discardableResult
+    @inlinable package final func withValue<R>(
+      merging valueDuringOperation: Value,
+      operation: () async throws -> R,
+      file: String = #fileID,
+      line: UInt = #line
+    ) async rethrows -> R {
+      let currentValue = wrappedValue
+      return try await withValue(
+        currentValue.merging(valueDuringOperation) { _, new in new },
+        operation: operation,
+        file: file,
+        line: line
+      )
+    }
+  }
+#endif

--- a/Sources/Helpers/TaskLocalHelpers.swift
+++ b/Sources/Helpers/TaskLocalHelpers.swift
@@ -8,12 +8,11 @@
 import Foundation
 
 extension TaskLocal where Value == JSONObject {
-  @inlinable
   @discardableResult
-  @_unsafeInheritExecutor
-  package func withValue<R>(
+  @inlinable package final func withValue<R>(
     merging valueDuringOperation: Value,
-    @_inheritActorContext operation: @Sendable () async throws -> R,
+    operation: () async throws -> R,
+    isolation: isolated (any Actor)? = #isolation,
     file: String = #fileID,
     line: UInt = #line
   ) async rethrows -> R {
@@ -21,6 +20,7 @@ extension TaskLocal where Value == JSONObject {
     return try await withValue(
       currentValue.merging(valueDuringOperation) { _, new in new },
       operation: operation,
+      isolation: isolation,
       file: file,
       line: line
     )

--- a/Sources/Helpers/TaskLocalHelpers.swift
+++ b/Sources/Helpers/TaskLocalHelpers.swift
@@ -29,6 +29,7 @@ import Foundation
   }
 #else
   extension TaskLocal where Value == JSONObject {
+    @_unsafeInheritExecutor
     @discardableResult
     @inlinable package final func withValue<R>(
       merging valueDuringOperation: Value,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
