### PR TITLE
fix(auth): decode MFA unenroll responses with id key

### DIFF
--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -757,7 +757,7 @@ public typealias AuthMFAVerifyResponse = Session
 
 public struct AuthMFAUnenrollResponse: Decodable, Hashable, Sendable {
   /// ID of the factor that was successfully unenrolled.
-  public let factorId: String
+  public let id: String
 }
 
 public struct AuthMFAListFactorsResponse: Decodable, Hashable, Sendable {

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -1804,8 +1804,8 @@ final class AuthClientTests: XCTestCase {
   func testMFAUnenroll() async throws {
     Mock(
       url: clientURL.appendingPathComponent("factors/123"),
-      statusCode: 204,
-      data: [.delete: Data(#"{"factor_id":"123"}"#.utf8)]
+      statusCode: 200,
+      data: [.delete: Data(#"{"id":"123"}"#.utf8)]
     )
     .snapshotRequest {
       #"""
@@ -1824,9 +1824,9 @@ final class AuthClientTests: XCTestCase {
 
     Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
-    let factorId = try await sut.mfa.unenroll(params: .init(factorId: "123")).factorId
+    let id = try await sut.mfa.unenroll(params: .init(factorId: "123")).id
 
-    expectNoDifference(factorId, "123")
+    expectNoDifference(id, "123")
   }
 
   func testMFAChallengeAndVerify() async throws {
@@ -2229,7 +2229,10 @@ final class AuthClientTests: XCTestCase {
     XCTAssertNil(Dependencies[sut.clientID].sessionStorage.get())
   }
 
-  func testRemoveSessionAndSignoutIfRefreshTokenNotFoundErrorReturned_withEmitLocalSessionAsInitialSession() async throws {
+  func
+    testRemoveSessionAndSignoutIfRefreshTokenNotFoundErrorReturned_withEmitLocalSessionAsInitialSession()
+    async throws
+  {
     let sut = makeSUT(emitLocalSessionAsInitialSession: true)
 
     Mock(
@@ -2676,7 +2679,9 @@ final class AuthClientTests: XCTestCase {
     XCTAssertNotNil(result.claims.aud)
   }
 
-  private func makeSUT(flowType: AuthFlowType = .pkce, emitLocalSessionAsInitialSession: Bool = false) -> AuthClient {
+  private func makeSUT(
+    flowType: AuthFlowType = .pkce, emitLocalSessionAsInitialSession: Bool = false
+  ) -> AuthClient {
     let sessionConfiguration = URLSessionConfiguration.default
     sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
     let session = URLSession(configuration: sessionConfiguration)


### PR DESCRIPTION
## Summary
- Rename `factorId` to `id` in `AuthMFAUnenrollResponse` to match the GoTrue API response shape (`{"id":"..."}`)
- Update test mock and assertion accordingly

## Why
The GoTrue `UnenrollFactorResponse` struct serializes as `{"id":"..."}` ([source](https://github.com/supabase/auth/blob/master/internal/api/mfa.go)), but the Swift SDK was decoding it as `factor_id`, causing a decoding mismatch.

## Test plan
- `swift test --filter AuthClientTests/testMFAUnenroll`

Closes #904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the MFA unenroll response property from `factorId` to `id`. This is a breaking change for integrations that read the unenroll response.

* **Tests**
  * Updated unenroll tests and assertions to expect the new response shape (`id`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->