### PR TITLE
fix(auth): make AuthClient an Actor

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -137,7 +137,7 @@ public actor AuthClient {
         var cancellables = Set<AnyCancellable>()
 
         NotificationCenter.default
-          .publisher(for: UIApplication.didBecomeActiveNotification)
+          .publisher(for: didBecomeActiveNotification)
           .sink(
             receiveCompletion: { _ in
               // hold ref to cancellable until it completes
@@ -152,7 +152,7 @@ public actor AuthClient {
           .store(in: &cancellables)
 
         NotificationCenter.default
-          .publisher(for: UIApplication.willResignActiveNotification)
+          .publisher(for: willResignActiveNotification)
           .sink(
             receiveCompletion: { _ in
               // hold ref to cancellable until it completes

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -788,7 +788,7 @@ public actor AuthClient {
       do {
         try await session(from: url)
       } catch {
-        await logger?.error("Failure loading session from url '\(url)' error: \(error)")
+        logger?.error("Failure loading session from url '\(url)' error: \(error)")
       }
     }
   }

--- a/Sources/Auth/AuthClientConfiguration.swift
+++ b/Sources/Auth/AuthClientConfiguration.swift
@@ -104,7 +104,7 @@ extension AuthClient {
   ///   - decoder: The JSON decoder to use for decoding responses.
   ///   - fetch: The asynchronous fetch handler for network requests.
   ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
-  public convenience init(
+  public init(
     url: URL? = nil,
     headers: [String: String] = [:],
     flowType: AuthFlowType = AuthClient.Configuration.defaultFlowType,

--- a/Sources/Auth/Deprecated.swift
+++ b/Sources/Auth/Deprecated.swift
@@ -105,7 +105,7 @@ extension AuthClient {
     deprecated,
     message: "Replace usages of this initializer with new init(url:headers:flowType:localStorage:logger:encoder:decoder:fetch)"
   )
-  public convenience init(
+  public init(
     url: URL,
     headers: [String: String] = [:],
     flowType: AuthFlowType = Configuration.defaultFlowType,

--- a/Sources/TestHelpers/MockExtensions.swift
+++ b/Sources/TestHelpers/MockExtensions.swift
@@ -12,7 +12,7 @@ import InlineSnapshotTesting
 extension Mock {
   package func snapshotRequest(
     message: @autoclosure () -> String = "",
-    record isRecording: Bool? = nil,
+    record isRecording: SnapshotTestingConfiguration.Record? = nil,
     timeout: TimeInterval = 5,
     syntaxDescriptor: InlineSnapshotSyntaxDescriptor = InlineSnapshotSyntaxDescriptor(),
     matches expected: (() -> String)? = nil,

--- a/Sources/TestHelpers/MockExtensions.swift
+++ b/Sources/TestHelpers/MockExtensions.swift
@@ -12,7 +12,7 @@ import InlineSnapshotTesting
 extension Mock {
   package func snapshotRequest(
     message: @autoclosure () -> String = "",
-    record isRecording: SnapshotTestingConfiguration.Record? = nil,
+    record isRecording: Bool? = nil,
     timeout: TimeInterval = 5,
     syntaxDescriptor: InlineSnapshotSyntaxDescriptor = InlineSnapshotSyntaxDescriptor(),
     matches expected: (() -> String)? = nil,


### PR DESCRIPTION
This pull request includes significant changes to the `AuthClient` class in `Sources/Auth/AuthClient.swift` to improve concurrency handling and integrate Combine for handling app lifecycle changes.

### Concurrency improvements:

* Changed `AuthClient` from a `final class` to an `actor` to leverage Swift's concurrency model.

To keep backward compatibility, had to mark a few properties and methods of `AuthClient` as `nonisolated`, the `nonisolated` mark, shall be removed on a next major release.

### Combine integration:
Because of the change from class to actor, I had to change the way we observe the notification center.

* Added `Combine` import conditionally based on availability.
* Refactored `observeAppLifecycleChanges` to use Combine publishers for handling app lifecycle notifications.

These changes improve the concurrency model of `AuthClient` and modernize the handling of app lifecycle events using Combine.