### PR TITLE
refactor: use Clock protocol when available

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.2"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
+    .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.0"),
   ],
   targets: [
     .target(
@@ -35,6 +36,7 @@ let package = Package(
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "HTTPTypes", package: "swift-http-types"),
+        .product(name: "Clocks", package: "swift-clocks"),
       ]
     ),
     .testTarget(

--- a/Sources/Helpers/AsyncValueSubject.swift
+++ b/Sources/Helpers/AsyncValueSubject.swift
@@ -1,0 +1,124 @@
+//
+//  AsyncValueSubject.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 31/10/24.
+//
+
+import ConcurrencyExtras
+import Foundation
+
+/// A thread-safe subject that wraps a single value and provides async access to its updates.
+/// Similar to Combine's CurrentValueSubject, but designed for async/await usage.
+package final class AsyncValueSubject<Value: Sendable>: Sendable {
+
+  /// Defines how values are buffered in the underlying AsyncStream.
+  package typealias BufferingPolicy = AsyncStream<Value>.Continuation.BufferingPolicy
+
+  /// Internal state container for the subject.
+  struct MutableState {
+    var value: Value
+    var continuations: [UInt: AsyncStream<Value>.Continuation] = [:]
+    var count: UInt = 0
+  }
+
+  let bufferingPolicy: BufferingPolicy
+  let mutableState: LockIsolated<MutableState>
+
+  /// Creates a new AsyncValueSubject with an initial value.
+  /// - Parameters:
+  ///   - initialValue: The initial value to store
+  ///   - bufferingPolicy: Determines how values are buffered in the AsyncStream (defaults to .unbounded)
+  package init(_ initialValue: Value, bufferingPolicy: BufferingPolicy = .unbounded) {
+    self.mutableState = LockIsolated(MutableState(value: initialValue))
+    self.bufferingPolicy = bufferingPolicy
+  }
+
+  deinit {
+    finish()
+  }
+
+  /// The current value stored in the subject.
+  package var value: Value {
+    mutableState.value
+  }
+
+  /// Sends a new value to the subject and notifies all observers.
+  /// - Parameter value: The new value to send
+  package func yield(_ value: Value) {
+    mutableState.withValue {
+      $0.value = value
+
+      for (_, continuation) in $0.continuations {
+        continuation.yield(value)
+      }
+    }
+  }
+
+  /// Resume the task awaiting the next iteration point by having it return
+  /// nil, which signifies the end of the iteration.
+  ///
+  /// Calling this function more than once has no effect. After calling
+  /// finish, the stream enters a terminal state and doesn't produce any
+  /// additional elements.
+  package func finish() {
+    for (_, continuation) in mutableState.continuations {
+      continuation.finish()
+    }
+  }
+
+  /// An AsyncStream that emits the current value and all subsequent updates.
+  package var values: AsyncStream<Value> {
+    AsyncStream(bufferingPolicy: bufferingPolicy) { continuation in
+      insert(continuation)
+    }
+  }
+
+  /// Observes changes to the subject's value by executing the provided handler.
+  /// - Parameters:
+  ///   - priority: The priority of the task that will observe changes (optional)
+  ///   - handler: A closure that will be called with each new value
+  /// - Returns: A task that can be cancelled to stop observing changes
+  @discardableResult
+  package func onChange(
+    priority: TaskPriority? = nil,
+    _ handler: @escaping @Sendable (Value) -> Void
+  ) -> Task<Void, Never> {
+    let stream = self.values
+    return Task(priority: priority) {
+      for await value in stream {
+        if Task.isCancelled {
+          break
+        }
+        handler(value)
+      }
+    }
+  }
+
+  /// Adds a new continuation to the subject and yields the current value.
+  private func insert(_ continuation: AsyncStream<Value>.Continuation) {
+    mutableState.withValue { state in
+      continuation.yield(state.value)
+      let id = state.count + 1
+      state.count = id
+      state.continuations[id] = continuation
+
+      continuation.onTermination = { [weak self] _ in
+        self?.remove(continuation: id)
+      }
+    }
+  }
+
+  /// Removes a continuation when it's terminated.
+  private func remove(continuation id: UInt) {
+    mutableState.withValue {
+      _ = $0.continuations.removeValue(forKey: id)
+    }
+  }
+}
+
+extension AsyncValueSubject where Value == Void {
+  package func yield() {
+    self.yield(())
+  }
+}

--- a/Sources/Helpers/Task+withTimeout.swift
+++ b/Sources/Helpers/Task+withTimeout.swift
@@ -26,7 +26,7 @@ package func withTimeout<R: Sendable>(
     group.addTask {
       let interval = deadline.timeIntervalSinceNow
       if interval > 0 {
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC * UInt64(interval))
+        try await _clock.sleep(for: interval)
       }
       try Task.checkCancellation()
       throw TimeoutError()

--- a/Sources/Helpers/_Clock.swift
+++ b/Sources/Helpers/_Clock.swift
@@ -1,0 +1,52 @@
+//
+//  _Clock.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 08/01/25.
+//
+
+import Clocks
+import Foundation
+
+package protocol _Clock: Sendable {
+  func sleep(for duration: TimeInterval) async throws
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension ContinuousClock: _Clock {
+  package func sleep(for duration: TimeInterval) async throws {
+    try await sleep(for: .seconds(duration))
+  }
+}
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension TestClock<Duration>: _Clock {
+  package func sleep(for duration: TimeInterval) async throws {
+    try await sleep(for: .seconds(duration))
+  }
+}
+
+/// `_Clock` used on platforms where ``Clock`` protocol isn't available.
+struct FallbackClock: _Clock {
+  func sleep(for duration: TimeInterval) async throws {
+    try await Task.sleep(nanoseconds: NSEC_PER_SEC * UInt64(duration))
+  }
+}
+
+// Resolves clock instance based on platform availability.
+let _resolveClock: @Sendable () -> any _Clock = {
+  if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
+    ContinuousClock()
+  } else {
+    FallbackClock()
+  }
+}
+
+// For overriding clock on tests, we use a mutable _clock in DEBUG builds.
+// nonisolated(unsafe) is safe to use if making sure we assign _clock once in test set up.
+//
+// _clock is read-only in RELEASE builds.
+#if DEBUG
+  nonisolated(unsafe) package var _clock = _resolveClock()
+#else
+  package let _clock = _resolveClock()
+#endif

--- a/Sources/Realtime/V2/RealtimeClientV2.swift
+++ b/Sources/Realtime/V2/RealtimeClientV2.swift
@@ -151,7 +151,7 @@ public final class RealtimeClientV2: Sendable {
     if status == .disconnected {
       let connectionTask = Task {
         if reconnect {
-          try? await Task.sleep(nanoseconds: NSEC_PER_SEC * UInt64(options.reconnectDelay))
+          try? await _clock.sleep(for: options.reconnectDelay)
 
           if Task.isCancelled {
             options.logger?.debug("Reconnect cancelled, returning")
@@ -349,7 +349,7 @@ public final class RealtimeClientV2: Sendable {
   private func startHeartbeating() {
     let heartbeatTask = Task { [weak self, options] in
       while !Task.isCancelled {
-        try? await Task.sleep(nanoseconds: NSEC_PER_SEC * UInt64(options.heartbeatInterval))
+        try? await _clock.sleep(for: options.heartbeatInterval)
         if Task.isCancelled {
           break
         }

--- a/Sources/Realtime/V2/RealtimeClientV2.swift
+++ b/Sources/Realtime/V2/RealtimeClientV2.swift
@@ -56,19 +56,19 @@ public final class RealtimeClientV2: Sendable {
     )
   }
 
-  private let statusEventEmitter = EventEmitter<RealtimeClientStatus>(initialEvent: .disconnected)
+  private let statusSubject = AsyncValueSubject<RealtimeClientStatus>(.disconnected)
 
   /// Listen for connection status changes.
   ///
   /// You can also use ``onStatusChange(_:)`` for a closure based method.
   public var statusChange: AsyncStream<RealtimeClientStatus> {
-    statusEventEmitter.stream()
+    statusSubject.values
   }
 
   /// The current connection status.
   public private(set) var status: RealtimeClientStatus {
-    get { statusEventEmitter.lastEvent }
-    set { statusEventEmitter.emit(newValue) }
+    get { statusSubject.value }
+    set { statusSubject.yield(newValue) }
   }
 
   /// Listen for connection status changes.
@@ -79,7 +79,8 @@ public final class RealtimeClientV2: Sendable {
   public func onStatusChange(
     _ listener: @escaping @Sendable (RealtimeClientStatus) -> Void
   ) -> RealtimeSubscription {
-    statusEventEmitter.attach(listener)
+    let task = statusSubject.onChange { listener($0) }
+    return RealtimeSubscription { task.cancel() }
   }
 
   public convenience init(url: URL, options: RealtimeClientOptions) {

--- a/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",

--- a/Tests/RealtimeTests/_PushTests.swift
+++ b/Tests/RealtimeTests/_PushTests.swift
@@ -6,11 +6,13 @@
 //
 
 import ConcurrencyExtras
+import Helpers
 import TestHelpers
 import XCTest
 
 @testable import Realtime
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class _PushTests: XCTestCase {
   var ws: FakeWebSocket!
   var socket: RealtimeClientV2!
@@ -26,6 +28,7 @@ final class _PushTests: XCTestCase {
 
     let (client, server) = FakeWebSocket.fakes()
     ws = server
+
     socket = RealtimeClientV2(
       url: URL(string: "https://localhost:54321/v1/realtime")!,
       options: RealtimeClientOptions(


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the current behavior?

Current code uses `Task.sleep` for waiting for time to pass, this isn't ideal when testing, since in tests we need to actually wait for time to pass.

Example, for testing a code that has a `Task.sleep(nanoseconds: NSEC_PER_SEC * 10)`, we need to actually wait for 10 seconds in test, which make tests take longer than it should.

## What is the new behavior?

Latest Swift offers a new protocol named `Clock` which solves this issue since there is a `TestClock` implementation which can be used on tests to "fake time to pass", unfortunately `Clock` is available only on newer OS versions, and Supabase support older platform for now.

So in this PR I had to add an intermediate `_Clock` protocol to make it possible to use `Clock` when available and fallback to the old `Task.sleep` on old platforms. This works fine since we always run tests on latest OS versions.