### PR TITLE
fix(storage): make signedURL optional in createSignedURLs response

### DIFF
--- a/Sources/Storage/Deprecated.swift
+++ b/Sources/Storage/Deprecated.swift
@@ -34,6 +34,38 @@ extension StorageClientConfiguration {
 
 extension StorageFileApi {
   @_disfavoredOverload
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use createSignedURLs(paths:expiresIn:download:) that returns [SignedURLResult] to handle paths that do not exist."
+  )
+  public func createSignedURLs(
+    paths: [String],
+    expiresIn: Int,
+    download: String? = nil
+  ) async throws -> [URL] {
+    let results: [SignedURLResult] = try await createSignedURLs(
+      paths: paths, expiresIn: expiresIn, download: download)
+    return results.compactMap(\.signedURL)
+  }
+
+  @_disfavoredOverload
+  @available(
+    *,
+    deprecated,
+    message:
+      "Use createSignedURLs(paths:expiresIn:download:) that returns [SignedURLResult] to handle paths that do not exist."
+  )
+  public func createSignedURLs(
+    paths: [String],
+    expiresIn: Int,
+    download: Bool
+  ) async throws -> [URL] {
+    try await createSignedURLs(paths: paths, expiresIn: expiresIn, download: download ? "" : nil)
+  }
+
+  @_disfavoredOverload
   @available(*, deprecated, message: "Please use method that returns FileUploadResponse.")
   @discardableResult
   public func upload(

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -71,8 +71,14 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     let message: String
   }
 
-  private struct SignedURLResponse: Decodable {
+  private struct SignedURLAPIResponse: Decodable {
     let signedURL: String
+  }
+
+  private struct SignedURLsAPIResponse: Decodable {
+    let signedURL: String?
+    let path: String
+    let error: String?
   }
 
   private func _uploadOrUpdate(
@@ -287,7 +293,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
         )
       )
     )
-    .decoded(as: SignedURLResponse.self, decoder: configuration.decoder)
+    .decoded(as: SignedURLAPIResponse.self, decoder: configuration.decoder)
 
     return try makeSignedURL(response.signedURL, download: download)
   }
@@ -313,6 +319,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   }
 
   /// Creates multiple signed URLs. Use a signed URL to share a file for a fixed amount of time.
+  ///
+  /// Each item in the returned array is a ``SignedURLResult``: either `.success(path:signedURL:)` or
+  /// `.failure(path:error:)`. Exactly one case is guaranteed per item.
   /// - Parameters:
   ///   - paths: The file paths to be downloaded, including the current file names. For example `["folder/image.png", "folder2/image2.png"]`.
   ///   - expiresIn: The number of seconds until the signed URLs expire. For example, `60` for URLs which are valid for one minute.
@@ -321,7 +330,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     paths: [String],
     expiresIn: Int,
     download: String? = nil
-  ) async throws -> [URL] {
+  ) async throws -> [SignedURLResult] {
     struct Params: Encodable {
       let expiresIn: Int
       let paths: [String]
@@ -338,12 +347,22 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
         )
       )
     )
-    .decoded(as: [SignedURLResponse].self, decoder: configuration.decoder)
+    .decoded(as: [SignedURLsAPIResponse].self, decoder: configuration.decoder)
 
-    return try response.map { try makeSignedURL($0.signedURL, download: download) }
+    return try response.map { item in
+      if let signedURLString = item.signedURL {
+        let url = try makeSignedURL(signedURLString, download: download)
+        return .success(path: item.path, signedURL: url)
+      } else {
+        return .failure(path: item.path, error: item.error ?? "Unknown error")
+      }
+    }
   }
 
   /// Creates multiple signed URLs. Use a signed URL to share a file for a fixed amount of time.
+  ///
+  /// Each item in the returned array is a ``SignedURLResult``: either `.success(path:signedURL:)` or
+  /// `.failure(path:error:)`. Exactly one case is guaranteed per item.
   /// - Parameters:
   ///   - paths: The file paths to be downloaded, including the current file names. For example `["folder/image.png", "folder2/image2.png"]`.
   ///   - expiresIn: The number of seconds until the signed URLs expire. For example, `60` for URLs which are valid for one minute.
@@ -352,7 +371,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     paths: [String],
     expiresIn: Int,
     download: Bool
