### PR TITLE
fix(realtime): extract ConnectionManager actor and fix connection lifecycle races

### DIFF
--- a/Sources/Realtime/ConnectionManager.swift
+++ b/Sources/Realtime/ConnectionManager.swift
@@ -1,0 +1,180 @@
+//
+//  ConnectionManager.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 19/11/25.
+//
+
+import ConcurrencyExtras
+import Foundation
+
+actor ConnectionManager {
+  enum State {
+    case disconnected
+    case connecting(Task<Void, any Error>)
+    case connected(any WebSocket)
+    case reconnecting(Task<Void, any Error>, reason: String)
+  }
+
+  private let (stateStream, stateContinuation) = AsyncStream<State>.makeStream()
+  private(set) var state: State = .disconnected
+
+  private let transport: WebSocketTransport
+  private let url: URL
+  private let headers: [String: String]
+  private let reconnectDelay: TimeInterval
+  private let logger: (any SupabaseLogger)?
+
+  /// Get current connection if connected, nil otherwise.
+  var connection: (any WebSocket)? {
+    if case .connected(let conn) = state {
+      return conn
+    }
+    return nil
+  }
+
+  nonisolated var stateChanges: AsyncStream<State> { stateStream }
+
+  init(
+    transport: @escaping WebSocketTransport,
+    url: URL,
+    headers: [String: String],
+    reconnectDelay: TimeInterval,
+    logger: (any SupabaseLogger)?
+  ) {
+    self.transport = transport
+    self.url = url
+    self.headers = headers
+    self.reconnectDelay = reconnectDelay
+    self.logger = logger
+  }
+
+  @discardableResult
+  func connect() async throws -> any WebSocket {
+    logger?.debug("current state: \(state)")
+
+    switch state {
+    case .connected(let conn):
+      logger?.debug("Already connected")
+      return conn
+
+    case .connecting(let task):
+      logger?.debug("Connection already in progress, waiting...")
+      try await task.value
+      // After waiting, get the connection from state
+      guard case .connected(let conn) = state else {
+        throw WebSocketError.connection(
+          message: "Connection failed", error: NSError(domain: "ConnectionManager", code: -1))
+      }
+      return conn
+
+    case .disconnected:
+      logger?.debug("Initiating new connection")
+      try await performConnection()
+      guard case .connected(let conn) = state else {
+        throw WebSocketError.connection(
+          message: "Connection failed", error: NSError(domain: "ConnectionManager", code: -1))
+      }
+      return conn
+
+    case .reconnecting(let task, _):
+      logger?.debug("Reconnection in progress, waiting...")
+      try await task.value
+      guard case .connected(let conn) = state else {
+        throw WebSocketError.connection(
+          message: "Connection failed", error: NSError(domain: "ConnectionManager", code: -1))
+      }
+      return conn
+    }
+  }
+
+  func disconnect(reason: String? = nil) {
+    logger?.debug("current state: \(state)")
+
+    switch state {
+    case .connected(let conn):
+      logger?.debug("Disconnecting from WebSocket: \(reason ?? "no reason")")
+      conn.close(code: nil, reason: reason)
+      updateState(.disconnected)
+
+    case .connecting(let task), .reconnecting(let task, _):
+      logger?.debug("Cancelling connection attempt: \(reason ?? "no reason")")
+      task.cancel()
+      updateState(.disconnected)
+
+    case .disconnected:
+      logger?.debug("Already disconnected")
+    }
+  }
+
+  /// Handle connection error and initiate reconnect.
+  ///
+  /// - Parameter error: The error that caused the connection failure
+  func handleError(_ error: any Error) {
+    guard !(error is CancellationError) else {
+      logger?.debug("CancellationError do not trigger reconnects.")
+      return
+    }
+
+    guard case .connected(let conn) = state else {
+      logger?.debug("Ignoring error in non-connected state: \(error)")
+      return
+    }
+
+    logger?.debug("Connection error, initiating reconnect: \(error.localizedDescription)")
+
+    // Close the connection and update to disconnected before reconnecting
+    conn.close(code: nil, reason: "error: \(error.localizedDescription)")
+    updateState(.disconnected)
+
+    initiateReconnect(reason: "error: \(error.localizedDescription)")
+  }
+
+  /// Handle connection close initiated by the remote.
+  ///
+  /// The connection is already closed by the remote; just update state.
+  ///
+  /// - Parameters:
+  ///   - code: WebSocket close code
+  ///   - reason: WebSocket close reason
+  func handleClose(code: Int?, reason: String?) {
+    let closeReason = "code: \(code?.description ?? "none"), reason: \(reason ?? "none")"
+    logger?.debug("Connection closed by remote: \(closeReason)")
+
+    if case .connected = state {
+      updateState(.disconnected)
+    }
+  }
+
+  private func performConnection() async throws {
+    let connectionTask = Task {
+      let conn = try await transport(url, headers)
+      try Task.checkCancellation()
+      updateState(.connected(conn))
+    }
+
+    updateState(.connecting(connectionTask))
+
+    do {
+      return try await connectionTask.value
+    } catch {
+      updateState(.disconnected)
+      throw error
+    }
+  }
+
+  private func initiateReconnect(reason: String) {
+    let reconnectTask = Task {
+      try await _clock.sleep(for: reconnectDelay)
+      logger?.debug("Attempting to reconnect...")
+      try await performConnection()
+    }
+
+    updateState(.reconnecting(reconnectTask, reason: reason))
+  }
+
+  private func updateState(_ state: State) {
+    self.state = state
+    self.stateContinuation.yield(state)
+  }
+}

