### PR TITLE
feat(supabase): consolidate client metadata into structured X-Client-Info header

### DIFF
--- a/Sources/Helpers/Version.swift
+++ b/Sources/Helpers/Version.swift
@@ -66,3 +66,25 @@ private let _platformVersion: String? = {
 #else
   package let platformVersion = _platformVersion
 #endif
+
+private let _runtimeVersion: String = {
+  #if swift(>=6.3)
+    return "6.3"
+  #elseif swift(>=6.2)
+    return "6.2"
+  #elseif swift(>=6.1)
+    return "6.1"
+  #elseif swift(>=6.0)
+    return "6.0"
+  #elseif swift(>=5.10)
+    return "5.10"
+  #else
+    return "unknown"
+  #endif
+}()
+
+#if DEBUG
+  package let runtimeVersion = isTesting ? "0.0.0" : _runtimeVersion
+#else
+  package let runtimeVersion = _runtimeVersion
+#endif

--- a/Sources/Helpers/Version.swift
+++ b/Sources/Helpers/Version.swift
@@ -67,7 +67,7 @@ private let _platformVersion: String? = {
   package let platformVersion = _platformVersion
 #endif
 
-private let _runtimeVersion: String = {
+private let _runtimeVersion: String? = {
   #if swift(>=6.3)
     return "6.3"
   #elseif swift(>=6.2)
@@ -79,12 +79,12 @@ private let _runtimeVersion: String = {
   #elseif swift(>=5.10)
     return "5.10"
   #else
-    return "unknown"
+    return nil
   #endif
 }()
 
 #if DEBUG
-  package let runtimeVersion = isTesting ? "0.0.0" : _runtimeVersion
+  package let runtimeVersion: String? = isTesting ? "0.0.0" : _runtimeVersion
 #else
   package let runtimeVersion = _runtimeVersion
 #endif

--- a/Sources/Supabase/Constants.swift
+++ b/Sources/Supabase/Constants.swift
@@ -8,17 +8,18 @@
 import Foundation
 
 let defaultHeaders: [String: String] = {
-  var headers = [
-    "X-Client-Info": "supabase-swift/\(version)"
-  ]
+  var clientInfo = "supabase-swift/\(version)"
 
   if let platform {
-    headers["X-Supabase-Client-Platform"] = platform
+    clientInfo += "; platform=\(platform)"
   }
 
   if let platformVersion {
-    headers["X-Supabase-Client-Platform-Version"] = platformVersion
+    clientInfo += "; platform-version=\(platformVersion)"
   }
 
-  return headers
+  clientInfo += "; runtime=swift"
+  clientInfo += "; runtime-version=\(runtimeVersion)"
+
+  return ["X-Client-Info": clientInfo]
 }()

--- a/Sources/Supabase/Constants.swift
+++ b/Sources/Supabase/Constants.swift
@@ -19,7 +19,10 @@ let defaultHeaders: [String: String] = {
   }
 
   clientInfo += "; runtime=swift"
-  clientInfo += "; runtime-version=\(runtimeVersion)"
+
+  if let runtimeVersion {
+    clientInfo += "; runtime-version=\(runtimeVersion)"
+  }
 
   return ["X-Client-Info": clientInfo]
 }()

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -69,9 +69,7 @@ final class SupabaseClientTests: XCTestCase {
       [
         "Apikey": "PUBLISHABLE_KEY",
         "Authorization": "Bearer PUBLISHABLE_KEY",
-        "X-Client-Info": "supabase-swift/0.0.0",
-        "X-Supabase-Client-Platform": "macOS",
-        "X-Supabase-Client-Platform-Version": "0.0.0",
+        "X-Client-Info": "supabase-swift/0.0.0; platform=macOS; platform-version=0.0.0; runtime=swift; runtime-version=0.0.0",
         "header_field": "header_value"
       ]
       """


### PR DESCRIPTION
## What

Consolidates the separate `X-Supabase-Client-Platform` and `X-Supabase-Client-Platform-Version` headers into a single structured `X-Client-Info` value using semicolon-delimited `key=value` pairs (same convention as `Content-Type` params):

```
X-Client-Info: supabase-swift/2.45.0; platform=iOS; platform-version=18.5.0; runtime=swift; runtime-version=5.10
```

Also adds two new fields that weren't previously sent: `runtime` (always `swift`) and `runtime-version` (detected at compile time via `#if swift(...)` chain).

## Why

Adding a new header in supabase-js is a breaking change — when the JS client runs inside an Edge Function, users define their CORS allowed headers explicitly, so any new header we introduce gets blocked until users update their config. `X-Client-Info` is already present in every allowlist, so extending it as a structured value lets us add new metadata fields freely without touching CORS or coordinating across all client libs.

## Changes

- `Sources/Helpers/Version.swift` — adds `runtimeVersion` using a compile-time `#if swift(...)` chain, following the same debug/test override pattern as `platform` and `platformVersion`
- `Sources/Supabase/Constants.swift` — builds the consolidated `X-Client-Info` value; removes the two standalone platform headers

## Notes for reviewers

- Data team sign-off is pending before merging — they need to confirm existing pipelines that rely on the standalone headers can migrate to parsing the new structured value
- The format is easily parseable: split on `; `, first segment is `lib/version`, rest are `key=value` pairs
- Future metadata fields just need a single `clientInfo += "; key=value"` line, no new headers

Closes SDK-905