### PR TITLE
fix(functions): set request timeout to 150 seconds when invoking functions

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -15,6 +15,11 @@ public final class FunctionsClient: Sendable {
     Data, URLResponse
   )
 
+  /// Request idle timeout: 150s (If an Edge Function doesn't send a response before the timeout, 504 Gateway Timeout will be returned)
+  ///
+  /// See more: https://supabase.com/docs/guides/functions/limits
+  public static let requestIdleTimeout: TimeInterval = 150
+
   /// The base URL for the functions.
   let url: URL
 
@@ -246,7 +251,8 @@ public final class FunctionsClient: Sendable {
       method: FunctionInvokeOptions.httpMethod(options.method) ?? .post,
       query: options.query,
       headers: mutableState.headers.merging(with: options.headers),
-      body: options.body
+      body: options.body,
+      timeoutInterval: FunctionsClient.requestIdleTimeout
     )
 
     if let region = options.region ?? region {

--- a/Sources/Helpers/HTTP/HTTPRequest.swift
+++ b/Sources/Helpers/HTTP/HTTPRequest.swift
@@ -18,19 +18,22 @@ package struct HTTPRequest: Sendable {
   package var query: [URLQueryItem]
   package var headers: HTTPFields
   package var body: Data?
+  package var timeoutInterval: TimeInterval
 
   package init(
     url: URL,
     method: HTTPTypes.HTTPRequest.Method,
     query: [URLQueryItem] = [],
     headers: HTTPFields = [:],
-    body: Data? = nil
+    body: Data? = nil,
+    timeoutInterval: TimeInterval = 60
   ) {
     self.url = url
     self.method = method
     self.query = query
     self.headers = headers
     self.body = body
+    self.timeoutInterval = timeoutInterval
   }
 
   package init?(
@@ -38,18 +41,19 @@ package struct HTTPRequest: Sendable {
     method: HTTPTypes.HTTPRequest.Method,
     query: [URLQueryItem] = [],
     headers: HTTPFields = [:],
-    body: Data?
+    body: Data? = nil,
+    timeoutInterval: TimeInterval = 60
   ) {
     guard let url = URL(string: urlString) else { return nil }
-    self.init(url: url, method: method, query: query, headers: headers, body: body)
+    self.init(url: url, method: method, query: query, headers: headers, body: body, timeoutInterval: timeoutInterval)
   }
 
   package var urlRequest: URLRequest {
-    var urlRequest = URLRequest(url: query.isEmpty ? url : url.appendingQueryItems(query))
+    var urlRequest = URLRequest(url: query.isEmpty ? url : url.appendingQueryItems(query), timeoutInterval: timeoutInterval)
     urlRequest.httpMethod = method.rawValue
     urlRequest.allHTTPHeaderFields = .init(headers.map { ($0.name.rawName, $0.value) }) { $1 }
     urlRequest.httpBody = body
-
+    
     if urlRequest.httpBody != nil, urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
       urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix
Close https://github.com/supabase/supabase-swift/issues/727

## What is the current behavior?

No request timeout defined, which uses default `URLSession` timeout which is 60 seconds.

## What is the new behavior?

Allow to specify a custom value for timeout a per-request basis, (internally, not configurable by the user)
Set all invoke functions requests timeout to 150 seconds

## Additional context

https://supabase.com/docs/guides/functions/limits
