### PR TITLE
fix(auth): emit local stored session as the initial session

### DIFF
--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -1,0 +1,215 @@
+// swift-tools-version:6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import Foundation
+import PackageDescription
+
+let package = Package(
+  name: "Supabase",
+  platforms: [
+    .iOS(.v13),
+    .macCatalyst(.v13),
+    .macOS(.v10_15),
+    .watchOS(.v6),
+    .tvOS(.v13),
+  ],
+  products: [
+    .library(name: "Auth", targets: ["Auth"]),
+    .library(name: "Functions", targets: ["Functions"]),
+    .library(name: "PostgREST", targets: ["PostgREST"]),
+    .library(name: "Realtime", targets: ["Realtime"]),
+    .library(name: "Storage", targets: ["Storage"]),
+    .library(
+      name: "Supabase",
+      targets: ["Supabase", "Functions", "PostgREST", "Auth", "Realtime", "Storage"]
+    ),
+  ],
+  traits: [
+    .init(
+      name: "EmitLocalSessionAsInitialSession",
+      description: "Emits the local stored session as the initial session.",
+      enabledTraits: []
+    )
+  ],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
+    .package(url: "https://github.com/apple/swift-http-types.git", from: "1.3.0"),
+    .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
+    .package(url: "https://github.com/WeTransfer/Mocker", from: "3.0.0"),
+  ],
+  targets: [
+    .target(
+      name: "Helpers",
+      dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
+        .product(name: "Clocks", package: "swift-clocks"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+      ]
+    ),
+    .testTarget(
+      name: "HelpersTests",
+      dependencies: [
+        .product(name: "CustomDump", package: "swift-custom-dump"),
+        "Helpers",
+      ]
+    ),
+    .target(
+      name: "Auth",
+      dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "Crypto", package: "swift-crypto"),
+        "Helpers",
+      ]
+    ),
+    .testTarget(
+      name: "AuthTests",
+      dependencies: [
+        .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        "Auth",
+        "Helpers",
+        "TestHelpers",
+      ],
+      exclude: [
+        "__Snapshots__"
+      ],
+      resources: [.process("Resources")]
+    ),
+    .target(
+      name: "Functions",
+      dependencies: [
+        "Helpers"
+      ]
+    ),
+    .testTarget(
+      name: "FunctionsTests",
+      dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        "Functions",
+        "Mocker",
+        "TestHelpers",
+      ]
+    ),
+    .testTarget(
+      name: "IntegrationTests",
+      dependencies: [
+        .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        "Helpers",
+        "Supabase",
+        "TestHelpers",
+      ],
+      resources: [
+        .process("Fixtures"),
+        .process("supabase"),
+      ]
+    ),
+    .target(
+      name: "PostgREST",
+      dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        "Helpers",
+      ]
+    ),
+    .testTarget(
+      name: "PostgRESTTests",
+      dependencies: [
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+        "Helpers",
+        "Mocker",
+        "PostgREST",
+        "TestHelpers",
+      ]
+    ),
+    .target(
+      name: "Realtime",
+      dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        "Helpers",
+      ]
+    ),
+    .testTarget(
+      name: "RealtimeTests",
+      dependencies: [
+        .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        "PostgREST",
+        "Realtime",
+        "TestHelpers",
+      ]
+    ),
+    .target(
+      name: "Storage",
+      dependencies: [
+        "Helpers"
+      ]
+    ),
+    .testTarget(
+      name: "StorageTests",
+      dependencies: [
+        .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        "Mocker",
+        "TestHelpers",
+        "Storage",
+      ],
+      resources: [
+        .copy("sadcat.jpg"),
+        .process("Fixtures"),
+      ]
+    ),
+    .target(
+      name: "Supabase",
+      dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        "Auth",
+        "Functions",
+        "PostgREST",
+        "Realtime",
+        "Storage",
+      ]
+    ),
+    .testTarget(
+      name: "SupabaseTests",
+      dependencies: [
+        .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        "Supabase",
+      ]
+    ),
+    .target(
+      name: "TestHelpers",
+      dependencies: [
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        "Auth",
+        "Mocker",
+      ]
+    ),
+  ],
+  swiftLanguageModes: [.v5]
+)
+
+for target in package.targets where !target.isTest {
+  target.swiftSettings = [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableExperimentalFeature("StrictConcurrency"),
+  ]
+}

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -2211,6 +2211,12 @@ final class AuthClientTests: XCTestCase {
 
     Dependencies[sut.clientID].sessionStorage.store(.expiredSession)
 
+    #if EmitLocalSessionAsInitialSession
+      let expectedEvents = [AuthChangeEvent.initialSession, .signedOut]
+    #else
+      let expectedEvents = [AuthChangeEvent.signedOut, .initialSession]
+    #endif
+
     try await assertAuthStateChanges(
       sut: sut,
       action: {
@@ -2221,7 +2227,7 @@ final class AuthClientTests: XCTestCase {
           XCTAssertEqual(error as? AuthError, .sessionMissing)
         }
       },
-      expectedEvents: [.initialSession, .signedOut]
+      expectedEvents: expectedEvents
     )
 
     XCTAssertNil(Dependencies[sut.clientID].sessionStorage.get())
@@ -2241,12 +2247,18 @@ final class AuthClientTests: XCTestCase {
 
     Dependencies[sut.clientID].sessionStorage.store(.expiredSession)
 
+    #if EmitLocalSessionAsInitialSession
+      let expectedEvents = [AuthChangeEvent.initialSession, .tokenRefreshed]
+    #else
+      let expectedEvents = [AuthChangeEvent.tokenRefreshed, .initialSession]
+    #endif
+
     try await assertAuthStateChanges(
       sut: sut,
       action: {
         _ = try await sut.session
       },
-      expectedEvents: [.initialSession, .tokenRefreshed]
+      expectedEvents: expectedEvents
     )
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

1. Customer reads the `currentSession` variable which returns the stored session, without validating if it is expired or not, and lets users in.
2. Then the customer attaches an authStateChange listener and receives initialSession = nil, since the stored session couldn't be refreshed.
3. The user has been logged in but now has no session, making all API calls fail.

Although the behavior above isn't wrong nor a bug, since it is documented that the `currentSession` may have been expired, it is a behavior that just brings more confusion to the usage.

## What is the new behavior?

Added a new trait `EmitLocalSessionAsInitialSession` for customers to opt-in to the new behavior since this is a breaking change.

```swift
supabase.auth.onAuthStateChanges { event, session in 
    if event == .initialSession {
        if let session {
            if session.isExpired {
                // Session exists but has been expired. It will try to refresh it in the background and emit a `tokenRefresh` or `signOut` event depending on the result.
                // Probably should show a loading indicator until a `tokenRefreshed`/`signOut` event is received.
            } else {
                // Session exists and is valid, can let user in.
            }
        } else {
            // Session does not exist, user needs to sign in
        }
    } else if event == .tokenRefreshed {
        assert(session != nil && session?.isExpired == false)
    } else if event == .signOut {
        assert(session == nil)
    }
}

```

## Additional context

https://github.com/supabase/supabase-swift/issues/630
https://github.com/supabase/supabase-swift/issues/753