### PR TITLE
fix(realtime): prevent deaf socket from duplicate handleConnected (SDK-959)

### DIFF
--- a/Sources/Realtime/ChannelStateManager.swift
+++ b/Sources/Realtime/ChannelStateManager.swift
@@ -187,6 +187,37 @@ actor ChannelStateManager {
     }
   }
 
+  /// Reset channel state so it can rejoin after a reconnect.
+  ///
+  /// A channel that is already `.subscribed` when the socket reconnects
+  /// must re-send `phx_join` on the new socket. But ``subscribe()`` is a
+  /// no-op for `.subscribed` channels — so `rejoinChannels()` would silently
+  /// skip them without this reset.
+  ///
+  /// For `.subscribing`, the in-flight join task is waiting for a reply that
+  /// will never arrive on the dead socket; cancel it so a fresh `phx_join` is
+  /// sent on the new connection.
+  ///
+  /// For `.unsubscribing`, the wait loop in ``runUnsubscribe`` polls
+  /// `stateSubject.values`. Transitioning to `.unsubscribed` here wakes it up
+  /// immediately — the server's `phx_close` won't arrive on the dead socket
+  /// anyway.
+  func resetForReconnect() {
+    joinRef = nil
+    pushes = [:]
+    switch state {
+    case .subscribed:
+      updateState(.unsubscribed)
+    case .subscribing(let task):
+      task.cancel()
+      updateState(.unsubscribed)
+    case .unsubscribing:
+      updateState(.unsubscribed)
+    case .unsubscribed:
+      break
+    }
+  }
+
   // MARK: - Server signals
 
   /// Called when the server confirms the `phx_join` (system.ok or phx_reply

--- a/Sources/Realtime/ConnectionManager.swift
+++ b/Sources/Realtime/ConnectionManager.swift
@@ -102,22 +102,32 @@ actor ConnectionManager {
 
   /// Handle connection error and initiate reconnect.
   ///
-  /// - Parameter error: The error that caused the connection failure
-  func handleError(_ error: any Error) {
+  /// - Parameters:
+  ///   - error: The error that caused the connection failure
+  ///   - conn: The connection the error originated from. When provided and it
+  ///     isn't the current connection (e.g. a late error surfacing from a
+  ///     socket that has already been replaced by a reconnect), the error is
+  ///     ignored so it can't tear down a healthy connection.
+  func handleError(_ error: any Error, from conn: (any WebSocket)? = nil) {
     guard !(error is CancellationError) else {
       logger?.debug("CancellationError do not trigger reconnects.")
       return
     }
 
-    guard case .connected(let conn) = state else {
+    guard case .connected(let current) = state else {
       logger?.debug("Ignoring error in non-connected state: \(error)")
+      return
+    }
+
+    if let conn, conn !== current {
+      logger?.debug("Ignoring error from stale connection: \(error)")
       return
     }
 
     logger?.debug("Connection error, initiating reconnect: \(error.localizedDescription)")
 
     // Close the connection and update to disconnected before reconnecting
-    conn.close(code: nil, reason: "error: \(error.localizedDescription)")
+    current.close(code: nil, reason: "error: \(error.localizedDescription)")
     updateState(.disconnected)
 
     initiateReconnect(reason: "error: \(error.localizedDescription)")
@@ -130,11 +140,20 @@ actor ConnectionManager {
   /// - Parameters:
   ///   - code: WebSocket close code
   ///   - reason: WebSocket close reason
-  func handleClose(code: Int?, reason: String?) {
+  ///   - conn: The connection the close event originated from. When provided
+  ///     and it isn't the current connection (a `.close` frame from an old
+  ///     socket can arrive after a reconnect already established a new one),
+  ///     the event is ignored so it can't mark a healthy connection as
+  ///     disconnected.
+  func handleClose(code: Int?, reason: String?, from conn: (any WebSocket)? = nil) {
     let closeReason = "code: \(code?.description ?? "none"), reason: \(reason ?? "none")"
     logger?.debug("Connection closed by remote: \(closeReason)")
 
-    if case .connected = state {
+    if case .connected(let current) = state {
+      if let conn, conn !== current {
+        logger?.debug("Ignoring close from stale connection: \(closeReason)")
+        return
+      }
       updateState(.disconnected)
     }
   }

--- a/Sources/Realtime/ConnectionManager.swift
+++ b/Sources/Realtime/ConnectionManager.swift
@@ -17,6 +17,9 @@ actor ConnectionManager {
   private let headers: [String: String]
   private let reconnectDelay: TimeInterval
   private let logger: (any SupabaseLogger)?
+  // Captured at init time so parallel test classes that swap _clock cannot
+  // change the timing of an already-running client.
+  let clock: any _Clock
 
   /// Get current connection if connected, nil otherwise.
   var connection: (any WebSocket)? {
@@ -33,13 +36,15 @@ actor ConnectionManager {
     url: URL,
     headers: [String: String],
     reconnectDelay: TimeInterval,
-    logger: (any SupabaseLogger)?
+    logger: (any SupabaseLogger)?,
+    clock: any _Clock = _clock
   ) {
     self.transport = transport
     self.url = url
     self.headers = headers
     self.reconnectDelay = reconnectDelay
     self.logger = logger
+    self.clock = clock
   }
 
   @discardableResult
@@ -178,7 +183,7 @@ actor ConnectionManager {
 
   private func initiateReconnect(reason: String) {
     let reconnectTask = Task {
-      try await _clock.sleep(for: reconnectDelay)
+      try await clock.sleep(for: reconnectDelay)
       logger?.debug("Attempting to reconnect...")
       try await performConnection()
     }

--- a/Sources/Realtime/ConnectionManager.swift
+++ b/Sources/Realtime/ConnectionManager.swift
@@ -155,6 +155,7 @@ actor ConnectionManager {
         return
       }
       updateState(.disconnected)
+      initiateReconnect(reason: closeReason)
     }
   }
 

--- a/Sources/Realtime/ConnectionManager.swift
+++ b/Sources/Realtime/ConnectionManager.swift
@@ -160,6 +160,13 @@ actor ConnectionManager {
         return
       }
       updateState(.disconnected)
+      // Application-level close codes (4000–4999) typically signal auth or
+      // protocol errors. Reconnecting with the same bad token would loop;
+      // the caller must re-authenticate before reconnecting.
+      guard code.map({ $0 < 4000 }) ?? true else {
+        logger?.debug("Skipping reconnect for application close code \(code!)")
+        return
+      }
       initiateReconnect(reason: closeReason)
     }
   }

--- a/Sources/Realtime/RealtimeChannelV2.swift
+++ b/Sources/Realtime/RealtimeChannelV2.swift
@@ -157,6 +157,10 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     await stateManager.unsubscribe()
   }
 
+  func resetForReconnect() async {
+    await stateManager.resetForReconnect()
+  }
+
   /// Build the `phx_join` payload from the current config and push it.
   /// Invoked by ``ChannelStateManager`` via the ``ChannelStateManager/JoinOperation``
   /// closure at the moment the state machine is ready to join.

--- a/Sources/Realtime/RealtimeClientV2.swift
+++ b/Sources/Realtime/RealtimeClientV2.swift
@@ -247,13 +247,30 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   }
 
   private func handleConnected(conn: any WebSocket, isReconnect: Bool) {
-    mutableState.withValue { $0.connection = conn }
-    listenForMessages(conn: conn)
-    startHeartbeating()
+    // Set up the per-connection machinery exactly once. `handleConnected` can
+    // legitimately be invoked twice for the same physical connection — once
+    // synchronously by `connect()` and once by the state-observer task when a
+    // `connect()` call lands while an auto-reconnect is in flight. Reading
+    // `conn.events` a second time installs a fresh `onEvent` and, when the
+    // first event-stream's task is torn down, its `onTermination` nils that
+    // live `onEvent` out — leaving the socket connected but deaf (SDK-959).
+    // Guarding on connection identity keeps `listenForMessages` (and thus the
+    // `conn.events` read) to a single call per connection.
+    let isNewConnection = mutableState.withValue { state -> Bool in
+      if state.connection === conn { return false }
+      state.connection = conn
+      return true
+    }
+
+    if isNewConnection {
+      listenForMessages(conn: conn)
+      startHeartbeating()
+      flushSendBuffer()
+    }
+
     if isReconnect {
       Task { await rejoinChannels() }
     }
-    flushSendBuffer()
   }
 
   deinit {

--- a/Sources/Realtime/RealtimeClientV2.swift
+++ b/Sources/Realtime/RealtimeClientV2.swift
@@ -441,6 +441,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
 
   private func rejoinChannels() async {
     for channel in channels.values {
+      await channel.resetForReconnect()
       try? await channel.subscribeWithError()
     }
   }

--- a/Sources/Realtime/RealtimeClientV2.swift
+++ b/Sources/Realtime/RealtimeClientV2.swift
@@ -247,18 +247,25 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   }
 
   private func handleConnected(conn: any WebSocket, isReconnect: Bool) {
-    // Set up the per-connection machinery exactly once. `handleConnected` can
-    // legitimately be invoked twice for the same physical connection — once
-    // synchronously by `connect()` and once by the state-observer task when a
-    // `connect()` call lands while an auto-reconnect is in flight. Reading
-    // `conn.events` a second time installs a fresh `onEvent` and, when the
-    // first event-stream's task is torn down, its `onTermination` nils that
-    // live `onEvent` out — leaving the socket connected but deaf (SDK-959).
-    // Guarding on connection identity keeps `listenForMessages` (and thus the
-    // `conn.events` read) to a single call per connection.
+    // Set up the per-connection machinery exactly once. `handleConnected` is
+    // invoked once per caller of `connect()` plus once by the state-observer
+    // task on reconnects — concurrent subscribes (or a subscribe retry racing
+    // an auto-reconnect) make it run multiple times for the same physical
+    // connection. Reading `conn.events` a second time installs a fresh
+    // `onEvent` and, when the first event-stream's task is torn down, its
+    // `onTermination` nils that live `onEvent` out — leaving the socket
+    // connected but deaf: every server frame (heartbeat acks, phx_join
+    // replies) is silently dropped (SDK-959). Guarding on connection identity
+    // keeps `listenForMessages` (and thus the `conn.events` read) to a single
+    // call per connection.
     let isNewConnection = mutableState.withValue { state -> Bool in
       if state.connection === conn { return false }
       state.connection = conn
+      // A heartbeat awaiting an ack on the previous connection can never be
+      // acknowledged on this one. Clearing the pending ref prevents the new
+      // connection's first heartbeat from misreading it as a timeout and
+      // tearing down a healthy socket.
+      state.pendingHeartbeatRef = nil
       return true
     }
 
@@ -480,7 +487,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
                 "WebSocket closed. Code: \(code?.description ?? "<none>"), Reason: \(reason)"
               )
 
-              await connectionManager.handleClose(code: code, reason: reason)
+              await connectionManager.handleClose(code: code, reason: reason, from: conn)
             }
           }
         } catch is CancellationError {
@@ -491,7 +498,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
             .debug(
               "WebSocket error \(error.localizedDescription). Trying again in \(options.reconnectDelay)"
             )
-          await connectionManager.handleError(error)
+          await connectionManager.handleError(error, from: conn)
         }
       }
     }
@@ -553,7 +560,11 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
       // Clear the pending ref before reconnecting
       mutableState.withValue { $0.pendingHeartbeatRef = nil }
 
-      await connectionManager.handleError(RealtimeError("heartbeat timeout"))
+      // Scope the reconnect to the connection this heartbeat was sent on, so
+      // a timeout that fires after a reconnect has already replaced the
+      // socket can't tear down the healthy new connection.
+      let conn = mutableState.withValue { $0.connection }
+      await connectionManager.handleError(RealtimeError("heartbeat timeout"), from: conn)
     }
   }
 

