### PR TITLE
[RealTimeChannelV2] Add filters instead of regular `String`

### DIFF
--- a/Sources/Realtime/RealtimeChannel+AsyncAwait.swift
+++ b/Sources/Realtime/RealtimeChannel+AsyncAwait.swift
@@ -6,6 +6,36 @@
 //
 
 import Foundation
+import PostgREST
+
+public enum RealtimeChannelV2Filter {
+  case eq(column: String, value: any URLQueryRepresentable)
+  case neq(column: String, value: any URLQueryRepresentable)
+  case gt(column: String, value: any URLQueryRepresentable)
+  case gte(column: String, value: any URLQueryRepresentable)
+  case lt(column: String, value: any URLQueryRepresentable)
+  case lte(column: String, value: any URLQueryRepresentable)
+  case `in`(column: String, value: [any URLQueryRepresentable])
+
+  var value: String {
+    switch self {
+    case .eq(let column, let value):
+      return "\(column)=eq.\(value.queryValue)"
+    case .neq(let column, let value):
+      return "\(column)=neq.\(value.queryValue)"
+    case .gt(let column, let value):
+      return "\(column)=gt.\(value.queryValue)"
+    case .gte(let column, let value):
+      return "\(column)=gte.\(value.queryValue)"
+    case .lt(let column, let value):
+      return "\(column)=lt.\(value.queryValue)"
+    case .lte(let column, let value):
+      return "\(column)=lte.\(value.queryValue)"
+    case .in(let column, let value):
+      return "\(column)=in.(\(value.map(\.queryValue).joined(separator: ",")))"
+    }
+  }
+}
 
 extension RealtimeChannelV2 {
   /// Listen for clients joining / leaving the channel using presences.
@@ -28,6 +58,22 @@ extension RealtimeChannelV2 {
     _: InsertAction.Type,
     schema: String = "public",
     table: String? = nil,
+    filter: RealtimeChannelV2Filter? = nil
+  ) -> AsyncStream<InsertAction> {
+    postgresChange(event: .insert, schema: schema, table: table, filter: filter?.value)
+      .compactErase()
+  }
+
+  /// Listen for postgres changes in a channel.
+  @available(
+    *,
+     deprecated,
+     message: "Use the new filter syntax instead."
+  )
+  public func postgresChange(
+    _: InsertAction.Type,
+    schema: String = "public",
+    table: String? = nil,
     filter: String? = nil
   ) -> AsyncStream<InsertAction> {
     postgresChange(event: .insert, schema: schema, table: table, filter: filter)
@@ -35,6 +81,22 @@ extension RealtimeChannelV2 {
   }
 
   /// Listen for postgres changes in a channel.
+  public func postgresChange(
+    _: UpdateAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: RealtimeChannelV2Filter? = nil
+  ) -> AsyncStream<UpdateAction> {
+    postgresChange(event: .update, schema: schema, table: table, filter: filter?.value)
+      .compactErase()
+  }
+
+  /// Listen for postgres changes in a channel.
+  @available(
+    *,
+     deprecated,
+     message: "Use the new filter syntax instead."
+  )
   public func postgresChange(
     _: UpdateAction.Type,
     schema: String = "public",
@@ -50,6 +112,22 @@ extension RealtimeChannelV2 {
     _: DeleteAction.Type,
     schema: String = "public",
     table: String? = nil,
+    filter: RealtimeChannelV2Filter? = nil
+  ) -> AsyncStream<DeleteAction> {
+    postgresChange(event: .delete, schema: schema, table: table, filter: filter?.value)
+      .compactErase()
+  }
+
+  /// Listen for postgres changes in a channel.
+  @available(
+    *,
+     deprecated,
+     message: "Use the new filter syntax instead."
+  )
+  public func postgresChange(
+    _: DeleteAction.Type,
+    schema: String = "public",
+    table: String? = nil,
     filter: String? = nil
   ) -> AsyncStream<DeleteAction> {
     postgresChange(event: .delete, schema: schema, table: table, filter: filter)
@@ -57,6 +135,21 @@ extension RealtimeChannelV2 {
   }
 
   /// Listen for postgres changes in a channel.
+  public func postgresChange(
+    _: AnyAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: RealtimeChannelV2Filter? = nil
+  ) -> AsyncStream<AnyAction> {
+    postgresChange(event: .all, schema: schema, table: table, filter: filter?.value)
+  }
+
+  /// Listen for postgres changes in a channel.
+  @available(
+    *,
+     deprecated,
+     message: "Use the new filter syntax instead."
+  )
   public func postgresChange(
     _: AnyAction.Type,
     schema: String = "public",


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR introduces static filters for `RealtimeChannelV2` instead of using a regular `String` (see my [Feature Request](https://github.com/orgs/supabase/discussions/33619#discussioncomment-12237630))

## What is the current behavior?
A `String` passed as a parameter by the client (error prone)

## What is the new behavior?
Use of SDK-defined filters, similar in syntax to a regular query.