### PR TITLE
fix(auth): include Cloudflare error codes in retryable network errors

### DIFF
--- a/Sources/Helpers/HTTP/RetryRequestInterceptor.swift
+++ b/Sources/Helpers/HTTP/RetryRequestInterceptor.swift
@@ -42,8 +42,13 @@ package actor RetryRequestInterceptor: HTTPClientInterceptor {
   ]
 
   /// The default set of retryable HTTP status codes.
+  ///
+  /// Includes Cloudflare-specific error codes (520-524, 530) which represent transient
+  /// infrastructure errors that should not cause session invalidation.
   package static let defaultRetryableHTTPStatusCodes: Set<Int> = [
     408, 500, 502, 503, 504,
+    // Cloudflare-specific transient errors
+    520, 521, 522, 523, 524, 530,
   ]
 
   /// The maximum number of retries.

--- a/Tests/HelpersTests/RetryRequestInterceptorTests.swift
+++ b/Tests/HelpersTests/RetryRequestInterceptorTests.swift
@@ -1,0 +1,146 @@
+//
+//  RetryRequestInterceptorTests.swift
+//  Helpers
+//
+//  Created by Guilherme Souza on 23/04/26.
+//
+
+import Foundation
+import HTTPTypes
+import XCTest
+
+@testable import Helpers
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+final class RetryRequestInterceptorTests: XCTestCase {
+
+  // MARK: - Helpers
+
+  func makeResponse(statusCode: Int) -> Helpers.HTTPResponse {
+    let urlResponse = HTTPURLResponse(
+      url: URL(string: "https://example.com")!,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: nil
+    )!
+    return Helpers.HTTPResponse(data: Data(), response: urlResponse)
+  }
+
+  func makeInterceptor(retryLimit: Int = 2) -> RetryRequestInterceptor {
+    RetryRequestInterceptor(
+      retryLimit: retryLimit,
+      exponentialBackoffBase: 2,
+      exponentialBackoffScale: 0
+    )
+  }
+
+  func makeRequest(method: HTTPTypes.HTTPRequest.Method = .get) -> Helpers.HTTPRequest {
+    Helpers.HTTPRequest(url: URL(string: "https://example.com")!, method: method)
+  }
+
+  // MARK: - defaultRetryableHTTPStatusCodes
+
+  func testDefaultRetryableHTTPStatusCodesContainsStandardCodes() {
+    let codes = RetryRequestInterceptor.defaultRetryableHTTPStatusCodes
+    XCTAssertTrue(codes.contains(408))
+    XCTAssertTrue(codes.contains(500))
+    XCTAssertTrue(codes.contains(502))
+    XCTAssertTrue(codes.contains(503))
+    XCTAssertTrue(codes.contains(504))
+  }
+
+  func testDefaultRetryableHTTPStatusCodesContainsCloudfareCodes() {
+    let codes = RetryRequestInterceptor.defaultRetryableHTTPStatusCodes
+    XCTAssertTrue(codes.contains(520), "520 (Cloudflare Unknown Error) should be retryable")
+    XCTAssertTrue(codes.contains(521), "521 (Web Server Down) should be retryable")
+    XCTAssertTrue(codes.contains(522), "522 (Connection Timed Out) should be retryable")
+    XCTAssertTrue(codes.contains(523), "523 (Origin Is Unreachable) should be retryable")
+    XCTAssertTrue(codes.contains(524), "524 (A Timeout Occurred) should be retryable")
+    XCTAssertTrue(codes.contains(530), "530 (Site Frozen) should be retryable")
+  }
+
+  // MARK: - Retry behavior for Cloudflare codes
+
+  func testRetriesOnCloudflareErrorCodes() async throws {
+    let interceptor = makeInterceptor(retryLimit: 2)
+    let request = makeRequest()
+    let cloudfareCodes = [520, 521, 522, 523, 524, 530]
+
+    for code in cloudfareCodes {
+      var callCount = 0
+      let finalResponse = try await interceptor.intercept(request) { _ in
+        callCount += 1
+        if callCount < 2 {
+          return self.makeResponse(statusCode: code) as Helpers.HTTPResponse
+        }
+        return self.makeResponse(statusCode: 200)
+      }
+      XCTAssertEqual(finalResponse.statusCode, 200, "Should retry on \(code) and succeed")
+      XCTAssertEqual(callCount, 2, "Should have called next twice for \(code)")
+    }
+  }
+
+  func testDoesNotRetryOnNonRetryableStatusCodes() async throws {
+    let interceptor = makeInterceptor(retryLimit: 2)
+    let request = makeRequest()
+    let nonRetryableCodes = [400, 401, 403, 404, 422]
+
+    for code in nonRetryableCodes {
+      var callCount = 0
+      let response = try await interceptor.intercept(request) { _ in
+        callCount += 1
+        return self.makeResponse(statusCode: code) as Helpers.HTTPResponse
+      }
+      XCTAssertEqual(response.statusCode, code)
+      XCTAssertEqual(callCount, 1, "Should not retry on \(code)")
+    }
+  }
+
+  func testRetriesOnStandardRetryableStatusCodes() async throws {
+    let interceptor = makeInterceptor(retryLimit: 2)
+    let request = makeRequest()
+    let retryableCodes = [408, 500, 502, 503, 504]
+
+    for code in retryableCodes {
+      var callCount = 0
+      let finalResponse = try await interceptor.intercept(request) { _ in
+        callCount += 1
+        if callCount < 2 {
+          return self.makeResponse(statusCode: code) as Helpers.HTTPResponse
+        }
+        return self.makeResponse(statusCode: 200)
+      }
+      XCTAssertEqual(finalResponse.statusCode, 200, "Should retry on \(code) and succeed")
+      XCTAssertEqual(callCount, 2, "Should have called next twice for \(code)")
+    }
+  }
+
+  func testDoesNotRetryOnNonRetryableMethod() async throws {
+    let interceptor = makeInterceptor(retryLimit: 2)
+    let request = makeRequest(method: .post)
+
+    var callCount = 0
+    let response = try await interceptor.intercept(request) { _ in
+      callCount += 1
+      return self.makeResponse(statusCode: 500)
+    }
+    XCTAssertEqual(response.statusCode, 500)
+    XCTAssertEqual(callCount, 1, "POST should not be retried")
+  }
+
+  func testRespectsRetryLimit() async throws {
+    let interceptor = makeInterceptor(retryLimit: 2)
+    let request = makeRequest()
+
+    var callCount = 0
+    let response = try await interceptor.intercept(request) { _ in
+      callCount += 1
+      return self.makeResponse(statusCode: 520)
+    }
+    XCTAssertEqual(response.statusCode, 520)
+    XCTAssertEqual(callCount, 2, "Should not exceed retryLimit")
+  }
+}