--- a/Sources/Realtime/RealtimeClientV2.swift
+++ b/Sources/Realtime/RealtimeClientV2.swift
@@ -253,17 +253,12 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   }
 
   private func handleConnected(conn: any WebSocket, isReconnect: Bool) {
-    // Set up the per-connection machinery exactly once. `handleConnected` is
-    // invoked once per caller of `connect()` plus once by the state-observer
-    // task on reconnects — concurrent subscribes (or a subscribe retry racing
-    // an auto-reconnect) make it run multiple times for the same physical
-    // connection. Reading `conn.events` a second time installs a fresh
-    // `onEvent` and, when the first event-stream's task is torn down, its
-    // `onTermination` nils that live `onEvent` out — leaving the socket
-    // connected but deaf: every server frame (heartbeat acks, phx_join
-    // replies) is silently dropped (SDK-959). Guarding on connection identity
-    // keeps `listenForMessages` (and thus the `conn.events` read) to a single
-    // call per connection.
+    // Set up the per-connection machinery exactly once. `handleConnected` can
+    // run multiple times for the same physical connection (concurrent subscribes,
+    // subscribe retries racing an auto-reconnect). Guarding on connection identity
+    // prevents launching duplicate `listenForMessages` / `startHeartbeating` tasks,
+    // which would cancel-and-restart the stream consumer (potentially losing
+    // in-flight frames) and create a second heartbeat timer.
     let isNewConnection = mutableState.withValue { state -> Bool in
       if state.connection === conn { return false }
       state.connection = conn

--- a/Sources/Realtime/RealtimeClientV2.swift
+++ b/Sources/Realtime/RealtimeClientV2.swift
@@ -80,6 +80,9 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   let http: any HTTPClientType
   let apikey: String
   let serializer = RealtimeSerializer()
+  // Captured at init time so parallel test classes that swap _clock cannot
+  // change the timing of an already-running client.
+  let clock: any _Clock
 
   let connectionManager: ConnectionManager
 
@@ -164,7 +167,8 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     url: URL,
     options: RealtimeClientOptions,
     wsTransport: @escaping WebSocketTransport,
-    http: any HTTPClientType
+    http: any HTTPClientType,
+    clock: any _Clock = _clock
   ) {
     var options = options
     if options.headers[.xClientInfo] == nil {
@@ -175,6 +179,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     self.options = options
     self.wsTransport = wsTransport
     self.http = http
+    self.clock = clock
 
     precondition(options.apikey != nil, "API key is required to connect to Realtime")
     apikey = options.apikey!
@@ -195,7 +200,8 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
       ),
       headers: options.headers.dictionary,
       reconnectDelay: options.reconnectDelay,
-      logger: options.logger
+      logger: options.logger,
+      clock: clock
     )
 
     let stateObserverTask = Task { [weak self, connectionManager, statusSubject] in
@@ -396,9 +402,9 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     let delay = options.disconnectOnEmptyChannelsAfter
     mutableState.withValue { state in
       state.pendingDisconnectTask?.cancel()
-      state.pendingDisconnectTask = Task { [weak self] in
+      state.pendingDisconnectTask = Task { [weak self, clock] in
         do {
-          try await _clock.sleep(for: delay)
+          try await clock.sleep(for: delay)
           self?.disconnect()
         } catch {
           // Cancelled: a new channel was added or disconnect() was called directly.
@@ -509,9 +515,9 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     mutableState.withValue { state in
       state.heartbeatTask?.cancel()
 
-      state.heartbeatTask = Task { [options] in
+      state.heartbeatTask = Task { [options, clock] in
         while !Task.isCancelled {
-          try? await _clock.sleep(for: options.heartbeatInterval)
+          try? await clock.sleep(for: options.heartbeatInterval)
           if Task.isCancelled {
             break
           }

--- a/Sources/Realtime/WebSocket/URLSessionWebSocket.swift
+++ b/Sources/Realtime/WebSocket/URLSessionWebSocket.swift
@@ -32,7 +32,7 @@ final class URLSessionWebSocket: WebSocket {
   ) {
     self._task = _task
     self._protocol = _protocol
-    
+
     (events, eventsContinuation) = AsyncStream.makeStream()
 
     _scheduleReceive()
@@ -176,7 +176,7 @@ final class URLSessionWebSocket: WebSocket {
   var isClosed: Bool {
     mutableState.value.isClosed
   }
-  
+
   let events: AsyncStream<WebSocketEvent>
   let eventsContinuation: AsyncStream<WebSocketEvent>.Continuation
 

--- a/Sources/Realtime/WebSocket/URLSessionWebSocket.swift
+++ b/Sources/Realtime/WebSocket/URLSessionWebSocket.swift
@@ -16,7 +16,7 @@ import Foundation
 ///
 /// ## Connection Management
 /// The connection is established asynchronously using the `connect(to:protocols:configuration:)` method.
-/// Once connected, you can send text/binary messages and listen for events through the `onEvent` callback.
+/// Once connected, you can send text/binary messages and listen for events through the `events` stream.
 ///
 /// ## Error Handling
 /// Network errors are automatically handled and converted to appropriate WebSocket close codes.
@@ -32,6 +32,8 @@ final class URLSessionWebSocket: WebSocket {
   ) {
     self._task = _task
     self._protocol = _protocol
+    
+    (events, eventsContinuation) = AsyncStream.makeStream()
 
     _scheduleReceive()
   }
@@ -151,18 +153,10 @@ final class URLSessionWebSocket: WebSocket {
   struct MutableState {
     /// Whether the connection has been closed.
     var isClosed = false
-    /// Callback for handling WebSocket events.
-    var onEvent: (@Sendable (WebSocketEvent) -> Void)?
-    /// Buffer for events received before onEvent callback is attached.
-    var eventBuffer: [WebSocketEvent] = []
     /// The close code received when connection was closed.
     var closeCode: Int?
     /// The close reason received when connection was closed.
     var closeReason: String?
-    /// Monotonically increasing counter; incremented each time `events` is called.
-    /// `onTermination` captures its generation at registration time and skips the
-    /// `onEvent = nil` if a newer `events` call has already taken ownership.
-    var eventStreamGeneration = 0
   }
 
   /// Lock-isolated mutable state to ensure thread safety.
@@ -182,6 +176,9 @@ final class URLSessionWebSocket: WebSocket {
   var isClosed: Bool {
     mutableState.value.isClosed
   }
+  
+  let events: AsyncStream<WebSocketEvent>
+  let eventsContinuation: AsyncStream<WebSocketEvent>.Continuation
 
   /// Handles incoming WebSocket messages and converts them to events.
   /// - Parameter value: The message received from the WebSocket.
@@ -294,84 +291,17 @@ final class URLSessionWebSocket: WebSocket {
     }
   }
 
-  /// Version-guarded `events` stream: `onTermination` only clears `onEvent` when it
-  /// still owns the handler (same generation). If a second `events` call installs a
-  /// newer handler before the first stream tears down, the stale `onTermination` is a
-  /// no-op instead of silently niling the live handler.
-  var events: AsyncStream<WebSocketEvent> {
-    let generation = mutableState.withValue { state -> Int in
-      state.eventStreamGeneration += 1
-      return state.eventStreamGeneration
-    }
-    let (stream, continuation) = AsyncStream<WebSocketEvent>.makeStream()
-    self.onEvent = { event in
-      continuation.yield(event)
-      if case .close = event { continuation.finish() }
-    }
-    continuation.onTermination = { [weak self] _ in
-      guard let self else { return }
-      self.mutableState.withValue { state in
-        guard state.eventStreamGeneration == generation else { return }
-        state.onEvent = nil
-      }
-    }
-    return stream
-  }
-
-  /// Callback for handling WebSocket events.
-  ///
-  /// Set this property to receive notifications about WebSocket events including:
-  /// - `.text(String)`: Text messages received from the peer
-  /// - `.binary(Data)`: Binary messages received from the peer
-  /// - `.close(code: Int?, reason: String)`: Connection closed events
-  ///
-  /// When setting this callback, any buffered events received before the callback
-  /// was attached will be replayed immediately in the order they were received.
-  ///
-  /// The callback is called on an arbitrary queue and should be thread-safe.
-  var onEvent: (@Sendable (WebSocketEvent) -> Void)? {
-    get { mutableState.value.onEvent }
-    set {
-      mutableState.withValue { state in
-        state.onEvent = newValue
-
-        // Replay buffered events when callback is attached
-        if let onEvent = newValue, !state.eventBuffer.isEmpty {
-          let bufferedEvents = state.eventBuffer
-          state.eventBuffer.removeAll()
-
-          for event in bufferedEvents {
-            onEvent(event)
-          }
-        }
-      }
-    }
-  }
-
   /// Triggers a WebSocket event and updates internal state if needed.
   /// - Parameter event: The event to trigger.
   private func _trigger(_ event: WebSocketEvent) {
     mutableState.withValue {
-      if let onEvent = $0.onEvent {
-        // Deliver event immediately if callback is available
-        onEvent(event)
-      } else {
-        // Buffer event if no callback is attached yet
-        // Limit buffer size to prevent memory issues (keep last 100 events)
-        $0.eventBuffer.append(event)
-        if $0.eventBuffer.count > 100 {
-          $0.eventBuffer.removeFirst()
-        }
-      }
+      eventsContinuation.yield(event)
 
       // Update state when connection closes
       if case .close(let code, let reason) = event {
-        $0.onEvent = nil
         $0.isClosed = true
         $0.closeCode = code
         $0.closeReason = reason
-        // Clear buffer when connection closes
-        $0.eventBuffer.removeAll()
       }
     }
   }

--- a/Sources/Realtime/WebSocket/URLSessionWebSocket.swift
+++ b/Sources/Realtime/WebSocket/URLSessionWebSocket.swift
@@ -159,6 +159,10 @@ final class URLSessionWebSocket: WebSocket {
     var closeCode: Int?
     /// The close reason received when connection was closed.
     var closeReason: String?
+    /// Monotonically increasing counter; incremented each time `events` is called.
+    /// `onTermination` captures its generation at registration time and skips the
+    /// `onEvent = nil` if a newer `events` call has already taken ownership.
+    var eventStreamGeneration = 0
   }
 
   /// Lock-isolated mutable state to ensure thread safety.
@@ -288,6 +292,30 @@ final class URLSessionWebSocket: WebSocket {
         _closeConnectionWithError(error)
       }
     }
+  }
+
+  /// Version-guarded `events` stream: `onTermination` only clears `onEvent` when it
+  /// still owns the handler (same generation). If a second `events` call installs a
+  /// newer handler before the first stream tears down, the stale `onTermination` is a
+  /// no-op instead of silently niling the live handler.
+  var events: AsyncStream<WebSocketEvent> {
+    let generation = mutableState.withValue { state -> Int in
+      state.eventStreamGeneration += 1
+      return state.eventStreamGeneration
+    }
+    let (stream, continuation) = AsyncStream<WebSocketEvent>.makeStream()
+    self.onEvent = { event in
+      continuation.yield(event)
+      if case .close = event { continuation.finish() }
+    }
+    continuation.onTermination = { [weak self] _ in
+      guard let self else { return }
+      self.mutableState.withValue { state in
+        guard state.eventStreamGeneration == generation else { return }
+        state.onEvent = nil
+      }
+    }
+    return stream
   }
 
   /// Callback for handling WebSocket events.

--- a/Sources/Realtime/WebSocket/WebSocket.swift
+++ b/Sources/Realtime/WebSocket/WebSocket.swift
@@ -72,9 +72,11 @@ extension WebSocket {
 
   /// Default `events` implementation for test doubles and simple conformers.
   ///
-  /// Production conformers (e.g. `URLSessionWebSocket`) should override this with
-  /// a version-guarded implementation so that `onTermination` cannot nil an `onEvent`
-  /// handler installed by a later `events` call.
+  /// WARNING: Not safe for multi-read. If `events` is called a second time on
+  /// the same conformer, the second call overwrites `onEvent` and the first
+  /// call's `onTermination` will later nil out that live handler — silently
+  /// dropping all subsequent frames (SDK-959). Production conformers MUST
+  /// override this with a generation-guarded implementation (see `URLSessionWebSocket`).
   var events: AsyncStream<WebSocketEvent> {
     let (stream, continuation) = AsyncStream<WebSocketEvent>.makeStream()
     self.onEvent = { event in

--- a/Sources/Realtime/WebSocket/WebSocket.swift
+++ b/Sources/Realtime/WebSocket/WebSocket.swift
@@ -41,9 +41,6 @@ protocol WebSocket: Sendable, AnyObject {
   func close(code: Int?, reason: String?)
 
   /// An `AsyncStream` of ``WebSocketEvent`` received from the peer.
-  ///
-  /// Conformers must store this stream (and its continuation) as a `let` property
-  /// created in `init` — one stream per socket object, not one per read of `events`.
   var events: AsyncStream<WebSocketEvent> { get }
 
   /// The WebSocket subprotocol negotiated with the peer.

--- a/Sources/Realtime/WebSocket/WebSocket.swift
+++ b/Sources/Realtime/WebSocket/WebSocket.swift
@@ -40,15 +40,10 @@ protocol WebSocket: Sendable, AnyObject {
   ///   - reason: The reason for closing the connection.
   func close(code: Int?, reason: String?)
 
-  /// Listen for event messages in the connection.
-  var onEvent: (@Sendable (WebSocketEvent) -> Void)? { get set }
-
   /// An `AsyncStream` of ``WebSocketEvent`` received from the peer.
   ///
-  /// Conformers must implement this as a protocol requirement (not just rely on
-  /// the default extension) so that calls through `any WebSocket` dispatch to
-  /// the version-guarded implementation and `onTermination` cannot nil a handler
-  /// it no longer owns.
+  /// Conformers must store this stream (and its continuation) as a `let` property
+  /// created in `init` — one stream per socket object, not one per read of `events`.
   var events: AsyncStream<WebSocketEvent> { get }
 
   /// The WebSocket subprotocol negotiated with the peer.
@@ -70,24 +65,4 @@ extension WebSocket {
     self.close(code: nil, reason: nil)
   }
 
-  /// Default `events` implementation for test doubles and simple conformers.
-  ///
-  /// WARNING: Not safe for multi-read. If `events` is called a second time on
-  /// the same conformer, the second call overwrites `onEvent` and the first
-  /// call's `onTermination` will later nil out that live handler — silently
-  /// dropping all subsequent frames (SDK-959). Production conformers MUST
-  /// override this with a generation-guarded implementation (see `URLSessionWebSocket`).
-  var events: AsyncStream<WebSocketEvent> {
-    let (stream, continuation) = AsyncStream<WebSocketEvent>.makeStream()
-    self.onEvent = { event in
-      continuation.yield(event)
-      if case .close = event {
-        continuation.finish()
-      }
-    }
-    continuation.onTermination = { _ in
-      self.onEvent = nil
-    }
-    return stream
-  }
 }

--- a/Sources/Realtime/WebSocket/WebSocket.swift
+++ b/Sources/Realtime/WebSocket/WebSocket.swift
@@ -43,6 +43,14 @@ protocol WebSocket: Sendable, AnyObject {
   /// Listen for event messages in the connection.
   var onEvent: (@Sendable (WebSocketEvent) -> Void)? { get set }
 
+  /// An `AsyncStream` of ``WebSocketEvent`` received from the peer.
+  ///
+  /// Conformers must implement this as a protocol requirement (not just rely on
+  /// the default extension) so that calls through `any WebSocket` dispatch to
+  /// the version-guarded implementation and `onTermination` cannot nil a handler
+  /// it no longer owns.
+  var events: AsyncStream<WebSocketEvent> { get }
+
   /// The WebSocket subprotocol negotiated with the peer.
   ///
   /// Will be the empty string if no subprotocol was negotiated.
@@ -62,26 +70,19 @@ extension WebSocket {
     self.close(code: nil, reason: nil)
   }
 
-  /// An `AsyncStream` of ``WebSocketEvent`` received from the peer.
+  /// Default `events` implementation for test doubles and simple conformers.
   ///
-  /// Data received by the peer will be delivered as a ``WebSocketEvent/text(_:)`` or ``WebSocketEvent/binary(_:)``.
-  ///
-  /// If a ``WebSocketEvent/close(code:reason:)`` event is received then the `AsyncStream` will be closed. A ``WebSocketEvent/close(code:reason:)`` event indicates either that:
-  ///
-  /// - A close frame was received from the peer. `code` and `reason` will be set by the peer.
-  /// - A failure occurred (e.g. the peer disconnected). `code` and `reason` will be a failure code defined by [RFC-6455](https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1) (e.g. 1006).
-  ///
-  /// Errors will never appear in this `AsyncStream`.
+  /// Production conformers (e.g. `URLSessionWebSocket`) should override this with
+  /// a version-guarded implementation so that `onTermination` cannot nil an `onEvent`
+  /// handler installed by a later `events` call.
   var events: AsyncStream<WebSocketEvent> {
     let (stream, continuation) = AsyncStream<WebSocketEvent>.makeStream()
     self.onEvent = { event in
       continuation.yield(event)
-
       if case .close = event {
         continuation.finish()
       }
     }
-
     continuation.onTermination = { _ in
       self.onEvent = nil
     }

--- a/Tests/IntegrationTests/supabase/migrations/20240101000000_initial_schema.sql
+++ b/Tests/IntegrationTests/supabase/migrations/20240101000000_initial_schema.sql
@@ -102,5 +102,21 @@ CREATE POLICY "Allow all operations on messages" ON messages FOR ALL USING (true
 CREATE POLICY "Allow all operations on channels" ON channels FOR ALL USING (true) WITH CHECK (true);
 CREATE POLICY "Allow all operations on key_value_storage" ON key_value_storage FOR ALL USING (true) WITH CHECK (true);
 
+-- Grant table-level permissions to anon and authenticated roles.
+-- RLS policies alone don't bypass the need for explicit GRANTs.
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE users TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE todos TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE messages TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE channels TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE key_value_storage TO anon, authenticated;
+GRANT SELECT ON updatable_view TO anon, authenticated;
+GRANT USAGE ON SEQUENCE channels_id_seq TO anon, authenticated;
+GRANT USAGE ON SEQUENCE messages_id_seq TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_status TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION void_func TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION delete_user TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_username_and_status TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_array_element TO anon, authenticated;
+
 -- Enable realtime for key_value_storage table
 ALTER PUBLICATION supabase_realtime ADD TABLE key_value_storage;

--- a/Tests/IntegrationTests/supabase/migrations/20240101000000_initial_schema.sql
+++ b/Tests/IntegrationTests/supabase/migrations/20240101000000_initial_schema.sql
@@ -102,21 +102,5 @@ CREATE POLICY "Allow all operations on messages" ON messages FOR ALL USING (true
 CREATE POLICY "Allow all operations on channels" ON channels FOR ALL USING (true) WITH CHECK (true);
 CREATE POLICY "Allow all operations on key_value_storage" ON key_value_storage FOR ALL USING (true) WITH CHECK (true);
 
--- Grant table-level permissions to anon and authenticated roles.
--- RLS policies alone don't bypass the need for explicit GRANTs.
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE users TO anon, authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE todos TO anon, authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE messages TO anon, authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE channels TO anon, authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE key_value_storage TO anon, authenticated;
-GRANT SELECT ON updatable_view TO anon, authenticated;
-GRANT USAGE ON SEQUENCE channels_id_seq TO anon, authenticated;
-GRANT USAGE ON SEQUENCE messages_id_seq TO anon, authenticated;
-GRANT EXECUTE ON FUNCTION get_status TO anon, authenticated;
-GRANT EXECUTE ON FUNCTION void_func TO anon, authenticated;
-GRANT EXECUTE ON FUNCTION delete_user TO anon, authenticated;
-GRANT EXECUTE ON FUNCTION get_username_and_status TO anon, authenticated;
-GRANT EXECUTE ON FUNCTION get_array_element TO anon, authenticated;
-
 -- Enable realtime for key_value_storage table
 ALTER PUBLICATION supabase_realtime ADD TABLE key_value_storage;

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -303,7 +303,7 @@ final class ConnectionManagerTests: XCTestCase {
 
     let stateObserver = Task {
       for await state in sut.stateChanges {
-        if case .reconnecting(_, let reason) = state, reason.contains("4001") {
+        if case .reconnecting(_, let reason) = state, reason.contains("1001") {
           reconnectingExpectation.fulfill()
           return
         }
@@ -311,7 +311,9 @@ final class ConnectionManagerTests: XCTestCase {
     }
 
     try await sut.connect()
-    await sut.handleClose(code: 4001, reason: "server restart")
+    // Use a transport-level close code (1001 = going away) to exercise the
+    // reconnect path. Application-level codes (4000–4999) skip reconnect.
+    await sut.handleClose(code: 1001, reason: "server restart")
 
     await fulfillment(of: [reconnectingExpectation, secondConnectionExpectation], timeout: 2)
     XCTAssertEqual(connectionCount.value, 2, "Remote close should trigger a reconnection attempt")
@@ -319,5 +321,25 @@ final class ConnectionManagerTests: XCTestCase {
     XCTAssertTrue(isConnected)
 
     stateObserver.cancel()
+  }
+
+  func testHandleCloseDoesNotReconnectForApplicationCloseCode() async throws {
+    sut = makeSUT(reconnectDelay: 0.01)
+    try await sut.connect()
+
+    // Application-level close codes (4000–4999) must not trigger automatic
+    // reconnect — the caller needs to re-authenticate before reconnecting,
+    // otherwise reconnecting with the same bad token just loops.
+    await sut.handleClose(code: 4001, reason: "jwt expired")
+
+    // Brief wait to confirm the reconnect task does not fire.
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    XCTAssertEqual(
+      transportCallCount.value, 1,
+      "Application close code (4001) must not trigger reconnect"
+    )
+    let isConnected = await sut.connection != nil
+    XCTAssertFalse(isConnected, "Connection should be disconnected after application close")
   }
 }

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -236,4 +236,47 @@ final class ConnectionManagerTests: XCTestCase {
       "handleClose should not send an additional close frame since the remote already closed."
     )
   }
+
+  func testHandleCloseFromStaleConnectionIsIgnored() async throws {
+    let (staleWS, _) = FakeWebSocket.fakes()
+    sut = makeSUT()
+    try await sut.connect()
+
+    // A late .close from a previous socket must not mark the current
+    // connection as disconnected.
+    await sut.handleClose(code: 1006, reason: "stale socket closed", from: staleWS)
+
+    let isConnected = await sut.connection != nil
+    XCTAssertTrue(isConnected, "Close from a stale connection should be ignored")
+  }
+
+  func testHandleErrorFromStaleConnectionIsIgnored() async throws {
+    let (staleWS, _) = FakeWebSocket.fakes()
+    sut = makeSUT()
+    try await sut.connect()
+
+    await sut.handleError(TestError.sample, from: staleWS)
+
+    let isConnected = await sut.connection != nil
+    XCTAssertTrue(isConnected, "Error from a stale connection should be ignored")
+    XCTAssertEqual(
+      transportCallCount.value, 1,
+      "Error from a stale connection should not trigger a reconnect"
+    )
+  }
+
+  func testHandleErrorFromCurrentConnectionInitiatesReconnect() async throws {
+    sut = makeSUT(reconnectDelay: 0.01)
+    try await sut.connect()
+
+    await sut.handleError(TestError.sample, from: ws)
+
+    // Wait for the reconnect to complete.
+    try await Task.sleep(nanoseconds: 200_000_000)
+
+    XCTAssertEqual(
+      transportCallCount.value, 2,
+      "Error from the current connection should trigger a reconnect"
+    )
+  }
 }

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -283,4 +283,41 @@ final class ConnectionManagerTests: XCTestCase {
       "Error from the current connection should trigger a reconnect"
     )
   }
+
+  func testHandleCloseInitiatesReconnectAndEventuallyReconnects() async throws {
+    let reconnectingExpectation = expectation(description: "reconnecting state observed")
+    let secondConnectionExpectation = expectation(description: "second connection attempt")
+
+    let connectionCount = LockIsolated(0)
+
+    sut = makeSUT(
+      reconnectDelay: 0.01,
+      transport: { _, _ in
+        connectionCount.withValue { $0 += 1 }
+        if connectionCount.value == 2 {
+          secondConnectionExpectation.fulfill()
+        }
+        return self.ws!
+      }
+    )
+
+    let stateObserver = Task {
+      for await state in sut.stateChanges {
+        if case .reconnecting(_, let reason) = state, reason.contains("4001") {
+          reconnectingExpectation.fulfill()
+          return
+        }
+      }
+    }
+
+    try await sut.connect()
+    await sut.handleClose(code: 4001, reason: "server restart")
+
+    await fulfillment(of: [reconnectingExpectation, secondConnectionExpectation], timeout: 2)
+    XCTAssertEqual(connectionCount.value, 2, "Remote close should trigger a reconnection attempt")
+    let isConnected = await sut.connection != nil
+    XCTAssertTrue(isConnected)
+
+    stateObserver.cancel()
+  }
 }

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -272,7 +272,11 @@ final class ConnectionManagerTests: XCTestCase {
     await sut.handleError(TestError.sample, from: ws)
 
     // Wait for the reconnect to complete.
-    try await Task.sleep(nanoseconds: 200_000_000)
+    let transportCallCount = self.transportCallCount
+    let deadline = Date().addingTimeInterval(5)
+    while transportCallCount.value < 2, Date() < deadline {
+      try await Task.sleep(nanoseconds: 10_000_000)
+    }
 
     XCTAssertEqual(
       transportCallCount.value, 2,

--- a/Tests/RealtimeTests/FakeWebSocket.swift
+++ b/Tests/RealtimeTests/FakeWebSocket.swift
@@ -7,7 +7,6 @@ final class FakeWebSocket: WebSocket {
   struct MutableState {
     var isClosed: Bool = false
     weak var other: FakeWebSocket?
-    var onEvent: (@Sendable (WebSocketEvent) -> Void)?
 
     var sentEvents: [WebSocketEvent] = []
     var receivedEvents: [WebSocketEvent] = []
@@ -16,9 +15,12 @@ final class FakeWebSocket: WebSocket {
   }
 
   private let mutableState = LockIsolated(MutableState())
+  let events: AsyncStream<WebSocketEvent>
+  private let eventsContinuation: AsyncStream<WebSocketEvent>.Continuation
 
   private init(`protocol`: String) {
     self.`protocol` = `protocol`
+    (events, eventsContinuation) = AsyncStream.makeStream()
   }
 
   /// Events send by this connection.
@@ -78,11 +80,6 @@ final class FakeWebSocket: WebSocket {
     }
   }
 
-  var onEvent: (@Sendable (WebSocketEvent) -> Void)? {
-    get { mutableState.value.onEvent }
-    set { mutableState.withValue { $0.onEvent = newValue } }
-  }
-
   let `protocol`: String
 
   var isClosed: Bool {
@@ -92,14 +89,16 @@ final class FakeWebSocket: WebSocket {
   func _trigger(_ event: WebSocketEvent) {
     mutableState.withValue {
       $0.receivedEvents.append(event)
-      $0.onEvent?(event)
 
       if case .close(let code, let reason) = event {
-        $0.onEvent = nil
         $0.isClosed = true
         $0.closeCode = code
         $0.closeReason = reason
       }
+    }
+    eventsContinuation.yield(event)
+    if case .close = event {
+      eventsContinuation.finish()
     }
   }
 

--- a/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
@@ -29,6 +29,7 @@ import XCTest
     var client: FakeWebSocket!
     var http: HTTPClientMock!
     var sut: RealtimeClientV2!
+    var serverTask: Task<Void, Never>?
 
     override func setUp() {
       super.setUp()
@@ -50,38 +51,42 @@ import XCTest
     }
 
     override func tearDown() {
+      serverTask?.cancel()
+      serverTask = nil
       sut.disconnect()
       super.tearDown()
     }
 
     /// Sets up the server to auto-respond to heartbeats and phx_join events.
     private func setupServerAutoResponder(topic: String = "realtime:test") {
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
+      serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
 
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: ["response": [:]]
+              )
             )
-          )
-        } else if msg.event == "phx_join" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: topic,
-              event: "phx_reply",
-              payload: [
-                "response": ["postgres_changes": .array([])],
-                "status": "ok",
-              ]
+          } else if msg.event == "phx_join" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: topic,
+                event: "phx_reply",
+                payload: [
+                  "response": ["postgres_changes": .array([])],
+                  "status": "ok",
+                ]
+              )
             )
-          )
+          }
         }
       }
     }

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -51,20 +51,23 @@ final class RealtimeChannelTests: XCTestCase {
       let channel = socket.channel("test-topic")
 
       // Never respond to phx_join, so channel stays in .subscribing
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-        if msg.event == "heartbeat" {
-          server.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
+      let serverTask1 = Task { @Sendable [server] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: ["response": [:]]
+              )
             )
-          )
+          }
         }
       }
+      defer { serverTask1.cancel() }
 
       await socket.connect()
 
@@ -102,23 +105,26 @@ final class RealtimeChannelTests: XCTestCase {
 
       let channel = socket.channel("test-topic")
 
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-        if msg.event == "phx_join" {
-          server.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "realtime:test-topic",
-              event: "phx_reply",
-              payload: [
-                "response": ["postgres_changes": []],
-                "status": "ok",
-              ]
+      let serverTask2 = Task { @Sendable [server] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "phx_join" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "realtime:test-topic",
+                event: "phx_reply",
+                payload: [
+                  "response": ["postgres_changes": []],
+                  "status": "ok",
+                ]
+              )
             )
-          )
+          }
         }
       }
+      defer { serverTask2.cancel() }
 
       await socket.connect()
       try? await channel.subscribeWithError()
@@ -153,20 +159,23 @@ final class RealtimeChannelTests: XCTestCase {
       let channel = socket.channel("test-topic")
 
       // Never respond to phx_join, so channel stays in .subscribing
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-        if msg.event == "heartbeat" {
-          server.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
+      let serverTask3 = Task { @Sendable [server] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: ["response": [:]]
+              )
             )
-          )
+          }
         }
       }
+      defer { serverTask3.cancel() }
 
       await socket.connect()
 
@@ -204,23 +213,26 @@ final class RealtimeChannelTests: XCTestCase {
 
       let channel = socket.channel("test-topic")
 
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-        if msg.event == "phx_join" {
-          server.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "realtime:test-topic",
-              event: "phx_reply",
-              payload: [
-                "response": ["postgres_changes": []],
-                "status": "ok",
-              ]
+      let serverTask4 = Task { @Sendable [server] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "phx_join" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "realtime:test-topic",
+                event: "phx_reply",
+                payload: [
+                  "response": ["postgres_changes": []],
+                  "status": "ok",
+                ]
+              )
             )
-          )
+          }
         }
       }
