### PR TITLE
fix(spm): declare missing direct product dependencies for strict framework linking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
         .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "Clocks", package: "swift-clocks"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
@@ -53,6 +54,8 @@ let package = Package(
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "Helpers",
       ]
     ),
@@ -75,7 +78,9 @@ let package = Package(
     .target(
       name: "Functions",
       dependencies: [
-        "Helpers"
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
+        "Helpers",
       ]
     ),
     .testTarget(
@@ -112,6 +117,7 @@ let package = Package(
       name: "PostgREST",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
         "Helpers",
       ]
     ),
@@ -133,6 +139,7 @@ let package = Package(
       name: "Realtime",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "Helpers",
       ]
@@ -150,7 +157,9 @@ let package = Package(
     .target(
       name: "Storage",
       dependencies: [
-        "Helpers"
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
+        "Helpers",
       ]
     ),
     .testTarget(
@@ -175,6 +184,7 @@ let package = Package(
       name: "Supabase",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "Auth",
         "Functions",
@@ -198,6 +208,7 @@ let package = Package(
         .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "Auth",
+        "Helpers",
         "Mocker",
       ]
     ),


### PR DESCRIPTION
## Summary

Fixes #1000. Under **Xcode 26**, building a test target that links a Supabase module as a separate `.framework` fails because several targets reference modules at link time that aren't declared as **direct** product dependencies. App builds merge objects into the app binary so transitive symbols resolve, but each framework gets its own `ld` step that only receives `-framework X` flags for directly declared dependencies. The clearest example:

```
Ld …/PackageFrameworks/Helpers.framework/Helpers (in target 'Helpers' from project 'Supabase')
Undefined symbols for architecture arm64:
  "IssueReporting.isTesting.unsafeMutableAddressor : Swift.Bool", referenced from:
    static (extension in Helpers):Foundation.JSONEncoder.supabase() … in Codable.o
ld: symbol(s) not found for architecture arm64
```

`Helpers/Version.swift` reads `isTesting`, which lives in `IssueReporting` and is reachable only via `XCTestDynamicOverlay`'s `@_exported import IssueReporting`. `Helpers` never declares `IssueReporting` as a direct product dependency, so the only thing putting it on `Helpers.framework`'s link line is **Swift autolinking** — which gets defeated in real dependency graphs (e.g. a second `IssueReporting` provider, `swift-issue-reporting` vs `xctest-dynamic-overlay`), at which point the symbol goes undefined.

## Fix

Apply the "declare what you import" principle across every production target, derived from an `import` scan of each `Sources/<Module>` tree vs. its current `dependencies:` array:

| Target | Added |
|---|---|
| `Helpers` | `IssueReporting` |
| `Auth` | `HTTPTypes`, `IssueReporting` |
| `Functions` | `ConcurrencyExtras`, `HTTPTypes` |
| `PostgREST` | `HTTPTypes` |
| `Realtime` | `HTTPTypes` |
| `Storage` | `ConcurrencyExtras`, `HTTPTypes` |
| `Supabase` | `HTTPTypes` |
| `TestHelpers` | `Helpers` |

This is broader than the minimal proposal in #1000 (Helpers + Auth only) on purpose: an Auth-only fix still leaves `Realtime.framework` and `Storage.framework` broken — e.g. `Storage` declares *neither* `ConcurrencyExtras` nor `HTTPTypes` today. `Helpers` only builds as a standalone dynamic framework (with its own failing `Ld`) when two or more sibling products that share it (`Auth`/`Realtime`/`Storage`) are linked, so fixing all targets makes every module framework self-contained.

**No new packages are introduced** — every added product already comes from a package in the existing dependency graph (`swift-http-types`, `swift-concurrency-extras`, `xctest-dynamic-overlay`), so resolution is unchanged. The change only *adds* declarations for dependencies that are already used, so it cannot affect compilation or runtime behavior.

Per the discussion in #1000, this intentionally does **not** re-add a `Helpers` library product (the other half of the closed #977) — `Helpers` stays internal; only its dependency declarations are corrected.

## Verification

`swift build` passes and resolves with no new dependencies.

Reproduced the exact failure end-to-end in a scratch Xcode project (iOS app + unit-test bundle, both linking `Auth`+`Realtime`+`Storage` so `Helpers` builds as its own dynamic framework) on **Xcode 26.5**. To make the latent gap deterministic in a minimal graph, `IssueReporting` autolinking is disabled (`-disable-autolink-framework IssueReporting`), simulating the defeated-autolink condition real apps hit. Only the package version differs between the two runs:

| supabase-swift | `Ld …/Helpers.framework/Helpers` |
| --- | --- |
| `2.46.0` (released) | ❌ `Undefined symbol: IssueReporting.isTesting.unsafeMutableAddressor` |
| this branch | ✅ **TEST BUILD SUCCEEDED** |

`otool -L …/Helpers.framework/Helpers` on the patched build confirms `@rpath/IssueReporting.framework/IssueReporting` is now on the link line via the dependency graph (autolink was off), which is what makes the link robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
