### PR TITLE
fix(realtime): make Apikey required

### DIFF
--- a/Sources/Realtime/RealtimeChannelV2.swift
+++ b/Sources/Realtime/RealtimeChannelV2.swift
@@ -499,7 +499,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
       )
       Task {
         await unsubscribe()
-        await subscribe()
+        try? await subscribeWithError()
       }
     }
 

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -22,7 +22,7 @@ final class RealtimeChannelTests: XCTestCase {
     ),
     socket: RealtimeClientV2(
       url: URL(string: "https://localhost:54321/realtime/v1")!,
-      options: RealtimeClientOptions()
+      options: RealtimeClientOptions(headers: ["apikey": "test-key"])
     ),
     logger: nil
   )
@@ -161,8 +161,8 @@ final class RealtimeChannelTests: XCTestCase {
     XCTAssertTrue(channel.callbackManager.callbacks.contains(where: { $0.isPresence }))
 
     // Start subscription process
-    let subscribeTask = Task {
-      await channel.subscribe()
+    Task {
+      try? await channel.subscribeWithError()
     }
 
     // Wait for the join message to be sent


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Realtime client can be initialized without an apikey

## What is the new behavior?

Realtime client now requires apikey to be present

## Additional context

https://github.com/supabase/realtime-js/pull/502