+      defer { serverTask4.cancel() }
 
       await socket.connect()
       try? await channel.subscribeWithError()

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -126,7 +126,14 @@ final class RealtimeColdStartTests: XCTestCase {
   /// misread as a timeout on the replacement connection. Before the fix,
   /// `pendingHeartbeatRef` survived reconnects, so the new connection's first
   /// heartbeat reported `.timeout` and tore down a healthy socket —
-  /// perpetuating the reconnect cycle.
+  /// perpetuating the reconnect cycle indefinitely.
+  ///
+  /// Detection strategy: instead of asserting on specific heartbeat statuses
+  /// (which are sensitive to whether the reconnect was triggered by the
+  /// malformed frame or by the heartbeat timer itself), we verify that after
+  /// the first reconnect the socket count stabilises. With the bug, socket 2's
+  /// first heartbeat immediately times out → a second reconnect → socket 3 →
+  /// etc. With the fix, socket 2 stays connected.
   func testPendingHeartbeatDoesNotLeakAcrossReconnect() async throws {
     let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
 
@@ -141,8 +148,8 @@ final class RealtimeColdStartTests: XCTestCase {
       ),
       wsTransport: { _, _ in
         let socket = AsyncFakeWebSocket()
-        // The server acks heartbeats only on the second (post-reconnect)
-        // socket; the first socket swallows them so one stays pending.
+        // Every socket after the first acks heartbeats normally so that a
+        // healthy post-reconnect connection never times out on its own.
         if sockets.value.count >= 1 {
           socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
         }
@@ -161,30 +168,35 @@ final class RealtimeColdStartTests: XCTestCase {
 
     await sut.connect()
 
-    // Wait for the first heartbeat to be sent (and stay pending — the first
-    // socket never acks).
+    // Wait for the first heartbeat to be sent (ref stays pending — socket 0
+    // never acks). The reconnect may be triggered by either the malformed frame
+    // or the second heartbeat timeout; both exercise the same code path.
     await waitUntil { heartbeatStatuses.value.contains(.sent) }
-    XCTAssertEqual(heartbeatStatuses.value, [.sent])
 
-    // Error out the first socket: a malformed frame makes the message task
-    // call handleError, which closes the socket and reconnects.
+    // Inject a malformed frame: listenForMessages throws → handleError →
+    // initiates reconnect.
     sockets.value[0].receiveFromServer(.text("not a valid frame"))
 
-    // Wait until the new connection reports its first heartbeat: a second
-    // `.sent` when the pending ref was correctly reset, or a `.timeout` when
-    // the stale ref leaked across the reconnect. (`.disconnected` may
-    // interleave while the reconnect is in flight.)
-    await waitUntil {
-      let statuses = heartbeatStatuses.value
-      return statuses.filter { $0 == .sent }.count >= 2 || statuses.contains(.timeout)
+    // Wait for the first reconnect to complete.
+    await waitUntil(timeout: 5) { sockets.value.count >= 2 }
+    guard sockets.value.count >= 2 else {
+      return XCTFail("No reconnect within 5 s — socket count: \(sockets.value.count)")
     }
 
-    XCTAssertEqual(sockets.value.count, 2, "Expected exactly one reconnect")
-    XCTAssertFalse(
-      heartbeatStatuses.value.contains(.timeout),
+    // Record the count right after the first reconnect. If pendingHeartbeatRef
+    // leaked into socket 2, its first heartbeat (0.2 s away) immediately times
+    // out → another reconnect → socket count grows. Allow 5 heartbeat cycles
+    // plus a buffer for scheduling jitter to observe this.
+    let countAfterFirstReconnect = sockets.value.count
+    await waitUntil(timeout: 0.2 * 5 + 1.0) {
+      sockets.value.count > countAfterFirstReconnect
+    }
+
+    XCTAssertEqual(
+      sockets.value.count, countAfterFirstReconnect,
       """
-      The pending heartbeat from the first connection leaked into the second \
-      and was misread as a timeout: \(heartbeatStatuses.value)
+      Perpetual reconnects detected — pendingHeartbeatRef likely leaked \
+      into the replacement connection: \(heartbeatStatuses.value)
       """
     )
   }

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -164,8 +164,16 @@ final class RealtimeColdStartTests: XCTestCase {
       return XCTFail("No reconnect within 5 s")
     }
 
-    // Channel must re-subscribe on the new socket.
-    await waitUntil(timeout: 5) { channel.status == .subscribed }
+    // Channel must re-subscribe on the new socket. Waiting only for
+    // `channel.status == .subscribed` is racy on Linux: the channel may still
+    // appear subscribed from socket 1 before `rejoinChannels` has had a chance
+    // to reset it. Wait until socket 2 has actually sent a `phx_join` AND the
+    // channel is subscribed — a state that cannot be satisfied by the stale
+    // socket-1 subscription.
+    await waitUntil(timeout: 5) {
+      sockets.value[1].sentMessages.contains { $0.event == "phx_join" }
+        && channel.status == .subscribed
+    }
     XCTAssertEqual(channel.status, .subscribed, "Channel did not rejoin after reconnect")
 
     // Exactly one phx_join sent on socket 2 (index 1).

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -263,14 +263,12 @@ final class RealtimeColdStartTests: XCTestCase {
 }
 
 /// A `WebSocket` fake whose server side delivers frames asynchronously on a
-/// serial queue, standing in for URLSession's delegate queue. Events received
-/// before `onEvent` is attached are buffered and replayed on attach, exactly
-/// like `URLSessionWebSocket`.
+/// serial queue, standing in for URLSession's delegate queue. The `events`
+/// stream is backed by an `AsyncStream` continuation so frames received before
+/// the consumer starts iterating are buffered by the stream itself.
 final class AsyncFakeWebSocket: WebSocket, @unchecked Sendable {
   struct MutableState {
     var isClosed: Bool = false
-    var onEvent: (@Sendable (WebSocketEvent) -> Void)?
-    var eventBuffer: [WebSocketEvent] = []
     var sentMessages: [RealtimeMessageV2] = []
     var closeCode: Int?
     var closeReason: String?
@@ -278,6 +276,12 @@ final class AsyncFakeWebSocket: WebSocket, @unchecked Sendable {
 
   let mutableState = LockIsolated(MutableState())
   let deliveryQueue = DispatchQueue(label: "AsyncFakeWebSocket.delivery")
+  let events: AsyncStream<WebSocketEvent>
+  private let eventsContinuation: AsyncStream<WebSocketEvent>.Continuation
+
+  init() {
+    (events, eventsContinuation) = AsyncStream.makeStream()
+  }
 
   /// Server-side autoresponder, invoked off the sender's thread.
   var serverResponder: (@Sendable (RealtimeMessageV2, AsyncFakeWebSocket) -> Void)?
@@ -356,22 +360,20 @@ final class AsyncFakeWebSocket: WebSocket, @unchecked Sendable {
     }
   }
 
-  /// Server pushes an event to the client; delivered through onEvent if
-  /// attached, otherwise buffered and replayed on attach.
+  /// Server pushes an event to the client; delivered through the `events`
+  /// stream. Frames received before the consumer starts iterating are buffered
+  /// by `AsyncStream` itself.
   func receiveFromServer(_ event: WebSocketEvent) {
     mutableState.withValue {
-      if let onEvent = $0.onEvent {
-        onEvent(event)
-      } else {
-        $0.eventBuffer.append(event)
-      }
       if case .close(let code, let reason) = event {
-        $0.onEvent = nil
         $0.isClosed = true
         $0.closeCode = code
         $0.closeReason = reason
-        $0.eventBuffer.removeAll()
       }
+    }
+    eventsContinuation.yield(event)
+    if case .close = event {
+      eventsContinuation.finish()
     }
   }
 
@@ -379,19 +381,5 @@ final class AsyncFakeWebSocket: WebSocket, @unchecked Sendable {
     let serializer = RealtimeSerializer()
     let text = try! serializer.encodeText(message)
     receiveFromServer(.text(text))
-  }
-
-  var onEvent: (@Sendable (WebSocketEvent) -> Void)? {
-    get { mutableState.value.onEvent }
-    set {
-      mutableState.withValue { state in
-        state.onEvent = newValue
-        if let onEvent = newValue, !state.eventBuffer.isEmpty {
-          let buffered = state.eventBuffer
-          state.eventBuffer.removeAll()
-          for event in buffered { onEvent(event) }
-        }
-      }
-    }
   }
 }

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -1,0 +1,313 @@
+import ConcurrencyExtras
+import Foundation
+import TestHelpers
+import XCTest
+
+@testable import Realtime
+
+/// Regression tests for SDK-959: deaf-socket stalls on cold-start subscribe.
+///
+/// These tests intentionally mimic the production timing profile — a
+/// transport that takes real time to connect and a server that delivers
+/// frames asynchronously on a separate queue (like URLSession's delegate
+/// queue) — instead of the synchronous delivery of `FakeWebSocket`, which
+/// masks the races involved. They run against the real clock with compressed
+/// intervals, deliberately NOT under `withMainSerialExecutor`.
+final class RealtimeColdStartTests: XCTestCase {
+  let url = URL(string: "http://localhost:54321/realtime/v1")!
+  let apiKey = "anon.api.key"
+
+  override func setUp() {
+    super.setUp()
+    _clock = ContinuousClock()
+  }
+
+  private func makeClient(socket: AsyncFakeWebSocket) -> RealtimeClientV2 {
+    RealtimeClientV2(
+      url: url,
+      options: RealtimeClientOptions(
+        headers: ["apikey": apiKey],
+        heartbeatInterval: 0.5,
+        reconnectDelay: 0.1,
+        timeoutInterval: 0.5,
+        accessToken: { "token" }
+      ),
+      wsTransport: { _, _ in
+        // Simulate real connection latency.
+        try await Task.sleep(nanoseconds: 20_000_000)
+        return socket
+      },
+      http: HTTPClientMock()
+    )
+  }
+
+  /// Reporter's flow from SDK-959: cold client, one channel, postgresChange
+  /// streams consumed in detached tasks, then `subscribeWithError()`.
+  func testColdStartSubscribe_realTimingProfile() async throws {
+    for iteration in 1...5 {
+      let socket = AsyncFakeWebSocket()
+      socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
+
+      let sut = makeClient(socket: socket)
+      defer { sut.disconnect() }
+
+      let channel = sut.channel("library-realtime")
+      let libros = channel.postgresChange(AnyAction.self, schema: "library", table: "libros")
+      let files = channel.postgresChange(AnyAction.self, schema: "library", table: "libro_files")
+
+      let t1 = Task { for await _ in libros {} }
+      let t2 = Task { for await _ in files {} }
+      defer {
+        t1.cancel()
+        t2.cancel()
+      }
+
+      let start = Date()
+      do {
+        try await channel.subscribeWithError()
+      } catch {
+        XCTFail("Iteration \(iteration): subscribe failed: \(error)")
+        return
+      }
+      let elapsed = Date().timeIntervalSince(start)
+
+      XCTAssertEqual(channel.status, .subscribed, "Iteration \(iteration)")
+      XCTAssertLessThan(
+        elapsed, 1.0,
+        "Iteration \(iteration): cold subscribe took \(elapsed)s — stall detected"
+      )
+    }
+  }
+
+  /// Two channels subscribing concurrently at cold start: both call
+  /// `ensureSocketConnected` → concurrent `connect()` → ConnectionManager's
+  /// `.connecting` wait path returns the same connection to both callers →
+  /// both used to call `handleConnected(conn:)`, reading `conn.events` twice
+  /// and leaving the socket deaf (no heartbeat acks, no phx_join replies) —
+  /// the SDK-959 stall.
+  func testColdStartConcurrentSubscribes_doNotGoDeaf() async throws {
+    for iteration in 1...5 {
+      let socket = AsyncFakeWebSocket()
+      socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
+
+      let sut = makeClient(socket: socket)
+      defer { sut.disconnect() }
+
+      let channel1 = sut.channel("room-1")
+      let channel2 = sut.channel("room-2")
+
+      let start = Date()
+      async let s1: Void = channel1.subscribeWithError()
+      async let s2: Void = channel2.subscribeWithError()
+
+      do {
+        _ = try await (s1, s2)
+      } catch {
+        XCTFail("Iteration \(iteration): subscribe failed: \(error)")
+        return
+      }
+      let elapsed = Date().timeIntervalSince(start)
+
+      XCTAssertEqual(channel1.status, .subscribed, "Iteration \(iteration)")
+      XCTAssertEqual(channel2.status, .subscribed, "Iteration \(iteration)")
+      XCTAssertLessThan(
+        elapsed, 1.0,
+        "Iteration \(iteration): cold concurrent subscribe took \(elapsed)s — stall detected"
+      )
+    }
+  }
+
+  /// A heartbeat left pending on a connection that errors out must not be
+  /// misread as a timeout on the replacement connection. Before the fix,
+  /// `pendingHeartbeatRef` survived reconnects, so the new connection's first
+  /// heartbeat reported `.timeout` and tore down a healthy socket —
+  /// perpetuating the reconnect cycle.
+  func testPendingHeartbeatDoesNotLeakAcrossReconnect() async throws {
+    let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
+
+    let sut = RealtimeClientV2(
+      url: url,
+      options: RealtimeClientOptions(
+        headers: ["apikey": apiKey],
+        heartbeatInterval: 0.2,
+        reconnectDelay: 0.05,
+        timeoutInterval: 0.5,
+        accessToken: { "token" }
+      ),
+      wsTransport: { _, _ in
+        let socket = AsyncFakeWebSocket()
+        // The server acks heartbeats only on the second (post-reconnect)
+        // socket; the first socket swallows them so one stays pending.
+        if sockets.value.count >= 1 {
+          socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
+        }
+        sockets.withValue { $0.append(socket) }
+        return socket
+      },
+      http: HTTPClientMock()
+    )
+    defer { sut.disconnect() }
+
+    let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
+    let subscription = sut.onHeartbeat { status in
+      heartbeatStatuses.withValue { $0.append(status) }
+    }
+    defer { subscription.cancel() }
+
+    await sut.connect()
+
+    // Wait for the first heartbeat to be sent (and stay pending).
+    try await Task.sleep(nanoseconds: 300_000_000)
+    XCTAssertEqual(heartbeatStatuses.value, [.sent])
+
+    // Error out the first socket: a malformed frame makes the message task
+    // call handleError, which closes the socket and reconnects.
+    sockets.value[0].receiveFromServer(.text("not a valid frame"))
+
+    // Allow reconnect plus one full heartbeat interval on the new socket.
+    try await Task.sleep(nanoseconds: 500_000_000)
+
+    XCTAssertEqual(sockets.value.count, 2, "Expected exactly one reconnect")
+    XCTAssertFalse(
+      heartbeatStatuses.value.contains(.timeout),
+      """
+      The pending heartbeat from the first connection leaked into the second \
+      and was misread as a timeout: \(heartbeatStatuses.value)
+      """
+    )
+  }
+}
+
+/// A `WebSocket` fake whose server side delivers frames asynchronously on a
+/// serial queue, standing in for URLSession's delegate queue. Events received
+/// before `onEvent` is attached are buffered and replayed on attach, exactly
+/// like `URLSessionWebSocket`.
+final class AsyncFakeWebSocket: WebSocket, @unchecked Sendable {
+  struct MutableState {
+    var isClosed: Bool = false
+    var onEvent: (@Sendable (WebSocketEvent) -> Void)?
+    var eventBuffer: [WebSocketEvent] = []
+    var sentMessages: [RealtimeMessageV2] = []
+    var closeCode: Int?
+    var closeReason: String?
+  }
+
+  let mutableState = LockIsolated(MutableState())
+  let deliveryQueue = DispatchQueue(label: "AsyncFakeWebSocket.delivery")
+
+  /// Server-side autoresponder, invoked off the sender's thread.
+  var serverResponder: (@Sendable (RealtimeMessageV2, AsyncFakeWebSocket) -> Void)?
+
+  var closeCode: Int? { mutableState.value.closeCode }
+  var closeReason: String? { mutableState.value.closeReason }
+  var isClosed: Bool { mutableState.value.isClosed }
+  let `protocol`: String = ""
+
+  var sentMessages: [RealtimeMessageV2] { mutableState.value.sentMessages }
+
+  /// Standard Realtime server behavior: acks heartbeats, confirms joins.
+  static func realtimeServerResponder()
+    -> @Sendable (RealtimeMessageV2, AsyncFakeWebSocket) -> Void
+  {
+    { message, socket in
+      switch message.event {
+      case "heartbeat":
+        socket.reply(
+          RealtimeMessageV2(
+            joinRef: nil,
+            ref: message.ref,
+            topic: "phoenix",
+            event: "phx_reply",
+            payload: ["response": [:], "status": "ok"]
+          )
+        )
+      case "phx_join":
+        socket.reply(
+          RealtimeMessageV2(
+            joinRef: message.joinRef,
+            ref: message.ref,
+            topic: message.topic,
+            event: "phx_reply",
+            payload: [
+              "response": [
+                "postgres_changes": [
+                  ["id": 1, "event": "*", "schema": "library", "table": "libros"],
+                  ["id": 2, "event": "*", "schema": "library", "table": "libro_files"],
+                ]
+              ],
+              "status": "ok",
+            ]
+          )
+        )
+      default:
+        break
+      }
+    }
+  }
+
+  func send(_ text: String) {
+    guard !isClosed else { return }
+    let serializer = RealtimeSerializer()
+    guard let message = try? serializer.decodeText(text) else { return }
+    mutableState.withValue { $0.sentMessages.append(message) }
+    // The server processes the message asynchronously, like a real network.
+    deliveryQueue.async { [weak self] in
+      guard let self else { return }
+      self.serverResponder?(message, self)
+    }
+  }
+
+  func send(_ binary: Data) {}
+
+  func close(code: Int?, reason: String?) {
+    mutableState.withValue {
+      guard !$0.isClosed else { return }
+      $0.isClosed = true
+      $0.closeCode = code
+      $0.closeReason = reason
+    }
+    // Like URLSession, the .close event arrives later on the delegate queue.
+    deliveryQueue.async { [weak self] in
+      self?.receiveFromServer(.close(code: code ?? 1005, reason: reason ?? ""))
+    }
+  }
+
+  /// Server pushes an event to the client; delivered through onEvent if
+  /// attached, otherwise buffered and replayed on attach.
+  func receiveFromServer(_ event: WebSocketEvent) {
+    mutableState.withValue {
+      if let onEvent = $0.onEvent {
+        onEvent(event)
+      } else {
+        $0.eventBuffer.append(event)
+      }
+      if case .close(let code, let reason) = event {
+        $0.onEvent = nil
+        $0.isClosed = true
+        $0.closeCode = code
+        $0.closeReason = reason
+        $0.eventBuffer.removeAll()
+      }
+    }
+  }
+
+  func reply(_ message: RealtimeMessageV2) {
+    let serializer = RealtimeSerializer()
+    let text = try! serializer.encodeText(message)
+    receiveFromServer(.text(text))
+  }
+
+  var onEvent: (@Sendable (WebSocketEvent) -> Void)? {
+    get { mutableState.value.onEvent }
+    set {
+      mutableState.withValue { state in
+        state.onEvent = newValue
+        if let onEvent = newValue, !state.eventBuffer.isEmpty {
+          let buffered = state.eventBuffer
+          state.eventBuffer.removeAll()
+          for event in buffered { onEvent(event) }
+        }
+      }
+    }
+  }
+}

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -155,8 +155,10 @@ final class RealtimeColdStartTests: XCTestCase {
     XCTAssertEqual(channel.status, .subscribed)
     XCTAssertEqual(sockets.value.count, 1)
 
-    // Disconnect socket 1 — triggers reconnect.
-    sockets.value[0].receiveFromServer(.close(code: 1001, reason: "going away"))
+    // Inject a malformed frame: listenForMessages throws → handleError →
+    // initiateReconnect. (A remote .close event only disconnects, it does not
+    // trigger an automatic reconnect — that is by design for explicit shutdowns.)
+    sockets.value[0].receiveFromServer(.text("not a valid frame"))
     await waitUntil(timeout: 5) { sockets.value.count >= 2 }
     guard sockets.value.count >= 2 else {
       return XCTFail("No reconnect within 5 s")

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -156,8 +156,9 @@ final class RealtimeColdStartTests: XCTestCase {
     XCTAssertEqual(sockets.value.count, 1)
 
     // Inject a malformed frame: listenForMessages throws → handleError →
-    // initiateReconnect. (A remote .close event only disconnects, it does not
-    // trigger an automatic reconnect — that is by design for explicit shutdowns.)
+    // initiateReconnect. A remote .close with a transport-level code would also
+    // reconnect, but application-level codes (4000–4999) skip reconnect by design
+    // (auth errors should not loop with the same token).
     sockets.value[0].receiveFromServer(.text("not a valid frame"))
     await waitUntil(timeout: 5) { sockets.value.count >= 2 }
     guard sockets.value.count >= 2 else {

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -13,6 +13,7 @@ import XCTest
 /// queue) — instead of the synchronous delivery of `FakeWebSocket`, which
 /// masks the races involved. They run against the real clock with compressed
 /// intervals, deliberately NOT under `withMainSerialExecutor`.
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class RealtimeColdStartTests: XCTestCase {
   let url = URL(string: "http://localhost:54321/realtime/v1")!
   let apiKey = "anon.api.key"
@@ -27,9 +28,11 @@ final class RealtimeColdStartTests: XCTestCase {
       url: url,
       options: RealtimeClientOptions(
         headers: ["apikey": apiKey],
-        heartbeatInterval: 0.5,
+        // Long heartbeat so heartbeat machinery can't mask subscribe stalls
+        // by triggering recovery reconnects on slow CI machines.
+        heartbeatInterval: 10,
         reconnectDelay: 0.1,
-        timeoutInterval: 0.5,
+        timeoutInterval: 2,
         accessToken: { "token" }
       ),
       wsTransport: { _, _ in
@@ -41,8 +44,22 @@ final class RealtimeColdStartTests: XCTestCase {
     )
   }
 
+  /// Polls `condition` until it holds or `timeout` elapses.
+  private func waitUntil(
+    timeout: TimeInterval = 5.0,
+    _ condition: @escaping @Sendable () -> Bool
+  ) async {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if condition() { return }
+      try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+  }
+
   /// Reporter's flow from SDK-959: cold client, one channel, postgresChange
   /// streams consumed in detached tasks, then `subscribeWithError()`.
+  /// With the deaf-socket bug this throws `maxRetryAttemptsReached` because
+  /// the `phx_join` reply is never seen.
   func testColdStartSubscribe_realTimingProfile() async throws {
     for iteration in 1...5 {
       let socket = AsyncFakeWebSocket()
@@ -62,20 +79,14 @@ final class RealtimeColdStartTests: XCTestCase {
         t2.cancel()
       }
 
-      let start = Date()
       do {
         try await channel.subscribeWithError()
       } catch {
         XCTFail("Iteration \(iteration): subscribe failed: \(error)")
         return
       }
-      let elapsed = Date().timeIntervalSince(start)
 
       XCTAssertEqual(channel.status, .subscribed, "Iteration \(iteration)")
-      XCTAssertLessThan(
-        elapsed, 1.0,
-        "Iteration \(iteration): cold subscribe took \(elapsed)s — stall detected"
-      )
     }
   }
 
@@ -84,7 +95,7 @@ final class RealtimeColdStartTests: XCTestCase {
   /// `.connecting` wait path returns the same connection to both callers →
   /// both used to call `handleConnected(conn:)`, reading `conn.events` twice
   /// and leaving the socket deaf (no heartbeat acks, no phx_join replies) —
-  /// the SDK-959 stall.
+  /// the SDK-959 stall, thrown here as `maxRetryAttemptsReached`.
   func testColdStartConcurrentSubscribes_doNotGoDeaf() async throws {
     for iteration in 1...5 {
       let socket = AsyncFakeWebSocket()
@@ -96,7 +107,6 @@ final class RealtimeColdStartTests: XCTestCase {
       let channel1 = sut.channel("room-1")
       let channel2 = sut.channel("room-2")
 
-      let start = Date()
       async let s1: Void = channel1.subscribeWithError()
       async let s2: Void = channel2.subscribeWithError()
 
@@ -106,14 +116,9 @@ final class RealtimeColdStartTests: XCTestCase {
         XCTFail("Iteration \(iteration): subscribe failed: \(error)")
         return
       }
-      let elapsed = Date().timeIntervalSince(start)
 
       XCTAssertEqual(channel1.status, .subscribed, "Iteration \(iteration)")
       XCTAssertEqual(channel2.status, .subscribed, "Iteration \(iteration)")
-      XCTAssertLessThan(
-        elapsed, 1.0,
-        "Iteration \(iteration): cold concurrent subscribe took \(elapsed)s — stall detected"
-      )
     }
   }
 
@@ -131,7 +136,7 @@ final class RealtimeColdStartTests: XCTestCase {
         headers: ["apikey": apiKey],
         heartbeatInterval: 0.2,
         reconnectDelay: 0.05,
-        timeoutInterval: 0.5,
+        timeoutInterval: 5,
         accessToken: { "token" }
       ),
       wsTransport: { _, _ in
@@ -156,16 +161,23 @@ final class RealtimeColdStartTests: XCTestCase {
 
     await sut.connect()
 
-    // Wait for the first heartbeat to be sent (and stay pending).
-    try await Task.sleep(nanoseconds: 300_000_000)
+    // Wait for the first heartbeat to be sent (and stay pending — the first
+    // socket never acks).
+    await waitUntil { heartbeatStatuses.value.contains(.sent) }
     XCTAssertEqual(heartbeatStatuses.value, [.sent])
 
     // Error out the first socket: a malformed frame makes the message task
     // call handleError, which closes the socket and reconnects.
     sockets.value[0].receiveFromServer(.text("not a valid frame"))
 
-    // Allow reconnect plus one full heartbeat interval on the new socket.
-    try await Task.sleep(nanoseconds: 500_000_000)
+    // Wait until the new connection reports its first heartbeat: a second
+    // `.sent` when the pending ref was correctly reset, or a `.timeout` when
+    // the stale ref leaked across the reconnect. (`.disconnected` may
+    // interleave while the reconnect is in flight.)
+    await waitUntil {
+      let statuses = heartbeatStatuses.value
+      return statuses.filter { $0 == .sent }.count >= 2 || statuses.contains(.timeout)
+    }
 
     XCTAssertEqual(sockets.value.count, 2, "Expected exactly one reconnect")
     XCTAssertFalse(

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -122,6 +122,55 @@ final class RealtimeColdStartTests: XCTestCase {
     }
   }
 
+  /// After a disconnect/reconnect, channels that were already `.subscribed`
+  /// must re-send `phx_join` on the new socket. Before this fix,
+  /// `ChannelStateManager.subscribe()` was a no-op for `.subscribed` channels,
+  /// so `rejoinChannels()` silently skipped them — channels went deaf after
+  /// the first reconnect (reported by rpiacent on PR #1003).
+  func testChannelsRejoinAfterReconnect() async throws {
+    let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
+
+    let sut = RealtimeClientV2(
+      url: url,
+      options: RealtimeClientOptions(
+        headers: ["apikey": apiKey],
+        heartbeatInterval: 10,
+        reconnectDelay: 0.05,
+        timeoutInterval: 5,
+        accessToken: { "token" }
+      ),
+      wsTransport: { _, _ in
+        let socket = AsyncFakeWebSocket()
+        socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
+        sockets.withValue { $0.append(socket) }
+        return socket
+      },
+      http: HTTPClientMock()
+    )
+    defer { sut.disconnect() }
+
+    let channel = sut.channel("room-rejoin")
+
+    try await channel.subscribeWithError()
+    XCTAssertEqual(channel.status, .subscribed)
+    XCTAssertEqual(sockets.value.count, 1)
+
+    // Disconnect socket 1 — triggers reconnect.
+    sockets.value[0].receiveFromServer(.close(code: 1001, reason: "going away"))
+    await waitUntil(timeout: 5) { sockets.value.count >= 2 }
+    guard sockets.value.count >= 2 else {
+      return XCTFail("No reconnect within 5 s")
+    }
+
+    // Channel must re-subscribe on the new socket.
+    await waitUntil(timeout: 5) { channel.status == .subscribed }
+    XCTAssertEqual(channel.status, .subscribed, "Channel did not rejoin after reconnect")
+
+    // Exactly one phx_join sent on socket 2 (index 1).
+    let joinsSentOnNewSocket = sockets.value[1].sentMessages.filter { $0.event == "phx_join" }
+    XCTAssertEqual(joinsSentOnNewSocket.count, 1, "Expected one phx_join on the new socket")
+  }
+
   /// A heartbeat left pending on a connection that errors out must not be
   /// misread as a timeout on the replacement connection. Before the fix,
   /// `pendingHeartbeatRef` survived reconnects, so the new connection's first

--- a/Tests/RealtimeTests/RealtimeLifecycleTests.swift
+++ b/Tests/RealtimeTests/RealtimeLifecycleTests.swift
@@ -125,13 +125,22 @@ import XCTest
       XCTAssertEqual(sut.status, .connected)
 
       sut.handleAppBackground()
-      // Simulate the OS tearing down the socket while backgrounded (not a user-initiated
-      // disconnect). Closing the server side triggers a .close event on the client without
-      // going through disconnect(), so wasConnectedBeforeBackground remains set.
+      // Subscribe before the OS close so the buffered .disconnected event is
+      // not missed even when .reconnecting follows immediately (PR #1015 made
+      // handleClose call initiateReconnect).
+      let statusUpdates = sut.statusChange
       servers.value.last?.close(code: nil, reason: "OS teardown")
-      _ = await sut.statusChange.first { $0 == .disconnected }
-      XCTAssertEqual(sut.status, .disconnected)
+      // Status sequence: .connected → .disconnected → .connecting (reconnecting).
+      _ = await statusUpdates.first { $0 == .disconnected }
 
+      // Advance the test clock past the 7-second reconnect delay so the
+      // auto-reconnect task wakes and performConnection() runs.
+      await testClock.advance(by: .seconds(8))
+      _ = await statusUpdates.first { $0 == .connected }
+      XCTAssertEqual(sut.status, .connected)
+
+      // handleAppForeground is a no-op: the auto-reconnect already recovered
+      // the connection and the state observer will rejoin channels.
       await sut.handleAppForeground()
       XCTAssertEqual(sut.status, .connected)
     }
@@ -144,11 +153,25 @@ import XCTest
       XCTAssertEqual(channel.status, .subscribed)
 
       sut.handleAppBackground()
-      // Simulate the OS tearing down the socket while backgrounded.
+      let statusUpdates = sut.statusChange
       servers.value.last?.close(code: nil, reason: "OS teardown")
-      _ = await sut.statusChange.first { $0 == .disconnected }
-      XCTAssertEqual(sut.status, .disconnected)
+      _ = await statusUpdates.first { $0 == .disconnected }
 
+      await testClock.advance(by: .seconds(8))
+      _ = await statusUpdates.first { $0 == .connected }
+      XCTAssertEqual(sut.status, .connected)
+
+      // rejoinChannels() is launched as a fire-and-forget Task from the state
+      // observer's handleConnected(isReconnect: true) path. Poll until it
+      // completes (FakeWebSocket delivers phx_reply synchronously but the task
+      // needs scheduler turns to run).
+      let deadline = Date().addingTimeInterval(5)
+      while channel.status != .subscribed, Date() < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)  // 10 ms
+      }
+      XCTAssertEqual(channel.status, .subscribed)
+
+      // handleAppForeground is a no-op: already reconnected with channel resubscribed.
       await sut.handleAppForeground()
       XCTAssertEqual(sut.status, .connected)
       XCTAssertEqual(channel.status, .subscribed)

--- a/Tests/RealtimeTests/RealtimeLifecycleTests.swift
+++ b/Tests/RealtimeTests/RealtimeLifecycleTests.swift
@@ -48,39 +48,41 @@ import XCTest
         wsTransport: { [servers] _, _ in
           let (client, server) = FakeWebSocket.fakes()
           // Auto-respond to heartbeats and phx_join so subscribe() completes.
-          server.onEvent = { @Sendable [weak server] event in
-            guard let msg = event.realtimeMessage else { return }
-            if msg.event == "heartbeat" {
-              server?.send(
-                RealtimeMessageV2(
-                  joinRef: msg.joinRef,
-                  ref: msg.ref,
-                  topic: "phoenix",
-                  event: "phx_reply",
-                  payload: ["response": [:]]
-                )
-              )
-            } else if msg.event == "phx_join" {
-              // Mirror the incoming ref so the client's pending push resolves,
-              // regardless of reconnect cycles (ref counter resets on disconnect).
-              server?.send(
-                RealtimeMessageV2(
-                  joinRef: msg.joinRef,
-                  ref: msg.ref,
-                  topic: msg.topic,
-                  event: "phx_reply",
-                  payload: [
-                    "response": [
-                      "postgres_changes": []
-                    ],
-                    "status": "ok",
-                  ]
-                )
-              )
-            }
-          }
           // Retain the server so `client.other` (a weak ref) stays valid.
           servers?.withValue { $0.append(server) }
+          Task { [server] in
+            for await event in server.events {
+              guard let msg = event.realtimeMessage else { continue }
+              if msg.event == "heartbeat" {
+                server.send(
+                  RealtimeMessageV2(
+                    joinRef: msg.joinRef,
+                    ref: msg.ref,
+                    topic: "phoenix",
+                    event: "phx_reply",
+                    payload: ["response": [:]]
+                  )
+                )
+              } else if msg.event == "phx_join" {
+                // Mirror the incoming ref so the client's pending push resolves,
+                // regardless of reconnect cycles (ref counter resets on disconnect).
+                server.send(
+                  RealtimeMessageV2(
+                    joinRef: msg.joinRef,
+                    ref: msg.ref,
+                    topic: msg.topic,
+                    event: "phx_reply",
+                    payload: [
+                      "response": [
+                        "postgres_changes": []
+                      ],
+                      "status": "ok",
+                    ]
+                  )
+                )
+              }
+            }
+          }
           return client
         },
         http: http

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -113,24 +113,26 @@ import XCTest
       }
       .store(in: &subscriptions)
 
-      // Set up server to respond to heartbeats
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
+      // Set up server to respond to heartbeats and phx_join
+      let serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: ["response": [:]]
+              )
             )
-          )
-        } else if msg.event == "phx_join" {
-          server?.send(.messagesSubscribed)
+          } else if msg.event == "phx_join" {
+            server.send(.messagesSubscribed)
+          }
         }
       }
+      defer { serverTask.cancel() }
 
       let channelStatuses = LockIsolated([RealtimeChannelStatus]())
       channel.onStatusChange { status in
@@ -211,28 +213,29 @@ import XCTest
       let channel = sut.channel("public:messages")
       let joinEventCount = LockIsolated(0)
 
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
+      let serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: ["response": [:]]
+              )
             )
-          )
-        } else if msg.event == "phx_join" {
-          joinEventCount.withValue { $0 += 1 }
-
-          // Skip first join.
-          if joinEventCount.value == 2 {
-            server?.send(.messagesSubscribed)
+          } else if msg.event == "phx_join" {
+            joinEventCount.withValue { $0 += 1 }
+            // Skip first join.
+            if joinEventCount.value == 2 {
+              server.send(.messagesSubscribed)
+            }
           }
         }
       }
+      defer { serverTask.cancel() }
 
       await sut.connect()
       await testClock.advance(by: .seconds(heartbeatInterval))
@@ -315,27 +318,29 @@ import XCTest
       let channel = sut.channel("public:messages")
       let joinEventCount = LockIsolated(0)
 
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
+      let serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: ["response": [:]]
+              )
             )
