### PR TITLE
test(realtime): add tests for optional refs handling in message serialization

### DIFF
--- a/Sources/Realtime/RealtimeMessageV2.swift
+++ b/Sources/Realtime/RealtimeMessageV2.swift
@@ -1,7 +1,13 @@
 import Foundation
 
+/// A message sent over the Realtime WebSocket connection.
+///
+/// Both `joinRef` and `ref` are optional because certain messages like heartbeats
+/// don't require a join reference as they don't refer to a specific channel.
 public struct RealtimeMessageV2: Hashable, Codable, Sendable {
+  /// Optional join reference. Nil for messages like heartbeats that don't belong to a specific channel.
   public let joinRef: String?
+  /// Optional message reference. Can be nil for certain message types.
   public let ref: String?
   public let topic: String
   public let event: String


### PR DESCRIPTION
## Description

This PR adds comprehensive tests for nil ref scenarios to verify and document that optional `ref` and `joinRef` fields are properly handled in JSON encoding/decoding. The Swift SDK already has the correct implementation with optional types, but these tests prevent regressions and ensure SDK parity with other language implementations.

## Context

The JavaScript SDK recently fixed an issue with message serialization in the Realtime library to properly handle null/undefined `ref` and `join_ref` fields when encoding messages ([PR #1862](https://github.com/supabase/supabase-js/pull/1862)).

The Swift SDK already has the correct implementation:
- Both `ref` and `joinRef` are optional (`String?`)
- `Codable` protocol properly encodes/decodes optionals as JSON null
- Heartbeats already use `nil` for `joinRef` correctly

## Changes

- Added comprehensive test coverage for nil ref scenarios:
  - Messages with both refs as nil
  - Heartbeat messages with nil joinRef
  - JSON encoding/decoding with nil values
  - Messages with both ref and joinRef
  - Messages with ref but nil joinRef
- Added documentation comments to `RealtimeMessageV2` struct explaining why refs are optional

## Testing

- ✅ All new tests pass (5/5)
- ✅ All existing tests pass (7/7 total in RealtimeMessageV2Tests)
- ✅ No breaking changes - this is purely additive (tests and documentation)

## Code Review Verification

- ✅ No binary serialization paths exist that don't handle optional refs (only JSON encoding is used)
- ✅ JSON encoding/decoding handles `nil` refs correctly (Codable does this automatically)
- ✅ Heartbeats already use `nil` for `joinRef` (confirmed in `RealtimeClientV2.swift:487`)

## Related

- Linear Issue: [SDK-532](https://linear.app/supabase/issue/SDK-532)
- JavaScript SDK PR: https://github.com/supabase/supabase-js/pull/1862