### PR TITLE
fix: update outdated error doc

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -56,7 +56,7 @@ public actor AuthClient {
 
   /// Returns the session, refreshing it if necessary.
   ///
-  /// If no session can be found, a ``AuthError/sessionNotFound`` error is thrown.
+  /// If no session can be found, a ``AuthError/sessionMissing`` error is thrown.
   public var session: Session {
     get async throws {
       try await sessionManager.session()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Just a docs update

## What is the current behavior?

Wrong error type

## What is the new behavior?

Correct error type

## Additional context

The old error type is deprecated - the new one works now.