### PR TITLE
feat(supabase): add W3C trace context propagation support

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		79FEFFC52B078D7900D36347 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FEFFC42B078D7900D36347 /* Models.swift */; };
 		79FEFFC72B078FB000D36347 /* SwiftUIHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FEFFC62B078FB000D36347 /* SwiftUIHelpers.swift */; };
 		79FEFFC92B0797F600D36347 /* AvatarImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FEFFC82B0797F600D36347 /* AvatarImage.swift */; };
+		AA110004AA110004AA110004 /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = AA110002AA110002AA110002 /* OpenTelemetryApi */; };
+		AA110005AA110005AA110005 /* OpenTelemetrySdk in Frameworks */ = {isa = PBXBuildFile; productRef = AA110003AA110003AA110003 /* OpenTelemetrySdk */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -129,6 +131,7 @@
 		793D8ECB2E983112006B6969 /* Realtime */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Realtime; sourceTree = "<group>"; };
 		793D8ED02E983112006B6969 /* Storage */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Storage; sourceTree = "<group>"; };
 		793D8F1E2E984184006B6969 /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
+		AA110006AA110006AA110006 /* Tracing */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Tracing; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +147,8 @@
 				79E2B55A2B97890F0042CD21 /* GoogleSignInSwift in Frameworks */,
 				7962989D2AEBC6F9000AA957 /* SVGView in Frameworks */,
 				79719ECE2ADF26C400737804 /* Supabase in Frameworks */,
+				AA110004AA110004AA110004 /* OpenTelemetryApi in Frameworks */,
+				AA110005AA110005AA110005 /* OpenTelemetrySdk in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -314,6 +319,7 @@
 				793D8ECB2E983112006B6969 /* Realtime */,
 				793D8ED02E983112006B6969 /* Storage */,
 				793D8F1E2E984184006B6969 /* Shared */,
+				AA110006AA110006AA110006 /* Tracing */,
 			);
 			name = Examples;
 			packageProductDependencies = (
@@ -325,6 +331,8 @@
 				79E2B5592B97890F0042CD21 /* GoogleSignInSwift */,
 				79BE42A02D942EFD00B9DDF4 /* Clerk */,
 				795FA98D2DF354B000F67AFF /* FacebookLogin */,
+				AA110002AA110002AA110002 /* OpenTelemetryApi */,
+				AA110003AA110003AA110003 /* OpenTelemetrySdk */,
 			);
 			productName = Examples;
 			productReference = 793895C62954ABFF0044F2B8 /* Examples.app */;
@@ -408,6 +416,7 @@
 				79E2B5562B97890F0042CD21 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				79BE429F2D942EFD00B9DDF4 /* XCRemoteSwiftPackageReference "clerk-ios" */,
 				795FA98C2DF354B000F67AFF /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */,
+				AA110001AA110001AA110001 /* XCRemoteSwiftPackageReference "opentelemetry-swift" */,
 			);
 			productRefGroup = 793895C72954ABFF0044F2B8 /* Products */;
 			projectDirPath = "";
@@ -970,6 +979,14 @@
 				minimumVersion = 7.0.0;
 			};
 		};
+		AA110001AA110001AA110001 /* XCRemoteSwiftPackageReference "opentelemetry-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1024,6 +1041,16 @@
 		79FEFFBB2B07874000D36347 /* Supabase */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Supabase;
+		};
+		AA110002AA110002AA110002 /* OpenTelemetryApi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA110001AA110001AA110001 /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
+			productName = OpenTelemetryApi;
+		};
+		AA110003AA110003AA110003 /* OpenTelemetrySdk */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA110001AA110001AA110001 /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
+			productName = OpenTelemetrySdk;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Examples/Examples/HomeView.swift
+++ b/Examples/Examples/HomeView.swift
@@ -48,6 +48,14 @@ struct HomeView: View {
         Label("Functions", systemImage: "function")
       }
 
