### PR TITLE
feat: add OSLogSupabaseLogger type

### DIFF
--- a/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
+++ b/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+#if canImport(OSLog)
+  import OSLog
+#endif
+
+/// A SupabaseLogger implementation that logs to OSLog.
+///
+/// This logger maps Supabase log levels to appropriate OSLog levels:
+/// - `.verbose` → `.info`
+/// - `.debug` → `.debug`
+/// - `.warning` → `.notice`
+/// - `.error` → `.error`
+///
+/// ## Usage
+///
+/// ```swift
+/// let logger = Logger(subsystem: "com.yourapp.supabase", category: "auth")
+/// let supabaseLogger = OSLogSupabaseLogger(logger)
+///
+/// // Use with Supabase client
+/// let supabase = SupabaseClient(
+///   supabaseURL: url,
+///   supabaseKey: key,
+///   options: .init(global: .init(logger: supabaseLogger))
+/// )
+/// ```
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+public struct OSLogSupabaseLogger: SupabaseLogger {
+  private let logger: Logger
+  
+  /// Creates a new OSLog-based logger with a provided Logger instance.
+  ///
+  /// - Parameter logger: The OSLog Logger instance to use for logging
+  public init(_ logger: Logger) {
+    self.logger = logger
+  }
+  
+  public func log(message: SupabaseLogMessage) {
+    let logMessage = message.description
+    
+    switch message.level {
+    case .verbose:
+      logger.info("\(logMessage, privacy: .public)")
+    case .debug:
+      logger.debug("\(logMessage, privacy: .public)")
+    case .warning:
+      logger.notice("\(logMessage, privacy: .public)")
+    case .error:
+      logger.error("\(logMessage, privacy: .public)")
+    }
+  }
+}

--- a/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
+++ b/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
@@ -2,53 +2,53 @@ import Foundation
 
 #if canImport(OSLog)
   import OSLog
-#endif
 
-/// A SupabaseLogger implementation that logs to OSLog.
-///
-/// This logger maps Supabase log levels to appropriate OSLog levels:
-/// - `.verbose` → `.info`
-/// - `.debug` → `.debug`
-/// - `.warning` → `.notice`
-/// - `.error` → `.error`
-///
-/// ## Usage
-///
-/// ```swift
-/// let supabaseLogger = OSLogSupabaseLogger()
-///
-/// // Use with Supabase client
-/// let supabase = SupabaseClient(
-///   supabaseURL: url,
-///   supabaseKey: key,
-///   options: .init(global: .init(logger: supabaseLogger))
-/// )
-/// ```
-@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
-public struct OSLogSupabaseLogger: SupabaseLogger {
-  private let logger: Logger
-
-  /// Creates a new OSLog-based logger with a provided Logger instance.
+  /// A SupabaseLogger implementation that logs to OSLog.
   ///
-  /// - Parameter logger: The OSLog Logger instance to use for logging.
-  public init(
-    _ logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "Supabase")
-  ) {
-    self.logger = logger
-  }
+  /// This logger maps Supabase log levels to appropriate OSLog levels:
+  /// - `.verbose` → `.info`
+  /// - `.debug` → `.debug`
+  /// - `.warning` → `.notice`
+  /// - `.error` → `.error`
+  ///
+  /// ## Usage
+  ///
+  /// ```swift
+  /// let supabaseLogger = OSLogSupabaseLogger()
+  ///
+  /// // Use with Supabase client
+  /// let supabase = SupabaseClient(
+  ///   supabaseURL: url,
+  ///   supabaseKey: key,
+  ///   options: .init(global: .init(logger: supabaseLogger))
+  /// )
+  /// ```
+  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+  public struct OSLogSupabaseLogger: SupabaseLogger {
+    private let logger: Logger
 
-  public func log(message: SupabaseLogMessage) {
-    let logMessage = message.description
+    /// Creates a new OSLog-based logger with a provided Logger instance.
+    ///
+    /// - Parameter logger: The OSLog Logger instance to use for logging.
+    public init(
+      _ logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "Supabase")
+    ) {
+      self.logger = logger
+    }
 
-    switch message.level {
-    case .verbose:
-      logger.info("\(logMessage, privacy: .public)")
-    case .debug:
-      logger.debug("\(logMessage, privacy: .public)")
-    case .warning:
-      logger.notice("\(logMessage, privacy: .public)")
-    case .error:
-      logger.error("\(logMessage, privacy: .public)")
+    public func log(message: SupabaseLogMessage) {
+      let logMessage = message.description
+
+      switch message.level {
+      case .verbose:
+        logger.info("\(logMessage, privacy: .public)")
+      case .debug:
+        logger.debug("\(logMessage, privacy: .public)")
+      case .warning:
+        logger.notice("\(logMessage, privacy: .public)")
+      case .error:
+        logger.error("\(logMessage, privacy: .public)")
+      }
     }
   }
-}
+#endif

--- a/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
+++ b/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
@@ -15,8 +15,7 @@ import Foundation
 /// ## Usage
 ///
 /// ```swift
-/// let logger = Logger(subsystem: "com.yourapp.supabase", category: "auth")
-/// let supabaseLogger = OSLogSupabaseLogger(logger)
+/// let supabaseLogger = OSLogSupabaseLogger()
 ///
 /// // Use with Supabase client
 /// let supabase = SupabaseClient(
@@ -28,17 +27,19 @@ import Foundation
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 public struct OSLogSupabaseLogger: SupabaseLogger {
   private let logger: Logger
-  
+
   /// Creates a new OSLog-based logger with a provided Logger instance.
   ///
-  /// - Parameter logger: The OSLog Logger instance to use for logging
-  public init(_ logger: Logger) {
+  /// - Parameter logger: The OSLog Logger instance to use for logging.
+  public init(
+    _ logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "Supabase")
+  ) {
     self.logger = logger
   }
-  
+
   public func log(message: SupabaseLogMessage) {
     let logMessage = message.description
-    
+
     switch message.level {
     case .verbose:
       logger.info("\(logMessage, privacy: .public)")

--- a/Sources/Helpers/Logger/SupabaseLogger.swift
+++ b/Sources/Helpers/Logger/SupabaseLogger.swift
@@ -214,3 +214,4 @@ extension SupabaseLogger {
     }
   }
 #endif
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the current behavior?

User needs to manually implement a `SupabaseLogger` which uses a `OSLog`.

## What is the new behavior?

We now provide a `SupabaseLogger` implementation that uses `OSLog`, since this is probably the most used logger across Apple projects.

