### PR TITLE
fix(auth): allow to pass a Keychain storage without a service defined

### DIFF
--- a/Sources/Auth/Internal/Keychain.swift
+++ b/Sources/Auth/Internal/Keychain.swift
@@ -3,11 +3,11 @@
   import Security
 
   struct Keychain {
-    let service: String
+    let service: String?
     let accessGroup: String?
 
     init(
-      service: String,
+      service: String?,
       accessGroup: String? = nil
     ) {
       self.service = service
@@ -55,8 +55,10 @@
     private func baseQuery(withKey key: String? = nil, data: Data? = nil) -> [String: Any] {
       var query: [String: Any] = [:]
       query[kSecClass as String] = kSecClassGenericPassword
-      query[kSecAttrService as String] = service
 
+      if let service {
+        query[kSecAttrService as String] = service
+      }
       if let key {
         query[kSecAttrAccount as String] = key
       }

--- a/Sources/Auth/Storage/KeychainLocalStorage.swift
+++ b/Sources/Auth/Storage/KeychainLocalStorage.swift
@@ -5,7 +5,7 @@
   public struct KeychainLocalStorage: AuthLocalStorage {
     private let keychain: Keychain
 
-    public init(service: String = "supabase.gotrue.swift", accessGroup: String? = nil) {
+    public init(service: String? = "supabase.gotrue.swift", accessGroup: String? = nil) {
       keychain = Keychain(service: service, accessGroup: accessGroup)
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## What is the current behavior?

When creating a custom KeychainLocalStorage it isn't possible to define the service as nil to make it use the default app keychain instance.

## What is the new behavior?

Allow to pass `nil` on the `service` param.

## Additional context

Add any other context or screenshots.
