### PR TITLE
feat: add support for broadcast replay configuration

### DIFF
--- a/Sources/Realtime/RealtimeJoinConfig.swift
+++ b/Sources/Realtime/RealtimeJoinConfig.swift
@@ -33,6 +33,20 @@ struct RealtimeJoinConfig: Codable, Hashable {
   }
 }
 
+/// Configuration for broadcast replay feature.
+/// Allows replaying broadcast messages from a specific timestamp.
+public struct ReplayOption: Codable, Hashable, Sendable {
+  /// Unix timestamp (in milliseconds) from which to start replaying messages
+  public var since: Int
+  /// Optional limit on the number of messages to replay
+  public var limit: Int?
+
+  public init(since: Int, limit: Int? = nil) {
+    self.since = since
+    self.limit = limit
+  }
+}
+
 public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
   /// Instructs server to acknowledge that broadcast message was received.
   public var acknowledgeBroadcasts: Bool = false
@@ -40,10 +54,23 @@ public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
   ///
   /// By default, broadcast messages are only sent to other clients.
   public var receiveOwnBroadcasts: Bool = false
+  /// Configures broadcast replay from a specific timestamp
+  public var replay: ReplayOption?
+
+  public init(
+    acknowledgeBroadcasts: Bool = false,
+    receiveOwnBroadcasts: Bool = false,
+    replay: ReplayOption? = nil
+  ) {
+    self.acknowledgeBroadcasts = acknowledgeBroadcasts
+    self.receiveOwnBroadcasts = receiveOwnBroadcasts
+    self.replay = replay
+  }
 
   enum CodingKeys: String, CodingKey {
     case acknowledgeBroadcasts = "ack"
     case receiveOwnBroadcasts = "self"
+    case replay
   }
 }
 


### PR DESCRIPTION
## Summary
- Added `ReplayOption` struct for configuring broadcast replay
- Added `replay` field to `BroadcastJoinConfig`
- Added public initializer to `BroadcastJoinConfig` to support replay configuration

## Changes
This PR implements broadcast replay support following the pattern from realtime-js PR #540:

1. **ReplayOption**: New struct with `since` (Int) and optional `limit` (Int?)
2. **BroadcastJoinConfig**: Added optional `replay` field
3. **Public initializer**: Added to enable replay configuration

## Usage
```swift
// Configure broadcast with replay
let config = RealtimeJoinConfig(
  broadcast: BroadcastJoinConfig(
    acknowledgeBroadcasts: true,
    receiveOwnBroadcasts: true,
    replay: ReplayOption(
      since: 1234567890,
      limit: 100
    )
  )
)

let channel = supabase.realtimeV2.channel("my-channel", config: config)

// Broadcast callback receives meta field
channel.onBroadcast { message in
  if let meta = message.payload["meta"] as? [String: Any],
     let replayed = meta["replayed"] as? Bool,
     replayed {
    print("Replayed message: \(meta["id"] ?? "")")
  }
}

await channel.subscribe()
```

## Test plan
- [ ] Verify type checking passes
- [ ] Test broadcast replay configuration
- [ ] Verify meta field is properly included in callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)