### PR TITLE
refactor(auth): change `AuthClientID` to `Int` to better visiblity of client usage

### DIFF
--- a/Sources/Auth/Internal/Dependencies.swift
+++ b/Sources/Auth/Internal/Dependencies.swift
@@ -15,10 +15,10 @@ struct Dependencies: Sendable {
 
   var urlOpener: URLOpener = .live
   var pkce: PKCE = .live
+  var logger: (any SupabaseLogger)?
 
   var encoder: JSONEncoder { configuration.encoder }
   var decoder: JSONDecoder { configuration.decoder }
-  var logger: (any SupabaseLogger)? { configuration.logger }
 }
 
 extension Dependencies {

--- a/Sources/Helpers/SupabaseLogger.swift
+++ b/Sources/Helpers/SupabaseLogger.swift
@@ -31,7 +31,7 @@ public struct SupabaseLogMessage: Codable, CustomStringConvertible, Sendable {
   public let function: String
   public let line: UInt
   public let timestamp: TimeInterval
-  public let additionalContext: JSONObject
+  public var additionalContext: JSONObject
 
   @usableFromInline
   init(
@@ -55,7 +55,8 @@ public struct SupabaseLogMessage: Codable, CustomStringConvertible, Sendable {
   }
 
   public var description: String {
-    let date = ISO8601DateFormatter.iso8601.value.string(from: Date(timeIntervalSince1970: timestamp))
+    let date = ISO8601DateFormatter.iso8601.value.string(
+      from: Date(timeIntervalSince1970: timestamp))
     let file = fileID.split(separator: ".", maxSplits: 1).first.map(String.init) ?? fileID
     var description = "\(date) [\(level)] [\(system)] [\(file).\(function):\(line)] \(message)"
     if !additionalContext.isEmpty {


### PR DESCRIPTION
This pull request introduces several changes to enhance logging capabilities and refactor the `AuthClient` class. The most important changes include modifying the `AuthClientID` type, adding a logger decorator, and updating the `Dependencies` structure to include a logger.

Enhancements to logging:

* [`Sources/Auth/AuthClient.swift`](diffhunk://#diff-5cb42ddf0c4428eaab423fe95ea140b1e0aeaf07f29d0beab53a1a711eb2abd0L17-R32): Changed `AuthClientID` type from `UUID` to `Int` and added `AuthClientLoggerDecorator` to include `client_id` in log messages.
* [`Sources/Helpers/SupabaseLogger.swift`](diffhunk://#diff-60e6e568eaef939f90aef284769b2cb06b9a9df9f99a059ebd80bfb230e79247L34-R34): Made `additionalContext` mutable in `SupabaseLogMessage` to allow modification of log messages.

Refactoring `AuthClient`:

* [`Sources/Auth/AuthClient.swift`](diffhunk://#diff-5cb42ddf0c4428eaab423fe95ea140b1e0aeaf07f29d0beab53a1a711eb2abd0R86-R100): Introduced a global client ID counter and updated the `AuthClient` initializer to increment and assign unique client IDs.

Updating dependencies:

* [`Sources/Auth/Internal/Dependencies.swift`](diffhunk://#diff-6dd8153adacaedbf5324b24e9d432403f43686923f2f8c0b9a0331cc14af2aaeR18-L21): Moved the `logger` property to be directly within the `Dependencies` structure instead of deriving it from the configuration.

Formatting improvements:

* [`Sources/Helpers/SupabaseLogger.swift`](diffhunk://#diff-60e6e568eaef939f90aef284769b2cb06b9a9df9f99a059ebd80bfb230e79247L58-R59): Improved the formatting of the `description` method in `SupabaseLogMessage` for better readability.