-  ) async throws -> [URL] {
+  ) async throws -> [SignedURLResult] {
     try await createSignedURLs(paths: paths, expiresIn: expiresIn, download: download ? "" : nil)
   }
 

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -98,6 +98,44 @@ public struct SignedURL: Decodable, Sendable {
   }
 }
 
+/// Represents the per-item result of a ``StorageFileApi/createSignedURLs(paths:expiresIn:download:)`` call.
+///
+/// It is guaranteed that exactly one case applies per item: either the URL was signed
+/// successfully, or the path did not exist / was inaccessible.
+public enum SignedURLResult: Sendable {
+  /// The URL was signed successfully.
+  /// - Parameters:
+  ///   - path: The requested file path.
+  ///   - signedURL: The signed URL ready for use.
+  case success(path: String, signedURL: URL)
+
+  /// The path could not be signed.
+  /// - Parameters:
+  ///   - path: The requested file path.
+  ///   - error: The reason the URL could not be created.
+  case failure(path: String, error: String)
+
+  /// The requested file path, available regardless of outcome.
+  public var path: String {
+    switch self {
+    case .success(let path, _): return path
+    case .failure(let path, _): return path
+    }
+  }
+
+  /// The signed URL, or `nil` if this result is a failure.
+  public var signedURL: URL? {
+    if case .success(_, let url) = self { return url }
+    return nil
+  }
+
+  /// The error message, or `nil` if this result is a success.
+  public var error: String? {
+    if case .failure(_, let error) = self { return error }
+    return nil
+  }
+}
+
 public struct SignedUploadURL: Sendable {
   public let signedURL: URL
   public let path: String

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -256,15 +256,25 @@ final class StorageFileAPITests: XCTestCase {
     .register()
 
     let paths = ["file.txt", "file2.txt"]
-    let urls = try await storage.from("bucket").createSignedURLs(
+    let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
       paths: paths,
       expiresIn: 3600
     )
-    XCTAssertEqual(urls.count, 2)
+    XCTAssertEqual(results.count, 2)
+    guard case .success(let path0, let url0) = results[0] else {
+      return XCTFail("Expected success for file.txt")
+    }
+    XCTAssertEqual(path0, "file.txt")
     XCTAssertEqual(
-      urls[0].absoluteString, "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+      url0.absoluteString,
+      "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+    guard case .success(let path1, let url1) = results[1] else {
+      return XCTFail("Expected success for file2.txt")
+    }
+    XCTAssertEqual(path1, "file2.txt")
     XCTAssertEqual(
-      urls[1].absoluteString, "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi")
+      url1.absoluteString,
+      "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi")
   }
 
   func testCreateSignedURLs_download() async throws {
@@ -303,18 +313,64 @@ final class StorageFileAPITests: XCTestCase {
     .register()
 
     let paths = ["file.txt", "file2.txt"]
-    let urls = try await storage.from("bucket").createSignedURLs(
+    let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
       paths: paths,
       expiresIn: 3600,
       download: true
     )
-    XCTAssertEqual(urls.count, 2)
+    XCTAssertEqual(results.count, 2)
+    guard case .success(_, let url0) = results[0] else {
+      return XCTFail("Expected success for file.txt")
+    }
     XCTAssertEqual(
-      urls[0].absoluteString,
+      url0.absoluteString,
       "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
+    guard case .success(_, let url1) = results[1] else {
+      return XCTFail("Expected success for file2.txt")
+    }
     XCTAssertEqual(
-      urls[1].absoluteString,
+      url1.absoluteString,
       "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi&download=")
+  }
+
+  func testCreateSignedURLs_withNullSignedURL() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/sign/bucket"),
+      statusCode: 200,
+      data: [
+        .post: Data(
+          """
+          [
+            {
+              "path": "file.txt",
+              "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+            },
+            {
+              "path": "missing.txt",
+              "signedURL": null,
+              "error": "Either the object does not exist or you do not have access to it"
+            }
+          ]
+          """.utf8
+        )
+      ]
+    )
+    .register()
+
+    let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
+      paths: ["file.txt", "missing.txt"],
+      expiresIn: 3600
+    )
+    XCTAssertEqual(results.count, 2)
+    guard case .success(let path0, _) = results[0] else {
+      return XCTFail("Expected success for file.txt")
+    }
+    XCTAssertEqual(path0, "file.txt")
+    guard case .failure(let path1, let error1) = results[1] else {
+      return XCTFail("Expected failure for missing.txt")
+    }
+    XCTAssertEqual(path1, "missing.txt")
+    XCTAssertEqual(error1, "Either the object does not exist or you do not have access to it")
   }
 
   func testRemove() async throws {

--- a/Tests/StorageTests/SupabaseStorageTests.swift
+++ b/Tests/StorageTests/SupabaseStorageTests.swift
@@ -64,11 +64,13 @@ final class SupabaseStorageTests: XCTestCase {
         """
         [
           {
+            "path": "file1.txt",
             "signedURL": "/sign/file1.txt?token=abc.def.ghi"
           },
           {
+            "path": "file2.txt",
             "signedURL": "/sign/file2.txt?token=abc.def.ghi"
-          },
+          }
         ]
         """.data(using: .utf8)!,
         HTTPURLResponse(
@@ -81,16 +83,26 @@ final class SupabaseStorageTests: XCTestCase {
     }
 
     let sut = makeSUT()
-    let urls = try await sut.from(bucketId).createSignedURLs(
+    let results: [SignedURLResult] = try await sut.from(bucketId).createSignedURLs(
       paths: ["file1.txt", "file2.txt"],
       expiresIn: 60
     )
 
-    assertInlineSnapshot(of: urls, as: .description) {
-      """
-      [http://localhost:54321/storage/v1/sign/file1.txt?token=abc.def.ghi, http://localhost:54321/storage/v1/sign/file2.txt?token=abc.def.ghi]
-      """
+    XCTAssertEqual(results.count, 2)
+    guard case .success(let path0, let url0) = results[0] else {
+      return XCTFail("Expected success for file1.txt")
     }
+    XCTAssertEqual(path0, "file1.txt")
+    XCTAssertEqual(
+      url0.absoluteString,
+      "http://localhost:54321/storage/v1/sign/file1.txt?token=abc.def.ghi")
+    guard case .success(let path1, let url1) = results[1] else {
+      return XCTFail("Expected success for file2.txt")
+    }
+    XCTAssertEqual(path1, "file2.txt")
+    XCTAssertEqual(
+      url1.absoluteString,
+      "http://localhost:54321/storage/v1/sign/file2.txt?token=abc.def.ghi")
   }
 
   #if !os(Linux) && !os(Android)


### PR DESCRIPTION
## Summary

When one of the requested paths does not exist, the Storage API returns `"signedURL": null` for that item. The Swift client was crashing with a `DecodingError` because the private response struct used a non-optional `String`.

The API guarantees exactly one of `signedURL` or `error` is non-null per item — never both, never neither — so the natural Swift representation is an enum.

## Changes

- **`Sources/Storage/Types.swift`**: Added `SignedURLResult` enum with `.success(path:signedURL:)` and `.failure(path:error:)` cases, plus `path`, `signedURL`, and `error` convenience accessors
- **`Sources/Storage/StorageFileApi.swift`**: `createSignedURLs` now returns `[SignedURLResult]`; added private `SignedURLsAPIResponse` and `SignedURLAPIResponse` structs to avoid name shadowing
- **`Sources/Storage/Deprecated.swift`**: Old `createSignedURLs -> [URL]` overloads kept with `@_disfavoredOverload @available(*, deprecated, ...)`; they delegate to the new method and `compactMap` out failures so existing callers continue to work without crashing
- **`Tests/StorageTests/StorageFileAPITests.swift`**: Added `testCreateSignedURLs_withNullSignedURL`; updated existing tests to pattern-match on enum cases
- **`Tests/StorageTests/SupabaseStorageTests.swift`**: Updated mock to include `path` field and assertions to use the new enum type

## Backward Compatibility

`SignedURL` struct is unchanged — no breaking API changes. Existing code calling `createSignedURLs(...)` continues to compile and run via the deprecated `[URL]` overloads, which silently drop failed items. The new `[SignedURLResult]` overload is preferred by the compiler.

## Test Plan

- [x] `testCreateSignedURLs_withNullSignedURL` — verifies null signedURL decodes without crashing and maps to `.failure`
- [x] `testCreateSignedURLs` and `testCreateSignedURLs_download` — updated to assert on `.success` cases
- [x] All `StorageTests` pass

Closes: [SDK-851](https://linear.app/supabase/issue/SDK-851)

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`