### PR TITLE
fix(realtime): wildcard event not handled in onBroadcast callback

### DIFF
--- a/Sources/Realtime/CallbackManager.swift
+++ b/Sources/Realtime/CallbackManager.swift
@@ -124,7 +124,7 @@ final class CallbackManager: Sendable {
       }
       return nil
     }
-    let callbacks = broadcastCallbacks.filter { $0.event == event }
+    let callbacks = broadcastCallbacks.filter { $0.event == "*" || $0.event.lowercased() == event.lowercased() }
     callbacks.forEach { $0.callback(json) }
   }
 

--- a/Tests/RealtimeTests/CallbackManagerTests.swift
+++ b/Tests/RealtimeTests/CallbackManagerTests.swift
@@ -203,7 +203,7 @@ final class CallbackManagerTests: XCTestCase {
     callbackManager.triggerBroadcast(event: "NEW_USER", json: jsonObject)
     XCTAssertEqual(caseInsensitiveMessage.value, jsonObject)
 
-    // Match wildcard event
+    // Match any events with wildcard
     let wildcardReceivedMessage = LockIsolated<JSONObject?>(nil)
     callbackManager.addBroadcastCallback(event: "*") {
       wildcardReceivedMessage.setValue($0)

--- a/Tests/RealtimeTests/CallbackManagerTests.swift
+++ b/Tests/RealtimeTests/CallbackManagerTests.swift
@@ -187,14 +187,29 @@ final class CallbackManagerTests: XCTestCase {
 
     let jsonObject = try JSONObject(message)
 
+    // Match exact event
     let receivedMessage = LockIsolated<JSONObject?>(nil)
     callbackManager.addBroadcastCallback(event: event) {
       receivedMessage.setValue($0)
     }
-
     callbackManager.triggerBroadcast(event: event, json: jsonObject)
-
     XCTAssertEqual(receivedMessage.value, jsonObject)
+
+    // Match event case-insensitive
+    let caseInsensitiveMessage = LockIsolated<JSONObject?>(nil)
+    callbackManager.addBroadcastCallback(event: event) {
+      caseInsensitiveMessage.setValue($0)
+    }
+    callbackManager.triggerBroadcast(event: "NEW_USER", json: jsonObject)
+    XCTAssertEqual(caseInsensitiveMessage.value, jsonObject)
+
+    // Match wildcard event
+    let wildcardReceivedMessage = LockIsolated<JSONObject?>(nil)
+    callbackManager.addBroadcastCallback(event: "*") {
+      wildcardReceivedMessage.setValue($0)
+    }
+    callbackManager.triggerBroadcast(event: event, json: jsonObject)
+    XCTAssertEqual(wildcardReceivedMessage.value, jsonObject)
   }
 
   func testTriggerPresenceDiffs() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Using "*" as event arg e.g. `onBroadcast(event: "*")` won't work. The callback is never triggered because the event never matched.

```swift
let subscription = = channel.onBroadcast(event: "*") { message in
    print("new message:", message) // This never gets logged
}
```

I found it because I thought I had a bug in my app code, but once I enabled global logging, I got the log from `RealtimeClientV2.onMessage` which means the event was actually sent and received, but the callback isn't triggered.

<img width="600" height="194" alt="image" src="https://github.com/user-attachments/assets/dcdc949d-2799-46d9-88ea-b3c27c90367b" />

## What is the new behavior?

Using "*" as event arg should work now.

## Additional context

The behavior is documented [here](https://supabase.com/docs/guides/realtime/broadcast?queryGroups=language&language=swift#receiving-broadcast-messages). It's also the same behavior (ie. treating "*" as wildcard) in other languages.

<img width="600" height="474" alt="image" src="https://github.com/user-attachments/assets/2e124179-fa49-4f49-84ac-c22e48189d4f" />
