### PR TITLE
feat(functions): support custom JSON encoder and decoder

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -28,6 +28,12 @@ public final class FunctionsClient: Sendable {
   /// The Region to invoke the functions in.
   let region: String?
 
+  /// The JSON encoder to use for encoding request bodies.
+  public let encoder: JSONEncoder
+
+  /// The JSON decoder to use for decoding response bodies.
+  public let decoder: JSONDecoder
+
   struct MutableState {
     /// Headers to be included in the requests.
     var headers = HTTPFields()
@@ -49,13 +55,17 @@ public final class FunctionsClient: Sendable {
   ///   - region: The Region to invoke the functions in.
   ///   - logger: SupabaseLogger instance to use.
   ///   - fetch: The fetch handler used to make requests. (Default: URLSession.shared.data(for:))
+  ///   - encoder: The JSON encoder to use for encoding request bodies. (Default: `JSONEncoder()`)
+  ///   - decoder: The JSON decoder to use for decoding response bodies. (Default: `JSONDecoder()`)
   @_disfavoredOverload
   public convenience init(
     url: URL,
     headers: [String: String] = [:],
     region: String? = nil,
     logger: (any SupabaseLogger)? = nil,
-    fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) }
+    fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
+    encoder: JSONEncoder = JSONEncoder(),
+    decoder: JSONDecoder = JSONDecoder()
   ) {
     self.init(
       url: url,
@@ -63,6 +73,8 @@ public final class FunctionsClient: Sendable {
       region: region,
       logger: logger,
       fetch: fetch,
+      encoder: encoder,
+      decoder: decoder,
       sessionConfiguration: .default
     )
   }
@@ -73,6 +85,8 @@ public final class FunctionsClient: Sendable {
     region: String? = nil,
     logger: (any SupabaseLogger)? = nil,
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
+    encoder: JSONEncoder = JSONEncoder(),
+    decoder: JSONDecoder = JSONDecoder(),
     sessionConfiguration: URLSessionConfiguration
   ) {
     var interceptors: [any HTTPClientInterceptor] = []
@@ -86,6 +100,8 @@ public final class FunctionsClient: Sendable {
       url: url,
       headers: headers,
       region: region,
+      encoder: encoder,
+      decoder: decoder,
       http: http,
       sessionConfiguration: sessionConfiguration
     )
@@ -95,11 +111,15 @@ public final class FunctionsClient: Sendable {
     url: URL,
     headers: [String: String],
     region: String?,
+    encoder: JSONEncoder = JSONEncoder(),
+    decoder: JSONDecoder = JSONDecoder(),
     http: any HTTPClientType,
     sessionConfiguration: URLSessionConfiguration = .default
   ) {
     self.url = url
     self.region = region
+    self.encoder = encoder
+    self.decoder = decoder
     self.http = http
     self.sessionConfiguration = sessionConfiguration
 
@@ -119,14 +139,26 @@ public final class FunctionsClient: Sendable {
   ///   - region: The Region to invoke the functions in.
   ///   - logger: SupabaseLogger instance to use.
   ///   - fetch: The fetch handler used to make requests. (Default: URLSession.shared.data(for:))
+  ///   - encoder: The JSON encoder to use for encoding request bodies. (Default: `JSONEncoder()`)
+  ///   - decoder: The JSON decoder to use for decoding response bodies. (Default: `JSONDecoder()`)
   public convenience init(
     url: URL,
     headers: [String: String] = [:],
     region: FunctionRegion? = nil,
     logger: (any SupabaseLogger)? = nil,
-    fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) }
+    fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
+    encoder: JSONEncoder = JSONEncoder(),
+    decoder: JSONDecoder = JSONDecoder()
   ) {
-    self.init(url: url, headers: headers, region: region?.rawValue, logger: logger, fetch: fetch)
+    self.init(
+      url: url,
+      headers: headers,
+      region: region?.rawValue,
+      logger: logger,
+      fetch: fetch,
+      encoder: encoder,
+      decoder: decoder
+    )
   }
 
   /// Updates the authorization header.
@@ -166,14 +198,16 @@ public final class FunctionsClient: Sendable {
   /// - Parameters:
   ///   - functionName: The name of the function to invoke.
   ///   - options: Options for invoking the function. (Default: empty `FunctionInvokeOptions`)
-  ///   - decoder: The JSON decoder to use for decoding the response. (Default: `JSONDecoder()`)
+  ///   - decoder: The JSON decoder to use for decoding the response. If `nil`, uses the client's
+  ///     decoder.
   /// - Returns: The decoded object of type `T`.
   public func invoke<T: Decodable>(
     _ functionName: String,
     options: FunctionInvokeOptions = .init(),
-    decoder: JSONDecoder = JSONDecoder()
+    decoder: JSONDecoder? = nil
   ) async throws -> T {
-    try await invoke(functionName, options: options) { data, _ in
+    let decoder = decoder ?? self.decoder
+    return try await invoke(functionName, options: options) { data, _ in
       try decoder.decode(T.self, from: data)
     }
   }

--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -28,9 +28,6 @@ public final class FunctionsClient: Sendable {
   /// The Region to invoke the functions in.
   let region: String?
 
-  /// The JSON encoder to use for encoding request bodies.
-  public let encoder: JSONEncoder
-
   /// The JSON decoder to use for decoding response bodies.
   public let decoder: JSONDecoder
 
@@ -55,7 +52,6 @@ public final class FunctionsClient: Sendable {
   ///   - region: The Region to invoke the functions in.
   ///   - logger: SupabaseLogger instance to use.
   ///   - fetch: The fetch handler used to make requests. (Default: URLSession.shared.data(for:))
-  ///   - encoder: The JSON encoder to use for encoding request bodies. (Default: `JSONEncoder()`)
   ///   - decoder: The JSON decoder to use for decoding response bodies. (Default: `JSONDecoder()`)
   @_disfavoredOverload
   public convenience init(
@@ -64,7 +60,6 @@ public final class FunctionsClient: Sendable {
     region: String? = nil,
     logger: (any SupabaseLogger)? = nil,
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
-    encoder: JSONEncoder = JSONEncoder(),
     decoder: JSONDecoder = JSONDecoder()
   ) {
     self.init(
@@ -73,7 +68,6 @@ public final class FunctionsClient: Sendable {
       region: region,
       logger: logger,
       fetch: fetch,
-      encoder: encoder,
       decoder: decoder,
       sessionConfiguration: .default
     )
@@ -85,7 +79,6 @@ public final class FunctionsClient: Sendable {
     region: String? = nil,
     logger: (any SupabaseLogger)? = nil,
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
-    encoder: JSONEncoder = JSONEncoder(),
     decoder: JSONDecoder = JSONDecoder(),
     sessionConfiguration: URLSessionConfiguration
   ) {
@@ -100,7 +93,6 @@ public final class FunctionsClient: Sendable {
       url: url,
       headers: headers,
       region: region,
-      encoder: encoder,
       decoder: decoder,
       http: http,
       sessionConfiguration: sessionConfiguration
@@ -111,14 +103,12 @@ public final class FunctionsClient: Sendable {
     url: URL,
     headers: [String: String],
     region: String?,
-    encoder: JSONEncoder = JSONEncoder(),
     decoder: JSONDecoder = JSONDecoder(),
     http: any HTTPClientType,
     sessionConfiguration: URLSessionConfiguration = .default
   ) {
     self.url = url
     self.region = region
-    self.encoder = encoder
     self.decoder = decoder
     self.http = http
     self.sessionConfiguration = sessionConfiguration
@@ -139,7 +129,6 @@ public final class FunctionsClient: Sendable {
   ///   - region: The Region to invoke the functions in.
   ///   - logger: SupabaseLogger instance to use.
   ///   - fetch: The fetch handler used to make requests. (Default: URLSession.shared.data(for:))
-  ///   - encoder: The JSON encoder to use for encoding request bodies. (Default: `JSONEncoder()`)
   ///   - decoder: The JSON decoder to use for decoding response bodies. (Default: `JSONDecoder()`)
   public convenience init(
     url: URL,
@@ -147,7 +136,6 @@ public final class FunctionsClient: Sendable {
     region: FunctionRegion? = nil,
     logger: (any SupabaseLogger)? = nil,
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
-    encoder: JSONEncoder = JSONEncoder(),
     decoder: JSONDecoder = JSONDecoder()
   ) {
     self.init(
@@ -156,7 +144,6 @@ public final class FunctionsClient: Sendable {
       region: region?.rawValue,
       logger: logger,
       fetch: fetch,
-      encoder: encoder,
       decoder: decoder
     )
   }

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -13,7 +13,7 @@ public enum FunctionsError: Error, LocalizedError {
     switch self {
     case .relayError:
       "Relay Error invoking the Edge Function"
-    case let .httpError(code, _):
+    case .httpError(let code, _):
       "Edge Function returned a non-2xx status code: \(code)"
     }
   }

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -39,14 +39,16 @@ public struct FunctionInvokeOptions: Sendable {
   ///   - query: The query to be included in the function invocation.
   ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
   ///   - region: The Region to invoke the function in.
-  ///   - body: The body data to be sent with the function invocation. (Default: nil)
+  ///   - body: The body data to be sent with the function invocation.
+  ///   - encoder: The JSON encoder to use for encoding the body. (Default: `JSONEncoder()`)
   @_disfavoredOverload
   public init(
     method: Method? = nil,
     query: [URLQueryItem] = [],
     headers: [String: String] = [:],
     region: String? = nil,
-    body: some Encodable
+    body: some Encodable,
+    encoder: JSONEncoder = JSONEncoder()
   ) {
     var defaultHeaders = HTTPFields()
 
@@ -58,9 +60,8 @@ public struct FunctionInvokeOptions: Sendable {
       defaultHeaders[.contentType] = "application/octet-stream"
       self.body = data
     default:
-      // default, assume this is JSON
       defaultHeaders[.contentType] = "application/json"
-      self.body = try? JSONEncoder().encode(body)
+      self.body = try? encoder.encode(body)
     }
 
     self.method = method
@@ -140,18 +141,21 @@ extension FunctionInvokeOptions {
   ///   - method: Method to use in the function invocation.
   ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
   ///   - region: The Region to invoke the function in.
-  ///   - body: The body data to be sent with the function invocation. (Default: nil)
+  ///   - body: The body data to be sent with the function invocation.
+  ///   - encoder: The JSON encoder to use for encoding the body. (Default: `JSONEncoder()`)
   public init(
     method: Method? = nil,
     headers: [String: String] = [:],
     region: FunctionRegion? = nil,
-    body: some Encodable
+    body: some Encodable,
+    encoder: JSONEncoder = JSONEncoder()
   ) {
     self.init(
       method: method,
       headers: headers,
       region: region?.rawValue,
-      body: body
+      body: body,
+      encoder: encoder
     )
   }
 

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -89,7 +89,9 @@ public final class SupabaseClient: Sendable {
           headers: headers,
           region: options.functions.region,
           logger: options.global.logger,
-          fetch: fetchWithAuth
+          fetch: fetchWithAuth,
+          encoder: options.functions.encoder,
+          decoder: options.functions.decoder
         )
       }
 

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -90,7 +90,6 @@ public final class SupabaseClient: Sendable {
           region: options.functions.region,
           logger: options.global.logger,
           fetch: fetchWithAuth,
-          encoder: options.functions.encoder,
           decoder: options.functions.decoder
         )
       }

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -118,13 +118,29 @@ public struct SupabaseClientOptions: Sendable {
     /// The Region to invoke the functions in.
     public let region: String?
 
+    /// The JSON encoder to use for encoding function request bodies.
+    public let encoder: JSONEncoder
+
+    /// The JSON decoder to use for decoding function response bodies.
+    public let decoder: JSONDecoder
+
     @_disfavoredOverload
-    public init(region: String? = nil) {
+    public init(
+      region: String? = nil,
+      encoder: JSONEncoder = JSONEncoder(),
+      decoder: JSONDecoder = JSONDecoder()
+    ) {
       self.region = region
+      self.encoder = encoder
+      self.decoder = decoder
     }
 
-    public init(region: FunctionRegion? = nil) {
-      self.init(region: region?.rawValue)
+    public init(
+      region: FunctionRegion? = nil,
+      encoder: JSONEncoder = JSONEncoder(),
+      decoder: JSONDecoder = JSONDecoder()
+    ) {
+      self.init(region: region?.rawValue, encoder: encoder, decoder: decoder)
     }
   }
 

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -118,36 +118,30 @@ public struct SupabaseClientOptions: Sendable {
     /// The Region to invoke the functions in.
     public let region: String?
 
-    /// The JSON encoder to use for encoding function request bodies.
-    public let encoder: JSONEncoder
-
     /// The JSON decoder to use for decoding function response bodies.
     public let decoder: JSONDecoder
 
     @_disfavoredOverload
     public init(
       region: String? = nil,
-      encoder: JSONEncoder = JSONEncoder(),
       decoder: JSONDecoder = JSONDecoder()
     ) {
       self.region = region
-      self.encoder = encoder
       self.decoder = decoder
     }
 
     public init(
       region: FunctionRegion? = nil,
-      encoder: JSONEncoder = JSONEncoder(),
       decoder: JSONDecoder = JSONDecoder()
     ) {
-      self.init(region: region?.rawValue, encoder: encoder, decoder: decoder)
+      self.init(region: region?.rawValue, decoder: decoder)
     }
   }
 
   public struct StorageOptions: Sendable {
     /// Whether storage client should be initialized with the new hostname format, i.e. `project-ref.storage.supabase.co`
     public let useNewHostname: Bool
-    
+
     public init(useNewHostname: Bool = false) {
       self.useNewHostname = useNewHostname
     }

--- a/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
+++ b/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
@@ -25,6 +25,22 @@ final class FunctionInvokeOptionsTests: XCTestCase {
     XCTAssertNotNil(options.body)
   }
 
+  func test_initWithEncodableBodyAndCustomEncoder() {
+    struct Body: Encodable {
+      let userName: String
+    }
+
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+
+    let options = FunctionInvokeOptions(body: Body(userName: "test"), encoder: encoder)
+    XCTAssertEqual(options.headers[.contentType], "application/json")
+
+    let json = try! JSONSerialization.jsonObject(with: options.body!) as! [String: Any]
+    XCTAssertNotNil(json["user_name"])
+    XCTAssertNil(json["userName"])
+  }
+
   func test_initWithCustomContentType() {
     let boundary = "Boundary-\(UUID().uuidString)"
     let contentType = "multipart/form-data; boundary=\(boundary)"

--- a/Tests/FunctionsTests/FunctionsClientTests.swift
+++ b/Tests/FunctionsTests/FunctionsClientTests.swift
@@ -55,21 +55,16 @@ final class FunctionsClientTests: XCTestCase {
     XCTAssertNotNil(client.headers[.init("X-Client-Info")!])
   }
 
-  func testInitWithCustomEncoder() async {
-    let encoder = JSONEncoder()
-    encoder.keyEncodingStrategy = .convertToSnakeCase
-
+  func testInitWithCustomDecoder() async {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
     let client = FunctionsClient(
       url: url,
       headers: ["apikey": apiKey],
-      encoder: encoder,
       decoder: decoder
     )
 
-    XCTAssertTrue(client.encoder === encoder)
     XCTAssertTrue(client.decoder === decoder)
   }
 

--- a/Tests/FunctionsTests/FunctionsClientTests.swift
+++ b/Tests/FunctionsTests/FunctionsClientTests.swift
@@ -55,6 +55,24 @@ final class FunctionsClientTests: XCTestCase {
     XCTAssertNotNil(client.headers[.init("X-Client-Info")!])
   }
 
+  func testInitWithCustomEncoder() async {
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+    let client = FunctionsClient(
+      url: url,
+      headers: ["apikey": apiKey],
+      encoder: encoder,
+      decoder: decoder
+    )
+
+    XCTAssertTrue(client.encoder === encoder)
+    XCTAssertTrue(client.decoder === decoder)
+  }
+
   func testInvoke() async throws {
     Mock(
       url: self.url.appendingPathComponent("hello_world"),

--- a/Tests/IntegrationTests/StorageFileIntegrationTests.swift
+++ b/Tests/IntegrationTests/StorageFileIntegrationTests.swift
@@ -184,10 +184,10 @@ final class StorageFileIntegrationTests: XCTestCase {
         """
         ▿ StorageError
           ▿ error: Optional<String>
-            - some: "InvalidRequest"
+            - some: "invalid_mime_type"
           - message: "mime type image/jpeg is not supported"
           ▿ statusCode: Optional<String>
-            - some: "400"
+            - some: "415"
 
         """
       }


### PR DESCRIPTION
Picks up and addresses the review feedback on #935 by @OlegBezr — thanks for the original contribution!

## Summary

- Adds `encoder` parameter to `FunctionInvokeOptions` for per-call JSON encoding customization (e.g. `.convertToSnakeCase`)
- Adds `decoder` parameter to `FunctionsClient` and `SupabaseClientOptions.FunctionsOptions` for client-level decoding customization — wired into `invoke<T: Decodable>` as the default decoder
- **Removes** the unused `encoder` from `FunctionsClient`/`FunctionsOptions` (encoding happens inside `FunctionInvokeOptions` before the client ever sees the body, so storing it on the client had no effect — this was the blocking review feedback)

This brings the Functions client in line with `DatabaseOptions` which already supports custom encoder/decoder.

## Usage

Per-call custom encoder:
```swift
let encoder = JSONEncoder()
encoder.keyEncodingStrategy = .convertToSnakeCase

try await client.functions.invoke(
  "my-function",
  options: .init(body: myPayload, encoder: encoder)
)
```

Client-level custom decoder via `SupabaseClient`:
```swift
let decoder = JSONDecoder()
decoder.keyDecodingStrategy = .convertFromSnakeCase

let client = SupabaseClient(
  supabaseURL: url,
  supabaseKey: key,
  options: .init(functions: .init(decoder: decoder))
)
```

Closes #935