### PR TITLE
fix(storage): guard against empty transform routing through render endpoint

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -453,7 +453,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     query additionalQueryItems: [URLQueryItem]? = nil
   ) async throws -> Data {
     var queryItems = options?.queryItems ?? []
-    let renderPath = options != nil ? "render/image/authenticated" : "object"
+    let renderPath = options.map { !$0.isEmpty } == true ? "render/image/authenticated" : "object"
     let _path = _getFinalPath(path)
 
     if let additionalQueryItems {
@@ -538,7 +538,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
       queryItems.append(contentsOf: optionsQueryItems)
     }
 
-    let renderPath = options != nil ? "render/image" : "object"
+    let renderPath = options.map { !$0.isEmpty } == true ? "render/image" : "object"
 
     components.path += "/\(renderPath)/public/\(bucketId)/\(path)"
     components.queryItems = !queryItems.isEmpty ? queryItems : nil

--- a/Sources/Storage/TransformOptions.swift
+++ b/Sources/Storage/TransformOptions.swift
@@ -20,7 +20,7 @@ public struct TransformOptions: Encodable, Sendable {
     width: Int? = nil,
     height: Int? = nil,
     resize: String? = nil,
-    quality: Int? = 80,
+    quality: Int? = nil,
     format: String? = nil
   ) {
     self.width = width
@@ -28,6 +28,10 @@ public struct TransformOptions: Encodable, Sendable {
     self.resize = resize
     self.quality = quality
     self.format = format
+  }
+
+  var isEmpty: Bool {
+    queryItems.isEmpty
   }
 
   var queryItems: [URLQueryItem] {

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -665,6 +665,46 @@ final class StorageFileAPITests: XCTestCase {
     XCTAssertEqual(data, Data("hello world".utf8))
   }
 
+  func testDownload_withEmptyTransformOptions() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/bucket/file.txt"),
+      statusCode: 200,
+      data: [
+        .get: Data("hello world".utf8)
+      ]
+    )
+    .register()
+
+    let data = try await storage.from("bucket")
+      .download(path: "file.txt", options: TransformOptions())
+
+    XCTAssertEqual(data, Data("hello world".utf8))
+  }
+
+  func testGetPublicURL_withEmptyTransformOptions() throws {
+    let publicURL = try storage.from("bucket")
+      .getPublicURL(path: "image.png", options: TransformOptions())
+
+    XCTAssertTrue(
+      publicURL.absoluteString.contains("/object/public/"),
+      "Empty transform should use /object/public/ path, got: \(publicURL.absoluteString)"
+    )
+    XCTAssertFalse(
+      publicURL.absoluteString.contains("/render/image/"),
+      "Empty transform should not use /render/image/ path, got: \(publicURL.absoluteString)"
+    )
+  }
+
+  func testGetPublicURL_withActualTransformOptions() throws {
+    let publicURL = try storage.from("bucket")
+      .getPublicURL(path: "image.png", options: TransformOptions(width: 200))
+
+    XCTAssertTrue(
+      publicURL.absoluteString.contains("/render/image/"),
+      "Non-empty transform should use /render/image/ path, got: \(publicURL.absoluteString)"
+    )
+  }
+
   func testDownload_withOptions() async throws {
     let imageData = try! Data(
       contentsOf: Bundle.module.url(forResource: "sadcat", withExtension: "jpg")!)
@@ -682,7 +722,7 @@ final class StorageFileAPITests: XCTestCase {
       curl \
       	--header "X-Client-Info: storage-swift/0.0.0" \
       	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/render/image/authenticated/bucket/sadcat.txt?format=cover&quality=80"
+      	"http://localhost:54321/storage/v1/render/image/authenticated/bucket/sadcat.txt?format=cover"
       """#
     }
     .register()

--- a/Tests/StorageTests/SupabaseStorageTests.swift
+++ b/Tests/StorageTests/SupabaseStorageTests.swift
@@ -53,7 +53,7 @@ final class SupabaseStorageTests: XCTestCase {
     )
     assertInlineSnapshot(of: baseUrlWithAllOptions, as: .description) {
       """
-      http://localhost:54321/storage/v1/render/image/public/tests/README.md?download=test&width=300&height=300&quality=80
+      http://localhost:54321/storage/v1/render/image/public/tests/README.md?download=test&width=300&height=300
       """
     }
   }

--- a/Tests/StorageTests/TransformOptionsTests.swift
+++ b/Tests/StorageTests/TransformOptionsTests.swift
@@ -9,8 +9,32 @@ final class TransformOptionsTests: XCTestCase {
     XCTAssertNil(options.width)
     XCTAssertNil(options.height)
     XCTAssertNil(options.resize)
-    XCTAssertEqual(options.quality, 80)  // Default value
+    XCTAssertNil(options.quality)
     XCTAssertNil(options.format)
+  }
+
+  func testIsEmpty_defaultOptions() {
+    XCTAssertTrue(TransformOptions().isEmpty)
+  }
+
+  func testIsEmpty_withWidth() {
+    XCTAssertFalse(TransformOptions(width: 200).isEmpty)
+  }
+
+  func testIsEmpty_withHeight() {
+    XCTAssertFalse(TransformOptions(height: 300).isEmpty)
+  }
+
+  func testIsEmpty_withResize() {
+    XCTAssertFalse(TransformOptions(resize: "cover").isEmpty)
+  }
+
+  func testIsEmpty_withQuality() {
+    XCTAssertFalse(TransformOptions(quality: 90).isEmpty)
+  }
+
+  func testIsEmpty_withFormat() {
+    XCTAssertFalse(TransformOptions(format: "webp").isEmpty)
   }
 
   func testCustomInitialization() {


### PR DESCRIPTION
## Summary

- Empty `TransformOptions()` no longer incorrectly routes `download()` and `getPublicURL()` through the `/render/image/` endpoint
- Adds `isEmpty` computed property to `TransformOptions` that returns `true` when no meaningful transform values are set
- Changes `quality` default from `80` to `nil` so `TransformOptions()` is a truly empty struct (server applies its own 80 default for actual transform requests)

## Root Cause

`download()` and `getPublicURL()` used `options != nil` to decide the render path. A `TransformOptions()` with default values still evaluated as non-nil, routing through `/render/image/` unnecessarily.

- File: `Sources/Storage/StorageFileApi.swift:456,541`
- Fix: Check `options.map { !$0.isEmpty } == true` instead of `options != nil`

## Changes

- **`TransformOptions`**: Added `isEmpty` property (`queryItems.isEmpty`); changed `quality` default from `80` to `nil`
- **`StorageFileApi`**: Updated `download()` and `getPublicURL()` render-path guard to use `isEmpty`
- **Tests**: Added 8 new tests covering `isEmpty` behavior and empty-transform endpoint routing; updated 2 snapshots that previously included `quality=80`

## Testing

### New Tests Added
- `TransformOptionsTests.testIsEmpty_defaultOptions` — `TransformOptions()` is empty
- `TransformOptionsTests.testIsEmpty_withWidth/Height/Resize/Quality/Format` — non-empty cases
- `StorageFileAPITests.testDownload_withEmptyTransformOptions` — uses `/object/` path
- `StorageFileAPITests.testGetPublicURL_withEmptyTransformOptions` — uses `/object/public/` path
- `StorageFileAPITests.testGetPublicURL_withActualTransformOptions` — uses `/render/image/` path

### Results
All 80 storage tests pass.

## Acceptance Criteria

- [x] Empty/default `TransformOptions` does not route through render endpoint
- [x] Actual transforms still correctly route through render endpoint
- [x] Unit tests added
- [x] No breaking changes (quality server default is 80, same as previous client-sent default)

## Linear

Closes [SDK-888](https://linear.app/supabase/issue/SDK-888/paritystorage-guard-against-empty-transform-routing-through-render)

Parity with [supabase-js PR #2219](https://github.com/supabase/supabase-js/pull/2219) (commit `993bb5fc`)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`