### PR TITLE
docs: improve README structure and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,44 @@
-# supabase-swift
+<p align="center">
+  <a href="https://supabase.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--light.svg">
+      <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+    </picture>
+  </a>
+
+  <h1 align="center">Supabase Swift SDK</h1>
+
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/getting-started">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/swift/introduction">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
+
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsupabase%2Fsupabase-swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/supabase/supabase-swift)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsupabase%2Fsupabase-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/supabase/supabase-swift)
 [![Coverage Status](https://coveralls.io/repos/github/supabase/supabase-swift/badge.svg?branch=main)](https://coveralls.io/github/supabase/supabase-swift?branch=main)
 
-Supabase SDK for Swift. Mirrors the design of [supabase-js](https://github.com/supabase/supabase-js/blob/master/README.md).
+</div>
 
-* Documentation: [https://supabase.com/docs/reference/swift/introduction](https://supabase.com/docs/reference/swift/introduction)
+## Libraries
 
-## Usage
+| Library | Description |
+|---------|-------------|
+| **Supabase** | Full client — includes all libraries below |
+| **Auth** | User authentication and session management |
+| **PostgREST** | Query your Postgres database via REST |
+| **Realtime** | Subscribe to database changes over WebSocket |
+| **Storage** | Manage files and objects |
+| **Functions** | Invoke Supabase Edge Functions |
+
+## Quick Start
 
 ### Requirements
+
 - iOS 13.0+ / macOS 10.15+ / tvOS 13+ / watchOS 6+ / visionOS 1+
 - Xcode 15.3+
 - Swift 5.10+
@@ -18,13 +47,13 @@ Supabase SDK for Swift. Mirrors the design of [supabase-js](https://github.com/s
 > Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.
 
 ### Installation
-Install the library using the Swift Package Manager.
+
+Add `supabase-swift` as a Swift Package Manager dependency:
 
 ```swift
 let package = Package(
     ...
     dependencies: [
-        ...
         .package(
             url: "https://github.com/supabase/supabase-swift.git",
             from: "2.0.0"
@@ -34,21 +63,20 @@ let package = Package(
         .target(
             name: "YourTargetName",
             dependencies: [
-                .product(name: "Supabase", package: "supabase-swift") // Add as a dependency
+                .product(name: "Supabase", package: "supabase-swift")
             ]
         )
     ]
 )
 ```
 
-If you're using Xcode, [use this guide](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to add `supabase-swift` to your project. Use `https://github.com/supabase-community/supabase-swift.git` for the url when Xcode asks.
+If you're using Xcode, [use this guide](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to add `supabase-swift` to your project. Use `https://github.com/supabase/supabase-swift.git` for the URL when Xcode asks.
 
-If you don't want the full Supabase environment, you can also add individual packages, such as `Functions`, `Auth`, `Realtime`, `Storage`, or `PostgREST`.
+You can also add individual libraries (`Auth`, `Realtime`, `Storage`, `PostgREST`, `Functions`) instead of the full `Supabase` product.
 
-Then you're able to import the package and establish the connection with the database.
+### Initialize the client
 
 ```swift
-/// Create a single supabase client for interacting with your database
 let client = SupabaseClient(
     supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
     supabaseKey: "your-publishable-key"
@@ -59,7 +87,7 @@ let client = SupabaseClient(
 
 ```swift
 let client = SupabaseClient(
-    supabaseURL: URL(string: "https://xyzcompany.supabase.co")!, 
+    supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
     supabaseKey: "your-publishable-key",
     options: SupabaseClientOptions(
         db: .init(
@@ -77,19 +105,20 @@ let client = SupabaseClient(
 )
 ```
 
-Additional examples are available [here](https://github.com/supabase/supabase-swift/tree/main/Examples).
+Additional examples are available in the [Examples](https://github.com/supabase/supabase-swift/tree/main/Examples) directory.
 
 ## Support Policy
 
-This document outlines the scope of support for Xcode, Swift, and the various platforms (iOS, macOS, tvOS, watchOS, and visionOS) in Supabase.
-
 ### Xcode
+
 We only support Xcode versions that are currently eligible for submitting apps to the App Store. Once a specific version of Xcode is no longer supported, its removal from Supabase **won't be treated as a breaking change** and will occur in a minor release.
 
 ### Swift
-The minimum supported Swift version corresponds to the minor version released with the oldest-supported Xcode version. When a Swift version reaches its end of support, it will be dropped from Supabase in a **minor release**, and **this won't be considered a breaking change**.
+
+The minimum supported Swift version corresponds to the minor version released with the oldest-supported Xcode version. When a Swift version reaches its end of support, it will be dropped in a **minor release**, and **this won't be considered a breaking change**.
 
 ### Platforms
+
 We maintain support for the four latest major versions of each platform, including the current version.
 
 When a platform version is no longer supported, Supabase will drop it in a **minor release**, and **this won't count as a breaking change**. For instance, iOS 14 will no longer be supported after the release of iOS 18, allowing its removal in a minor update.
@@ -97,18 +126,35 @@ When a platform version is no longer supported, Supabase will drop it in a **min
 For macOS, the named yearly releases are treated as major versions for this policy, regardless of their version numbers.
 
 > [!IMPORTANT]
-> Android, Linux and Windows works but aren't supported, and may stop working on future versions of the library.
+> Android, Linux and Windows work but aren't officially supported, and may stop working in future versions of the library.
 
 ## Contributing
 
-- Fork the repo on GitHub
-- Clone the project to your own machine
-- Commit changes to your own branch
-- Push your work back up to your fork
-- Submit a Pull request so that we can review your changes and merge
+We welcome contributions! Please see the steps below.
 
-## Sponsors
+1. Fork the repo and clone it locally.
+2. Create a feature branch (`git checkout -b feature/my-feature`).
+3. Make your changes and add tests.
+4. Run `make format` to format Swift code.
+5. Run `make PLATFORM=IOS XCODEBUILD_ARGUMENT=test xcodebuild` to verify tests pass.
+6. Commit using [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(auth): add PKCE support`).
+7. Open a pull request against `main`.
 
-We are building the features of Firebase using enterprise-grade, open source products. We support existing communities wherever possible, and if the products don’t exist we build them and open source them ourselves. Thanks to these sponsors who are making the OSS ecosystem better for everyone.
+## Support
 
-[![New Sponsor](https://user-images.githubusercontent.com/10214025/90518111-e74bbb00-e198-11ea-8f88-c9e3c1aa4b5b.png)](https://github.com/sponsors/supabase)
+- **Documentation**: [supabase.com/docs/reference/swift](https://supabase.com/docs/reference/swift/introduction)
+- **Community**: [GitHub Discussions](https://github.com/supabase/supabase/discussions)
+- **Issues**: [GitHub Issues](https://github.com/supabase/supabase-swift/issues)
+- **Discord**: [Supabase Discord](https://discord.supabase.com)
+
+## License
+
+This project is licensed under the MIT License — see the [LICENSE](./LICENSE) file for details.
+
+---
+
+<div align="center">
+
+**[Website](https://supabase.com) • [Documentation](https://supabase.com/docs) • [Community](https://github.com/supabase/supabase/discussions) • [Twitter](https://twitter.com/supabase)**
+
+</div>

--- a/README.md
+++ b/README.md
@@ -1,28 +1,10 @@
-<p align="center">
-  <a href="https://supabase.io">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--light.svg">
-      <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
-    </picture>
-  </a>
-
-  <h1 align="center">Supabase Swift SDK</h1>
-
-  <p align="center">
-    <a href="https://supabase.com/docs/guides/getting-started">Guides</a>
-    ·
-    <a href="https://supabase.com/docs/reference/swift/introduction">Reference Docs</a>
-  </p>
-</p>
-
-<div align="center">
+# supabase-swift
 
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsupabase%2Fsupabase-swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/supabase/supabase-swift)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsupabase%2Fsupabase-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/supabase/supabase-swift)
 [![Coverage Status](https://coveralls.io/repos/github/supabase/supabase-swift/badge.svg?branch=main)](https://coveralls.io/github/supabase/supabase-swift?branch=main)
 
-</div>
+[Guides](https://supabase.com/docs/guides/getting-started) · [Reference Docs](https://supabase.com/docs/reference/swift/introduction)
 
 ## Libraries
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 
 ## Libraries
 
-| Library | Description |
-|---------|-------------|
-| **Supabase** | Full client — includes all libraries below |
-| **Auth** | User authentication and session management |
-| **PostgREST** | Query your Postgres database via REST |
-| **Realtime** | Subscribe to database changes over WebSocket |
-| **Storage** | Manage files and objects |
-| **Functions** | Invoke Supabase Edge Functions |
+| Library        | Description                                  |
+|----------------|----------------------------------------------|
+| **Supabase**   | Full client — includes all libraries below   |
+| **Auth**       | User authentication and session management   |
+| **PostgREST**  | Query your Postgres database via REST        |
+| **Realtime**   | Subscribe to database changes over WebSocket |
+| **Storage**    | Manage files and objects                     |
+| **Functions**  | Invoke Supabase Edge Functions               |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
-# supabase-swift
+<p align="center">
+  <a href="https://supabase.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--light.svg">
+      <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+    </picture>
+  </a>
+
+  <h1 align="center">Supabase Swift SDK</h1>
+
+  <p align="center">
+    <a href="https://supabase.com/docs/guides/getting-started">Guides</a>
+    ·
+    <a href="https://supabase.com/docs/reference/swift/introduction">Reference Docs</a>
+  </p>
+</p>
+
+<div align="center">
 
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsupabase%2Fsupabase-swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/supabase/supabase-swift)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsupabase%2Fsupabase-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/supabase/supabase-swift)
 [![Coverage Status](https://coveralls.io/repos/github/supabase/supabase-swift/badge.svg?branch=main)](https://coveralls.io/github/supabase/supabase-swift?branch=main)
 
-[Guides](https://supabase.com/docs/guides/getting-started) · [Reference Docs](https://supabase.com/docs/reference/swift/introduction)
+</div>
 
 ## Libraries
 


### PR DESCRIPTION
## Summary

- Removes the "Mirrors the design of supabase-js" tagline
- Adds a centered logo header with light/dark mode support, matching the style of [supabase-js](https://github.com/supabase/supabase-js)
- Adds a Libraries table giving a quick overview of all available modules
- Renames Usage → Quick Start; cleans up installation and init copy
- Fixes a stale Xcode installation URL (`supabase-community` → `supabase`)
- Expands Contributing with format, test, and conventional commits steps
- Adds a Support section (docs, community, issues, Discord)
- Adds a License section and a footer link bar
- Removes the outdated Sponsors section (broken image, stale copy)

## Test plan

- [ ] Verify rendered Markdown looks correct on the GitHub repo page
- [ ] Confirm logo images load in both light and dark mode
- [ ] Check all links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)