### PR TITLE
ci: add 30-minute timeout to build and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
   macos:
     name: xcodebuild (macOS latest)
     runs-on: macos-15
+    timeout-minutes: 30
     strategy:
       matrix:
         command: [test, ""]
@@ -98,6 +99,7 @@ jobs:
   macos-legacy:
     name: xcodebuild (macOS legacy)
     runs-on: macos-14
+    timeout-minutes: 30
     strategy:
       matrix:
         command: [test, ""]
@@ -134,6 +136,7 @@ jobs:
   spm:
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: macos-15
+    timeout-minutes: 30
     strategy:
       matrix:
         config: [debug, release]
@@ -150,6 +153,7 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: "Cache Swift Package"
@@ -182,6 +186,7 @@ jobs:
   library-evolution:
     name: Library (evolution)
     runs-on: macos-15
+    timeout-minutes: 30
     strategy:
       matrix:
         xcode: ["16.3"]
@@ -205,6 +210,7 @@ jobs:
     name: Examples
     needs: [macos]
     runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Cache derived data
@@ -233,6 +239,7 @@ jobs:
     name: Test docs
     needs: [macos]
     runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Cache Swift build


### PR DESCRIPTION
Add timeout-minutes: 30 to all build and test jobs (macos, macos-legacy, spm, linux, library-evolution, examples, docs) to prevent indefinite job execution. Non-build/test jobs rely on GitHub's default 6-hour timeout.

**Changes:**
- Adds 30-minute timeout to build/test workflows
- Removes timeouts from validation/automation jobs (format-check, api-stability, ci-success, release-please, conventional-commits, block-merge, label, stale)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added 30-minute execution time limits to continuous integration build and test jobs across all supported platforms to cap job durations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->