### PR TITLE
chore: update GitHub App token action to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,17 @@ jobs:
 
     steps:
       - name: Generate token
-        id: generate-token
-        uses: tibdex/github-app-token@v1
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -45,4 +46,4 @@ jobs:
       - name: Run semantic-release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflow to use the newer `actions/create-github-app-token@v2` action instead of the deprecated `tibdex/github-app-token@v1`.

## Changes
- Upgraded from `tibdex/github-app-token@v1` to `actions/create-github-app-token@v2`
- Updated parameter names from snake_case to kebab-case:
  - `app_id` → `app-id`
  - `private_key` → `private-key`
- Added `persist-credentials: false` for improved security
- Updated step id reference from `generate-token` to `app-token`

## Motivation
The `tibdex/github-app-token` action is no longer maintained and GitHub recommends using the official `actions/create-github-app-token` action for better security and continued support.

## Testing
- [ ] GitHub Actions workflow should continue to work as expected
- [ ] Semantic release process should function normally