### PR TITLE
fix(realtime): reconnect on remote close instead of staying disconnected forever

### DIFF
--- a/Sources/Realtime/ConnectionManager.swift
+++ b/Sources/Realtime/ConnectionManager.swift
@@ -155,6 +155,7 @@ actor ConnectionManager {
         return
       }
       updateState(.disconnected)
+      initiateReconnect(reason: closeReason)
     }
   }
 

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -283,4 +283,41 @@ final class ConnectionManagerTests: XCTestCase {
       "Error from the current connection should trigger a reconnect"
     )
   }
+
+  func testHandleCloseInitiatesReconnectAndEventuallyReconnects() async throws {
+    let reconnectingExpectation = expectation(description: "reconnecting state observed")
+    let secondConnectionExpectation = expectation(description: "second connection attempt")
+
+    let connectionCount = LockIsolated(0)
+
+    sut = makeSUT(
+      reconnectDelay: 0.01,
+      transport: { _, _ in
+        connectionCount.withValue { $0 += 1 }
+        if connectionCount.value == 2 {
+          secondConnectionExpectation.fulfill()
+        }
+        return self.ws!
+      }
+    )
+
+    let stateObserver = Task {
+      for await state in sut.stateChanges {
+        if case .reconnecting(_, let reason) = state, reason.contains("4001") {
+          reconnectingExpectation.fulfill()
+          return
+        }
+      }
+    }
+
+    try await sut.connect()
+    await sut.handleClose(code: 4001, reason: "server restart")
+
+    await fulfillment(of: [reconnectingExpectation, secondConnectionExpectation], timeout: 2)
+    XCTAssertEqual(connectionCount.value, 2, "Remote close should trigger a reconnection attempt")
+    let isConnected = await sut.connection != nil
+    XCTAssertTrue(isConnected)
+
+    stateObserver.cancel()
+  }
 }


### PR DESCRIPTION
## Summary

- `handleClose` in `ConnectionManager` was transitioning to `.disconnected` but never calling `initiateReconnect`, so any server-initiated WebSocket close (deploy restart, load-balancer timeout, etc.) left the SDK permanently disconnected.
- Fix: added `initiateReconnect(reason: closeReason)` inside the `.connected` guard in `handleClose`, mirroring the existing behavior in `handleError`.
- SDK-initiated disconnects are unaffected — `disconnect()` transitions away from `.connected` before the close event arrives, so the guard fails safely and no reconnect is triggered.

## Test Plan

- [x] Added `testHandleCloseInitiatesReconnectAndEventuallyReconnects` — verifies that a remote close transitions through `.reconnecting` and completes a second transport call.
- [x] Existing `testHandleCloseUpdatesStateWithoutSendingAnotherCloseFrame` continues to pass (no spurious extra close frame).
- [x] All `ConnectionManagerTests` pass (8/8).

## Related

Companion to #1003.