### PR TITLE
feat(postgrest): add URL length validation and timeout protection

### DIFF
--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -139,6 +139,21 @@ public class PostgrestBuilder: @unchecked Sendable {
       }
     }
 
+    let fullUrl =
+      request.query.isEmpty
+      ? request.url
+      : request.url.appendingQueryItems(request.query)
+    let urlLength = fullUrl.absoluteString.count
+    if urlLength > configuration.urlLengthLimit {
+      configuration.logger?.warning(
+        "Request URL is \(urlLength) characters, which exceeds the limit of \(configuration.urlLengthLimit). If selecting many fields, consider using a view. If filtering with large arrays, consider using an RPC function."
+      )
+    }
+
+    if let timeout = configuration.timeout {
+      request.timeoutInterval = timeout
+    }
+
     var attempt = 0
     while true {
       try Task.checkCancellation()

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -23,6 +23,12 @@ public final class PostgrestClient: Sendable {
     public var decoder: JSONDecoder
     /// Whether automatic retries are enabled for transient errors. Defaults to `true`.
     public var retryEnabled: Bool
+    /// Optional timeout in seconds for PostgREST requests. When set, requests automatically
+    /// abort after this duration to prevent indefinite hangs.
+    public var timeout: TimeInterval?
+    /// Maximum URL length in characters before a warning is logged. Defaults to 8000.
+    /// Protects against exceeding server URL limits with large queries.
+    public var urlLengthLimit: Int
 
     let logger: (any SupabaseLogger)?
 
@@ -36,6 +42,8 @@ public final class PostgrestClient: Sendable {
     ///   - encoder: The JSONEncoder to use for encoding.
     ///   - decoder: The JSONDecoder to use for decoding.
     ///   - retryEnabled: Whether to automatically retry on transient errors (HTTP 503, 520, network errors). Defaults to `true`.
+    ///   - timeout: Optional timeout in seconds. When set, requests abort after this duration.
+    ///   - urlLengthLimit: Maximum URL length before a warning is logged. Defaults to 8000.
     public init(
       url: URL,
       schema: String? = nil,
@@ -44,7 +52,9 @@ public final class PostgrestClient: Sendable {
       fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
       encoder: JSONEncoder = PostgrestClient.Configuration.jsonEncoder,
       decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder,
-      retryEnabled: Bool = true
+      retryEnabled: Bool = true,
+      timeout: TimeInterval? = nil,
+      urlLengthLimit: Int = 8000
     ) {
       self.url = url
       self.schema = schema
@@ -54,6 +64,8 @@ public final class PostgrestClient: Sendable {
       self.encoder = encoder
       self.decoder = decoder
       self.retryEnabled = retryEnabled
+      self.timeout = timeout
+      self.urlLengthLimit = urlLengthLimit
     }
   }
 
@@ -79,6 +91,8 @@ public final class PostgrestClient: Sendable {
   ///   - encoder: The JSONEncoder to use for encoding.
   ///   - decoder: The JSONDecoder to use for decoding.
   ///   - retryEnabled: Whether to automatically retry on transient errors (HTTP 503, 520, network errors). Defaults to `true`.
+  ///   - timeout: Optional timeout in seconds. When set, requests abort after this duration.
+  ///   - urlLengthLimit: Maximum URL length before a warning is logged. Defaults to 8000.
   public convenience init(
     url: URL,
     schema: String? = nil,
@@ -87,7 +101,9 @@ public final class PostgrestClient: Sendable {
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
     encoder: JSONEncoder = PostgrestClient.Configuration.jsonEncoder,
     decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder,
-    retryEnabled: Bool = true
+    retryEnabled: Bool = true,
+    timeout: TimeInterval? = nil,
+    urlLengthLimit: Int = 8000
   ) {
     self.init(
       configuration: Configuration(
@@ -98,7 +114,9 @@ public final class PostgrestClient: Sendable {
         fetch: fetch,
         encoder: encoder,
         decoder: decoder,
-        retryEnabled: retryEnabled
+        retryEnabled: retryEnabled,
+        timeout: timeout,
+        urlLengthLimit: urlLengthLimit
       )
     )
   }

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -41,7 +41,9 @@ public final class SupabaseClient: Sendable {
           logger: options.global.logger,
           fetch: fetchWithAuth,
           encoder: options.db.encoder,
-          decoder: options.db.decoder
+          decoder: options.db.decoder,
+          timeout: options.db.timeout,
+          urlLengthLimit: options.db.urlLengthLimit
         )
       }
 

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -23,14 +23,26 @@ public struct SupabaseClientOptions: Sendable {
     /// The JSONDecoder to use when decoding database response objects.
     public let decoder: JSONDecoder
 
+    /// Optional timeout in seconds for PostgREST requests. When set, requests automatically
+    /// abort after this duration to prevent indefinite hangs.
+    public let timeout: TimeInterval?
+
+    /// Maximum URL length in characters before a warning is logged. Defaults to 8000.
+    /// Protects against exceeding server URL limits with large queries.
+    public let urlLengthLimit: Int
+
     public init(
       schema: String? = nil,
       encoder: JSONEncoder = PostgrestClient.Configuration.jsonEncoder,
-      decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder
+      decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder,
+      timeout: TimeInterval? = nil,
+      urlLengthLimit: Int = 8000
     ) {
       self.schema = schema
       self.encoder = encoder
       self.decoder = decoder
+      self.timeout = timeout
+      self.urlLengthLimit = urlLengthLimit
     }
   }
 
@@ -131,7 +143,7 @@ public struct SupabaseClientOptions: Sendable {
   public struct StorageOptions: Sendable {
     /// Whether storage client should be initialized with the new hostname format, i.e. `project-ref.storage.supabase.co`
     public let useNewHostname: Bool
-    
+
     public init(useNewHostname: Bool = false) {
       self.useNewHostname = useNewHostname
     }

--- a/Tests/PostgRESTTests/PostgrestURLLengthAndTimeoutTests.swift
+++ b/Tests/PostgRESTTests/PostgrestURLLengthAndTimeoutTests.swift
@@ -3,6 +3,7 @@
 //  Supabase
 //
 
+import ConcurrencyExtras
 import Foundation
 import Mocker
 import XCTest
@@ -82,12 +83,12 @@ final class PostgrestURLLengthAndTimeoutTests: PostgrestQueryTests {
   }
 
   func testTimeoutIsAppliedToRequest() async throws {
-    var capturedTimeoutInterval: TimeInterval?
+    let capturedTimeoutInterval = LockIsolated<TimeInterval?>(nil)
 
     let client = PostgrestClient(
       url: url,
       fetch: { request in
-        capturedTimeoutInterval = request.timeoutInterval
+        capturedTimeoutInterval.setValue(request.timeoutInterval)
         return (
           Data("[]".utf8),
           HTTPURLResponse(
@@ -106,16 +107,16 @@ final class PostgrestURLLengthAndTimeoutTests: PostgrestQueryTests {
       .select()
       .execute()
 
-    XCTAssertEqual(capturedTimeoutInterval, 5.0)
+    XCTAssertEqual(capturedTimeoutInterval.value, 5.0)
   }
 
   func testDefaultTimeoutIntervalUsedWhenNoTimeoutConfigured() async throws {
-    var capturedTimeoutInterval: TimeInterval?
+    let capturedTimeoutInterval = LockIsolated<TimeInterval?>(nil)
 
     let client = PostgrestClient(
       url: url,
       fetch: { request in
-        capturedTimeoutInterval = request.timeoutInterval
+        capturedTimeoutInterval.setValue(request.timeoutInterval)
         return (
           Data("[]".utf8),
           HTTPURLResponse(
@@ -134,7 +135,7 @@ final class PostgrestURLLengthAndTimeoutTests: PostgrestQueryTests {
       .execute()
 
     // Default URLSession timeout is 60 seconds
-    XCTAssertEqual(capturedTimeoutInterval, 60.0)
+    XCTAssertEqual(capturedTimeoutInterval.value, 60.0)
   }
 
   func testConfigurationStoresTimeoutAndURLLengthLimit() {

--- a/Tests/PostgRESTTests/PostgrestURLLengthAndTimeoutTests.swift
+++ b/Tests/PostgRESTTests/PostgrestURLLengthAndTimeoutTests.swift
@@ -1,0 +1,155 @@
+//
+//  PostgrestURLLengthAndTimeoutTests.swift
+//  Supabase
+//
+
+import Foundation
+import Mocker
+import XCTest
+
+@testable import PostgREST
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+final class PostgrestURLLengthAndTimeoutTests: PostgrestQueryTests {
+
+  final class MockLogger: SupabaseLogger, @unchecked Sendable {
+    var warningLogs: [String] = []
+
+    func log(message: SupabaseLogMessage) {
+      if message.level == .warning {
+        warningLogs.append(message.message)
+      }
+    }
+  }
+
+  func testURLLengthWarningIsLoggedWhenExceedingLimit() async throws {
+    let logger = MockLogger()
+    let client = PostgrestClient(
+      url: url,
+      logger: logger,
+      fetch: { try await self.session.data(for: $0) },
+      urlLengthLimit: 50
+    )
+
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [.get: Data("[]".utf8)]
+    )
+    .register()
+
+    // URL will be something like: http://localhost:54321/rest/v1/users?select=id,username,email,created_at,updated_at
+    // which is well over 50 characters
+    try await client
+      .from("users")
+      .select("id,username,email,created_at,updated_at")
+      .execute()
+
+    XCTAssertFalse(logger.warningLogs.isEmpty, "Expected a warning log for URL exceeding limit")
+    XCTAssertTrue(
+      logger.warningLogs[0].contains("exceeds the limit of 50"),
+      "Expected warning to mention the limit"
+    )
+  }
+
+  func testNoURLLengthWarningWhenWithinLimit() async throws {
+    let logger = MockLogger()
+    let client = PostgrestClient(
+      url: url,
+      logger: logger,
+      fetch: { try await self.session.data(for: $0) },
+      urlLengthLimit: 8000
+    )
+
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [.get: Data("[]".utf8)]
+    )
+    .register()
+
+    try await client
+      .from("users")
+      .select()
+      .execute()
+
+    XCTAssertTrue(logger.warningLogs.isEmpty, "Expected no warning log for short URL")
+  }
+
+  func testTimeoutIsAppliedToRequest() async throws {
+    var capturedTimeoutInterval: TimeInterval?
+
+    let client = PostgrestClient(
+      url: url,
+      fetch: { request in
+        capturedTimeoutInterval = request.timeoutInterval
+        return (
+          Data("[]".utf8),
+          HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      },
+      timeout: 5.0
+    )
+
+    try await client
+      .from("users")
+      .select()
+      .execute()
+
+    XCTAssertEqual(capturedTimeoutInterval, 5.0)
+  }
+
+  func testDefaultTimeoutIntervalUsedWhenNoTimeoutConfigured() async throws {
+    var capturedTimeoutInterval: TimeInterval?
+
+    let client = PostgrestClient(
+      url: url,
+      fetch: { request in
+        capturedTimeoutInterval = request.timeoutInterval
+        return (
+          Data("[]".utf8),
+          HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      }
+    )
+
+    try await client
+      .from("users")
+      .select()
+      .execute()
+
+    // Default URLSession timeout is 60 seconds
+    XCTAssertEqual(capturedTimeoutInterval, 60.0)
+  }
+
+  func testConfigurationStoresTimeoutAndURLLengthLimit() {
+    let config = PostgrestClient.Configuration(
+      url: url,
+      timeout: 30.0,
+      urlLengthLimit: 5000
+    )
+    XCTAssertEqual(config.timeout, 30.0)
+    XCTAssertEqual(config.urlLengthLimit, 5000)
+  }
+
+  func testConfigurationDefaultsForTimeoutAndURLLengthLimit() {
+    let config = PostgrestClient.Configuration(url: url)
+    XCTAssertNil(config.timeout)
+    XCTAssertEqual(config.urlLengthLimit, 8000)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `timeout` (optional `TimeInterval`) to `PostgrestClient.Configuration` — sets `URLRequest.timeoutInterval` to auto-abort slow requests
- Adds `urlLengthLimit` (default 8000) to log a warning before requests with very long URLs that may exceed server limits
- Both options propagate from `SupabaseClientOptions.DatabaseOptions` to `PostgrestClient`

## Changes

- **`PostgrestClient.Configuration`**: New `timeout: TimeInterval?` and `urlLengthLimit: Int` fields
- **`PostgrestBuilder.execute()`**: Checks URL length and logs warning; applies timeout to request
- **`SupabaseClientOptions.DatabaseOptions`**: Exposes both options to `SupabaseClient` users
- **`SupabaseClient`**: Passes `timeout` and `urlLengthLimit` when creating `PostgrestClient`
- **Tests**: 6 unit tests covering configuration defaults, timeout propagation, and URL length warning

## Testing

- Unit tests: `PostgrestURLLengthAndTimeoutTests` — 6/6 passing
- All existing PostgREST tests: 84/84 passing

## Risk Assessment

- **Breaking changes**: None — all new fields have defaults
- **Backward compatibility**: Maintained
- **Performance impact**: Negligible (one string length check per request)

## Acceptance Criteria

- [x] `timeout` option added to PostgrestClient configuration
- [x] `urlLengthLimit` option added with default of 8000
- [x] URL length validation before request execution
- [x] Timeout applied via `URLRequest.timeoutInterval`
- [x] Unit tests cover both features

Closes: [SDK-700](https://linear.app/supabase/issue/SDK-700)
Related: [SDK-646](https://linear.app/supabase/issue/SDK-646)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`