--- a/Tests/HelpersTests/RetryRequestInterceptorTests.swift
+++ b/Tests/HelpersTests/RetryRequestInterceptorTests.swift
@@ -5,6 +5,7 @@
 //  Created by Guilherme Souza on 23/04/26.
 //
 
+import ConcurrencyExtras
 import Foundation
 import HTTPTypes
 import XCTest
@@ -70,16 +71,16 @@ final class RetryRequestInterceptorTests: XCTestCase {
     let cloudfareCodes = [520, 521, 522, 523, 524, 530]
 
     for code in cloudfareCodes {
-      var callCount = 0
+      let callCount = LockIsolated(0)
       let finalResponse = try await interceptor.intercept(request) { _ in
-        callCount += 1
-        if callCount < 2 {
-          return self.makeResponse(statusCode: code) as Helpers.HTTPResponse
+        callCount.withValue { $0 += 1 }
+        if callCount.value < 2 {
+          return self.makeResponse(statusCode: code)
         }
         return self.makeResponse(statusCode: 200)
       }
       XCTAssertEqual(finalResponse.statusCode, 200, "Should retry on \(code) and succeed")
-      XCTAssertEqual(callCount, 2, "Should have called next twice for \(code)")
+      XCTAssertEqual(callCount.value, 2, "Should have called next twice for \(code)")
     }
   }
 
@@ -89,13 +90,13 @@ final class RetryRequestInterceptorTests: XCTestCase {
     let nonRetryableCodes = [400, 401, 403, 404, 422]
 
     for code in nonRetryableCodes {
-      var callCount = 0
+      let callCount = LockIsolated(0)
       let response = try await interceptor.intercept(request) { _ in
-        callCount += 1
-        return self.makeResponse(statusCode: code) as Helpers.HTTPResponse
+        callCount.withValue { $0 += 1 }
+        return self.makeResponse(statusCode: code)
       }
       XCTAssertEqual(response.statusCode, code)
-      XCTAssertEqual(callCount, 1, "Should not retry on \(code)")
+      XCTAssertEqual(callCount.value, 1, "Should not retry on \(code)")
     }
   }
 
@@ -105,16 +106,16 @@ final class RetryRequestInterceptorTests: XCTestCase {
     let retryableCodes = [408, 500, 502, 503, 504]
 
     for code in retryableCodes {
-      var callCount = 0
+      let callCount = LockIsolated(0)
       let finalResponse = try await interceptor.intercept(request) { _ in
-        callCount += 1
-        if callCount < 2 {
-          return self.makeResponse(statusCode: code) as Helpers.HTTPResponse
+        callCount.withValue { $0 += 1 }
+        if callCount.value < 2 {
+          return self.makeResponse(statusCode: code)
         }
         return self.makeResponse(statusCode: 200)
       }
       XCTAssertEqual(finalResponse.statusCode, 200, "Should retry on \(code) and succeed")
-      XCTAssertEqual(callCount, 2, "Should have called next twice for \(code)")
+      XCTAssertEqual(callCount.value, 2, "Should have called next twice for \(code)")
     }
   }
 
@@ -122,25 +123,25 @@ final class RetryRequestInterceptorTests: XCTestCase {
     let interceptor = makeInterceptor(retryLimit: 2)
     let request = makeRequest(method: .post)
 
-    var callCount = 0
+    let callCount = LockIsolated(0)
     let response = try await interceptor.intercept(request) { _ in
-      callCount += 1
+      callCount.withValue { $0 += 1 }
       return self.makeResponse(statusCode: 500)
     }
     XCTAssertEqual(response.statusCode, 500)
-    XCTAssertEqual(callCount, 1, "POST should not be retried")
+    XCTAssertEqual(callCount.value, 1, "POST should not be retried")
   }
 
   func testRespectsRetryLimit() async throws {
     let interceptor = makeInterceptor(retryLimit: 2)
     let request = makeRequest()
 
-    var callCount = 0
+    let callCount = LockIsolated(0)
     let response = try await interceptor.intercept(request) { _ in
-      callCount += 1
+      callCount.withValue { $0 += 1 }
       return self.makeResponse(statusCode: 520)
     }
     XCTAssertEqual(response.statusCode, 520)
-    XCTAssertEqual(callCount, 2, "Should not exceed retryLimit")
+    XCTAssertEqual(callCount.value, 2, "Should not exceed retryLimit")
   }
 }


### PR DESCRIPTION
## Summary

Expands `defaultRetryableHTTPStatusCodes` in `RetryRequestInterceptor` to include Cloudflare-specific error codes 520–524 and 530. These transient infrastructure errors are now retried instead of propagated, which prevents session invalidation during Cloudflare outages.

SDK parity with supabase-js [commit 7f47b366](https://github.com/supabase/supabase-js/pull/2239).

## Changes

- **`RetryRequestInterceptor.swift`**: Added 520, 521, 522, 523, 524, 530 to `defaultRetryableHTTPStatusCodes`
- **`RetryRequestInterceptorTests.swift`**: New test file with 7 tests covering Cloudflare codes, standard retryable codes, non-retryable codes, non-retryable HTTP methods, and retry limit enforcement

## Root Cause

Sessions were being wiped during Cloudflare outages (reported in #733) because Cloudflare's non-standard 5xx codes (520–524, 530) were not recognized as transient infrastructure errors and thus were not retried.

## Testing

### Reproduction Test
- Created `testDefaultRetryableHTTPStatusCodesContainsCloudfareCodes` — failed before fix, passes after
- Created `testRetriesOnCloudflareErrorCodes` — failed before fix, passes after

### Test Coverage
- 7 new unit tests covering all Cloudflare codes and edge cases
- All 90 HelpersTests pass

## Risk Assessment

- **Breaking changes**: None — only adds codes to an existing set
- **Backward compatibility**: Maintained
- **Performance impact**: Negligible

## Acceptance Criteria

- [x] `defaultRetryableHTTPStatusCodes` expanded to include 520-524, 530
- [x] Unit tests added
- [x] No breaking changes

## Linear Issue

Closes: [SDK-887](https://linear.app/supabase/issue/SDK-887/parityauth-include-cloudflare-error-codes-in-retryable-network-errors)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`