### PR TITLE
chore: add @supabase/sdk as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grdsdev
+* @grdsdev @supabase/sdk


### PR DESCRIPTION
## Summary

- Adds `@supabase/sdk` team alongside `@grdsdev` as a global codeowner in `.github/CODEOWNERS`

## Why

Ensures the SDK team is automatically requested for review on all PRs, consistent with how other Supabase SDKs (e.g. supabase-js) handle codeownership.