### PR TITLE
fix(spm): declare directly-imported transitive deps on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
         .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "Clocks", package: "swift-clocks"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
@@ -53,6 +54,8 @@ let package = Package(
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "Helpers",
       ]
     ),
@@ -75,7 +78,9 @@ let package = Package(
     .target(
       name: "Functions",
       dependencies: [
-        "Helpers"
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
+        "Helpers",
       ]
     ),
     .testTarget(
@@ -112,6 +117,7 @@ let package = Package(
       name: "PostgREST",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
         "Helpers",
       ]
     ),
@@ -133,6 +139,7 @@ let package = Package(
       name: "Realtime",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "Helpers",
       ]
@@ -150,7 +157,9 @@ let package = Package(
     .target(
       name: "Storage",
       dependencies: [
-        "Helpers"
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
+        "Helpers",
       ]
     ),
     .testTarget(
@@ -175,6 +184,7 @@ let package = Package(
       name: "Supabase",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "Auth",
         "Functions",


### PR DESCRIPTION
## Summary

Several Swift targets import modules they only reach **transitively** through `Helpers` (or via `@_exported` re-exports) without declaring them as direct product dependencies. This compiles and links fine in the package's own builds, but breaks framework linking in external consumer projects under Xcode 26's stricter implicit-dependency rules — surfacing as `Undefined symbols ... IssueReporting.isTesting` when `Helpers.framework` / `Auth.framework` link.

This declares each target's directly-imported modules as direct product dependencies so the `-framework X` linker flags propagate.

## Root Cause

Each Supabase module is built as a separate `.framework` with its own `ld` step. When a target imports a module but only reaches it transitively, the linker flag for that module isn't propagated in consumer projects that rely on declared product dependencies (Xcode 26 explicit-modules strict linking). App-target builds and the package's own SPM scheme builds don't hit this — SPM computes the full transitive link closure and passes `-framework` for everything regardless of declarations.

Confirmed undeclared direct imports (verified against `import` statements in source):

| Target | Imports but didn't declare |
|--------|----------------------------|
| `Helpers` | `IssueReporting` (`isTesting` in `Version.swift`, via `XCTestDynamicOverlay`'s `@_exported import`) |
| `Auth` | `HTTPTypes`, `IssueReporting` |
| `Functions` | `ConcurrencyExtras`, `HTTPTypes` |
| `PostgREST` | `HTTPTypes` |
| `Realtime` | `HTTPTypes` |
| `Storage` | `ConcurrencyExtras`, `HTTPTypes` |
| `Supabase` | `HTTPTypes` |

This follows the existing precedent in `Realtime`, which already declares `IssueReporting` because it imports it.

## Changes

- **Package.swift**: Added the directly-imported product dependencies listed above to each target. No source code changes — purely dependency-declaration hygiene.

## Testing

Verified on **Xcode 26.5** (Build 17F42), iOS 26.5 Simulator:

- `swift build` — clean, no warnings.
- `xcodebuild clean build-for-testing -scheme Auth -destination 'platform=iOS Simulator,...,OS=26.5'` — **TEST BUILD SUCCEEDED**.
- `xcodebuild build-for-testing -scheme Supabase ...OS=26.5` — **TEST BUILD SUCCEEDED** (all module frameworks link: Helpers, Auth, Functions, PostgREST, Realtime, Storage, Supabase).
- `xcodebuild test -scheme Auth ...OS=26.5` — **TEST SUCCEEDED**, 167 tests, 0 failures.

> [!NOTE]
> The exact link failure can't be reproduced from the package's own SPM scheme (it succeeds both before and after this change) because SPM passes the full transitive `-framework` closure for its own builds. The failure manifests in external consumer Xcode projects under Xcode 26 explicit-modules strict linking. The fix is principled and verified non-regressing: it makes every target declare exactly the modules it imports.

## Risk Assessment

- **Breaking changes**: None — only adds already-present (transitive) modules as explicit deps.
- **Behavior**: Unchanged; no source modified.

## Linear Issue

Closes: [SDK-966](https://linear.app/supabase/issue/SDK-966/helpers-auth-framework-link-fails-under-xcode-26-implicit-transitive)

Related:
- supabase/supabase-swift#1000
- Closed PR supabase/supabase-swift#977 (same diagnosis)
- Closed PR supabase/supabase-swift#948 (removed `@_exported import Helpers` from Auth)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`