### PR TITLE
fix(ci): always run CI Success check on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,34 +5,10 @@ on:
     branches:
       - main
       - release/*
-    paths:
-      - "Sources/**"
-      - "Tests/**"
-      - "Examples/**"
-      - "*.swift"
-      - "Package.swift"
-      - "Package.resolved"
-      - ".github/workflows/ci.yml"
-      - "Makefile"
-      - "*.xcodeproj/**"
-      - "*.xcworkspace/**"
-      - ".swiftpm/**"
   pull_request:
     branches:
       - "*"
       - release/*
-    paths:
-      - "Sources/**"
-      - "Tests/**"
-      - "Examples/**"
-      - "*.swift"
-      - "Package.swift"
-      - "Package.resolved"
-      - ".github/workflows/ci.yml"
-      - "Makefile"
-      - "*.xcodeproj/**"
-      - "*.xcworkspace/**"
-      - ".swiftpm/**"
   workflow_dispatch:
 
 concurrency:
@@ -282,8 +258,8 @@ jobs:
 
   format-check:
     name: Format check (changed files only)
-    runs-on: macos-26
     if: github.event_name == 'pull_request'
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

Remove all `paths` filters from the CI workflow so it always triggers on every pull request and push to main/release branches.

## Root cause

When a PR only touched files outside the path filters (e.g. `.github/CODEOWNERS` in [PR #983](https://github.com/supabase/supabase-swift/pull/983)), the entire CI workflow never triggered. GitHub distinguishes between a check that is **skipped** and one that is **missing**: a workflow that never triggered creates no check run at all, leaving the required `CI Success` check permanently absent and blocking the PR from merging.

## Fix

Remove path filters entirely. CI now runs on every PR regardless of what changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)