### PR TITLE
test: exclude __Snapshots__ directories from test targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,6 +90,9 @@ let package = Package(
         "Functions",
         "Mocker",
         "TestHelpers",
+      ],
+      exclude: [
+        "__Snapshots__"
       ]
     ),
     .testTarget(
@@ -123,6 +126,9 @@ let package = Package(
         "Mocker",
         "PostgREST",
         "TestHelpers",
+      ],
+      exclude: [
+        "__Snapshots__"
       ]
     ),
     .target(
@@ -159,6 +165,9 @@ let package = Package(
         "Mocker",
         "TestHelpers",
         "Storage",
+      ],
+      exclude: [
+        "__Snapshots__"
       ],
       resources: [
         .copy("sadcat.jpg"),


### PR DESCRIPTION
## Summary

Fixes Swift Package Manager warnings about unhandled snapshot files by explicitly excluding `__Snapshots__` directories from test targets.

## Changes

- Added `exclude: ["__Snapshots__"]` to the following test targets in `Package.swift`:
  - `FunctionsTests` (5 snapshot files)
  - `PostgRESTTests` (32 snapshot files)
  - `StorageTests` (1 snapshot file)

## Why

These snapshot files are generated and managed by `swift-snapshot-testing` and should not be processed as test resources. Without explicit exclusion, Swift Package Manager issues warnings about unhandled files.

## Test plan

- [x] `swift build` completes without warnings about unhandled files
- [x] Tests still run successfully with snapshot testing functionality intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)