### PR TITLE
fix(tests): grant API access to integration test tables and functions

### DIFF
--- a/Tests/IntegrationTests/supabase/migrations/20260601000000_grant_api_access.sql
+++ b/Tests/IntegrationTests/supabase/migrations/20260601000000_grant_api_access.sql
@@ -1,0 +1,22 @@
+-- Grant API access to tables for anon and authenticated roles.
+-- Required since Supabase no longer grants public schema access by default
+-- (see https://github.com/orgs/supabase/discussions/45329).
+GRANT ALL ON TABLE public.users TO anon, authenticated;
+GRANT ALL ON TABLE public.todos TO anon, authenticated;
+GRANT ALL ON TABLE public.messages TO anon, authenticated;
+GRANT ALL ON TABLE public.channels TO anon, authenticated;
+GRANT ALL ON TABLE public.key_value_storage TO anon, authenticated;
+
+-- Grant SELECT on updatable view
+GRANT SELECT ON public.updatable_view TO anon, authenticated;
+
+-- Grant sequence usage for SERIAL primary key columns
+GRANT USAGE, SELECT ON SEQUENCE public.channels_id_seq TO anon, authenticated;
+GRANT USAGE, SELECT ON SEQUENCE public.messages_id_seq TO anon, authenticated;
+
+-- Grant EXECUTE on RPC functions
+GRANT EXECUTE ON FUNCTION public.get_status(TEXT) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.void_func() TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_user() TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_username_and_status(TEXT) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_array_element(INT[], INT) TO anon, authenticated;


### PR DESCRIPTION
## Summary

The Supabase platform no longer auto-grants `public` schema access to the `anon` and `authenticated` roles for new projects (see [announcement](https://github.com/orgs/supabase/discussions/45329), effective for new projects as of May 30 2026). The CI integration-test job uses `supabase/setup-cli@latest`, so any fresh project it spins up now follows the new behavior — tables, views, and functions are invisible to the REST API without explicit `GRANT` statements.

## Changes

- `Tests/IntegrationTests/supabase/migrations/20260601000000_grant_api_access.sql`: new migration that grants `ALL` on all five integration-test tables, `SELECT` on `updatable_view`, `USAGE/SELECT` on the two SERIAL sequences, and `EXECUTE` on all five RPC functions — to both `anon` and `authenticated` roles.

## Root cause

`Tests/IntegrationTests/supabase/migrations/20240101000000_initial_schema.sql` creates tables and enables RLS with permissive policies but never grants object-level privileges. On new Supabase projects the `public` role no longer inherits those grants, so every PostgREST call returns 404/permission-denied even with a passing RLS policy.

## Test plan

- [x] Migration added after the initial schema (sorts correctly by timestamp)
- [x] Covers all tables, the updatable view, both SERIAL sequences, and all RPC functions referenced by integration tests
- [ ] CI integration-test job should pass once the migration is applied via `supabase db reset`

## References

Closes the CI failures introduced by https://github.com/orgs/supabase/discussions/45329