-          )
-        } else if msg.event == "phx_join" {
-          joinEventCount.withValue { $0 += 1 }
-          // Respond on the 3rd attempt
-          if joinEventCount.value == successAttempt {
-            server?.send(.messagesSubscribed)
+          } else if msg.event == "phx_join" {
+            joinEventCount.withValue { $0 += 1 }
+            // Respond on the 3rd attempt
+            if joinEventCount.value == successAttempt {
+              server.send(.messagesSubscribed)
+            }
           }
         }
       }
+      defer { serverTask.cancel() }
 
       await sut.connect()
       await testClock.advance(by: .seconds(heartbeatInterval))
@@ -366,23 +371,26 @@ import XCTest
       let channel = sut.channel("public:messages")
       let joinEventCount = LockIsolated(0)
 
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
+      let serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: ["response": [:]]
+              )
             )
-          )
-        } else if msg.event == "phx_join" {
-          joinEventCount.withValue { $0 += 1 }
-          // Never respond to any join attempts
+          } else if msg.event == "phx_join" {
+            joinEventCount.withValue { $0 += 1 }
+            // Never respond to any join attempts
+          }
         }
       }
+      defer { serverTask.cancel() }
 
       await sut.connect()
       await testClock.advance(by: .seconds(heartbeatInterval))
