### PR TITLE
test(storage): increase code coverage

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Storage.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Storage.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1510"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -26,8 +26,29 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Storage"
+            BuildableName = "Storage"
+            BlueprintName = "Storage"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StorageTests"
+               BuildableName = "StorageTests"
+               BlueprintName = "StorageTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -156,10 +156,13 @@ let package = Package(
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        "Mocker",
+        "TestHelpers",
         "Storage",
       ],
       resources: [
-        .copy("sadcat.jpg")
+        .copy("sadcat.jpg"),
+        .process("Fixtures"),
       ]
     ),
     .target(

--- a/Sources/Helpers/Codable.swift
+++ b/Sources/Helpers/Codable.swift
@@ -1,0 +1,36 @@
+//
+//  Codable.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 20/01/25.
+//
+
+import ConcurrencyExtras
+import Foundation
+
+extension JSONDecoder {
+  private static let supportedDateFormatters: [UncheckedSendable<ISO8601DateFormatter>] = [
+    ISO8601DateFormatter.iso8601WithFractionalSeconds,
+    ISO8601DateFormatter.iso8601,
+  ]
+
+  /// Default `JSONDecoder` for decoding types from Supabase.
+  package static let `default`: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .custom { decoder in
+      let container = try decoder.singleValueContainer()
+      let string = try container.decode(String.self)
+
+      for formatter in supportedDateFormatters {
+        if let date = formatter.value.date(from: string) {
+          return date
+        }
+      }
+
+      throw DecodingError.dataCorruptedError(
+        in: container, debugDescription: "Invalid date format: \(string)"
+      )
+    }
+    return decoder
+  }()
+}

--- a/Sources/Helpers/HTTP/HTTPFields.swift
+++ b/Sources/Helpers/HTTP/HTTPFields.swift
@@ -1,37 +1,70 @@
 import HTTPTypes
 
