### PR TITLE
chore(docs): cleanup SlackClone example

### DIFF
--- a/Examples/SlackClone/AuthView.swift
+++ b/Examples/SlackClone/AuthView.swift
@@ -31,7 +31,6 @@ final class AuthViewModel {
   }
 }
 
-@MainActor
 struct AuthView: View {
   @Bindable var model = AuthViewModel()
 

--- a/Examples/SlackClone/ChannelListView.swift
+++ b/Examples/SlackClone/ChannelListView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-@MainActor
 struct ChannelListView: View {
   @Bindable var store = Dependencies.shared.channel
   @Binding var channel: Channel?

--- a/Examples/SlackClone/ChannelStore.swift
+++ b/Examples/SlackClone/ChannelStore.swift
@@ -22,10 +22,10 @@ final class ChannelStore {
     Task {
       channels = await fetchChannels()
 
-      let channel = await supabase.realtimeV2.channel("public:channels")
+      let channel = supabase.channel("public:channels")
 
-      let insertions = await channel.postgresChange(InsertAction.self, table: "channels")
-      let deletions = await channel.postgresChange(DeleteAction.self, table: "channels")
+      let insertions = channel.postgresChange(InsertAction.self, table: "channels")
+      let deletions = channel.postgresChange(DeleteAction.self, table: "channels")
 
       await channel.subscribe()
 
@@ -47,7 +47,7 @@ final class ChannelStore {
     do {
       let userId = try await supabase.auth.session.user.id
       let channel = AddChannel(slug: name, createdBy: userId)
-      try await supabase.database
+      try await supabase
         .from("channels")
         .insert(channel)
         .execute()
@@ -62,7 +62,7 @@ final class ChannelStore {
       return channel
     }
 
-    let channel: Channel = try await supabase.database
+    let channel: Channel = try await supabase
       .from("channels")
       .select()
       .eq("id", value: id)
@@ -90,7 +90,7 @@ final class ChannelStore {
 
   private func fetchChannels() async -> [Channel] {
     do {
-      return try await supabase.database.from("channels").select().execute().value
+      return try await supabase.from("channels").select().execute().value
     } catch {
       dump(error)
       toast = .init(status: .error, title: "Error", description: error.localizedDescription)

--- a/Examples/SlackClone/Dependencies.swift
+++ b/Examples/SlackClone/Dependencies.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Supabase
 
+@MainActor
 class Dependencies {
   static let shared = Dependencies()
 

--- a/Examples/SlackClone/Logger.swift
+++ b/Examples/SlackClone/Logger.swift
@@ -10,45 +10,19 @@ import OSLog
 import Supabase
 
 extension Logger {
-  static let main = Self(subsystem: "com.supabase.SlackClone", category: "app")
+  static let main = Self(subsystem: "com.supabase.slack-clone", category: "app")
+  static let supabase = Self(subsystem: "com.supabase.slack-clone", category: "supabase")
 }
 
-@Observable
-final class LogStore: SupabaseLogger {
-  private let lock = NSLock()
-  private var loggers: [String: Logger] = [:]
-
-  static let shared = LogStore()
-
-  @MainActor
-  var messages: [SupabaseLogMessage] = []
-
+struct SupaLogger: SupabaseLogger {
   func log(message: SupabaseLogMessage) {
-    Task {
-      await add(message: message)
+    let logger = Logger.supabase
+
+    switch message.level {
+    case .debug: logger.debug("\(message, privacy: .public)")
+    case .error: logger.error("\(message, privacy: .public)")
+    case .verbose: logger.info("\(message, privacy: .public)")
+    case .warning: logger.notice("\(message, privacy: .public)")
     }
-
-    lock.withLock {
-      if loggers[message.system] == nil {
-        loggers[message.system] = Logger(
-          subsystem: "com.supabase.SlackClone.supabase-swift",
-          category: message.system
-        )
-      }
-
-      let logger = loggers[message.system]!
-
-      switch message.level {
-      case .debug: logger.debug("\(message, privacy: .public)")
-      case .error: logger.error("\(message, privacy: .public)")
-      case .verbose: logger.info("\(message, privacy: .public)")
-      case .warning: logger.notice("\(message, privacy: .public)")
-      }
-    }
-  }
-
-  @MainActor
-  private func add(message: SupabaseLogMessage) {
-    messages.insert(message, at: 0)
   }
 }

--- a/Examples/SlackClone/MessageStore.swift
+++ b/Examples/SlackClone/MessageStore.swift
@@ -103,11 +103,11 @@ final class MessageStore {
 
   private init() {
     Task {
-      let channel = await supabase.realtimeV2.channel("public:messages")
+      let channel = supabase.channel("public:messages")
 
-      let insertions = await channel.postgresChange(InsertAction.self, table: "messages")
-      let updates = await channel.postgresChange(UpdateAction.self, table: "messages")
-      let deletions = await channel.postgresChange(DeleteAction.self, table: "messages")
+      let insertions = channel.postgresChange(InsertAction.self, table: "messages")
+      let updates = channel.postgresChange(UpdateAction.self, table: "messages")
+      let deletions = channel.postgresChange(DeleteAction.self, table: "messages")
 
       await channel.subscribe()
 
@@ -176,7 +176,7 @@ final class MessageStore {
 
   /// Fetch all messages and their authors.
   private func fetchMessages(_ channelId: Channel.ID) async throws -> [Message] {
-    try await supabase.database
+    try await supabase
       .from("messages")
       .select("*,user:user_id(*),channel:channel_id(*)")
       .eq("channel_id", value: channelId)

--- a/Examples/SlackClone/MessagesView.swift
+++ b/Examples/SlackClone/MessagesView.swift
@@ -9,7 +9,6 @@ import Realtime
 import Supabase
 import SwiftUI
 
-@MainActor
 struct MessagesView: View {
   let store = Dependencies.shared.messages
   let userStore = Dependencies.shared.users
@@ -74,7 +73,7 @@ struct MessagesView: View {
         channelId: channel.id
       )
 
-      try await supabase.database.from("messages").insert(message).execute()
+      try await supabase.from("messages").insert(message).execute()
       newMessage = ""
     } catch {
       dump(error)

--- a/Examples/SlackClone/Supabase.swift
+++ b/Examples/SlackClone/Supabase.swift
@@ -25,7 +25,7 @@ let supabase = SupabaseClient(
   supabaseKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0",
   options: SupabaseClientOptions(
     db: .init(encoder: encoder, decoder: decoder),
-    auth: .init(redirectToURL: URL(string: "com.supabase.slack-clone://")),
-    global: SupabaseClientOptions.GlobalOptions(logger: LogStore.shared)
+    auth: .init(redirectToURL: URL(string: "com.supabase.slack-clone://login-callback")),
+    global: SupabaseClientOptions.GlobalOptions(logger: SupaLogger())
   )
 )

--- a/Examples/SlackClone/supabase/config.toml
+++ b/Examples/SlackClone/supabase/config.toml
@@ -71,7 +71,7 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000", "com.supabase.slack-clone://"]
+additional_redirect_urls = ["https://127.0.0.1:3000", "com.supabase.slack-clone://*"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.

--- a/Sources/Realtime/V2/RealtimeChannelV2.swift
+++ b/Sources/Realtime/V2/RealtimeChannelV2.swift
@@ -193,7 +193,7 @@ public final class RealtimeChannelV2: Sendable {
     )
   }
 
-  public func updateAuth(jwt: String) async {
+  public func updateAuth(jwt: String?) async {
     logger?.debug("Updating auth token for channel \(topic)")
     await push(
       RealtimeMessageV2(
@@ -201,7 +201,7 @@ public final class RealtimeChannelV2: Sendable {
         ref: socket.makeRef().description,
         topic: topic,
         event: ChannelEvent.accessToken,
-        payload: ["access_token": .string(jwt)]
+        payload: ["access_token": jwt.map { .string($0) } ?? .null]
       )
     )
   }

--- a/Sources/Realtime/V2/RealtimeClientV2.swift
+++ b/Sources/Realtime/V2/RealtimeClientV2.swift
@@ -347,7 +347,7 @@ public final class RealtimeClientV2: Sendable {
     }
 
     for channel in channels.values {
-      if let token, channel.status == .subscribed {
+      if channel.status == .subscribed {
         await channel.updateAuth(jwt: token)
       }
     }

--- a/Sources/Realtime/V2/RealtimeClientV2.swift
+++ b/Sources/Realtime/V2/RealtimeClientV2.swift
@@ -348,7 +348,11 @@ public final class RealtimeClientV2: Sendable {
 
     for channel in channels.values {
       if channel.status == .subscribed {
-        await channel.updateAuth(jwt: token)
+        options.logger?.debug("Updating auth token for channel \(channel.topic)")
+        await channel.push(
+          ChannelEvent.accessToken,
+          payload: ["access_token": token.map { .string($0) } ?? .null]
+        )
       }
     }
   }

--- a/Sources/Realtime/V2/RealtimeJoinConfig.swift
+++ b/Sources/Realtime/V2/RealtimeJoinConfig.swift
@@ -32,6 +32,7 @@ struct RealtimeJoinConfig: Codable, Hashable {
 }
 
 public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
+  /// Instructs server to acknowledge that broadcast message was received.
   public var acknowledgeBroadcasts: Bool = false
   /// Broadcast messages back to the sender.
   ///
@@ -45,6 +46,7 @@ public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
 }
 
 public struct PresenceJoinConfig: Codable, Hashable, Sendable {
+  /// Track presence payload across clients.
   public var key: String = ""
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Clean up SlackClone example
- Deprecate `updateAuth(jwt:)` from `RealtimeChannelV2`, use `setAuth` from `RealtimeClientV2` instead.
- Allow to clear token when `setAuth` is  called with `nil` value.