### PR TITLE
fix(functions): sync auth headers on auth state change

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -388,9 +388,11 @@ public final class SupabaseClient: Sendable {
       return nil
     }
 
-    realtime.setAuth(accessToken)
-    await realtimeV2.setAuth(accessToken)
-    functions.setAuth(token: accessToken)
+    if let accessToken {
+      functions.setAuth(token: accessToken)
+      realtime.setAuth(accessToken)
+      await realtimeV2.setAuth(accessToken)
+    }
   }
 
   private func _initRealtimeClient() -> RealtimeClientV2 {


### PR DESCRIPTION
## Summary
FunctionsClient auth headers are not updated when auth state changes.

## Problem
While `realtime` and `realtimeV2` receive `setAuth()` calls in `handleTokenChanged()`, `functions` was missing. This causes `_invokeWithStreamedResponse` to send the anon key instead of the user's access token.

## Solution
Add `mutableState.functions?.setAuth(token: accessToken)` in `handleTokenChanged()` to sync auth headers when user signs in/out or token refreshes.

## Related
Closes #877