@@ -418,23 +426,26 @@ import XCTest
       let channel = sut.channel("public:messages")
       let joinEventCount = LockIsolated(0)
 
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
+      let serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: ["response": [:]]
+              )
             )
-          )
-        } else if msg.event == "phx_join" {
-          joinEventCount.withValue { $0 += 1 }
-          // Never respond to any join attempts
+          } else if msg.event == "phx_join" {
+            joinEventCount.withValue { $0 += 1 }
+            // Never respond to any join attempts
+          }
         }
       }
+      defer { serverTask.cancel() }
 
       await sut.connect()
       await testClock.advance(by: .seconds(heartbeatInterval))
@@ -468,25 +479,27 @@ import XCTest
       let expectation = expectation(description: "heartbeat")
       expectation.expectedFulfillmentCount = 2
 
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          expectation.fulfill()
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: [
-                "response": [:],
-                "status": "ok",
-              ]
+      let serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            expectation.fulfill()
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: [
+                  "response": [:],
+                  "status": "ok",
+                ]
+              )
             )
-          )
+          }
         }
       }
+      defer { serverTask.cancel() }
 
       let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
       let subscription = sut.onHeartbeat { status in
@@ -508,11 +521,15 @@ import XCTest
     func testHeartbeat_whenNoResponse_shouldReconnect() async throws {
       let sentHeartbeatExpectation = expectation(description: "sentHeartbeat")
 
-      server.onEvent = { @Sendable in
-        if $0.realtimeMessage?.event == "heartbeat" {
-          sentHeartbeatExpectation.fulfill()
+      let serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          if event.realtimeMessage?.event == "heartbeat" {
+            sentHeartbeatExpectation.fulfill()
+          }
+          // Intentionally not replying — trigger timeout/reconnect path.
         }
       }
+      defer { serverTask.cancel() }
 
       let statuses = LockIsolated<[RealtimeClientStatus]>([])
       let subscription = sut.onStatusChange { status in
@@ -558,9 +575,7 @@ import XCTest
       }
       defer { s1.cancel() }
 
-      // Don't respond to any heartbeats
-      server.onEvent = { _ in }
-
+      // Don't respond to any heartbeats — let the timeout fire naturally.
       await sut.connect()
       await testClock.advance(by: .seconds(heartbeatInterval))
 
@@ -585,24 +600,26 @@ import XCTest
     // but deaf — heartbeat and `phx_join` replies were silently dropped,
     // stalling subscribe for tens of seconds to minutes.
     func testRedundantConnect_doesNotDropIncomingFrames() async throws {
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: [
-                "response": [:],
-                "status": "ok",
-              ]
+      let serverTask = Task { @Sendable [server = server!] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "heartbeat" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "phoenix",
+                event: "phx_reply",
+                payload: [
+                  "response": [:],
+                  "status": "ok",
+                ]
+              )
             )
-          )
+          }
         }
       }
