### PR TITLE
fix: remove kSecUseDataProtectionKeychain

### DIFF
--- a/Sources/Auth/Internal/Keychain.swift
+++ b/Sources/Auth/Internal/Keychain.swift
@@ -67,11 +67,6 @@
         query[kSecAttrAccessGroup as String] = accessGroup
       }
 
-      // this is highly recommended for all keychain operations and makes the
-      // macOS keychain item behave like an iOS keychain item
-      // https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain
-      query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
-
       return query
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Revert: https://github.com/supabase/supabase-swift/pull/455
Fix https://github.com/supabase/supabase-swift/issues/516

The addition on `kSecUseDataProtectionKeychain` broke when using on macOS so I decided to revert the change until I can better research about this.