### PR TITLE
feat(storage): add support for additional query items in download method

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -35,7 +35,7 @@ enum FileUpload {
     }
 
     switch self {
-    case let .data(data):
+    case .data(let data):
       formData.append(
         data,
         withName: "",
@@ -43,7 +43,7 @@ enum FileUpload {
         mimeType: options.contentType ?? mimeType(forPathExtension: path.pathExtension)
       )
 
-    case let .url(url):
+    case .url(let url):
       formData.append(url, withName: "")
     }
   }
@@ -422,14 +422,21 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// - Parameters:
   ///   - path: The file path to be downloaded, including the path and file name. For example `folder/image.png`.
   ///   - options: Transform the asset before serving it to the client.
+  ///   - additionalQueryItems: Additional query items to be added to the request.
+  /// - Returns: The data of the downloaded file.
   @discardableResult
   public func download(
     path: String,
-    options: TransformOptions? = nil
+    options: TransformOptions? = nil,
+    query additionalQueryItems: [URLQueryItem]? = nil
   ) async throws -> Data {
-    let queryItems = options?.queryItems ?? []
+    var queryItems = options?.queryItems ?? []
     let renderPath = options != nil ? "render/image/authenticated" : "object"
     let _path = _getFinalPath(path)
+
+    if let additionalQueryItems {
+      queryItems.append(contentsOf: additionalQueryItems)
+    }
 
     return try await execute(
       HTTPRequest(

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -581,6 +581,34 @@ final class StorageFileAPITests: XCTestCase {
     XCTAssertEqual(data, Data("hello world".utf8))
   }
 
+  func testDownloadWithAdditionalQuery() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/bucket/file.txt"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .get: Data("hello world".utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/storage/v1/object/bucket/file.txt?version=1"
+      """#
+    }
+    .register()
+
+    let data = try await storage.from("bucket")
+      .download(
+        path: "file.txt",
+        query: [URLQueryItem(name: "version", value: "1")]
+      )
+
+    XCTAssertEqual(data, Data("hello world".utf8))
+  }
+
   func testDownload_withOptions() async throws {
     let imageData = try! Data(
       contentsOf: Bundle.module.url(forResource: "sadcat", withExtension: "jpg")!)


### PR DESCRIPTION
### Summary
Adds support for passing additional query items to the `download` method in `StorageFileApi`, allowing users to append custom query parameters to download requests.

### Motivation
This enhancement enables users to pass custom query parameters (e.g., version numbers, cache control, etc.) when downloading files from storage, providing more flexibility in how files are requested.

### Changes
- Added optional `query additionalQueryItems: [URLQueryItem]?` parameter to `StorageFileApi.download()` method
- Query items are merged with existing transform options query items
- Added test case `testDownloadWithAdditionalQuery()` to verify the functionality
- Improved pattern matching syntax consistency (from `case let .data(data):` to `case .data(let data):`)

### Testing
- Added unit test that verifies additional query items are correctly appended to the request
- Test verifies the query parameter `version=1` is included in the download request
- All existing tests continue to pass

### Example Usage
```swift
let data = try await storage.from("bucket")
  .download(
    path: "file.txt",
    query: [URLQueryItem(name: "version", value: "1")]
  )
```