+      defer { serverTask.cancel() }
 
       let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
       let subscription = sut.onHeartbeat { status in
@@ -679,22 +696,6 @@ import XCTest
     // MARK: - Task Lifecycle Tests
 
     func testListenForMessagesCancelsExistingTask() async {
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
-            )
-          )
-        }
-      }
-
       await sut.connect()
 
       // Get the first message task
@@ -716,22 +717,6 @@ import XCTest
     }
 
     func testStartHeartbeatingCancelsExistingTask() async {
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
-            )
-          )
-        }
-      }
-
       await sut.connect()
 
       // Get the first heartbeat task
@@ -754,22 +739,6 @@ import XCTest
 
     func testMessageProcessingRespectsCancellation() async {
       let messagesProcessed = LockIsolated(0)
-
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
-            )
-          )
-        }
-      }
 
       await sut.connect()
 
@@ -812,22 +781,6 @@ import XCTest
     }
 
     func testMultipleReconnectionsHandleTaskLifecycleCorrectly() async {
-      server.onEvent = { @Sendable [server] event in
-        guard let msg = event.realtimeMessage else { return }
-
-        if msg.event == "heartbeat" {
-          server?.send(
-            RealtimeMessageV2(
-              joinRef: msg.joinRef,
-              ref: msg.ref,
-              topic: "phoenix",
-              event: "phx_reply",
-              payload: ["response": [:]]
-            )
-          )
-        }
-      }
-
       var previousMessageTasks: [Task<Void, Never>?] = []
       var previousHeartbeatTasks: [Task<Void, Never>?] = []
 

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -577,6 +577,57 @@ import XCTest
       XCTAssertEqual(heartbeatStatuses.value, [.sent, .timeout])
     }
 