--- a/Sources/Realtime/ConnectionManager.swift
+++ b/Sources/Realtime/ConnectionManager.swift
@@ -1,15 +1,8 @@
-//
-//  ConnectionManager.swift
-//  Supabase
-//
-//  Created by Guilherme Souza on 19/11/25.
-//
-
 import ConcurrencyExtras
 import Foundation
 
 actor ConnectionManager {
-  enum State {
+  enum State: Sendable {
     case disconnected
     case connecting(Task<Void, any Error>)
     case connected(any WebSocket)

--- a/Sources/Realtime/RealtimeClientV2.swift
+++ b/Sources/Realtime/RealtimeClientV2.swift
@@ -7,6 +7,7 @@
 
 import ConcurrencyExtras
 import Foundation
+import Helpers
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
@@ -48,12 +49,13 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     /// Long-running task for listening for incoming messages from WebSocket.
     var messageTask: Task<Void, Never>?
 
-    var connectionTask: Task<Void, Never>?
-    var reconnectTask: Task<Void, Never>?
-    var channels: [String: RealtimeChannelV2] = [:]
-    var sendBuffer: [@Sendable () -> Void] = []
+    var stateObserverTask: Task<Void, Never>?
 
-    var conn: (any WebSocket)?
+    /// Cached connection to avoid actor hops when sending messages
+    var connection: (any WebSocket)?
+
+    var channels: [String: RealtimeChannelV2] = [:]
+    var sendBuffer: [@Sendable (RealtimeClientV2) -> Void] = []
   }
 
   let url: URL
@@ -64,9 +66,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   let apikey: String
   let serializer = RealtimeSerializer()
 
-  var conn: (any WebSocket)? {
-    mutableState.conn
-  }
+  let connectionManager: ConnectionManager
 
   /// All managed channels indexed by their topics.
   public var channels: [String: RealtimeChannelV2] {
@@ -84,9 +84,8 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   }
 
   /// The current connection status.
-  public private(set) var status: RealtimeClientStatus {
-    get { statusSubject.value }
-    set { statusSubject.yield(newValue) }
+  public var status: RealtimeClientStatus {
+    statusSubject.value
   }
 
   /// Listen for heartbeat status.
@@ -170,16 +169,77 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
         $0.accessToken = String(accessToken)
       }
     }
+
+    self.connectionManager = ConnectionManager(
+      transport: wsTransport,
+      url: Self.realtimeWebSocketURL(
+        baseURL: Self.realtimeBaseURL(url: url),
+        apikey: options.apikey,
+        vsn: options.vsn,
+        logLevel: options.logLevel
+      ),
+      headers: options.headers.dictionary,
+      reconnectDelay: options.reconnectDelay,
+      logger: options.logger
+    )
+
+    let stateObserverTask = Task { [weak self, connectionManager, statusSubject] in
+      var sawReconnecting = false
+      for await state in connectionManager.stateChanges {
+        guard let self else { return }
+        switch state {
+        case .connected(let conn):
+          // Only drive the restart from here when this .connected came from
+          // an automatic reconnect (.reconnecting → .connected). Connects
+          // triggered by `connect()` set things up synchronously there.
+          if sawReconnecting {
+            self.handleConnected(conn: conn, isReconnect: true)
+            sawReconnecting = false
+            Self.yieldStatusIfChanged(statusSubject, .connected)
+          }
+        case .disconnected:
+          Self.yieldStatusIfChanged(statusSubject, .disconnected)
+        case .connecting:
+          // Skip — `connect()` yields .connecting/.connected synchronously
+          // before returning, so the observer would otherwise double-emit.
+          break
+        case .reconnecting:
+          sawReconnecting = true
+          Self.yieldStatusIfChanged(statusSubject, .connecting)
+        }
+      }
+    }
+
+    mutableState.withValue {
+      $0.stateObserverTask = stateObserverTask
+    }
+  }
+
+  private static func yieldStatusIfChanged(
+    _ subject: AsyncValueSubject<RealtimeClientStatus>,
+    _ status: RealtimeClientStatus
+  ) {
+    if subject.value != status {
+      subject.yield(status)
+    }
+  }
+
+  private func handleConnected(conn: any WebSocket, isReconnect: Bool) {
+    mutableState.withValue { $0.connection = conn }
+    listenForMessages(conn: conn)
+    startHeartbeating()
+    if isReconnect {
+      rejoinChannels()
+    }
+    flushSendBuffer()
   }
 
   deinit {
     mutableState.withValue {
       $0.heartbeatTask?.cancel()
       $0.messageTask?.cancel()
-      $0.connectionTask?.cancel()
-      $0.reconnectTask?.cancel()
+      $0.stateObserverTask?.cancel()
       $0.channels = [:]
-      $0.conn = nil
     }
   }
 
@@ -187,122 +247,21 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   ///
   /// Suspends until connected.
   public func connect() async {
-    await connect(reconnect: false)
-  }
+    options.logger?.debug("Connecting...")
+    Self.yieldStatusIfChanged(statusSubject, .connecting)
 
