### PR TITLE
feat(functions): add region as forceFunctionRegion query parameter

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -246,10 +246,11 @@ public final class FunctionsClient: Sendable {
   private func buildRequest(functionName: String, options: FunctionInvokeOptions)
     -> Helpers.HTTPRequest
   {
+    var query = options.query
     var request = HTTPRequest(
       url: url.appendingPathComponent(functionName),
       method: FunctionInvokeOptions.httpMethod(options.method) ?? .post,
-      query: options.query,
+      query: query,
       headers: mutableState.headers.merging(with: options.headers),
       body: options.body,
       timeoutInterval: FunctionsClient.requestIdleTimeout
@@ -257,6 +258,8 @@ public final class FunctionsClient: Sendable {
 
     if let region = options.region ?? region {
       request.headers[.xRegion] = region
+      query.appendOrUpdate(URLQueryItem(name: "forceFunctionRegion", value: region))
+      request.query = query
     }
 
     return request

--- a/Tests/FunctionsTests/FunctionsClientTests.swift
+++ b/Tests/FunctionsTests/FunctionsClientTests.swift
@@ -164,6 +164,7 @@ final class FunctionsClientTests: XCTestCase {
 
     Mock(
       url: url.appendingPathComponent("hello-world"),
+      ignoreQuery: true,
       statusCode: 200,
       data: [.post: Data()]
     )
@@ -174,7 +175,7 @@ final class FunctionsClientTests: XCTestCase {
       	--header "X-Client-Info: functions-swift/0.0.0" \
       	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
       	--header "x-region: ca-central-1" \
-      	"http://localhost:5432/functions/v1/hello-world"
+      	"http://localhost:5432/functions/v1/hello-world?forceFunctionRegion=ca-central-1"
       """#
     }
     .register()
@@ -185,6 +186,7 @@ final class FunctionsClientTests: XCTestCase {
   func testInvokeWithRegion() async throws {
     Mock(
       url: url.appendingPathComponent("hello-world"),
+      ignoreQuery: true,
       statusCode: 200,
       data: [.post: Data()]
     )
@@ -195,7 +197,7 @@ final class FunctionsClientTests: XCTestCase {
       	--header "X-Client-Info: functions-swift/0.0.0" \
       	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
       	--header "x-region: ca-central-1" \
-      	"http://localhost:5432/functions/v1/hello-world"
+      	"http://localhost:5432/functions/v1/hello-world?forceFunctionRegion=ca-central-1"
       """#
     }
     .register()

--- a/Tests/FunctionsTests/__Snapshots__/RequestTests/testInvokeWithCustomRegion.1.txt
+++ b/Tests/FunctionsTests/__Snapshots__/RequestTests/testInvokeWithCustomRegion.1.txt
@@ -3,4 +3,4 @@ curl \
 	--header "apikey: supabase.anon.key" \
 	--header "x-client-info: functions-swift/x.y.z" \
 	--header "x-region: ap-northeast-1" \
-	"http://localhost:5432/functions/v1/hello-world"
+	"http://localhost:5432/functions/v1/hello-world?forceFunctionRegion=ap-northeast-1"


### PR DESCRIPTION
## Summary

This PR ports the feature from [supabase/functions-js#100](https://github.com/supabase/functions-js/pull/100) to add region as a `forceFunctionRegion` query parameter alongside the existing `x-region` header.

## Changes

- Updated `FunctionsClient.buildRequest()` to add the `forceFunctionRegion` query parameter when a region is specified
- Modified tests to verify both the `x-region` header and `forceFunctionRegion` query parameter are sent
- Maintains backward compatibility with existing `x-region` header functionality

## Implementation Details

When a region is specified (either in the client or in invoke options), the Functions client now:
1. Sets the `x-region` header (existing behavior)
2. Adds a `forceFunctionRegion` query parameter with the same region value (new behavior)

This dual approach ensures better compatibility with edge function routing mechanisms.

## Test Plan

- ✅ All existing tests pass
- ✅ Updated `testInvokeWithRegion` to verify query parameter is added
- ✅ Updated `testInvokeWithRegionDefinedInClient` to verify query parameter is added
- ✅ Verified no region results in no query parameter (existing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)