### PR TITLE
feat(postgrest): add stripNulls method for null value stripping

### DIFF
--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -23,6 +23,9 @@ public class PostgrestBuilder: @unchecked Sendable {
 
     /// Whether automatic retries are enabled for this request.
     var retryEnabled: Bool
+
+    /// An error to throw when execute() is called, set when an invalid method combination is detected.
+    var pendingError: String?
   }
 
   let mutableState: LockIsolated<MutableState>
@@ -115,7 +118,12 @@ public class PostgrestBuilder: @unchecked Sendable {
     options: FetchOptions,
     decode: @Sendable (Data) throws -> T
   ) async throws -> PostgrestResponse<T> {
-    let (baseRequest, retryEnabled) = mutableState.withValue { ($0.request, $0.retryEnabled) }
+    let (baseRequest, retryEnabled) = try mutableState.withValue {
+      if let message = $0.pendingError {
+        throw PostgrestError(message: message)
+      }
+      return ($0.request, $0.retryEnabled)
+    }
     var request = baseRequest
 
     if options.head {

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -121,7 +121,24 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   ///  Return `value` as a string in CSV format.
   public func csv() -> PostgrestTransformBuilder {
     mutableState.withValue {
+      let preferComponents = $0.request.headers[.prefer]?.components(separatedBy: ",") ?? []
+      if preferComponents.contains("return=stripped-nulls") {
+        $0.pendingError = "`.csv()` cannot be combined with `.stripNulls()`"
+      }
       $0.request.headers[.accept] = "text/csv"
+    }
+    return self
+  }
+
+  /// Strip null values from the response.
+  ///
+  /// Requires PostgREST 11.2.0+. Not compatible with ``csv()``.
+  public func stripNulls() -> PostgrestTransformBuilder {
+    mutableState.withValue {
+      if $0.request.headers[.accept] == "text/csv" {
+        $0.pendingError = "`.stripNulls()` cannot be combined with `.csv()`"
+      }
+      $0.request.headers.appendOrUpdate(.prefer, value: "return=stripped-nulls")
     }
     return self
   }

--- a/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
@@ -571,4 +571,61 @@ final class PostgrestTransformBuilderTests: PostgrestQueryTests {
       .maxAffected(3)
       .execute()
   }
+
+  func testStripNulls() async throws {
+    Mock(
+      url: url.appendingPathComponent("countries"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .get: Data("[]".utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "Accept: application/json" \
+      	--header "Content-Type: application/json" \
+      	--header "Prefer: return=stripped-nulls" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/countries?select=*"
+      """#
+    }
+    .register()
+
+    try await sut
+      .from("countries")
+      .select()
+      .stripNulls()
+      .execute()
+  }
+
+  func testStripNullsWithCSVThrowsError() async throws {
+    do {
+      try await sut
+        .from("countries")
+        .select()
+        .csv()
+        .stripNulls()
+        .execute()
+      XCTFail("Expected error to be thrown")
+    } catch let error as PostgrestError {
+      XCTAssertEqual(error.message, "`.stripNulls()` cannot be combined with `.csv()`")
+    }
+  }
+
+  func testCSVWithStripNullsThrowsError() async throws {
+    do {
+      try await sut
+        .from("countries")
+        .select()
+        .stripNulls()
+        .csv()
+        .execute()
+      XCTFail("Expected error to be thrown")
+    } catch let error as PostgrestError {
+      XCTAssertEqual(error.message, "`.csv()` cannot be combined with `.stripNulls()`")
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds `.stripNulls()` to `PostgrestTransformBuilder` for SDK parity with supabase-js. The method sets `Prefer: return=stripped-nulls` header, causing PostgREST to omit null-valued properties from response JSON. Requires PostgREST 11.2.0+.

## Changes

- **`PostgrestTransformBuilder`**: Added `stripNulls()` method that appends `return=stripped-nulls` to the `Prefer` header
- **`PostgrestBuilder`**: Added `pendingError` to `MutableState` to detect and throw on invalid method combinations at `execute()` time
- **`PostgrestTransformBuilder`**: Modified `csv()` to detect incompatible `stripNulls()` combination
- **Tests**: 3 new tests — snapshot test for header, and two error tests for incompatible combos

## Usage

```swift
let data = try await supabase
  .from("characters")
  .select()
  .stripNulls()
  .execute()
  .value
```

## Acceptance Criteria

- [x] `.stripNulls()` method added to `PostgrestTransformBuilder`
- [x] `Prefer: return=stripped-nulls` header set correctly
- [x] Error thrown when combined with `.csv()`
- [x] Unit tests (3 new tests, all passing)
- [x] No breaking changes

## Test Plan

- [x] `testStripNulls` — verifies `Prefer: return=stripped-nulls` header via snapshot
- [x] `testStripNullsWithCSVThrowsError` — `.csv().stripNulls().execute()` throws `PostgrestError`
- [x] `testCSVWithStripNullsThrowsError` — `.stripNulls().csv().execute()` throws `PostgrestError`
- [x] All existing PostgREST tests continue to pass (93 total)

Closes: [SDK-883](https://linear.app/supabase/issue/SDK-883)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`