### PR TITLE
ci: allow any scope when creating PR

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -17,12 +17,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          scopes: |
-            realtime
-            auth
-            storage
-            functions
-            postgrest
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"


### PR DESCRIPTION
## What is the current behavior?

Requires specific scopes when creating PR

## What is the new behavior?

Allows any scope.