### PR TITLE
fix(auth): recognize ?error= query param in implicit grant redirect URLs

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -857,9 +857,9 @@ public actor AuthClient {
   private func handleImplicitGrantFlow(params: [String: String]) async throws -> Session {
     precondition(configuration.flowType == .implicit, "Method only allowed for implicit flow.")
 
-    if let errorDescription = params["error_description"] {
+    if let errorMessage = params["error_description"] ?? params["error"] {
       throw AuthError.implicitGrantRedirect(
-        message: errorDescription.replacingOccurrences(of: "+", with: " ")
+        message: errorMessage.replacingOccurrences(of: "+", with: " ")
       )
     }
 
@@ -1454,7 +1454,7 @@ public actor AuthClient {
   }
 
   private func isImplicitGrantFlow(params: [String: String]) -> Bool {
-    params["access_token"] != nil || params["error_description"] != nil
+    params["access_token"] != nil || params["error_description"] != nil || params["error"] != nil
   }
 
   private func isPKCEFlow(params: [String: String]) -> Bool {

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -986,6 +986,48 @@ final class AuthClientTests: XCTestCase {
     }
   }
 
+  func testSessionWithURL_implicitFlow_errorQueryParam() async throws {
+    let sut = makeSUT(flowType: .implicit)
+
+    let url = URL(
+      string:
+        "https://dummy-url.com/callback?error=access_denied&error_description=User+denied+access"
+    )!
+
+    do {
+      try await sut.session(from: url)
+      XCTFail("Expected implicitGrantRedirect error")
+    } catch let AuthError.implicitGrantRedirect(message) {
+      expectNoDifference(message, "User denied access")
+    }
+  }
+
+  func testSessionWithURL_implicitFlow_errorQueryParamNoDescription() async throws {
+    let sut = makeSUT(flowType: .implicit)
+
+    let url = URL(string: "https://dummy-url.com/callback?error=access_denied")!
+
+    do {
+      try await sut.session(from: url)
+      XCTFail("Expected implicitGrantRedirect error")
+    } catch let AuthError.implicitGrantRedirect(message) {
+      expectNoDifference(message, "access_denied")
+    }
+  }
+
+  func testSessionWithURL_implicitFlow_errorHashFragmentNoDescription() async throws {
+    let sut = makeSUT(flowType: .implicit)
+
+    let url = URL(string: "https://dummy-url.com/callback#error=access_denied")!
+
+    do {
+      try await sut.session(from: url)
+      XCTFail("Expected implicitGrantRedirect error")
+    } catch let AuthError.implicitGrantRedirect(message) {
+      expectNoDifference(message, "access_denied")
+    }
+  }
+
   func testSessionWithURL_implicitFlow_recoveryType() async throws {
     Mock(
       url: clientURL.appendingPathComponent("user"),


### PR DESCRIPTION
## Summary

OAuth providers send error callbacks as query parameters (`?error=access_denied`) in addition to hash fragments (`#error=...`). The implicit grant detection only checked for `error_description`, so URLs with only `?error=access_denied` fell through to "Not a valid implicit grant flow URL" instead of returning the actual OAuth error.

## Changes

- `Sources/Auth/AuthClient.swift:1457` — `isImplicitGrantFlow`: added `params["error"] != nil` to detect error-only query param redirects
- `Sources/Auth/AuthClient.swift:860` — `handleImplicitGrantFlow`: use `error_description ?? error` so `error` becomes the fallback message when no description is provided (mirrors `handlePKCEFlow`)

## Root cause

`isImplicitGrantFlow` only checked `params["access_token"] != nil || params["error_description"] != nil`. OAuth providers like GitHub/Google can send `?error=access_denied` without `error_description`, causing the URL to fail the gate and throw the wrong error.

## Test plan

- [x] `testSessionWithURL_implicitFlow_errorQueryParam` — `?error=&error_description=` returns `AuthError.implicitGrantRedirect` with description
- [x] `testSessionWithURL_implicitFlow_errorQueryParamNoDescription` — `?error=access_denied` returns error with `access_denied` as message
- [x] `testSessionWithURL_implicitFlow_errorHashFragmentNoDescription` — `#error=access_denied` returns error with `access_denied` as message
- [x] Existing `testSessionWithURL_implicitFlow_error` (hash fragment + description) still passes
- [x] Full AuthTests suite green (exit code 0)

## Linear

Closes SDK-1033