### PR TITLE
chore: update minimum Swift version to 6.1 and Xcode to 16.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,7 @@ body:
     attributes:
       label: Swift Version
       description: What version of Swift are you using?
-      placeholder: ex. 5.10
+      placeholder: ex. 6.1
     validations:
       required: true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ This is the official Supabase SDK for Swift, mirroring the design of supabase-js
 
 ### Requirements
 
-- Xcode 15.3+ (supports versions eligible for App Store submission)
-- Swift 5.10+
+- Xcode 16.3+ (supports versions eligible for App Store submission)
+- Swift 6.1+
 - Supported platforms: iOS 13.0+, macOS 10.15+, tvOS 13+, watchOS 6+, visionOS 1+
 - Linux is supported for building but not officially supported for production use
 

--- a/Examples/Examples/Profile/UserIdentityList.swift
+++ b/Examples/Examples/Profile/UserIdentityList.swift
@@ -237,30 +237,28 @@ struct UserIdentityList: View {
     }
     .id(id)
     .navigationTitle("Linked Identities")
-    #if swift(>=5.10)
-      .toolbar {
-        ToolbarItem(placement: .primaryAction) {
-          if !providers.isEmpty {
-            Menu {
-              ForEach(providers) { provider in
-                Button {
-                  Task {
-                    await linkProvider(provider)
-                  }
-                } label: {
-                  Label(
-                    provider.rawValue.capitalized,
-                    systemImage: iconForProvider(provider.rawValue)
-                  )
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        if !providers.isEmpty {
+          Menu {
+            ForEach(providers) { provider in
+              Button {
+                Task {
+                  await linkProvider(provider)
                 }
+              } label: {
+                Label(
+                  provider.rawValue.capitalized,
+                  systemImage: iconForProvider(provider.rawValue)
+                )
               }
-            } label: {
-              Label("Link Account", systemImage: "plus")
             }
+          } label: {
+            Label("Link Account", systemImage: "plus")
           }
         }
       }
-    #endif
+    }
   }
 
   private func iconForProvider(_ provider: String) -> String {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import Foundation

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Supabase SDK for Swift. Mirrors the design of [supabase-js](https://github.com/s
 
 ### Requirements
 - iOS 13.0+ / macOS 10.15+ / tvOS 13+ / watchOS 6+ / visionOS 1+
-- Xcode 15.3+
-- Swift 5.10+
+- Xcode 16.3+
+- Swift 6.1+
 
 > [!IMPORTANT]
 > Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.


### PR DESCRIPTION
## Summary
Updates minimum version requirements for the SDK:
- Swift: 5.10 → 6.1
- Xcode: 15.3 → 16.3

## Changes
- Update swift-tools-version from 5.10 to 6.1 in Package.swift
- Update Xcode requirement from 15.3+ to 16.3+ in documentation
- Update Swift requirement from 5.10+ to 6.1+ in README.md and AGENTS.md
- Remove `swift(>=5.10)` conditional compilation in UserIdentityList.swift
- Update bug report template placeholder to 6.1

## Notes
According to the project's support policy, dropping support for older Swift/Xcode versions is not considered a breaking change and occurs in minor releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)