### PR TITLE
chore: fix Swift Package Manager dependency instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ let package = Package(
     targets: [
         .target(
             name: "YourTargetName",
-            dependencies: ["Supabase"] // Add as a dependency
+            dependencies: [
+                .product(name: "Supabase", package: "supabase-swift") // Add as a dependency
+            ]
         )
     ]
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

The code snippet in README.md gave me the error "product 'Supabase' required by package '<package>' target '<target>' not found. Did you mean '.product(name: "Supabase", package: "supabase-swift")'?". Applying the suggested fix worked, so I thought I'd update the README to do this directly :)

## What is the current behavior?

When just declaring Supabase as a dependency, Xcode fails to find the relevant package.

## What is the new behavior?

With this change, Xcode can properly find the Supabase package.