+      // Tracing Tab
+      NavigationStack {
+        TracingExampleView()
+      }
+      .tabItem {
+        Label("Tracing", systemImage: "chart.line.uptrend.xyaxis")
+      }
+
       // Profile Tab
       ProfileView()
         .tabItem {

--- a/Examples/Examples/Tracing/OTelTraceContextProvider.swift
+++ b/Examples/Examples/Tracing/OTelTraceContextProvider.swift
@@ -1,0 +1,23 @@
+//
+//  OTelTraceContextProvider.swift
+//  Examples
+//
+//  Implements TraceContextProvider using opentelemetry-swift.
+//
+
+import OpenTelemetryApi
+import Supabase
+
+/// Reads the active OpenTelemetry span from thread-local context and formats it as a W3C `traceparent` header.
+///
+/// Pass an instance to ``SupabaseClientOptions/GlobalOptions/tracePropagation`` when constructing `SupabaseClient`.
+struct OTelTraceContextProvider: TraceContextProvider {
+  func traceContext() -> [String: String] {
+    guard let span = OpenTelemetry.instance.contextProvider.activeSpan,
+      span.context.isValid
+    else { return [:] }
+    let ctx = span.context
+    let flags = String(format: "%02x", ctx.traceFlags.rawValue)
+    return ["traceparent": "00-\(ctx.traceId.hexString)-\(ctx.spanId.hexString)-\(flags)"]
+  }
+}

--- a/Examples/Examples/Tracing/TracingExampleView.swift
+++ b/Examples/Examples/Tracing/TracingExampleView.swift
@@ -1,0 +1,147 @@
+//
+//  TracingExampleView.swift
+//  Examples
+//
+//  Demonstrates W3C trace context propagation with Supabase and OpenTelemetry.
+//
+
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import Supabase
+import SwiftUI
+
+// A SupabaseClient configured with trace propagation via OTelTraceContextProvider.
+// In your app, configure tracePropagation once when initializing your shared client.
+private let tracingClient: SupabaseClient = {
+  let url = URL(string: SupabaseConfig["SUPABASE_URL"] ?? "https://example.supabase.co")!
+  let key =
+    SupabaseConfig["SUPABASE_PUBLISHABLE_KEY"] ?? SupabaseConfig["SUPABASE_ANON_KEY"] ?? ""
+  return SupabaseClient(
+    supabaseURL: url,
+    supabaseKey: key,
+    options: .init(
+      global: .init(tracePropagation: OTelTraceContextProvider())
+    )
+  )
+}()
+
+struct TracingExampleView: View {
+  @State private var traceparent = ""
+  @State private var status = ""
+  @State private var isRunning = false
+
+  var body: some View {
+    List {
+      Section {
+        Text(
+          "Each outgoing Supabase request is tagged with the active OpenTelemetry span via the W3C traceparent header."
+        )
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+      }
+
+      Section("Client Setup") {
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Initialize SupabaseClient with:")
+            .font(.caption)
+            .foregroundColor(.secondary)
+          Text(
+            """
+            SupabaseClient(
+              supabaseURL: url,
+              supabaseKey: key,
+              options: .init(
+                global: .init(
+                  tracePropagation:
+                    OTelTraceContextProvider()
+                )
+              )
+            )
+            """
+          )
+          .font(.caption.monospaced())
+          .padding(8)
+          .background(Color(.secondarySystemBackground))
+          .cornerRadius(6)
+        }
+        .padding(.vertical, 4)
+      }
+
+      Section("Live Demo") {
+        Button {
+          runDemo()
+        } label: {
+          HStack {
+            Label(
+              "Start span & query Supabase",
+              systemImage: "antenna.radiowaves.left.and.right"
+            )
+            Spacer()
+            if isRunning {
+              ProgressView()
+            }
+          }
+        }
+        .disabled(isRunning)
+
+        if !traceparent.isEmpty {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Injected traceparent:")
+              .font(.caption)
+              .foregroundColor(.secondary)
+            Text(traceparent)
+              .font(.caption.monospaced())
+              .textSelection(.enabled)
+          }
+          .padding(.vertical, 4)
+        }
+
+        if !status.isEmpty {
+          Text(status)
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+    }
+    .navigationTitle("Tracing")
+  }
+
+  @MainActor
+  private func runDemo() {
+    isRunning = true
+    traceparent = ""
+    status = ""
+
+    Task { @MainActor in
+      let provider = TracerProviderSdk()
+      OpenTelemetry.registerTracerProvider(tracerProvider: provider)
+      let tracer = OpenTelemetry.instance.tracerProvider.get(
+        instrumentationName: "supabase-swift-examples",
+        instrumentationVersion: nil
+      )
+
+      let span = tracer.spanBuilder(spanName: "supabase.query").startSpan()
+      OpenTelemetry.instance.contextProvider.setActiveSpan(span)
+      defer {
+        span.end()
+        OpenTelemetry.instance.contextProvider.removeContextForSpan(span)
+      }
+
+      let ctx = span.context
+      let flags = String(format: "%02x", ctx.traceFlags.rawValue)
+      traceparent = "00-\(ctx.traceId.hexString)-\(ctx.spanId.hexString)-\(flags)"
+
+      do {
+        _ = try await tracingClient.from("todos").select().execute()
+        status =
+          "Request completed. Check your tracing backend for trace ID: \(ctx.traceId.hexString)"
+      } catch {
+        // The request was sent with the traceparent header even if it failed.
+        status =
+          "Request sent with traceparent header. (Error: \(error.localizedDescription))"
+      }
+
+      isRunning = false
+    }
+  }
+}

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -188,8 +188,16 @@ public final class SupabaseClient: Sendable {
       encoder: options.auth.encoder,
       decoder: options.auth.decoder,
       fetch: {
+        [tracePropagation = options.global.tracePropagation, session = options.global.session]
+        urlRequest in
         // DON'T use `fetchWithAuth` method within the AuthClient as it may cause a deadlock.
-        try await options.global.session.data(for: $0)
+        var urlRequest = urlRequest
+        if let traceHeaders = tracePropagation?.traceContext() {
+          for (key, value) in traceHeaders {
+            urlRequest.setValue(value, forHTTPHeaderField: key)
+          }
+        }
+        return try await session.data(for: urlRequest)
       },
       autoRefreshToken: options.auth.autoRefreshToken,
       emitLocalSessionAsInitialSession: options.auth.emitLocalSessionAsInitialSession
@@ -358,6 +366,11 @@ public final class SupabaseClient: Sendable {
     var request = request
     if let token {
       request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+    if let traceHeaders = options.global.tracePropagation?.traceContext() {
+      for (key, value) in traceHeaders {
+        request.setValue(value, forHTTPHeaderField: key)
+      }
     }
     return request
   }

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -427,8 +427,16 @@ public final class SupabaseClient: Sendable {
     }
 
     if realtimeOptions.fetch == nil {
-      realtimeOptions.fetch = { [session = options.global.session] request in
-        try await session.data(for: request)
+      realtimeOptions.fetch = {
+        [tracePropagation = options.global.tracePropagation, session = options.global.session]
+        request in
+        var request = request
+        if let traceHeaders = tracePropagation?.traceContext() {
+          for (key, value) in traceHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+          }
+        }
+        return try await session.data(for: request)
       }
     }
 

--- a/Sources/Supabase/TraceContext.swift
+++ b/Sources/Supabase/TraceContext.swift
@@ -1,0 +1,32 @@
+//
+//  TraceContext.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 10/06/26.
+//
+
+/// Provides W3C trace context headers to inject into every outgoing HTTP request.
+///
+/// Implement this protocol using any OpenTelemetry-compatible library and pass the instance
+/// via ``SupabaseClientOptions/GlobalOptions/tracePropagation``.
+///
+/// Example using opentelemetry-swift:
+///
+/// ```swift
+/// import OpenTelemetryApi
+///
+/// struct OTelTraceContextProvider: TraceContextProvider {
+///   func traceContext() -> [String: String] {
+///     guard let span = OpenTelemetry.instance.contextProvider.activeSpan else { return [:] }
+///     let traceId = span.context.traceId.hexString
+///     let spanId = span.context.spanId.hexString
+///     return ["traceparent": "00-\(traceId)-\(spanId)-01"]
+///   }
+/// }
+/// ```
+public protocol TraceContextProvider: Sendable {
+  /// Returns the trace context headers to inject into the current request.
+  ///
+  /// Called once per outgoing HTTP request. Return an empty dictionary when no active span exists.
+  func traceContext() -> [String: String]
+}

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -103,14 +103,23 @@ public struct SupabaseClientOptions: Sendable {
     /// The logger  to use across all Supabase sub-packages.
     public let logger: (any SupabaseLogger)?
 
+    /// An optional provider for W3C trace context headers.
+    ///
+    /// When set, ``TraceContextProvider/traceContext()`` is called once per outgoing request and
+    /// the returned headers (e.g. `traceparent`) are injected before the request is sent.
+    /// Set to `nil` (default) to disable trace propagation.
+    public let tracePropagation: (any TraceContextProvider)?
+
     public init(
       headers: [String: String] = [:],
       session: URLSession = .shared,
-      logger: (any SupabaseLogger)? = nil
+      logger: (any SupabaseLogger)? = nil,
+      tracePropagation: (any TraceContextProvider)? = nil
     ) {
       self.headers = headers
       self.session = session
       self.logger = logger
+      self.tracePropagation = tracePropagation
     }
   }
 

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -12,23 +12,41 @@ import XCTest
 // MARK: - Helpers
 
 private final class RequestCapturingProtocol: URLProtocol {
-  static var capturedRequests: [URLRequest] = []
-  static var stubbedData = Data("[]".utf8)
-  static var stubbedStatusCode = 200
+  // NSLock guards the mutable statics — startLoading runs on the URLSession delegate queue.
+  private static let lock = NSLock()
+  private static var _capturedRequests: [URLRequest] = []
+  private static var _stubbedData = Data("[]".utf8)
+  private static var _stubbedStatusCode = 200
+
+  static var capturedRequests: [URLRequest] {
+    get { lock.withLock { _capturedRequests } }
+    set { lock.withLock { _capturedRequests = newValue } }
+  }
+
+  static var stubbedData: Data {
+    get { lock.withLock { _stubbedData } }
+    set { lock.withLock { _stubbedData = newValue } }
+  }
+
+  static var stubbedStatusCode: Int {
+    get { lock.withLock { _stubbedStatusCode } }
+    set { lock.withLock { _stubbedStatusCode = newValue } }
+  }
 
   override class func canInit(with request: URLRequest) -> Bool { true }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
   override func startLoading() {
-    Self.capturedRequests.append(request)
+    let captured = request
+    Self.lock.withLock { Self._capturedRequests.append(captured) }
     let response = HTTPURLResponse(
       url: request.url!,
-      statusCode: Self.stubbedStatusCode,
+      statusCode: Self.lock.withLock { Self._stubbedStatusCode },
       httpVersion: "HTTP/1.1",
       headerFields: nil
     )!
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-    client?.urlProtocol(self, didLoad: Self.stubbedData)
+    client?.urlProtocol(self, didLoad: Self.lock.withLock { Self._stubbedData })
     client?.urlProtocolDidFinishLoading(self)
   }
 
@@ -242,6 +260,41 @@ final class SupabaseClientTests: XCTestCase {
       RequestCapturingProtocol.capturedRequests.isEmpty, "Expected at least one request")
     let request = try XCTUnwrap(RequestCapturingProtocol.capturedRequests.first)
     XCTAssertNil(request.value(forHTTPHeaderField: "traceparent"))
+  }
+
+  func testTracePropagationInjectsHeaderIntoAuthRequests() async throws {
+    struct MockTraceContextProvider: TraceContextProvider {
+      func traceContext() -> [String: String] {
+        ["traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"]
+      }
+    }
+
+    RequestCapturingProtocol.capturedRequests = []
+
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        auth: SupabaseClientOptions.AuthOptions(
+          storage: AuthLocalStorageMock(),
+          autoRefreshToken: false
+        ),
+        global: SupabaseClientOptions.GlobalOptions(
+          session: makeMockSession(),
+          tracePropagation: MockTraceContextProvider()
+        )
+      )
+    )
+
+    _ = try? await client.auth.signUp(email: "test@example.com", password: "password123")
+
+    XCTAssertFalse(
+      RequestCapturingProtocol.capturedRequests.isEmpty, "Expected at least one request")
+    let request = try XCTUnwrap(RequestCapturingProtocol.capturedRequests.first)
+    XCTAssertEqual(
+      request.value(forHTTPHeaderField: "traceparent"),
+      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+    )
   }
 
   func testClientInitWithCustomAccessToken() async {

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -9,6 +9,38 @@ import XCTest
 @testable import Realtime
 @testable import Supabase
 
+// MARK: - Helpers
+
+private final class RequestCapturingProtocol: URLProtocol {
+  static var capturedRequests: [URLRequest] = []
+  static var stubbedData = Data("[]".utf8)
+  static var stubbedStatusCode = 200
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    Self.capturedRequests.append(request)
+    let response = HTTPURLResponse(
+      url: request.url!,
+      statusCode: Self.stubbedStatusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: nil
+    )!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: Self.stubbedData)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
+private func makeMockSession() -> URLSession {
+  let config = URLSessionConfiguration.ephemeral
+  config.protocolClasses = [RequestCapturingProtocol.self]
+  return URLSession(configuration: config)
+}
+
 final class AuthLocalStorageMock: AuthLocalStorage {
   func store(key _: String, value _: Data) throws {}
 
@@ -150,6 +182,66 @@ final class SupabaseClientTests: XCTestCase {
       client.realtimeV2.options.fetch,
       "user-provided realtime fetch should be preserved"
     )
+  }
+
+  func testTracePropagationInjectsTraceParentHeader() async throws {
+    struct MockTraceContextProvider: TraceContextProvider {
+      func traceContext() -> [String: String] {
+        ["traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"]
+      }
+    }
+
+    RequestCapturingProtocol.capturedRequests = []
+
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        auth: SupabaseClientOptions.AuthOptions(
+          storage: AuthLocalStorageMock(),
+          autoRefreshToken: false
+        ),
+        global: SupabaseClientOptions.GlobalOptions(
+          session: makeMockSession(),
+          tracePropagation: MockTraceContextProvider()
+        )
+      )
+    )
+
+    _ = try? await client.from("todos").select().execute()
+
+    XCTAssertFalse(
+      RequestCapturingProtocol.capturedRequests.isEmpty, "Expected at least one request")
+    let request = try XCTUnwrap(RequestCapturingProtocol.capturedRequests.first)
+    XCTAssertEqual(
+      request.value(forHTTPHeaderField: "traceparent"),
+      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+    )
+  }
+
+  func testTracePropagationIsNoOpWhenNil() async throws {
+    RequestCapturingProtocol.capturedRequests = []
+
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        auth: SupabaseClientOptions.AuthOptions(
+          storage: AuthLocalStorageMock(),
+          autoRefreshToken: false
+        ),
+        global: SupabaseClientOptions.GlobalOptions(
+          session: makeMockSession()
+        )
+      )
+    )
+
+    _ = try? await client.from("todos").select().execute()
+
+    XCTAssertFalse(
+      RequestCapturingProtocol.capturedRequests.isEmpty, "Expected at least one request")
+    let request = try XCTUnwrap(RequestCapturingProtocol.capturedRequests.first)
+    XCTAssertNil(request.value(forHTTPHeaderField: "traceparent"))
   }
 
   func testClientInitWithCustomAccessToken() async {


### PR DESCRIPTION
## Summary

Adds protocol-based W3C trace context propagation to `SupabaseClient`, mirroring the `tracePropagation` option from supabase-js v2.106.0. A new `TraceContextProvider` protocol lets users inject `traceparent` / `tracestate` headers into every outgoing HTTP request without introducing any OTel library dependency in the SDK.

## Changes

- `Sources/Supabase/TraceContext.swift`: new `TraceContextProvider` protocol with DocC docs and an opentelemetry-swift usage example
- `Sources/Supabase/Types.swift`: `tracePropagation: (any TraceContextProvider)?` added to `GlobalOptions` (default `nil`, fully backward-compatible)
- `Sources/Supabase/SupabaseClient.swift`: trace headers injected in `adapt(request:)` (PostgREST / Storage / Functions), Auth fetch closure, and Realtime V2 default fetch closure — all four sub-clients covered
- `Tests/SupabaseTests/SupabaseClientTests.swift`: 3 new tests — header injection via PostgREST path, nil-provider no-op, Auth-path coverage; URLProtocol stub guarded with `NSLock` against the delegate-queue data race

## Usage

```swift
import OpenTelemetryApi

struct OTelTraceContextProvider: TraceContextProvider {
    func traceContext() -> [String: String] {
        guard let span = OpenTelemetry.instance.contextProvider.activeSpan else { return [:] }
        let traceId = span.context.traceId.hexString
        let spanId  = span.context.spanId.hexString
        return ["traceparent": "00-\(traceId)-\(spanId)-01"]
    }
}

let supabase = SupabaseClient(
    supabaseURL: url,
    supabaseKey: key,
    options: SupabaseClientOptions(
        global: .init(tracePropagation: OTelTraceContextProvider())
    )
)
// All sub-client requests now carry: traceparent: 00-<trace-id>-<span-id>-01
```

## Test plan

- [x] `testTracePropagationInjectsTraceParentHeader` — PostgREST path gets `traceparent`
- [x] `testTracePropagationIsNoOpWhenNil` — no header when provider is nil
- [x] `testTracePropagationInjectsHeaderIntoAuthRequests` — Auth path gets `traceparent`
- [x] Full `SupabaseTests` suite: 8/8 passing
- [x] Full package suite: all pre-existing tests unchanged (Storage/Realtime integration failures are pre-existing, require a live Supabase instance)

## Linear

Closes SDK-1043