### PR TITLE
fix: use host(percentEncoded:) to avoid iOS 26 crash in SupabaseClient

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -165,7 +165,19 @@ public final class SupabaseClient: Sendable {
       .merging(with: HTTPFields(options.global.headers))
 
     // default storage key uses the supabase project ref as a namespace
-    let defaultStorageKey = "sb-\(supabaseURL.host!.split(separator: ".")[0])-auth-token"
+    let host: String
+    if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+      guard let h = supabaseURL.host(percentEncoded: false) else {
+        preconditionFailure("supabaseURL must have a valid host.")
+      }
+      host = h
+    } else {
+      guard let h = supabaseURL.host else {
+        preconditionFailure("supabaseURL must have a valid host.")
+      }
+      host = h
+    }
+    let defaultStorageKey = "sb-\(host.split(separator: ".")[0])-auth-token"
 
     _auth = AuthClient(
       url: supabaseURL.appendingPathComponent("/auth/v1"),

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -166,7 +166,7 @@ public final class SupabaseClient: Sendable {
 
     // default storage key uses the supabase project ref as a namespace
     let optionalHost: String?
-    if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+    if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, visionOS 1, *) {
       optionalHost = supabaseURL.host(percentEncoded: false)
     } else {
       optionalHost = supabaseURL.host

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -165,17 +165,14 @@ public final class SupabaseClient: Sendable {
       .merging(with: HTTPFields(options.global.headers))
 
     // default storage key uses the supabase project ref as a namespace
-    let host: String
+    let optionalHost: String?
     if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
-      guard let h = supabaseURL.host(percentEncoded: false) else {
-        preconditionFailure("supabaseURL must have a valid host.")
-      }
-      host = h
+      optionalHost = supabaseURL.host(percentEncoded: false)
     } else {
-      guard let h = supabaseURL.host else {
-        preconditionFailure("supabaseURL must have a valid host.")
-      }
-      host = h
+      optionalHost = supabaseURL.host
+    }
+    guard let host = optionalHost else {
+      preconditionFailure("supabaseURL must have a valid host.")
     }
     let defaultStorageKey = "sb-\(host.split(separator: ".")[0])-auth-token"
 


### PR DESCRIPTION
## What

Replaces the deprecated `URL.host` force-unwrap with `URL.host(percentEncoded: false)` (iOS 16+/macOS 13+) when building the default auth storage key, with a fallback to `URL.host` on older platforms.

## Why

Apple changed `URL.host` (deprecated) in the iOS 26 beta so that it returns `nil` for valid HTTPS URLs. The existing force-unwrap (`supabaseURL.host!`) therefore crashes on iOS 26 for any valid Supabase URL. `URL.host(percentEncoded: false)` is the non-deprecated replacement and behaves correctly across all supported versions.

A `preconditionFailure` replaces the implicit crash so the missing-host case is clearly communicated rather than opaque.

Fixes #960