### PR TITLE
feat(postgrest): implement maxAffected method for row limit enforcement

### DIFF
--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -169,4 +169,19 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
 
     return self
   }
+
+  /// Set the maximum number of rows that can be affected by the query.
+  ///
+  /// Only available in PostgREST v13+ and only works with PATCH, DELETE methods and RPC calls.
+  /// Note: This method doesn't validate the HTTP method - ensure you only use it with compatible operations.
+  ///
+  /// - Parameters:
+  ///   - value: The maximum number of rows that can be affected
+  public func maxAffected(_ value: Int) -> PostgrestTransformBuilder {
+    mutableState.withValue {
+      $0.request.headers.appendOrUpdate(.prefer, value: "handling=strict")
+      $0.request.headers.appendOrUpdate(.prefer, value: "max-affected=\(value)")
+    }
+    return self
+  }
 }


### PR DESCRIPTION
## Summary
- Implement `maxAffected` method in `PostgrestTransformBuilder` for PostgREST v13+ row limit enforcement
- Add comprehensive tests covering UPDATE, DELETE, RPC, and SELECT operations
- Remove method validation to allow flexible usage with documentation notes

## Features
- Sets `handling=strict` and `max-affected=<value>` headers for row limit enforcement
- Works with PATCH, DELETE methods and RPC calls (as documented)
- Includes test for calling method multiple times (last value wins)
- No runtime validation - relies on documentation for proper usage

## Test plan
- [x] Test `maxAffected` on UPDATE operations
- [x] Test `maxAffected` on DELETE operations  
- [x] Test `maxAffected` on RPC calls
- [x] Test `maxAffected` on SELECT (demonstrates no validation)
- [x] Test calling `maxAffected` multiple times
- [x] Verify correct Prefer headers are set in all cases

🤖 Generated with [Claude Code](https://claude.ai/code)