### PR TITLE
fix: make the return value of accessToken nullable

### DIFF
--- a/Sources/Realtime/V2/Types.swift
+++ b/Sources/Realtime/V2/Types.swift
@@ -22,7 +22,7 @@ public struct RealtimeClientOptions: Sendable {
   var disconnectOnSessionLoss: Bool
   var connectOnSubscribe: Bool
   var fetch: (@Sendable (_ request: URLRequest) async throws -> (Data, URLResponse))?
-  package var accessToken: (@Sendable () async throws -> String)?
+  package var accessToken: (@Sendable () async throws -> String?)?
   package var logger: (any SupabaseLogger)?
 
   public static let defaultHeartbeatInterval: TimeInterval = 15
@@ -39,7 +39,7 @@ public struct RealtimeClientOptions: Sendable {
     disconnectOnSessionLoss: Bool = Self.defaultDisconnectOnSessionLoss,
     connectOnSubscribe: Bool = Self.defaultConnectOnSubscribe,
     fetch: (@Sendable (_ request: URLRequest) async throws -> (Data, URLResponse))? = nil,
-    accessToken: (@Sendable () async throws -> String)? = nil,
+    accessToken: (@Sendable () async throws -> String?)? = nil,
     logger: (any SupabaseLogger)? = nil
   ) {
     self.headers = HTTPFields(headers)

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -357,7 +357,7 @@ public final class SupabaseClient: Sendable {
     return request
   }
 
-  private func _getAccessToken() async throws -> String {
+  private func _getAccessToken() async throws -> String? {
     if let accessToken = options.auth.accessToken {
       try await accessToken()
     } else {
@@ -407,7 +407,7 @@ public final class SupabaseClient: Sendable {
 
     if realtimeOptions.accessToken == nil {
       realtimeOptions.accessToken = { [weak self] in
-        try await self?._getAccessToken() ?? ""
+        try await self?._getAccessToken()
       }
     } else {
       reportIssue(

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -64,7 +64,7 @@ public struct SupabaseClientOptions: Sendable {
     /// Note that this function may be called concurrently and many times. Use memoization and locking techniques if this is not supported by the client libraries.
     /// When set, the `auth` namespace of the Supabase client cannot be used.
     /// Create another client if you wish to use Supabase Auth and third-party authentications concurrently in the same application.
-    public let accessToken: (@Sendable () async throws -> String)?
+    public let accessToken: (@Sendable () async throws -> String?)?
 
     public init(
       storage: any AuthLocalStorage,
@@ -74,7 +74,7 @@ public struct SupabaseClientOptions: Sendable {
       encoder: JSONEncoder = AuthClient.Configuration.jsonEncoder,
       decoder: JSONDecoder = AuthClient.Configuration.jsonDecoder,
       autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
-      accessToken: (@Sendable () async throws -> String)? = nil
+      accessToken: (@Sendable () async throws -> String?)? = nil
     ) {
       self.storage = storage
       self.redirectToURL = redirectToURL
@@ -163,7 +163,7 @@ extension SupabaseClientOptions.AuthOptions {
       encoder: JSONEncoder = AuthClient.Configuration.jsonEncoder,
       decoder: JSONDecoder = AuthClient.Configuration.jsonDecoder,
       autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
-      accessToken: (@Sendable () async throws -> String)? = nil
+      accessToken: (@Sendable () async throws -> String?)? = nil
     ) {
       self.init(
         storage: AuthClient.Configuration.defaultLocalStorage,


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix

## What is the current behavior?

Currently `nil` cannot be returned from `accessToken` function.

## What is the new behavior?

`nil` can be returned from `accessToken` when the user on the third-party auth is not signed in.

## Additional context

https://github.com/supabase/supabase-js/pull/1332
