### PR TITLE
fix(auth): `URLError` coercion for `RetryableError` causing session to be deleted

### DIFF
--- a/Sources/Auth/Internal/SessionManager.swift
+++ b/Sources/Auth/Internal/SessionManager.swift
@@ -108,6 +108,8 @@ private actor LiveSessionManager {
             // the same is true for AuthError.
             if let error = error as? URLError, error.shouldRetry {
               throw error
+            } else if let error = error as? any RetryableError, error.shouldRetry {
+              throw error
             } else {
               remove()
               throw error

--- a/Sources/Auth/Internal/SessionManager.swift
+++ b/Sources/Auth/Internal/SessionManager.swift
@@ -106,7 +106,7 @@ private actor LiveSessionManager {
             // Need to do this check here, because not all RetryableError's should be retried.
             // URLError conforms to RetryableError, but only a subset of URLError should be retried,
             // the same is true for AuthError.
-            if let error = error as? any RetryableError, error.shouldRetry {
+            if let error = error as? URLError, error.shouldRetry {
               throw error
             } else {
               remove()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the issue described in https://github.com/supabase/supabase-swift/issues/596

## What is the current behavior?
- Only strictly `URLError` are retried or any error that directly conforms to `RetryableError`

## What is the new behavior?
- Any `NSError` or `Error` that conforms to `URLError` and is retryable will be retried along with any error that directly conforms to `RetryableError`
