### PR TITLE
fix(spm): close intermediate-consumer linking gap

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
   products: [
     .library(name: "Auth", targets: ["Auth"]),
     .library(name: "Functions", targets: ["Functions"]),
+    .library(name: "Helpers", targets: ["Helpers"]),
     .library(name: "PostgREST", targets: ["PostgREST"]),
     .library(name: "Realtime", targets: ["Realtime"]),
     .library(name: "Storage", targets: ["Storage"]),
@@ -41,6 +42,7 @@ let package = Package(
         .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "Clocks", package: "swift-clocks"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(


### PR DESCRIPTION
## Problem

`Helpers` is a build-time dependency of `Auth`, `Functions`, `PostgREST`, `Realtime`, and `Storage`, but it isn't exported as a library product, and its product-deps under-declare what it actually uses at link time:

```swift
.target(
  name: "Helpers",
  dependencies: [
    .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
    .product(name: "HTTPTypes", package: "swift-http-types"),
    .product(name: "Clocks", package: "swift-clocks"),
    .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
    // ↑ XCTestDynamicOverlay is declared, but Helpers also uses
    //   IssueReporting symbols (via the new-identity API migration in
    //   xctest-dynamic-overlay) that aren't reachable from this product.
  ]
)
```

Both gaps are invisible to direct consumers — Xcode targets that depend on `Auth` (or any sibling) directly resolve the missing transitives through the project's overall package graph. SwiftPM's static linking permissiveness papers over the rest.

The gaps surface for **intermediate-SPM consumers**: a SwiftPM library that re-exports `Auth`/`Realtime`/`Storage` to a downstream Xcode test bundle. The test bundle re-links `Auth.framework` from the intermediate library's link closure, which doesn't include the silently-resolved transitives. Linking fails:

```
Undefined symbol: IssueReporting.IssueContext.current.getter
Undefined symbol: IssueReporting.IssueReporters.current.getter
Undefined symbol: IssueReporting.FailureObserver.current.getter
Undefined symbol: IssueReporting.FailureObserver.withLock(_:)
Undefined symbol: IssueReporting.isTesting
Undefined symbol: Helpers.ObservationToken.cancel()
Undefined symbol: Helpers.AnyJSON.<…>
```

## Repro

```swift
// Intermediate library Package.swift
.target(
    name: "MyLib",
    dependencies: [
        .product(name: "Auth", package: "supabase-swift"),
        .product(name: "Realtime", package: "supabase-swift"),
    ]
)

// Downstream Xcode app + test bundle that depends on MyLib.
// Building the app target succeeds.
// Building the test bundle (which re-links Auth.framework) fails with
// the undefined symbols above.
```

Switching the Xcode target to depend on `Auth` directly (skipping `MyLib`) makes the symbols resolve through the wider package graph, masking the bug.

## Fix

Two-line patch:

1. Expose `Helpers` as a library product, so intermediate consumers can link it explicitly.
2. Declare `IssueReporting` as an explicit product dep on the `Helpers` target, so its symbols are part of the link closure that flows through the product.

```diff
   products: [
+    .library(name: "Helpers", targets: ["Helpers"]),
     .library(name: "Auth", targets: ["Auth"]),
     ...
   ],
   ...
   .target(
     name: "Helpers",
     dependencies: [
       ...
       .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+      .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
     ]
   ),
```