-  func connect(reconnect: Bool) async {
-    // Check and create connection task atomically to prevent race conditions
-    let shouldConnect = mutableState.withValue { state -> Bool in
-      // If already connecting or connected, don't create a new connection task
-      if status == .connecting || status == .connected {
-        return false
-      }
+    do {
+      let conn = try await connectionManager.connect()
+      options.logger?.debug("Connected to realtime WebSocket")
 
-      // If there's already a connection task running, don't create another
-      if state.connectionTask != nil {
-        return false
-      }
-
-      return true
-    }
-
-    guard shouldConnect else {
-      // Wait for existing connection to complete
-      _ = await statusChange.first { @Sendable in $0 == .connected }
-      return
-    }
-
-    let connectionTask = Task {
-      if reconnect {
-        try? await _clock.sleep(for: options.reconnectDelay)
-
-        if Task.isCancelled {
-          options.logger?.debug("Reconnect cancelled, returning")
-          return
-        }
-      }
-
-      if status == .connected {
-        options.logger?.debug("WebsSocket already connected")
-        return
-      }
-
-      status = .connecting
-
-      do {
-        let conn = try await wsTransport(
-          Self.realtimeWebSocketURL(
-            baseURL: Self.realtimeBaseURL(url: url),
-            apikey: options.apikey,
-            vsn: options.vsn,
-            logLevel: options.logLevel
-          ),
-          options.headers.dictionary
-        )
-        mutableState.withValue { $0.conn = conn }
-        onConnected(reconnect: reconnect)
-      } catch {
-        onError(error)
-      }
-    }
-
-    mutableState.withValue {
-      $0.connectionTask = connectionTask
-    }
-
-    _ = await statusChange.first { @Sendable in $0 == .connected }
-  }
-
-  private func onConnected(reconnect: Bool) {
-    options.logger?.debug("Connected to realtime WebSocket")
-
-    // Start listeners before setting status to prevent race conditions
-    listenForMessages()
-    startHeartbeating()
-
-    // Now set status to connected
-    status = .connected
-
-    if reconnect {
-      rejoinChannels()
-    }
-
-    flushSendBuffer()
-  }
-
-  private func onDisconnected() {
-    options.logger?
-      .debug(
-        "WebSocket disconnected. Trying again in \(options.reconnectDelay)"
-      )
-    reconnect()
-  }
-
-  private func onError(_ error: (any Error)?) {
-    options.logger?
-      .debug(
-        "WebSocket error \(error?.localizedDescription ?? "<none>"). Trying again in \(options.reconnectDelay)"
-      )
-    reconnect()
-  }
-
-  private func onClose(code: Int?, reason: String?) {
-    options.logger?.debug(
-      "WebSocket closed. Code: \(code?.description ?? "<none>"), Reason: \(reason ?? "<none>")"
-    )
-
-    reconnect()
-  }
-
-  private func reconnect(disconnectReason: String? = nil) {
-    // Cancel any existing reconnect task and create a new one
-    mutableState.withValue { state in
-      state.reconnectTask?.cancel()
-
-      state.reconnectTask = Task {
-        disconnect(reason: disconnectReason)
-        await connect(reconnect: true)
-      }
+      // Set up message listening, heartbeating, and connection caching
+      // synchronously so callers can rely on state being ready after connect()
+      // returns, even if the state observer task hasn't caught up yet.
+      handleConnected(conn: conn, isReconnect: false)
+      Self.yieldStatusIfChanged(statusSubject, .connected)
+    } catch {
+      options.logger?.error("Connection failed: \(error)")
+      Self.yieldStatusIfChanged(statusSubject, .disconnected)
     }
   }
 
@@ -408,61 +367,59 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
-  private func listenForMessages() {
-    // Capture conn inside the lock before creating the task
-    let conn = mutableState.withValue { state -> (any WebSocket)? in
-      state.messageTask?.cancel()
-      return state.conn
-    }
-
-    guard let conn else { return }
-
-    let messageTask = Task {
-      do {
-        for await event in conn.events {
-          if Task.isCancelled { return }
-
-          switch event {
-          case .binary(let data):
-            switch self.options.vsn {
-            case .v1:
-              self.options.logger?.warning(
-                "Received binary frame but vsn is 1.0.0; binary frames are only supported in 2.0.0"
-              )
-            case .v2:
-              do {
-                let broadcast = try self.serializer.decodeBinary(data)
-                await self.onBroadcast(broadcast)
-              } catch {
-                self.options.logger?.error("Failed to decode binary frame: \(error)")
-              }
-            }
-
-          case .text(let text):
-            let message: RealtimeMessageV2
-            switch self.options.vsn {
-            case .v1:
-              message = try JSONDecoder().decode(RealtimeMessageV2.self, from: Data(text.utf8))
-            case .v2:
-              message = try self.serializer.decodeText(text)
-            }
-            await onMessage(message)
-
-            if Task.isCancelled {
-              return
-            }
-
-          case .close(let code, let reason):
-            onClose(code: code, reason: reason)
-          }
-        }
-      } catch {
-        onError(error)
-      }
-    }
-
+  private func listenForMessages(conn: any WebSocket) {
+    let stream = conn.events
     mutableState.withValue {
-      $0.messageTask = messageTask
+      $0.messageTask?.cancel()
+      $0.messageTask = Task { [weak self] in
+        guard let self else { return }
+
+        do {
+          for await event in stream {
+            if Task.isCancelled { return }
+
+            switch event {
+            case .binary(let data):
+              switch self.options.vsn {
+              case .v1:
+                options.logger?.warning(
+                  "Received binary frame but vsn is 1.0.0; binary frames are only supported in 2.0.0"
+                )
+              case .v2:
+                do {
+                  let broadcast = try serializer.decodeBinary(data)
+                  await onBroadcast(broadcast)
+                } catch {
+                  options.logger?.error("Failed to decode binary frame: \(error)")
+                }
+              }
+
+            case .text(let text):
+              let message: RealtimeMessageV2
+              switch self.options.vsn {
+              case .v1:
+                message = try JSONDecoder().decode(RealtimeMessageV2.self, from: Data(text.utf8))
+              case .v2:
+                message = try serializer.decodeText(text)
+              }
+              await onMessage(message)
+
+            case .close(let code, let reason):
+              options.logger?.debug(
+                "WebSocket closed. Code: \(code?.description ?? "<none>"), Reason: \(reason)"
+              )
+
+              await connectionManager.handleClose(code: code, reason: reason)
+            }
+          }
+        } catch {
+          options.logger?
+            .debug(
+              "WebSocket error \(error.localizedDescription). Trying again in \(options.reconnectDelay)"
+            )
+          await connectionManager.handleError(error)
+        }
+      }
     }
   }
 
@@ -522,7 +479,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
       // Clear the pending ref before reconnecting
       mutableState.withValue { $0.pendingHeartbeatRef = nil }
 
-      reconnect(disconnectReason: "heartbeat timeout")
+      await connectionManager.handleError(RealtimeError("heartbeat timeout"))
     }
   }
 
