### PR TITLE
chore: drop support for Swift 5.10 and Xcode 15.x

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,7 @@ body:
     attributes:
       label: Swift Version
       description: What version of Swift are you using?
-      placeholder: ex. 5.10
+      placeholder: ex. 6.0
     validations:
       required: true
 

--- a/Examples/Examples/Profile/UserIdentityList.swift
+++ b/Examples/Examples/Profile/UserIdentityList.swift
@@ -55,7 +55,7 @@ struct UserIdentityList: View {
       }
     }
     .id(id)
-    #if swift(>=5.10)
+    #if swift(>=6.0)
       .toolbar {
         ToolbarItem(placement: .primaryAction) {
           Menu("Add") {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import Foundation

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Supabase client for Swift. Mirrors the design of [supabase-js](https://github.co
 
 ### Requirements
 - iOS 13.0+ / macOS 10.15+ / tvOS 13+ / watchOS 6+ / visionOS 1+
-- Xcode 15.3+
-- Swift 5.10+
+- Xcode 16.0+
+- Swift 6.0+
 
 > [!IMPORTANT]
 > Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.


### PR DESCRIPTION
## Summary
- Update minimum Swift version from 5.10 to 6.0
- Update minimum Xcode version from 15.3 to 16.0
- Update Package.swift swift-tools-version to 6.0
- Update bug report template example version
- Update Swift version checks in example code

## Rationale
According to our [Support Policy](https://github.com/supabase/supabase-swift#support-policy), dropping Swift and Xcode versions is not considered a breaking change and can be done in minor releases. 

With the release of Xcode 26 on September 15, 2025, we can now safely drop support for Swift 5.10 and Xcode 15.x to take advantage of new Swift 6 features and improvements while maintaining our policy of supporting current submission-eligible Xcode versions.

## Test plan
- [ ] Verify Package.swift builds with Swift 6.0+
- [ ] Confirm all existing functionality works with new minimum requirements
- [ ] Check that CI passes with updated toolchain requirements

🤖 Generated with [Claude Code](https://claude.ai/code)