### PR TITLE
test(auth): verify corrupted session storage returns nil

### DIFF
--- a/Tests/AuthTests/StoredSessionTests.swift
+++ b/Tests/AuthTests/StoredSessionTests.swift
@@ -8,9 +8,35 @@ import XCTest
 final class StoredSessionTests: XCTestCase {
   let clientID = AuthClientID()
 
+  func testGet_withCorruptedJSON_returnsNil() throws {
+    let localStorage = InMemoryLocalStorage()
+    try localStorage.store(
+      key: "supabase.auth.token",
+      value: Data("not-valid-json".utf8)
+    )
+
+    let testClientID = AuthClientID()
+    Dependencies[testClientID] = Dependencies(
+      configuration: AuthClient.Configuration(
+        url: URL(string: "http://localhost")!,
+        storageKey: "supabase.auth.token",
+        localStorage: localStorage,
+        logger: nil
+      ),
+      http: HTTPClientMock(),
+      api: .init(clientID: testClientID),
+      codeVerifierStorage: .mock,
+      sessionStorage: .live(clientID: testClientID),
+      sessionManager: .live(clientID: testClientID)
+    )
+
+    let sut = Dependencies[testClientID].sessionStorage
+    XCTAssertNil(sut.get())
+  }
+
   func testStoredSession() throws {
     #if os(Android)
-    throw XCTSkip("Disabled for android due to #filePath not existing on emulator")
+      throw XCTSkip("Disabled for android due to #filePath not existing on emulator")
     #endif
 
     Dependencies[clientID] = Dependencies(


### PR DESCRIPTION
## Summary

`SessionStorage.live()` already handles JSON decode failures by catching all errors and returning `nil` (treating corrupted storage as absent rather than propagating downstream). This behavior had no explicit test coverage — this PR adds it.

## Changes

- `Tests/AuthTests/StoredSessionTests.swift`: added `testGet_withCorruptedJSON_returnsNil` — stores raw invalid JSON bytes directly in `InMemoryLocalStorage`, calls `sessionStorage.get()`, and asserts it returns `nil`

## Root cause

`SessionStorage.swift:55-63` — the `do/catch` wrapping `JSONDecoder().decode(Session.self, from:)` already returns `nil` on any error. The parity issue from supabase-js was already matched; only explicit test coverage was missing.

## Test plan

- [x] Reproduction test added: `Tests/AuthTests/StoredSessionTests.swift:testGet_withCorruptedJSON_returnsNil`
- [x] Full AuthTests suite green: `make PLATFORM=IOS XCODEBUILD_ARGUMENT="test -only-testing AuthTests" xcodebuild`

## Linear

Closes SDK-1040