### PR TITLE
fix(auth): remove session when it has been revoked

### DIFF
--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -107,6 +107,9 @@ struct APIClient: Sendable {
         reasons: error.weakPassword?.reasons ?? []
       )
     } else if errorCode == .sessionNotFound {
+      // The `session_id` inside the JWT does not correspond to a row in the
+      // `sessions` table. This usually means the user has signed out, has been
+      // deleted, or their session has somehow been terminated.
       await sessionManager.remove()
       eventEmitter.emit(.signedOut, session: nil)
       return .sessionMissing

--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -106,7 +106,7 @@ struct APIClient: Sendable {
         message: error._getErrorMessage(),
         reasons: error.weakPassword?.reasons ?? []
       )
-    } else if errorCode == .sessionNotFound {
+    } else if [.sessionNotFound, .refreshTokenNotFound].contains(errorCode) {
       // The `session_id` inside the JWT does not correspond to a row in the
       // `sessions` table. This usually means the user has signed out, has been
       // deleted, or their session has somehow been terminated.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Considering the scenario where a user is logged on both web and mobile using the Swift SDK, when the user signs out from the web using global scope, all sessions are removed from the auth service, including the session from the mobile app.

Any authenticated call made by the Swift SDK after that will throw an error and get it stuck in a state where it says it is signed in, but the session isn't accepted by the server.

## What is the new behavior?

Once the SDK gets a `session_not_found` or `refresh_token_not_found` error returned by the auth service, the SDK removes the session from storage and triggers a `SIGNED_OUT` event, cleaning up state.

## Additional context

Add any other context or screenshots.