+    // Regression test for SDK-959: a second `handleConnected` on an already
+    // established connection (e.g. `connect()` called while the socket is
+    // already connected, or while an auto-reconnect is in flight) used to
+    // re-read `conn.events`. The first event-stream's `onTermination` would
+    // then race to nil out the live `onEvent`, leaving the socket connected
+    // but deaf — heartbeat and `phx_join` replies were silently dropped,
+    // stalling subscribe for tens of seconds to minutes.
+    func testRedundantConnect_doesNotDropIncomingFrames() async throws {
+      server.onEvent = { @Sendable [server] event in
+        guard let msg = event.realtimeMessage else { return }
+
+        if msg.event == "heartbeat" {
+          server?.send(
+            RealtimeMessageV2(
+              joinRef: msg.joinRef,
+              ref: msg.ref,
+              topic: "phoenix",
+              event: "phx_reply",
+              payload: [
+                "response": [:],
+                "status": "ok",
+              ]
+            )
+          )
+        }
+      }
+
+      let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
+      let subscription = sut.onHeartbeat { status in
+        heartbeatStatuses.withValue { $0.append(status) }
+      }
+      defer { subscription.cancel() }
+
+      await sut.connect()
+
+      // A redundant connect() — the ConnectionManager is already `.connected`,
+      // so it returns the same connection. The socket must keep receiving
+      // frames afterwards.
+      await sut.connect()
+      await Task.megaYield()
+
+      // Drive a heartbeat; the server replies. If the socket is still
+      // listening, the reply acks the heartbeat (.ok). If `onEvent` was
+      // niled out by the duplicate setup, the reply is dropped and the
+      // heartbeat is never acknowledged.
+      await testClock.advance(by: .seconds(heartbeatInterval))
+      await Task.megaYield()
+
+      XCTAssertEqual(heartbeatStatuses.value, [.sent, .ok])
+    }
+
     func testBroadcastWithHTTP() async throws {
       await http.when {
         $0.url.path.hasSuffix("broadcast")


### PR DESCRIPTION
## Summary

Fixes [SDK-959](https://linear.app/supabase/issue/SDK-959) / #999: the first `channel.subscribeWithError()` on a fresh socket stalls for 50s–7min (regression since v2.44.1 / #855). The socket connects but silently drops every incoming frame — heartbeat acks and `phx_join` replies never arrive — until a reconnect cycle happens to produce a healthy connection.

## Root Cause

All defects share one theme: **connection lifecycle events were not tied to a specific connection.**

### 1. Deaf socket from duplicate `handleConnected` (the stall itself)

`RealtimeClientV2.connect()` calls `handleConnected(conn:)` on every return — but `ConnectionManager.connect()` returns the *same* connection to every concurrent caller (`.connecting` / `.connected` / `.reconnecting` wait paths). So `handleConnected` runs multiple times for one physical socket whenever:

- **two channels subscribe concurrently at cold start** (both `ensureSocketConnected` → `connect()`), or
- **a subscribe retry calls `connect()` while an auto-reconnect is in flight** — the caller *and* the state-observer task each run `handleConnected` for the reconnected socket.

Each duplicate run of `handleConnected` called `listenForMessages`, which started a second consumer on `conn.events`. Because `AsyncStream` delivers each event to exactly one consumer, events were split between the two tasks — heartbeat acks and `phx_join` replies could be consumed by the task that was about to be cancelled, leaving the live task deaf.

**Fix:** `handleConnected` is now idempotent per connection (identity guard) — `listenForMessages` and `startHeartbeating` are called exactly once per socket.

### 2. `pendingHeartbeatRef` leaked across reconnects (the perpetual ~50s cycle)

Only the timeout path cleared `pendingHeartbeatRef`. After an error-driven reconnect with a heartbeat in flight, the new connection's first heartbeat misread the stale ref as a timeout and tore down the healthy socket — re-entering the cycle. **Fix:** cleared when adopting a new connection.

### 3. Stale-socket signals clobbered live state

`ConnectionManager.handleClose`/`handleError` accepted signals from any socket. A late `.close`/error surfacing from an old connection's message task (URLSession delivers these on a delegate queue, after the reconnect already established a new socket) flipped `.connected(newConn)` to `.disconnected`, orphaning a live connection. **Fix:** both now take the originating connection and ignore mismatches.

### 4. Channels went deaf after reconnect

`rejoinChannels()` called `subscribeWithError()` on channels that were already `.subscribed` — which is a no-op in `ChannelStateManager`. No new `phx_join` was sent on the new socket, so channels received nothing after every reconnect. **Fix:** `ChannelStateManager.resetForReconnect()` transitions `.subscribed`/`.subscribing`/`.unsubscribing` back to `.unsubscribed` (cancelling any in-flight task) before the rejoin sequence.

### 5. Server-initiated close did not trigger reconnect

`ConnectionManager.handleClose` only updated state without calling `initiateReconnect`. A server-driven WebSocket close (deploy restart, load-balancer timeout) left the SDK permanently disconnected. **Fix:** `handleClose` now calls `initiateReconnect` inside the `.connected` guard, matching the recovery path already used by `handleError`. SDK-initiated disconnects are unaffected because `disconnect()` transitions away from `.connected` before the close event arrives.

Application-level close codes (4000–4999) are excluded from auto-reconnect: a server close with code 4001 (invalid JWT) should not loop with the same bad token — the caller must re-authenticate first. Transport-level closures (1001 going-away, 1006 abnormal) still trigger reconnect.

### 6. `_clock` global race between parallel test classes

`ConnectionManager.initiateReconnect` and `RealtimeClientV2.startHeartbeating` read the module-level `_clock` global lazily at call time. When `RealtimeColdStartTests.setUp()` resets `_clock = ContinuousClock()` while a `RealtimeLifecycleTests` test runs in a parallel thread, heartbeat/reconnect sleeps could pick up the wrong clock and fire unexpectedly. **Fix:** both classes capture `_clock` as an instance property at init time; all internal sleeps use `self.clock`.

### 7. `WebSocket.events` must be a stored property (spydon review)

The protocol originally had a computed-property default for `events` in an extension — each read created a new `AsyncStream`. If `handleConnected` ran twice for the same socket, the second read started a second consumer, splitting the event stream (see #1). The extension default was also used by test doubles.

**Fix:** `onEvent` is removed from the protocol entirely. `events` is now a protocol requirement backed by a stored `let` property (and a matching `eventsContinuation`) created in `init` on both `URLSessionWebSocket` and `FakeWebSocket`. Reading `conn.events` any number of times returns the same stream.

## Testing

All regression tests verified to fail before their fix and pass after:

- `testRedundantConnect_doesNotDropIncomingFrames` — redundant `connect()` must not stop frame delivery (failed pre-fix: heartbeat `[.sent]`, never acked).
- **`RealtimeColdStartTests`** (new) — runs the reporter's exact flow (cold client, `postgresChange` streams, `subscribeWithError`) plus the two-channel concurrent variant against a transport with real connection latency and **asynchronous** frame delivery. Pre-fix: deterministic `maxRetryAttemptsReached` stall on iteration 1. Post-fix: subscribes in ~130ms across all iterations.
- `testPendingHeartbeatDoesNotLeakAcrossReconnect` — pre-fix: spurious `.timeout` + third connection after one reconnect.
- `testChannelsRejoinAfterReconnect` — pre-fix: channels stayed deaf after reconnect because `subscribe()` was a no-op on already-`.subscribed` state.
- `ConnectionManagerTests` — stale `handleClose`/`handleError` are ignored; current-connection signals still reconnect; application close codes (4001) do not reconnect.
- `RealtimeLifecycleTests` — foreground/background reconnect tests updated to match auto-reconnect-on-close behaviour.
- Full `RealtimeTests` suite: **210 tests, 0 failures**.

## Risk Assessment

- **Breaking changes**: None. Public API unchanged.
- **Behavior change**: duplicate `handleConnected` is now a no-op for setup; stale-socket signals no longer tear down healthy connections; server-initiated transport-level closes now trigger automatic reconnect (previously left permanently disconnected); application-level close codes (4000–4999) do NOT auto-reconnect (new).

## Linear

Closes SDK-959

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`