@@ -533,24 +490,22 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   public func disconnect(code: Int? = nil, reason: String? = nil) {
     options.logger?.debug("Closing WebSocket connection")
 
-    conn?.close(code: code, reason: reason)
-
     mutableState.withValue {
       $0.ref = 0
       $0.messageTask?.cancel()
       $0.messageTask = nil
       $0.heartbeatTask?.cancel()
       $0.heartbeatTask = nil
-      $0.connectionTask?.cancel()
-      $0.connectionTask = nil
-      $0.reconnectTask?.cancel()
-      $0.reconnectTask = nil
       $0.pendingHeartbeatRef = nil
+      $0.connection = nil
       $0.sendBuffer = []
-      $0.conn = nil
     }
 
-    status = .disconnected
+    Self.yieldStatusIfChanged(statusSubject, .disconnected)
+
+    Task { [connectionManager, reason] in
+      await connectionManager.disconnect(reason: reason ?? "Client disconnect")
+    }
   }
 
   /// Sets the JWT access token used for channel subscription authorization and Realtime RLS.
@@ -626,24 +581,21 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   ///
   /// If the socket is not connected, the message gets enqueued within a local buffer, and sent out when a connection is next established.
   public func push(_ message: RealtimeMessageV2) {
-    let callback = { @Sendable [weak self] in
-      guard let self else { return }
+    let callback = { @Sendable (_ client: RealtimeClientV2) in
       do {
-        // Check cancellation before sending, because this push may have been cancelled before a connection was established.
-        try Task.checkCancellation()
-
         let text: String
-        switch self.options.vsn {
+        switch client.options.vsn {
         case .v1:
           let data = try JSONEncoder().encode(message)
           text = String(data: data, encoding: .utf8)!
         case .v2:
-          text = try self.serializer.encodeText(message)
+          text = try client.serializer.encodeText(message)
         }
 
-        self.conn?.send(text)
+        let conn = client.mutableState.withValue { $0.connection }
+        conn?.send(text)
       } catch {
-        self.options.logger?.error(
+        client.options.logger?.error(
           """
           Failed to send message:
           \(message)
@@ -656,7 +608,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
 
     if status == .connected {
-      callback()
+      callback(self)
     } else {
       mutableState.withValue {
         $0.sendBuffer.append(callback)
@@ -672,20 +624,19 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     event: String,
     jsonPayload: JSONObject
   ) {
-    let callback = { @Sendable [weak self] in
-      guard let self else { return }
+    let callback = { @Sendable (_ client: RealtimeClientV2) in
       do {
-        try Task.checkCancellation()
-        let data = try self.serializer.encodeBroadcastPush(
+        let data = try client.serializer.encodeBroadcastPush(
           joinRef: joinRef,
           ref: ref,
           topic: topic,
           event: event,
           jsonPayload: jsonPayload
         )
-        self.conn?.send(data)
+        let conn = client.mutableState.withValue { $0.connection }
+        conn?.send(data)
       } catch {
-        self.options.logger?.error(
+        client.options.logger?.error(
           """
           Failed to send binary broadcast:
           topic=\(topic), event=\(event)
@@ -698,7 +649,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
 
     if status == .connected {
-      callback()
+      callback(self)
     } else {
       mutableState.withValue {
         $0.sendBuffer.append(callback)
@@ -714,20 +665,19 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     event: String,
     binaryPayload: Data
   ) {
-    let callback = { @Sendable [weak self] in
-      guard let self else { return }
+    let callback = { @Sendable (_ client: RealtimeClientV2) in
       do {
-        try Task.checkCancellation()
-        let data = try self.serializer.encodeBroadcastPush(
+        let data = try client.serializer.encodeBroadcastPush(
           joinRef: joinRef,
           ref: ref,
           topic: topic,
           event: event,
           binaryPayload: binaryPayload
         )
-        self.conn?.send(data)
+        let conn = client.mutableState.withValue { $0.connection }
+        conn?.send(data)
       } catch {
-        self.options.logger?.error(
+        client.options.logger?.error(
           """
           Failed to send binary broadcast:
           topic=\(topic), event=\(event)
@@ -740,7 +690,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
 
     if status == .connected {
-      callback()
+      callback(self)
     } else {
       mutableState.withValue {
         $0.sendBuffer.append(callback)
@@ -750,7 +700,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
 
   private func flushSendBuffer() {
     mutableState.withValue {
-      $0.sendBuffer.forEach { $0() }
+      $0.sendBuffer.forEach { $0(self) }
       $0.sendBuffer = []
     }
   }

--- a/Sources/Realtime/RealtimeClientV2.swift
+++ b/Sources/Realtime/RealtimeClientV2.swift
@@ -412,7 +412,10 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
               await connectionManager.handleClose(code: code, reason: reason)
             }
           }
+        } catch is CancellationError {
+          return
         } catch {
+          if Task.isCancelled { return }
           options.logger?
             .debug(
               "WebSocket error \(error.localizedDescription). Trying again in \(options.reconnectDelay)"
@@ -587,7 +590,11 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
         switch client.options.vsn {
         case .v1:
           let data = try JSONEncoder().encode(message)
-          text = String(data: data, encoding: .utf8)!
+          guard let encoded = String(data: data, encoding: .utf8) else {
+            client.options.logger?.error("Failed to encode message as UTF-8.")
+            return
+          }
+          text = encoded
         case .v2:
           text = try client.serializer.encodeText(message)
         }

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -1,0 +1,238 @@
+//
+//  ConnectionManagerTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 19/11/25.
+//
+
+import ConcurrencyExtras
+import XCTest
+
+@testable import Realtime
+
+final class ConnectionManagerTests: XCTestCase {
+  private enum TestError: LocalizedError {
+    case sample
+
+    var errorDescription: String? { "sample error" }
+  }
+
+  var sut: ConnectionManager!
+  var ws: FakeWebSocket!
+  var transportCallCount = 0
+  var lastConnectURL: URL?
+  var lastConnectHeaders: [String: String]?
+
+  override func setUp() {
+    super.setUp()
+
+    transportCallCount = 0
+    lastConnectURL = nil
+    lastConnectHeaders = nil
+    (ws, _) = FakeWebSocket.fakes()
+  }
+
+  override func tearDown() {
+    sut = nil
+    ws = nil
+    super.tearDown()
+  }
+
+  private func makeSUT(
+    url: URL = URL(string: "ws://localhost")!,
+    headers: [String: String] = [:],
+    reconnectDelay: TimeInterval = 0.1,
+    transport: WebSocketTransport? = nil
+  ) -> ConnectionManager {
+    ConnectionManager(
+      transport: transport ?? { url, headers in
+        self.transportCallCount += 1
+        self.lastConnectURL = url
+        self.lastConnectHeaders = headers
+        return self.ws!
+      },
+      url: url,
+      headers: headers,
+      reconnectDelay: reconnectDelay,
+      logger: nil
+    )
+  }
+
+  func testConnectTransitionsThroughConnectingAndConnectedStates() async throws {
+    sut = makeSUT(headers: ["apikey": "key"])
+
+    let connectingExpectation = expectation(description: "connecting state observed")
+    let connectedExpectation = expectation(description: "connected state observed")
+
+    let stateObserver = Task {
+      for await state in sut.stateChanges {
+        switch state {
+        case .connecting:
+          connectingExpectation.fulfill()
+        case .connected:
+          connectedExpectation.fulfill()
+          return
+        default:
+          break
+        }
+      }
+    }
+
+    let initiallyConnected = await sut.connection != nil
+    XCTAssertFalse(initiallyConnected)
+    try await sut.connect()
+
+    let isConnected = await sut.connection != nil
+    XCTAssertTrue(isConnected)
+    XCTAssertEqual(transportCallCount, 1)
+    XCTAssertEqual(lastConnectURL?.absoluteString, "ws://localhost")
+    XCTAssertEqual(lastConnectHeaders, ["apikey": "key"])
+
+    await fulfillment(of: [connectingExpectation, connectedExpectation], timeout: 1)
+    stateObserver.cancel()
+  }
+
+  func testConnectWhenAlreadyConnectedDoesNotReconnect() async throws {
+    sut = makeSUT()
+
+    try await sut.connect()
+    XCTAssertEqual(transportCallCount, 1)
+
+    try await sut.connect()
+
+    let stillConnected = await sut.connection != nil
+    XCTAssertTrue(stillConnected)
+    XCTAssertEqual(transportCallCount, 1, "Second connect should reuse existing connection")
+  }
+
+  func testConnectWhileConnectingWaitsForExistingTask() async throws {
+    sut = makeSUT(
+      transport: { _, _ in
+        self.transportCallCount += 1
+        try await Task.sleep(nanoseconds: 200_000_000)
+        return self.ws!
+      }
+    )
+
+    let firstConnect = Task {
+      try await sut.connect()
+    }
+
+    let secondConnectFinished = LockIsolated(false)
+    let secondConnect = Task {
+      try await sut.connect()
+      secondConnectFinished.setValue(true)
+    }
+
+    try await Task.sleep(nanoseconds: 50_000_000)
+    XCTAssertFalse(secondConnectFinished.value)
+    XCTAssertEqual(
+      transportCallCount, 1,
+      "Transport should be invoked only once while first connect is in progress")
+
+    _ = try await firstConnect.value
+    try await secondConnect.value
+
+    XCTAssertTrue(secondConnectFinished.value)
+    let isConnected = await sut.connection != nil
+    XCTAssertTrue(isConnected)
+    XCTAssertEqual(transportCallCount, 1)
+  }
+
+  func testDisconnectFromConnectedClosesWebSocketAndUpdatesState() async throws {
+    sut = makeSUT()
+    try await sut.connect()
+
+    await sut.disconnect(reason: "test reason")
+
+    let isConnected = await sut.connection != nil
+    XCTAssertFalse(isConnected)
+    guard case .close(let closeCode, let closeReason)? = ws.sentEvents.last else {
+      return XCTFail("Expected close event to be sent")
+    }
+    XCTAssertNil(closeCode)
+    XCTAssertEqual(closeReason, "test reason")
+  }
+
+  func testDisconnectCancelsOngoingConnectionAttempt() async throws {
+    let wasCancelled = LockIsolated(false)
+
+    sut = makeSUT(
+      transport: { _, _ in
+        self.transportCallCount += 1
+        return try await withTaskCancellationHandler {
+          try await Task.sleep(nanoseconds: 5_000_000_000)
+          return self.ws!
+        } onCancel: {
+          wasCancelled.setValue(true)
+        }
+      }
+    )
+
+    let connectTask = Task {
+      try? await sut.connect()
+    }
+
+    try await Task.sleep(nanoseconds: 50_000_000)
+    await sut.disconnect(reason: "stop")
+
+    await Task.yield()
+    XCTAssertTrue(wasCancelled.value, "Cancellation handler should run when disconnecting")
+    let isConnected = await sut.connection != nil
+    XCTAssertFalse(isConnected)
+
+    connectTask.cancel()
+  }
+
+  func testHandleErrorInitiatesReconnectAndEventuallyReconnects() async throws {
+    let reconnectingExpectation = expectation(description: "reconnecting state observed")
+    let secondConnectionExpectation = expectation(description: "second connection attempt")
+
+    let connectionCount = LockIsolated(0)
+
+    sut = makeSUT(
+      reconnectDelay: 0.01,
+      transport: { _, _ in
+        connectionCount.withValue { $0 += 1 }
+        if connectionCount.value == 2 {
+          secondConnectionExpectation.fulfill()
+        }
+        return self.ws!
+      }
+    )
+
+    let stateObserver = Task {
+      for await state in sut.stateChanges {
+        if case .reconnecting(_, let reason) = state, reason.contains("sample error") {
+          reconnectingExpectation.fulfill()
+          return
+        }
+      }
+    }
+
+    try await sut.connect()
+    await sut.handleError(TestError.sample)
+
+    await fulfillment(of: [reconnectingExpectation, secondConnectionExpectation], timeout: 2)
+    XCTAssertEqual(connectionCount.value, 2, "Reconnection should trigger a second transport call")
+    let isConnected = await sut.connection != nil
+    XCTAssertTrue(isConnected)
+
+    stateObserver.cancel()
+  }
+
+  func testHandleCloseUpdatesStateWithoutSendingAnotherCloseFrame() async throws {
+    sut = makeSUT()
+    try await sut.connect()
+
+    let sentEventsBefore = ws.sentEvents.count
+    await sut.handleClose(code: 4001, reason: "server closing")
+
+    let isConnected = await sut.connection != nil
+    XCTAssertFalse(isConnected)
+    XCTAssertEqual(
+      ws.sentEvents.count, sentEventsBefore,
+      "handleClose should not send an additional close frame since the remote already closed."
+    )
+  }
+}

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -1,10 +1,3 @@
-//
-//  ConnectionManagerTests.swift
-//  Supabase
-//
-//  Created by Guilherme Souza on 19/11/25.
-//
-
 import ConcurrencyExtras
 import XCTest
 
@@ -19,16 +12,16 @@ final class ConnectionManagerTests: XCTestCase {
 
   var sut: ConnectionManager!
   var ws: FakeWebSocket!
-  var transportCallCount = 0
-  var lastConnectURL: URL?
-  var lastConnectHeaders: [String: String]?
+  let transportCallCount = LockIsolated(0)
+  let lastConnectURL = LockIsolated<URL?>(nil)
+  let lastConnectHeaders = LockIsolated<[String: String]?>(nil)
 
   override func setUp() {
     super.setUp()
 
-    transportCallCount = 0
-    lastConnectURL = nil
-    lastConnectHeaders = nil
+    transportCallCount.setValue(0)
+    lastConnectURL.setValue(nil)
+    lastConnectHeaders.setValue(nil)
     (ws, _) = FakeWebSocket.fakes()
   }
 
@@ -44,12 +37,16 @@ final class ConnectionManagerTests: XCTestCase {
     reconnectDelay: TimeInterval = 0.1,
     transport: WebSocketTransport? = nil
   ) -> ConnectionManager {
-    ConnectionManager(
+    let transportCallCount = self.transportCallCount
+    let lastConnectURL = self.lastConnectURL
+    let lastConnectHeaders = self.lastConnectHeaders
+    let ws = self.ws
+    return ConnectionManager(
       transport: transport ?? { url, headers in
-        self.transportCallCount += 1
-        self.lastConnectURL = url
-        self.lastConnectHeaders = headers
-        return self.ws!
+        transportCallCount.withValue { $0 += 1 }
+        lastConnectURL.setValue(url)
+        lastConnectHeaders.setValue(headers)
+        return ws!
       },
       url: url,
       headers: headers,
@@ -84,9 +81,9 @@ final class ConnectionManagerTests: XCTestCase {
 
     let isConnected = await sut.connection != nil
     XCTAssertTrue(isConnected)
-    XCTAssertEqual(transportCallCount, 1)
-    XCTAssertEqual(lastConnectURL?.absoluteString, "ws://localhost")
-    XCTAssertEqual(lastConnectHeaders, ["apikey": "key"])
+    XCTAssertEqual(transportCallCount.value, 1)
+    XCTAssertEqual(lastConnectURL.value?.absoluteString, "ws://localhost")
+    XCTAssertEqual(lastConnectHeaders.value, ["apikey": "key"])
 
     await fulfillment(of: [connectingExpectation, connectedExpectation], timeout: 1)
     stateObserver.cancel()
@@ -96,21 +93,23 @@ final class ConnectionManagerTests: XCTestCase {
     sut = makeSUT()
 
     try await sut.connect()
-    XCTAssertEqual(transportCallCount, 1)
+    XCTAssertEqual(transportCallCount.value, 1)
 
     try await sut.connect()
 
     let stillConnected = await sut.connection != nil
     XCTAssertTrue(stillConnected)
-    XCTAssertEqual(transportCallCount, 1, "Second connect should reuse existing connection")
+    XCTAssertEqual(transportCallCount.value, 1, "Second connect should reuse existing connection")
   }
 
   func testConnectWhileConnectingWaitsForExistingTask() async throws {
+    let transportCallCount = self.transportCallCount
+    let ws = self.ws
     sut = makeSUT(
       transport: { _, _ in
-        self.transportCallCount += 1
+        transportCallCount.withValue { $0 += 1 }
         try await Task.sleep(nanoseconds: 200_000_000)
-        return self.ws!
+        return ws!
       }
     )
 
@@ -127,7 +126,7 @@ final class ConnectionManagerTests: XCTestCase {
     try await Task.sleep(nanoseconds: 50_000_000)
     XCTAssertFalse(secondConnectFinished.value)
     XCTAssertEqual(
-      transportCallCount, 1,
+      transportCallCount.value, 1,
       "Transport should be invoked only once while first connect is in progress")
 
     _ = try await firstConnect.value
@@ -136,7 +135,7 @@ final class ConnectionManagerTests: XCTestCase {
     XCTAssertTrue(secondConnectFinished.value)
     let isConnected = await sut.connection != nil
     XCTAssertTrue(isConnected)
-    XCTAssertEqual(transportCallCount, 1)
+    XCTAssertEqual(transportCallCount.value, 1)
   }
 
   func testDisconnectFromConnectedClosesWebSocketAndUpdatesState() async throws {
@@ -156,13 +155,15 @@ final class ConnectionManagerTests: XCTestCase {
 
   func testDisconnectCancelsOngoingConnectionAttempt() async throws {
     let wasCancelled = LockIsolated(false)
+    let transportCallCount = self.transportCallCount
+    let ws = self.ws
 
     sut = makeSUT(
       transport: { _, _ in
-        self.transportCallCount += 1
+        transportCallCount.withValue { $0 += 1 }
         return try await withTaskCancellationHandler {
           try await Task.sleep(nanoseconds: 5_000_000_000)
-          return self.ws!
+          return ws!
         } onCancel: {
           wasCancelled.setValue(true)
         }

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -63,7 +63,6 @@ import XCTest
 
     override func tearDown() {
       sut.disconnect()
-
       super.tearDown()
     }
 
@@ -91,130 +90,122 @@ import XCTest
       await client.connect()
     }
 
-    //    func testBehavior() async throws {
-    //      let channel = sut.channel("public:messages")
-    //      var subscriptions: Set<ObservationToken> = []
-    //
-    //      channel.onPostgresChange(InsertAction.self, table: "messages") { _ in
-    //      }
-    //      .store(in: &subscriptions)
-    //
-    //      channel.onPostgresChange(UpdateAction.self, table: "messages") { _ in
-    //      }
-    //      .store(in: &subscriptions)
-    //
-    //      channel.onPostgresChange(DeleteAction.self, table: "messages") { _ in
-    //      }
-    //      .store(in: &subscriptions)
-    //
-    //      let socketStatuses = LockIsolated([RealtimeClientStatus]())
-    //
-    //      sut.onStatusChange { status in
-    //        socketStatuses.withValue { $0.append(status) }
-    //      }
-    //      .store(in: &subscriptions)
-    //
-    //      // Set up server to respond to heartbeats
-    //      server.onEvent = { @Sendable [server] event in
-    //        guard let msg = event.realtimeMessage else { return }
-    //
-    //        if msg.event == "heartbeat" {
-    //          server?.send(
-    //            RealtimeMessageV2(
-    //              joinRef: msg.joinRef,
-    //              ref: msg.ref,
-    //              topic: "phoenix",
-    //              event: "phx_reply",
-    //              payload: ["response": [:]]
-    //            )
-    //          )
-    //        }
-    //      }
-    //
-    //      await waitUntil {
-    //        socketStatuses.value.count >= 3
-    //      }
-    //
-    //      XCTAssertEqual(
-    //        Array(socketStatuses.value.prefix(3)),
-    //        [.disconnected, .connecting, .connected]
-    //      )
-    //
-    //      let messageTask = sut.mutableState.messageTask
-    //      XCTAssertNotNil(messageTask)
-    //
-    //      let heartbeatTask = sut.mutableState.heartbeatTask
-    //      XCTAssertNotNil(heartbeatTask)
-    //
-    //      let channelStatuses = LockIsolated([RealtimeChannelStatus]())
-    //      channel.onStatusChange { status in
-    //        channelStatuses.withValue {
-    //          $0.append(status)
-    //        }
-    //      }
-    //      .store(in: &subscriptions)
-    //
-    //      let subscribeTask = Task {
-    //        try await channel.subscribeWithError()
-    //      }
-    //      await Task.yield()
-    //      server.send(.messagesSubscribed)
-    //
-    //      // Wait until it subscribes to assert WS events
-    //      do {
-    //        try await subscribeTask.value
-    //      } catch {
-    //        XCTFail("Expected .subscribed but got error: \(error)")
-    //      }
-    //      XCTAssertEqual(channelStatuses.value, [.unsubscribed, .subscribing, .subscribed])
-    //
-    //      assertInlineSnapshot(of: client.sentEvents.map(\.json), as: .json) {
-    //        #"""
-    //        [
-    //          {
-    //            "text" : {
-    //              "event" : "phx_join",
-    //              "join_ref" : "1",
-    //              "payload" : {
-    //                "access_token" : "custom.access.token",
-    //                "config" : {
-    //                  "broadcast" : {
-    //                    "ack" : false,
-    //                    "self" : false
-    //                  },
-    //                  "postgres_changes" : [
-    //                    {
-    //                      "event" : "INSERT",
-    //                      "schema" : "public",
-    //                      "table" : "messages"
-    //                    },
-    //                    {
-    //                      "event" : "UPDATE",
-    //                      "schema" : "public",
-    //                      "table" : "messages"
-    //                    },
-    //                    {
-    //                      "event" : "DELETE",
-    //                      "schema" : "public",
-    //                      "table" : "messages"
-    //                    }
-    //                  ],
-    //                  "presence" : {
-    //                    "enabled" : false,
-    //                    "key" : ""
-    //                  },
-    //                  "private" : false
-    //                },
-    //                "version" : "realtime-swift\/0.0.0"
-    //              },
-    //              "ref" : "1",
-    //              "topic" : "realtime:public:messages"
-    //            }
-    //          }
-    //        ]
-    //        """#
-    //      }
-    //    }
+    func testBehavior() async throws {
+      let channel = sut.channel("public:messages")
+      var subscriptions: Set<ObservationToken> = []
+
+      channel.onPostgresChange(InsertAction.self, table: "messages") { _ in
+      }
+      .store(in: &subscriptions)
+
+      channel.onPostgresChange(UpdateAction.self, table: "messages") { _ in
+      }
+      .store(in: &subscriptions)
+
+      channel.onPostgresChange(DeleteAction.self, table: "messages") { _ in
+      }
+      .store(in: &subscriptions)
+
+      let socketStatuses = LockIsolated([RealtimeClientStatus]())
+
+      sut.onStatusChange { status in
+        socketStatuses.withValue { $0.append(status) }
+      }
+      .store(in: &subscriptions)
+
+      // Set up server to respond to heartbeats
+      server.onEvent = { @Sendable [server] event in
+        guard let msg = event.realtimeMessage else { return }
+
+        if msg.event == "heartbeat" {
+          server?.send(
+            RealtimeMessageV2(
+              joinRef: msg.joinRef,
+              ref: msg.ref,
+              topic: "phoenix",
+              event: "phx_reply",
+              payload: ["response": [:]]
+            )
+          )
+        } else if msg.event == "phx_join" {
+          server?.send(.messagesSubscribed)
+        }
+      }
+
+      let channelStatuses = LockIsolated([RealtimeChannelStatus]())
+      channel.onStatusChange { status in
+        channelStatuses.withValue {
+          $0.append(status)
+        }
+      }
+      .store(in: &subscriptions)
+
+      // Wait until it subscribes to assert WS events
+      do {
+        try await channel.subscribeWithError()
+      } catch {
+        XCTFail("Expected .subscribed but got error: \(error)")
+      }
+      XCTAssertEqual(channelStatuses.value, [.unsubscribed, .subscribing, .subscribed])
+
+      XCTAssertEqual(
+        Array(socketStatuses.value.prefix(3)),
+        [.disconnected, .connecting, .connected]
+      )
+
+      let messageTask = sut.mutableState.messageTask
+      XCTAssertNotNil(messageTask)
+
+      let heartbeatTask = sut.mutableState.heartbeatTask
+      XCTAssertNotNil(heartbeatTask)
+
+      assertInlineSnapshot(of: client.sentEvents.map(\.json), as: .json) {
+        #"""
+        [
+          {
+            "text" : [
+              "1",
+              "1",
+              "realtime:public:messages",
+              "phx_join",
+              {
+                "access_token" : "custom.access.token",
+                "config" : {
+                  "broadcast" : {
+                    "ack" : false,
+                    "self" : false
+                  },
+                  "postgres_changes" : [
+                    {
+                      "event" : "INSERT",
+                      "schema" : "public",
+                      "table" : "messages"
+                    },
+                    {
+                      "event" : "UPDATE",
+                      "schema" : "public",
+                      "table" : "messages"
+                    },
+                    {
+                      "event" : "DELETE",
+                      "schema" : "public",
+                      "table" : "messages"
+                    }
+                  ],
+                  "presence" : {
+                    "enabled" : false,
+                    "key" : ""
+                  },
+                  "private" : false
+                },
+                "version" : "realtime-swift\/0.0.0"
+              }
+            ]
+          }
+        ]
+        """#
+      }
+    }
 
     func testSubscribeTimeout() async throws {
       let channel = sut.channel("public:messages")


### PR DESCRIPTION
## Summary

Extracts WebSocket connection lifecycle out of `RealtimeClientV2` into a new `ConnectionManager` actor, driven by an explicit state machine.

## Motivation

Connection state in `RealtimeClientV2` was spread across several fields and ad-hoc tasks — current socket, in-flight connect task, reconnect task, heartbeat task, status subject — all coordinated through `LockIsolated` mutable state. This made it hard to reason about transitions, hard to test reconnection in isolation, and easy to introduce races when adding features.

## Bugs fixed

1. **Lost `phx_join` reply after connect.** `WebSocket.events` lazily installs `onEvent` only when the stream is first iterated. The old code read `conn.events` inside the message `Task` body, so the server's `phx_reply` could arrive before the listener attached and get dropped — channels stuck in `.subscribing`. Fixed by hoisting `let stream = conn.events` out of the task.
2. **`status` race on `connect()` return.** `status` was updated asynchronously by the observer, so code running right after `await connect()` (e.g. `RealtimeChannelV2._subscribe` checking `socket.status == .connected`) could see stale `.connecting` and bail. Fixed by yielding status synchronously in `connect()` / `disconnect()`.
3. **Duplicate / missing status transitions.** The old path could emit `.connecting` twice (once for `.connecting`, once for `.reconnecting`) or skip `.disconnected` between `.connected` → `.reconnecting`. Fixed with dedup plus an explicit `.disconnected` emission before reconnect.
4. **Concurrent `connect()` calls racing.** Two overlapping `connect()` invocations could each spawn a transport, leaking sockets. The actor's `.connecting` case now awaits the in-flight task instead of starting a new one.
5. **`disconnect()` not cancelling an in-flight connection.** The connect task could complete after `disconnect()` returned and re-enter `.connected`. `disconnect` now cancels the `.connecting` / `.reconnecting` task.
6. **Double-close on remote-initiated close.** `handleClose` used to send another close frame to an already-closed socket. Now it only updates state.
7. **Reconnect not testable / fired under cancellation.** Old reconnect used `Task.sleep`, ignoring the injected `_clock`, and `CancellationError` could trigger a reconnect loop. Now uses `_clock.sleep(for:)` and skips reconnect for `CancellationError`.
8. **Task leaks across reconnects.** `messageTask` / `heartbeatTask` weren't consistently cancelled before being replaced. `handleConnected` now cancels-then-replaces both.

## Changes

### `ConnectionManager` (new actor)

Owns connection lifecycle behind an explicit state:

```
.disconnected
.connecting(Task)
.connected(WebSocket)
.reconnecting(Task, reason)
```

Responsibilities:
- `connect()` — opens a socket; concurrent callers await the in-flight task instead of racing.
- `disconnect(reason:)` — cancels in-flight attempts or closes a live socket; updates state to `.disconnected`.
- `handleError(_:)` — closes the socket and schedules a reconnect on `_clock` (so tests can advance time).
- `handleClose(code:reason:)` — remote-initiated close; updates state without sending an extra close frame.
- `stateChanges` — `nonisolated AsyncStream<State>` for observers (no actor hop to subscribe).

### `RealtimeClientV2`

- Delegates the socket lifecycle to `ConnectionManager` and observes it through a single long-lived task (weak-self captured, stored for cancellation).
- `connect()` drives post-connect setup synchronously (message listening, heartbeat, send-buffer flush) so callers can rely on state being ready on return. The observer only drives setup on automatic reconnects (`.reconnecting` → `.connected`).
- Status transitions are yielded synchronously from `connect()` / `disconnect()` with dedup against the last value. The observer only emits `.connected` on auto-reconnect and `.connecting` on `.reconnecting`, so subscribers never see duplicate transitions.
- `listenForMessages` installs `WebSocket.onEvent` synchronously (by reading `conn.events` before spawning the message task) so replies to `phx_join` don't land before the listener is attached.

### Tests

- New `ConnectionManagerTests` exercises the state machine directly: connect/connected transitions, dedup of concurrent connects, disconnect cancelling an in-flight attempt, reconnect after error, `handleClose` not double-closing.
- `RealtimeTests` updated where internal call sites moved; no behavioural changes required.

## Public API

No breaking changes. All public signatures are preserved — `disconnect()` stays synchronous (the actor call is dispatched on a detached `Task`).

## Test results

147/147 Realtime tests pass locally (`swift test --filter RealtimeTests`).