### PR TITLE
chore: change 'client' to 'SDK' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsupabase%2Fsupabase-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/supabase/supabase-swift)
 [![Coverage Status](https://coveralls.io/repos/github/supabase/supabase-swift/badge.svg?branch=main)](https://coveralls.io/github/supabase/supabase-swift?branch=main)
 
-Supabase client for Swift. Mirrors the design of [supabase-js](https://github.com/supabase/supabase-js/blob/master/README.md).
+Supabase SDK for Swift. Mirrors the design of [supabase-js](https://github.com/supabase/supabase-js/blob/master/README.md).
 
 * Documentation: [https://supabase.com/docs/reference/swift/introduction](https://supabase.com/docs/reference/swift/introduction)
 


### PR DESCRIPTION
Updated the description of the Supabase client to reflect it as an SDK.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