-package extension HTTPFields {
-  init(_ dictionary: [String: String]) {
+extension HTTPFields {
+  package init(_ dictionary: [String: String]) {
     self.init(dictionary.map { .init(name: .init($0.key)!, value: $0.value) })
   }
-  
-  var dictionary: [String: String] {
+
+  package var dictionary: [String: String] {
     let keyValues = self.map {
       ($0.name.rawName, $0.value)
     }
-    
+
     return .init(keyValues, uniquingKeysWith: { $1 })
   }
-  
-  mutating func merge(with other: Self) {
+
+  package mutating func merge(with other: Self) {
     for field in other {
       self[field.name] = field.value
     }
   }
-  
-  func merging(with other: Self) -> Self {
+
+  package func merging(with other: Self) -> Self {
     var copy = self
-    
+
     for field in other {
       copy[field.name] = field.value
     }
 
     return copy
   }
+
+  /// Append or update a value in header.
+  ///
+  /// Example:
+  /// ```swift
+  /// var headers: HTTPFields = [
+  ///   "Prefer": "count=exact,return=representation"
+  /// ]
+  ///
+  /// headers.appendOrUpdate(.prefer, value: "return=minimal")
+  /// #expect(headers == ["Prefer": "count=exact,return=minimal"]
+  /// ```
+  package mutating func appendOrUpdate(
+    _ name: HTTPField.Name,
+    value: String,
+    separator: String = ","
+  ) {
+    if let currentValue = self[name] {
+      var components = currentValue.components(separatedBy: separator)
+
+      if let key = value.split(separator: "=").first,
+        let index = components.firstIndex(where: { $0.hasPrefix("\(key)=") })
+      {
+        components[index] = value
+      } else {
+        components.append(value)
+      }
+
+      self[name] = components.joined(separator: separator)
+    } else {
+      self[name] = value
+    }
+  }
 }
 
-package extension HTTPField.Name {
-  static let xClientInfo = HTTPField.Name("X-Client-Info")!
-  static let xRegion = HTTPField.Name("x-region")!
-  static let xRelayError = HTTPField.Name("x-relay-error")!
+extension HTTPField.Name {
+  package static let xClientInfo = HTTPField.Name("X-Client-Info")!
+  package static let xRegion = HTTPField.Name("x-region")!
+  package static let xRelayError = HTTPField.Name("x-relay-error")!
 }

--- a/Sources/Storage/Codable.swift
+++ b/Sources/Storage/Codable.swift
@@ -9,34 +9,19 @@ import ConcurrencyExtras
 import Foundation
 
 extension JSONEncoder {
+  @available(*, deprecated, message: "Access to storage encoder is going to be removed.")
   public static let defaultStorageEncoder: JSONEncoder = {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
     return encoder
   }()
+
+  static let unconfiguredEncoder: JSONEncoder = .init()
 }
 
 extension JSONDecoder {
-  public static let defaultStorageDecoder: JSONDecoder = {
-    let decoder = JSONDecoder()
-    let formatter = LockIsolated(ISO8601DateFormatter())
-    formatter.withValue {
-      $0.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    }
-
-    decoder.dateDecodingStrategy = .custom { decoder in
-      let container = try decoder.singleValueContainer()
-      let string = try container.decode(String.self)
-
-      if let date = formatter.withValue({ $0.date(from: string) }) {
-        return date
-      }
-
-      throw DecodingError.dataCorruptedError(
-        in: container, debugDescription: "Invalid date format: \(string)"
-      )
-    }
-
-    return decoder
-  }()
+  @available(*, deprecated, message: "Access to storage decoder is going to be removed.")
+  public static var defaultStorageDecoder: JSONDecoder {
+    .default
+  }
 }

--- a/Sources/Storage/Deprecated.swift
+++ b/Sources/Storage/Deprecated.swift
@@ -11,7 +11,8 @@ extension StorageClientConfiguration {
   @available(
     *,
     deprecated,
-    message: "Replace usages of this initializer with new init(url:headers:encoder:decoder:session:logger)"
+    message:
+      "Replace usages of this initializer with new init(url:headers:encoder:decoder:session:logger)"
   )
   public init(
     url: URL,
@@ -101,7 +102,8 @@ extension StorageFileApi {
 @available(
   *,
   deprecated,
-  message: "File was deprecated and it isn't used in the package anymore, if you're using it on your application, consider replacing it as it will be removed on the next major release."
+  message:
+    "File was deprecated and it isn't used in the package anymore, if you're using it on your application, consider replacing it as it will be removed on the next major release."
 )
 public struct File: Hashable, Equatable {
   public var name: String
@@ -121,7 +123,8 @@ public struct File: Hashable, Equatable {
   *,
   deprecated,
   renamed: "MultipartFormData",
-  message: "FormData was deprecated in favor of MultipartFormData, and it isn't used in the package anymore, if you're using it on your application, consider replacing it as it will be removed on the next major release."
+  message:
+    "FormData was deprecated in favor of MultipartFormData, and it isn't used in the package anymore, if you're using it on your application, consider replacing it as it will be removed on the next major release."
 )
 public class FormData {
   var files: [File] = []

--- a/Sources/Storage/Helpers.swift
+++ b/Sources/Storage/Helpers.swift
@@ -27,7 +27,7 @@ import Helpers
           kUTTagClassFilenameExtension, pathExtension as CFString, nil
         )?.takeRetainedValue(),
           let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-          .takeRetainedValue()
+            .takeRetainedValue()
         {
           return contentType as String
         }
@@ -43,7 +43,7 @@ import Helpers
           kUTTagClassFilenameExtension, pathExtension as CFString, nil
         )?.takeRetainedValue(),
           let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-          .takeRetainedValue()
+            .takeRetainedValue()
         {
           return contentType as String
         }
@@ -62,7 +62,7 @@ import Helpers
         kUTTagClassFilenameExtension, pathExtension as CFString, nil
       )?.takeRetainedValue(),
         let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-        .takeRetainedValue()
+          .takeRetainedValue()
       {
         return contentType as String
       }

--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Helpers
 import HTTPTypes
+import Helpers
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
@@ -36,7 +36,7 @@ public class StorageApi: @unchecked Sendable {
 
     let response = try await http.send(request)
 
-    guard (200 ..< 300).contains(response.statusCode) else {
+    guard (200..<300).contains(response.statusCode) else {
       if let error = try? configuration.decoder.decode(
         StorageError.self,
         from: response.data

--- a/Sources/Storage/StorageError.swift
+++ b/Sources/Storage/StorageError.swift
@@ -5,7 +5,7 @@ public struct StorageError: Error, Decodable, Sendable {
   public var message: String
   public var error: String?
 
-  public init(statusCode: String?, message: String, error: String?) {
+  public init(statusCode: String? = nil, message: String, error: String? = nil) {
     self.statusCode = statusCode
     self.message = message
     self.error = error

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -383,6 +383,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// - Parameters:
   ///   - paths: An array of files to be deletes, including the path and file name. For example [`folder/image.png`].
   /// - Returns: A list of removed ``FileObject``.
+  @discardableResult
   public func remove(paths: [String]) async throws -> [FileObject] {
     try await execute(
       HTTPRequest(

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -640,7 +640,11 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     headers[.xUpsert] = "\(options.upsert)"
     headers[.duplex] = options.duplex
 
-    let formData = MultipartFormData()
+    #if DEBUG
+      let formData = MultipartFormData(boundary: testingBoundary.value)
+    #else
+      let formData = MultipartFormData()
+    #endif
     file.encode(to: formData, withPath: path, options: options)
 
     struct UploadResponse: Decodable {

--- a/Tests/StorageTests/BucketOptionsTests.swift
+++ b/Tests/StorageTests/BucketOptionsTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+@testable import Storage
+
+final class BucketOptionsTests: XCTestCase {
+  func testDefaultInitialization() {
+    let options = BucketOptions()
+
+    XCTAssertFalse(options.public)
+    XCTAssertNil(options.fileSizeLimit)
+    XCTAssertNil(options.allowedMimeTypes)
+  }
+
+  func testCustomInitialization() {
+    let options = BucketOptions(
+      public: true,
+      fileSizeLimit: "5242880",
+      allowedMimeTypes: ["image/jpeg", "image/png"]
+    )
+
+    XCTAssertTrue(options.public)
+    XCTAssertEqual(options.fileSizeLimit, "5242880")
+    XCTAssertEqual(options.allowedMimeTypes, ["image/jpeg", "image/png"])
+  }
+}

--- a/Tests/StorageTests/FileOptionsTests.swift
+++ b/Tests/StorageTests/FileOptionsTests.swift
@@ -1,0 +1,30 @@
+import Helpers
+import XCTest
+
+@testable import Storage
+
+final class FileOptionsTests: XCTestCase {
+  func testDefaultInitialization() {
+    let options = FileOptions()
+
+    XCTAssertEqual(options.cacheControl, "3600")
+    XCTAssertNil(options.contentType)
+    XCTAssertFalse(options.upsert)
+    XCTAssertNil(options.metadata)
+  }
+
+  func testCustomInitialization() {
+    let metadata: [String: AnyJSON] = ["key": .string("value")]
+    let options = FileOptions(
+      cacheControl: "7200",
+      contentType: "image/jpeg",
+      upsert: true,
+      metadata: metadata
+    )
+
+    XCTAssertEqual(options.cacheControl, "7200")
+    XCTAssertEqual(options.contentType, "image/jpeg")
+    XCTAssertTrue(options.upsert)
+    XCTAssertEqual(options.metadata?["key"], .string("value"))
+  }
+}

--- a/Tests/StorageTests/Fixtures/file.txt
+++ b/Tests/StorageTests/Fixtures/file.txt
@@ -1,0 +1,1 @@
+hello world!

--- a/Tests/StorageTests/MultipartFormDataTests.swift
+++ b/Tests/StorageTests/MultipartFormDataTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+@testable import Storage
+
+final class MultipartFormDataTests: XCTestCase {
+  func testBoundaryGeneration() {
+    let formData = MultipartFormData()
+    XCTAssertFalse(formData.boundary.isEmpty)
+    XCTAssertTrue(formData.contentType.contains("multipart/form-data; boundary="))
+  }
+
+  func testAppendingData() {
+    let formData = MultipartFormData()
+    let testData = "Hello World".data(using: .utf8)!
+
+    formData.append(testData, withName: "test", fileName: "test.txt", mimeType: "text/plain")
+
+    XCTAssertGreaterThan(formData.contentLength, 0)
+  }
+
+  func testContentHeaders() {
+    let formData = MultipartFormData()
+    let testData = "Test".data(using: .utf8)!
+
+    formData.append(
+      testData,
+      withName: "file",
+      fileName: "test.txt",
+      mimeType: "text/plain"
+    )
+
+    XCTAssertTrue(formData.contentType.hasPrefix("multipart/form-data"))
+  }
+}

--- a/Tests/StorageTests/StorageBucketAPITests.swift
+++ b/Tests/StorageTests/StorageBucketAPITests.swift
@@ -1,0 +1,268 @@
+import InlineSnapshotTesting
+import XCTest
+
+@testable import Storage
+
+final class StorageBucketAPITests: XCTestCase {
+  var storage: SupabaseStorageClient!
+  var mockResponses: [(Data, URLResponse)]!
+
+  var snapshot: ((URLRequest) -> Void)?
+
+  override func setUp() {
+    super.setUp()
+    mockResponses = []
+
+    let mockSession = StorageHTTPSession(
+      fetch: { [weak self] request in
+        self?.snapshot?(request)
+
+        guard let response = self?.mockResponses.removeFirst() else {
+          throw StorageError(message: "No mock response available")
+        }
+        return response
+      },
+      upload: { [weak self] request, data in
+        self?.snapshot?(request)
+
+        guard let response = self?.mockResponses.removeFirst() else {
+          throw StorageError(message: "No mock response available")
+        }
+        return response
+      }
+    )
+
+    JSONEncoder.defaultStorageEncoder.outputFormatting = [
+      .sortedKeys
+    ]
+
+    storage = SupabaseStorageClient(
+      configuration: StorageClientConfiguration(
+        url: URL(string: "http://example.com")!,
+        headers: ["X-Client-Info": "storage-swift/0.0.0"],
+        session: mockSession,
+        logger: nil
+      )
+    )
+  }
+
+  func testGetBucket() async throws {
+    let jsonResponse = """
+      {
+          "id": "bucket123",
+          "name": "test-bucket",
+          "owner": "owner123",
+          "public": false,
+          "created_at": "2024-01-01T00:00:00.000Z",
+          "updated_at": "2024-01-01T00:00:00.000Z"
+      }
+      """.data(using: .utf8)!
+
+    mockResponses = [
+      (
+        jsonResponse,
+        HTTPURLResponse(
+          url: URL(string: "http://example.com")!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	"http://example.com/bucket/bucket123"
+        """#
+      }
+    }
+
+    let bucket = try await storage.getBucket("bucket123")
+    XCTAssertEqual(bucket.id, "bucket123")
+    XCTAssertEqual(bucket.name, "test-bucket")
+  }
+
+  func testListBuckets() async throws {
+    let jsonResponse = """
+      [{
+          "id": "bucket123",
+          "name": "test-bucket",
+          "owner": "owner123",
+          "public": false,
+          "created_at": "2024-01-01T00:00:00.000Z",
+          "updated_at": "2024-01-01T00:00:00.000Z"
+      }]
+      """.data(using: .utf8)!
+
+    mockResponses = [
+      (
+        jsonResponse,
+        HTTPURLResponse(
+          url: URL(string: "http://example.com")!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	"http://example.com/bucket"
+        """#
+      }
+    }
+
+    let buckets = try await storage.listBuckets()
+    XCTAssertEqual(buckets.count, 1)
+    XCTAssertEqual(buckets[0].name, "test-bucket")
+  }
+
+  func testCreateBucket() async throws {
+    let jsonResponse = """
+      {
+          "id": "newbucket",
+          "name": "new-bucket",
+          "owner": "owner123",
+          "public": true,
+          "created_at": "2024-01-01T00:00:00.000Z",
+          "updated_at": "2024-01-01T00:00:00.000Z"
+      }
+      """.data(using: .utf8)!
+
+    mockResponses = [
+      (
+        jsonResponse,
+        HTTPURLResponse(
+          url: URL(string: "http://example.com")!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--data "{\"id\":\"newbucket\",\"name\":\"newbucket\",\"public\":true}" \
+        	"http://example.com/bucket"
+        """#
+      }
+    }
+
+    let options = BucketOptions(public: true)
+    try await storage.createBucket(
+      "newbucket",
+      options: options
+    )
+  }
+
+  func testUpdateBucket() async throws {
+    let jsonResponse = """
+      {
+          "id": "bucket123",
+          "name": "updated-bucket",
+          "owner": "owner123",
+          "public": true,
+          "created_at": "2024-01-01T00:00:00.000Z",
+          "updated_at": "2024-01-01T00:00:00.000Z"
+      }
+      """.data(using: .utf8)!
+
+    mockResponses = [
+      (
+        jsonResponse,
+        HTTPURLResponse(
+          url: URL(string: "http://example.com")!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request PUT \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--data "{\"id\":\"bucket123\",\"name\":\"bucket123\",\"public\":true}" \
+        	"http://example.com/bucket/bucket123"
+        """#
+      }
+    }
+
+    let options = BucketOptions(public: true)
+    try await storage.updateBucket(
+      "bucket123",
+      options: options
+    )
+  }
+
+  func testDeleteBucket() async throws {
+    mockResponses = [
+      (
+        Data(),
+        HTTPURLResponse(
+          url: URL(string: "http://example.com")!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request DELETE \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	"http://example.com/bucket/bucket123"
+        """#
+      }
+    }
+
+    try await storage.deleteBucket("bucket123")
+  }
+
+  func testEmptyBucket() async throws {
+    mockResponses = [
+      (
+        Data(),
+        HTTPURLResponse(
+          url: URL(string: "http://example.com")!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request POST \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	"http://example.com/bucket/bucket123/empty"
+        """#
+      }
+    }
+
+    try await storage.emptyBucket("bucket123")
+  }
+}

--- a/Tests/StorageTests/StorageErrorTests.swift
+++ b/Tests/StorageTests/StorageErrorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import Storage
+
+final class StorageErrorTests: XCTestCase {
+  func testErrorInitialization() {
+    let error = StorageError(
+      statusCode: "404",
+      message: "File not found",
+      error: "NotFound"
+    )
+
+    XCTAssertEqual(error.statusCode, "404")
+    XCTAssertEqual(error.message, "File not found")
+    XCTAssertEqual(error.error, "NotFound")
+  }
+
+  func testLocalizedError() {
+    let error = StorageError(
+      statusCode: "500",
+      message: "Internal server error",
+      error: nil
+    )
+
+    XCTAssertEqual(error.errorDescription, "Internal server error")
+  }
+
+  func testDecoding() throws {
+    let json = """
+      {
+          "statusCode": "403",
+          "message": "Unauthorized access",
+          "error": "Forbidden"
+      }
+      """.data(using: .utf8)!
+
+    let error = try JSONDecoder().decode(StorageError.self, from: json)
+
+    XCTAssertEqual(error.statusCode, "403")
+    XCTAssertEqual(error.message, "Unauthorized access")
+    XCTAssertEqual(error.error, "Forbidden")
+  }
+}

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -608,4 +608,107 @@ final class StorageFileAPITests: XCTestCase {
 
     XCTAssertEqual(data, imageData)
   }
+
+  func testInfo() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/info/bucket/file.txt"),
+      statusCode: 200,
+      data: [
+        .get: Data(
+          """
+          {
+            "name": "file.txt",
+            "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+            "version": "2"
+          }
+          """.utf8
+        )
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/storage/v1/object/info/bucket/file.txt"
+      """#
+    }
+    .register()
+
+    let info = try await storage.from("bucket").info(path: "file.txt")
+
+    XCTAssertEqual(info.name, "file.txt")
+  }
+
+  func testExists() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/bucket/file.txt"),
+      statusCode: 200,
+      data: [
+        .head: Data()
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--head \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+      """#
+    }
+    .register()
+
+    let exists = try await storage.from("bucket").exists(path: "file.txt")
+
+    XCTAssertTrue(exists)
+  }
+
+  func testExists_400_error() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/bucket/file.txt"),
+      statusCode: 400,
+      data: [
+        .head: Data()
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--head \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+      """#
+    }
+    .register()
+
+    let exists = try await storage.from("bucket").exists(path: "file.txt")
+
+    XCTAssertFalse(exists)
+  }
+
+  func testExists_404_error() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/bucket/file.txt"),
+      statusCode: 404,
+      data: [
+        .head: Data()
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--head \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+      """#
+    }
+    .register()
+
+    let exists = try await storage.from("bucket").exists(path: "file.txt")
+
+    XCTAssertFalse(exists)
+  }
 }

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -1,0 +1,284 @@
+import Helpers
+import InlineSnapshotTesting
+import XCTest
+
+@testable import Storage
+
+final class StorageFileAPITests: XCTestCase {
+  let url = URL(string: "http://localhost:54321/storage/v1")!
+
+  var storage: SupabaseStorageClient!
+  var mockResponses: [(Data, URLResponse)]!
+
+  var snapshot: ((URLRequest) -> Void)?
+
+  override func setUp() {
+    super.setUp()
+    mockResponses = []
+
+    let mockSession = StorageHTTPSession(
+      fetch: { [weak self] request in
+        self?.snapshot?(request)
+
+        guard let response = self?.mockResponses.removeFirst() else {
+          throw StorageError(message: "No mock response available")
+        }
+        return response
+      },
+      upload: { [weak self] request, data in
+        self?.snapshot?(request)
+
+        guard let response = self?.mockResponses.removeFirst() else {
+          throw StorageError(message: "No mock response available")
+        }
+        return response
+      }
+    )
+
+    JSONEncoder.defaultStorageEncoder.outputFormatting = [.sortedKeys]
+    JSONEncoder.unconfiguredEncoder.outputFormatting = [.sortedKeys]
+
+    storage = SupabaseStorageClient(
+      configuration: StorageClientConfiguration(
+        url: url,
+        headers: ["X-Client-Info": "storage-swift/0.0.0"],
+        session: mockSession,
+        logger: nil
+      )
+    )
+  }
+
+  func testListFiles() async throws {
+    // Setup mock response
+    let jsonResponse = """
+      [{
+          "name": "test.txt",
+          "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+          "updatedAt": "2024-01-01T00:00:00Z",
+          "createdAt": "2024-01-01T00:00:00Z",
+          "lastAccessedAt": "2024-01-01T00:00:00Z",
+          "metadata": {}
+      }]
+      """.data(using: .utf8)!
+
+    mockResponses = [
+      (
+        jsonResponse,
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
+        	"http://localhost:54321/storage/v1/object/list/bucket"
+        """#
+      }
+    }
+
+    let result = try await storage.from("bucket").list(path: "folder")
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result[0].name, "test.txt")
+  }
+
+  func testMove() async throws {
+    mockResponses = [
+      (
+        Data(),
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"new\/path.txt\",\"sourceKey\":\"old\/path.txt\"}" \
+        	"http://localhost:54321/storage/v1/object/move"
+        """#
+      }
+    }
+
+    try await storage.from("bucket").move(
+      from: "old/path.txt",
+      to: "new/path.txt"
+    )
+  }
+
+  func testCopy() async throws {
+    mockResponses = [
+      (
+        """
+        {"Key": "object/dest/file.txt"}
+        """.data(using: .utf8)!,
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"dest\/file.txt\",\"sourceKey\":\"source\/file.txt\"}" \
+        	"http://localhost:54321/storage/v1/object/copy"
+        """#
+      }
+    }
+
+    let key = try await storage.from("bucket").copy(
+      from: "source/file.txt",
+      to: "dest/file.txt"
+    )
+    XCTAssertEqual(key, "object/dest/file.txt")
+  }
+
+  func testCreateSignedURL() async throws {
+    mockResponses = [
+      (
+        """
+        {"signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"}
+        """.data(using: .utf8)!,
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--data "{\"expiresIn\":3600}" \
+        	"http://localhost:54321/storage/v1/object/sign/bucket/file.txt"
+        """#
+      }
+    }
+
+    let url = try await storage.from("bucket").createSignedURL(
+      path: "file.txt",
+      expiresIn: 3600
+    )
+    XCTAssertEqual(
+      url.absoluteString, "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+  }
+
+  func testCreateSignedURLs() async throws {
+    mockResponses = [
+      (
+        """
+        [
+        {"path": "file.txt", "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"},
+        {"path": "file2.txt", "signedURL": "object/upload/sign/bucket/file2.txt?token=abc.def.ghi"}
+        ]
+        """.data(using: .utf8)!,
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    snapshot = {
+      assertInlineSnapshot(of: $0, as: .curl) {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--data "{\"expiresIn\":3600,\"paths\":[\"file.txt\",\"file2.txt\"]}" \
+        	"http://localhost:54321/storage/v1/object/sign/bucket"
+        """#
+      }
+    }
+
+    let paths = ["file.txt", "file2.txt"]
+    let urls = try await storage.from("bucket").createSignedURLs(
+      paths: paths,
+      expiresIn: 3600
+    )
+    XCTAssertEqual(urls.count, 2)
+    XCTAssertEqual(
+      urls[0].absoluteString, "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+    XCTAssertEqual(
+      urls[1].absoluteString, "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi")
+  }
+
+  func testNonSuccessStatusCode() async throws {
+    mockResponses = [
+      (
+        """
+        {"message":"Error"}
+        """.data(using: .utf8)!,
+        HTTPURLResponse(
+          url: url,
+          statusCode: 412,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    do {
+      try await storage.from("bucket")
+        .move(from: "source", to: "destination")
+    } catch let error as StorageError {
+      XCTAssertEqual(error.message, "Error")
+    }
+  }
+
+  func testNonSuccessStatusCodeWithNonJSONResponse() async throws {
+    mockResponses = [
+      (
+        "error".data(using: .utf8)!,
+        HTTPURLResponse(
+          url: url,
+          statusCode: 412,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    ]
+
+    do {
+      try await storage.from("bucket")
+        .move(from: "source", to: "destination")
+    } catch let error as HTTPError {
+      XCTAssertEqual(error.data, Data("error".utf8))
+      XCTAssertEqual(error.response.statusCode, 412)
+    }
+  }
+}

--- a/Tests/StorageTests/TransformOptionsTests.swift
+++ b/Tests/StorageTests/TransformOptionsTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import Storage
+
+final class TransformOptionsTests: XCTestCase {
+  func testDefaultInitialization() {
+    let options = TransformOptions()
+
+    XCTAssertNil(options.width)
+    XCTAssertNil(options.height)
+    XCTAssertNil(options.resize)
+    XCTAssertEqual(options.quality, 80)  // Default value
+    XCTAssertNil(options.format)
+  }
+
+  func testCustomInitialization() {
+    let options = TransformOptions(
+      width: 100,
+      height: 200,
+      resize: "cover",
+      quality: 90,
+      format: "webp"
+    )
+
+    XCTAssertEqual(options.width, 100)
+    XCTAssertEqual(options.height, 200)
+    XCTAssertEqual(options.resize, "cover")
+    XCTAssertEqual(options.quality, 90)
+    XCTAssertEqual(options.format, "webp")
+  }
+
+  func testQueryItemsGeneration() {
+    let options = TransformOptions(
+      width: 100,
+      height: 200,
+      resize: "cover",
+      quality: 90,
+      format: "webp"
+    )
+
+    let queryItems = options.queryItems
+
+    XCTAssertEqual(queryItems.count, 5)
+
+    XCTAssertEqual(queryItems[0].name, "width")
+    XCTAssertEqual(queryItems[0].value, "100")
+
+    XCTAssertEqual(queryItems[1].name, "height")
+    XCTAssertEqual(queryItems[1].value, "200")
+
+    XCTAssertEqual(queryItems[2].name, "resize")
+    XCTAssertEqual(queryItems[2].value, "cover")
+
+    XCTAssertEqual(queryItems[3].name, "quality")
+    XCTAssertEqual(queryItems[3].value, "90")
+
+    XCTAssertEqual(queryItems[4].name, "format")
+    XCTAssertEqual(queryItems[4].value, "webp")
+  }
+
+  func testPartialQueryItemsGeneration() {
+    let options = TransformOptions(width: 100, quality: 75)
+
+    let queryItems = options.queryItems
+
+    XCTAssertEqual(queryItems.count, 2)
+
+    XCTAssertEqual(queryItems[0].name, "width")
+    XCTAssertEqual(queryItems[0].value, "100")
+
+    XCTAssertEqual(queryItems[1].name, "quality")
+    XCTAssertEqual(queryItems[1].value, "75")
+  }
+}

--- a/Tests/StorageTests/__Snapshots__/StorageBucketAPITests/StorageBucketAPITests-testCreateBucket.1.txt
+++ b/Tests/StorageTests/__Snapshots__/StorageBucketAPITests/StorageBucketAPITests-testCreateBucket.1.txt
@@ -1,0 +1,6 @@
+curl \
+	--request POST \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: storage-swift/2.24.4" \
+	--data "{\"public\":true,\"id\":\"newbucket\",\"name\":\"newbucket\"}" \
+	"http://example.com/bucket"


### PR DESCRIPTION
This pull request includes multiple changes to improve code functionality, enhance test coverage, and update dependencies. The most important changes include enabling code coverage in the Xcode scheme, adding new helper methods and extensions, updating the `StorageFileApi` class, and adding new test cases.

### Enhancements to Code Functionality:

* [`.swiftpm/xcode/xcshareddata/xcschemes/Storage.xcscheme`](diffhunk://#diff-8897d86c8839d937e0592123176437149aa6a6d7ccf456ab35ff7681402d8139L4-R4): Enabled code coverage and added `StorageTests` as a testable reference. [[1]](diffhunk://#diff-8897d86c8839d937e0592123176437149aa6a6d7ccf456ab35ff7681402d8139L4-R4) [[2]](diffhunk://#diff-8897d86c8839d937e0592123176437149aa6a6d7ccf456ab35ff7681402d8139L29-R51)
* [`Sources/Helpers/Codable.swift`](diffhunk://#diff-034749198a11163105aaa02894117d9d617fa4a5c7bee399c20e622ed721a5e1R1-R36): Added a new `JSONDecoder` extension with a default decoder for Supabase.
* [`Sources/Helpers/HTTP/HTTPFields.swift`](diffhunk://#diff-e28a96f8307a304583b3cec22b3672cae67491f584e07abc0be5dfdaf5abe8d1L3-R22): Added a new `appendOrUpdate` method to `HTTPFields` for updating header values. [[1]](diffhunk://#diff-e28a96f8307a304583b3cec22b3672cae67491f584e07abc0be5dfdaf5abe8d1L3-R22) [[2]](diffhunk://#diff-e28a96f8307a304583b3cec22b3672cae67491f584e07abc0be5dfdaf5abe8d1R31-R69)

### Updates to `StorageFileApi` Class:

* [`Sources/Storage/StorageFileApi.swift`](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fL73-R73): Updated the `StorageFileApi` class to use `JSONEncoder.unconfiguredEncoder` and modified the `makeSignedURL` method to handle `String` instead of `URL`. [[1]](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fL73-R73) [[2]](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fL277-R277) [[3]](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fL328-R328) [[4]](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fL357-R375) [[5]](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fR386) [[6]](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fL405-R406) [[7]](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fL548-R549) [[8]](diffhunk://#diff-50761a80b24c84da7b9874bd5a8eaa4e60529c7e241be4f35c5138ad4b9c732fR643-R647)

### Test Coverage Enhancements:

* [`Tests/StorageTests/BucketOptionsTests.swift`](diffhunk://#diff-13aa928a5c6a6ed093b2be1ddd23547327274d575bb37df1a6cae3f8dbbe8064R1-R25): Added new test cases for `BucketOptions` to verify default and custom initialization.
* [`Tests/StorageTests/FileOptionsTests.swift`](diffhunk://#diff-6d70b3b6ca97742632662f8d86c3978bba8af0b9e4fb3a4e8d6ccc9f857259caR1-R30): Added new test cases for `FileOptions` to verify default and custom initialization.
* [`Tests/StorageTests/MultipartFormDataTests.swift`](diffhunk://#diff-97ae8c743359ed2b03accbb643b55f528369b11de6e495b435c92e12de1aec8cR1-R34): Added new test cases for `MultipartFormData` to test boundary generation, data appending, and content headers.

### Dependency Updates:

* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR159-R165): Added `Mocker` and `TestHelpers` dependencies and included a new resource directory `Fixtures`.

### Deprecated Code Updates:

* [`Sources/Storage/Codable.swift`](diffhunk://#diff-eef941032fa1eaac64bda150eeff699381a2584b9ce5bf2f317a5b80f602e5c8R12-L41): Marked `defaultStorageEncoder` and `defaultStorageDecoder` as deprecated.
* [`Sources/Storage/Deprecated.swift`](diffhunk://#diff-7ad3462a3a724fa494bd7eb628e77a3aab92be028a52e63208b3d656c6ffa056L14-R15): Updated deprecation messages for initializers and deprecated structs. [[1]](diffhunk://#diff-7ad3462a3a724fa494bd7eb628e77a3aab92be028a52e63208b3d656c6ffa056L14-R15) [[2]](diffhunk://#diff-7ad3462a3a724fa494bd7eb628e77a3aab92be028a52e63208b3d656c6ffa056L104-R106) [[3]](diffhunk://#diff-7ad3462a3a724fa494bd7eb628e77a3aab92be028a52e63208b3d656c6ffa056L124-R127)