### PR TITLE
feat: add sdk-compliance.yaml for supabase/sdk capability matrix

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -1,0 +1,8 @@
+on:
+  pull_request:
+    paths:
+      - sdk-compliance.yaml
+
+jobs:
+  validate:
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -1,7 +1,13 @@
+name: Validate SDK Compliance
+
 on:
   pull_request:
     paths:
-      - sdk-compliance.yaml
+      - 'sdk-compliance.yaml'
+      - '.github/workflows/validate-capabilities.yml'
+
+permissions:
+  contents: read
 
 jobs:
   validate:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1,6 +1,6 @@
 sdk: swift
 
-# Sparse declaration — only features that differ from the default (not_implemented) are listed.
+# Full declaration of all features from the supabase/sdk capability registry.
 # See https://github.com/supabase/sdk for the canonical feature registry.
 
 features:
@@ -14,6 +14,7 @@ features:
   auth.sign_in.sign_in_with_sso:           implemented
   auth.sign_in.sign_in_with_id_token:      implemented
   auth.sign_in.sign_in_anonymously:        implemented
+  auth.sign_in.sign_in_with_web3:          not_implemented
   auth.sign_in.verify_otp:                 implemented
   auth.sign_in.resend_confirmation:        implemented
   auth.sign_in.reset_password:             implemented
@@ -48,9 +49,29 @@ features:
   auth.admin.get_user:                     implemented
   auth.admin.list_users:                   implemented
   auth.admin.invite_user:                  implemented
+  auth.admin.sign_out:                     not_implemented
   auth.admin.generate_link:
     status: partially_implemented
     note: "Method exists but response decoding is incomplete; returns a placeholder response."
+  auth.admin.list_mfa_factors:             not_implemented
+  auth.admin.delete_mfa_factor:            not_implemented
+  auth.admin.create_provider:              not_implemented
+  auth.admin.delete_provider:              not_implemented
+  auth.admin.update_provider:              not_implemented
+  auth.admin.get_provider:                 not_implemented
+  auth.admin.list_providers:               not_implemented
+
+  auth.passkey.register_passkey:           not_implemented
+  auth.passkey.sign_in_with_passkey:       not_implemented
+
+  auth.passkey_admin.list_passkeys:        not_implemented
+  auth.passkey_admin.delete_passkey:       not_implemented
+
+  auth.oauth_server.approve_authorization:     not_implemented
+  auth.oauth_server.deny_authorization:        not_implemented
+  auth.oauth_server.get_authorization_details: not_implemented
+  auth.oauth_server.list_grants:               not_implemented
+  auth.oauth_server.revoke_grant:              not_implemented
 
   auth.oauth_admin.create_client:          implemented
   auth.oauth_admin.delete_client:          implemented
@@ -73,6 +94,8 @@ features:
     status: partially_implemented
     note: "A custom URLSession can be supplied; a full HTTP client adapter protocol is not exposed."
   client.request_configuration.global_headers: implemented
+
+  client.observability.trace_propagation:  not_implemented
 
   # ── Database ───────────────────────────────────────────────────────────────
 
@@ -113,6 +136,7 @@ features:
   database.using_filters.regex:            implemented
   database.using_filters.regex_icase:      implemented
   database.using_filters.is_distinct:      implemented
+  database.using_filters.not_in:           not_implemented
   database.using_filters.like_all:         implemented
   database.using_filters.like_any:         implemented
   database.using_filters.ilike_all:        implemented
@@ -122,6 +146,7 @@ features:
   database.using_modifiers.limit:          implemented
   database.using_modifiers.range:          implemented
   database.using_modifiers.single_row:     implemented
+  database.using_modifiers.maybe_single_row: not_implemented
   database.using_modifiers.strip_nulls:    implemented
   database.using_modifiers.format_csv:     implemented
   database.using_modifiers.format_geojson: implemented
@@ -131,8 +156,10 @@ features:
   database.using_modifiers.relationship_embed:
     status: partially_implemented
     note: "Supported via query-string syntax in select() (e.g. 'user(*)'); no dedicated relationship builder API."
+  database.using_modifiers.dry_run:        not_implemented
 
   database.configuration.auto_retry:       implemented
+  database.configuration.request_timeout:  not_implemented
 
   # ── Functions ──────────────────────────────────────────────────────────────
 
@@ -150,6 +177,7 @@ features:
 
   realtime.client.connect:                 implemented
   realtime.client.disconnect:              implemented
+  realtime.client.endpoint_url:            not_implemented
   realtime.client.get_channels:            implemented
   realtime.client.remove_channel:          implemented
   realtime.client.remove_all_channels:     implemented
@@ -162,6 +190,7 @@ features:
   realtime.client.is_connecting:
     status: partially_implemented
     note: "No dedicated isConnecting property; the current state is exposed via the status enum (check status == .connecting)."
+  realtime.client.is_disconnecting:        not_implemented
 
   realtime.channel.channel:               implemented
   realtime.channel.subscribe:             implemented
@@ -180,6 +209,7 @@ features:
 
   realtime.presence.track:                implemented
   realtime.presence.untrack:              implemented
+  realtime.presence.presence_state:       not_implemented
   realtime.presence.presence_key:         implemented
 
   realtime.configuration.custom_websocket_transport: implemented
@@ -219,3 +249,29 @@ features:
   storage.file_buckets.move_cross_bucket:        implemented
   storage.file_buckets.upload_with_metadata:     implemented
   storage.file_buckets.url_cache_nonce:          implemented
+  storage.file_buckets.download_as_stream:       not_implemented
+
+  # ── Storage — Vector Buckets ───────────────────────────────────────────────
+
+  storage.vector_buckets.create_vector_bucket:   not_implemented
+  storage.vector_buckets.list_vector_buckets:    not_implemented
+  storage.vector_buckets.delete_vector_bucket:   not_implemented
+  storage.vector_buckets.access_vector_index:    not_implemented
+  storage.vector_buckets.create_index:           not_implemented
+  storage.vector_buckets.delete_index:           not_implemented
+  storage.vector_buckets.get_index:              not_implemented
+  storage.vector_buckets.list_indexes:           not_implemented
+  storage.vector_buckets.put_vectors:            not_implemented
+  storage.vector_buckets.get_vectors:            not_implemented
+  storage.vector_buckets.delete_vectors:         not_implemented
+  storage.vector_buckets.list_vectors:           not_implemented
+  storage.vector_buckets.query_vectors:          not_implemented
+  storage.vector_buckets.parallel_scan:          not_implemented
+
+  # ── Storage — Analytics Buckets ────────────────────────────────────────────
+
+  storage.analytics.create_analytics_bucket:    not_implemented
+  storage.analytics.list_analytics_buckets:     not_implemented
+  storage.analytics.delete_analytics_bucket:    not_implemented
+  storage.analytics.iceberg_namespace:          not_implemented
+  storage.analytics.iceberg_table:              not_implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -1,0 +1,221 @@
+sdk: swift
+
+# Sparse declaration — only features that differ from the default (not_implemented) are listed.
+# See https://github.com/supabase/sdk for the canonical feature registry.
+
+features:
+
+  # ── Auth ───────────────────────────────────────────────────────────────────
+
+  auth.sign_in.sign_up:                    implemented
+  auth.sign_in.sign_in_with_password:      implemented
+  auth.sign_in.sign_in_with_oauth:         implemented
+  auth.sign_in.sign_in_with_otp:           implemented
+  auth.sign_in.sign_in_with_sso:           implemented
+  auth.sign_in.sign_in_with_id_token:      implemented
+  auth.sign_in.sign_in_anonymously:        implemented
+  auth.sign_in.verify_otp:                 implemented
+  auth.sign_in.resend_confirmation:        implemented
+  auth.sign_in.reset_password:             implemented
+  auth.sign_in.reauthenticate:             implemented
+  auth.sign_in.exchange_code_for_session:  implemented
+
+  auth.session.get_session:                implemented
+  auth.session.get_user:                   implemented
+  auth.session.get_claims:                 implemented
+  auth.session.refresh_session:            implemented
+  auth.session.set_session:                implemented
+  auth.session.sign_out:                   implemented
+  auth.session.update_user:                implemented
+  auth.session.subscribe_auth_events:      implemented
+  auth.session.auto_refresh:               implemented
+
+  auth.identities.link_identity:           implemented
+  auth.identities.unlink_identity:         implemented
+  auth.identities.list_identities:         implemented
+
+  auth.mfa.enroll:                         implemented
+  auth.mfa.challenge:                      implemented
+  auth.mfa.verify:                         implemented
+  auth.mfa.unenroll:                       implemented
+  auth.mfa.challenge_and_verify:           implemented
+  auth.mfa.list_factors:                   implemented
+  auth.mfa.get_authenticator_assurance_level: implemented
+
+  auth.admin.create_user:                  implemented
+  auth.admin.delete_user:                  implemented
+  auth.admin.update_user:                  implemented
+  auth.admin.get_user:                     implemented
+  auth.admin.list_users:                   implemented
+  auth.admin.invite_user:                  implemented
+  auth.admin.generate_link:
+    status: partially_implemented
+    note: "Method exists but response decoding is incomplete; returns a placeholder response."
+
+  auth.oauth_admin.create_client:          implemented
+  auth.oauth_admin.delete_client:          implemented
+  auth.oauth_admin.get_client:             implemented
+  auth.oauth_admin.list_clients:           implemented
+  auth.oauth_admin.regenerate_client_secret: implemented
+  auth.oauth_admin.update_client:          implemented
+
+  # ── Client ─────────────────────────────────────────────────────────────────
+
+  client.authentication_integration.third_party_auth:        implemented
+  client.authentication_integration.cross_client_token_sync: implemented
+  client.authentication_integration.oauth_flow_type:         implemented
+  client.authentication_integration.session_url_detection:   implemented
+
+  client.session_management.custom_storage:  implemented
+  client.session_management.persist_session: implemented
+
+  client.request_configuration.custom_http_client:
+    status: partially_implemented
+    note: "A custom URLSession can be supplied; a full HTTP client adapter protocol is not exposed."
+  client.request_configuration.global_headers: implemented
+
+  # ── Database ───────────────────────────────────────────────────────────────
+
+  database.query.from_table:                implemented
+  database.query.select:                    implemented
+  database.query.schema_selection:          implemented
+  database.query.rpc:                       implemented
+
+  database.mutate.insert:                   implemented
+  database.mutate.update:                   implemented
+  database.mutate.upsert:                   implemented
+  database.mutate.delete:                   implemented
+  database.mutate.select_after_mutation:    implemented
+
+  database.using_filters.eq:               implemented
+  database.using_filters.neq:              implemented
+  database.using_filters.gt:               implemented
+  database.using_filters.gte:              implemented
+  database.using_filters.lt:               implemented
+  database.using_filters.lte:              implemented
+  database.using_filters.like:             implemented
+  database.using_filters.ilike:            implemented
+  database.using_filters.is:               implemented
+  database.using_filters.in:               implemented
+  database.using_filters.contains:         implemented
+  database.using_filters.contained_by:     implemented
+  database.using_filters.range_gt:         implemented
+  database.using_filters.range_gte:        implemented
+  database.using_filters.range_lt:         implemented
+  database.using_filters.range_lte:        implemented
+  database.using_filters.range_adjacent:   implemented
+  database.using_filters.overlaps:         implemented
+  database.using_filters.text_search:      implemented
+  database.using_filters.match:            implemented
+  database.using_filters.not:              implemented
+  database.using_filters.or:               implemented
+  database.using_filters.raw:              implemented
+  database.using_filters.regex:            implemented
+  database.using_filters.regex_icase:      implemented
+  database.using_filters.is_distinct:      implemented
+  database.using_filters.like_all:         implemented
+  database.using_filters.like_any:         implemented
+  database.using_filters.ilike_all:        implemented
+  database.using_filters.ilike_any:        implemented
+
+  database.using_modifiers.order:          implemented
+  database.using_modifiers.limit:          implemented
+  database.using_modifiers.range:          implemented
+  database.using_modifiers.single_row:     implemented
+  database.using_modifiers.strip_nulls:    implemented
+  database.using_modifiers.format_csv:     implemented
+  database.using_modifiers.format_geojson: implemented
+  database.using_modifiers.explain:        implemented
+  database.using_modifiers.max_affected_rows: implemented
+  database.using_modifiers.request_cancellation: implemented
+  database.using_modifiers.relationship_embed:
+    status: partially_implemented
+    note: "Supported via query-string syntax in select() (e.g. 'user(*)'); no dedicated relationship builder API."
+
+  database.configuration.auto_retry:       implemented
+
+  # ── Functions ──────────────────────────────────────────────────────────────
+
+  functions.invocation.invoke:             implemented
+  functions.invocation.set_auth_token:     implemented
+  functions.invocation.method_override:    implemented
+  functions.invocation.streaming_response: implemented
+  functions.invocation.region_selection:   implemented
+  functions.invocation.request_cancellation: implemented
+  functions.invocation.timeout:
+    status: partially_implemented
+    note: "Default idle timeout is a hardcoded 150 s constant; no per-invocation override is exposed."
+
+  # ── Realtime ───────────────────────────────────────────────────────────────
+
+  realtime.client.connect:                 implemented
+  realtime.client.disconnect:              implemented
+  realtime.client.get_channels:            implemented
+  realtime.client.remove_channel:          implemented
+  realtime.client.remove_all_channels:     implemented
+  realtime.client.connection_state:        implemented
+  realtime.client.listen_heartbeats:       implemented
+  realtime.client.set_auth_token:          implemented
+  realtime.client.is_connected:
+    status: partially_implemented
+    note: "No dedicated isConnected property; the current state is exposed via the status enum (check status == .connected)."
+  realtime.client.is_connecting:
+    status: partially_implemented
+    note: "No dedicated isConnecting property; the current state is exposed via the status enum (check status == .connecting)."
+
+  realtime.channel.channel:               implemented
+  realtime.channel.subscribe:             implemented
+  realtime.channel.unsubscribe:           implemented
+  realtime.channel.send:                  implemented
+  realtime.channel.broadcast_http:        implemented
+
+  realtime.subscriptions.broadcast:               implemented
+  realtime.subscriptions.postgres_changes:        implemented
+  realtime.subscriptions.subscribe_presence:      implemented
+  realtime.subscriptions.postgres_changes_filter: implemented
+  realtime.subscriptions.private_channel:         implemented
+  realtime.subscriptions.broadcast_self:          implemented
+  realtime.subscriptions.broadcast_ack:           implemented
+  realtime.subscriptions.broadcast_replay:        implemented
+
+  realtime.presence.track:                implemented
+  realtime.presence.untrack:              implemented
+  realtime.presence.presence_key:         implemented
+
+  realtime.configuration.custom_websocket_transport: implemented
+  realtime.configuration.reconnect_backoff:          implemented
+  realtime.configuration.heartbeat_interval:         implemented
+  realtime.configuration.access_token_callback:      implemented
+  realtime.configuration.deferred_disconnect:        implemented
+  realtime.configuration.custom_logger:              implemented
+  realtime.configuration.binary_protocol:            implemented
+
+  # ── Storage ────────────────────────────────────────────────────────────────
+
+  storage.file_buckets.create_file_bucket:       implemented
+  storage.file_buckets.get_bucket:               implemented
+  storage.file_buckets.list_file_buckets:        implemented
+  storage.file_buckets.update_bucket:            implemented
+  storage.file_buckets.delete_file_bucket:       implemented
+  storage.file_buckets.empty_bucket:             implemented
+  storage.file_buckets.access_bucket:            implemented
+  storage.file_buckets.upload:                   implemented
+  storage.file_buckets.download:                 implemented
+  storage.file_buckets.list_files:               implemented
+  storage.file_buckets.move:                     implemented
+  storage.file_buckets.copy:                     implemented
+  storage.file_buckets.remove:                   implemented
+  storage.file_buckets.get_public_url:           implemented
+  storage.file_buckets.create_signed_url:        implemented
+  storage.file_buckets.create_signed_urls:       implemented
+  storage.file_buckets.create_signed_upload_url: implemented
+  storage.file_buckets.upload_with_signed_url:   implemented
+  storage.file_buckets.update_file:              implemented
+  storage.file_buckets.file_exists:              implemented
+  storage.file_buckets.file_info:                implemented
+  storage.file_buckets.list_files_paginated:     implemented
+  storage.file_buckets.download_with_transform:  implemented
+  storage.file_buckets.copy_cross_bucket:        implemented
+  storage.file_buckets.move_cross_bucket:        implemented
+  storage.file_buckets.upload_with_metadata:     implemented
+  storage.file_buckets.url_cache_nonce:          implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -59,8 +59,8 @@ features:
   auth.admin.get_provider:                 not_implemented
   auth.admin.list_providers:               not_implemented
 
-  auth.passkey.register_passkey:           not_implemented
-  auth.passkey.sign_in_with_passkey:       not_implemented
+  auth.passkey.register_passkey:           implemented
+  auth.passkey.sign_in_with_passkey:       implemented
 
   auth.passkey_admin.list_passkeys:        not_implemented
   auth.passkey_admin.delete_passkey:       not_implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -50,9 +50,7 @@ features:
   auth.admin.list_users:                   implemented
   auth.admin.invite_user:                  implemented
   auth.admin.sign_out:                     not_implemented
-  auth.admin.generate_link:
-    status: partially_implemented
-    note: "Method exists but response decoding is incomplete; returns a placeholder response."
+  auth.admin.generate_link:                not_implemented
   auth.admin.list_mfa_factors:             not_implemented
   auth.admin.delete_mfa_factor:            not_implemented
   auth.admin.create_provider:              not_implemented


### PR DESCRIPTION
## Summary

- Adds `sdk-compliance.yaml` at the repository root — a full declaration of all 216 features from the [supabase/sdk](https://github.com/supabase/sdk) capability registry, with explicit status for each one.
- Adds `.github/workflows/validate-capabilities.yml` to validate the file against the canonical registry on every PR that touches it.

## What is supabase/sdk?

`supabase/sdk` is the canonical, machine-readable feature registry for all official Supabase client SDKs. Each SDK repo declares compliance via a `sdk-compliance.yaml` file; a [static site](https://supabase.github.io/sdk/) is generated from the aggregated data to show cross-SDK parity at a glance.

## Coverage

Derived from static analysis of the Swift source (reflects 2.48.0):

| Area | Implemented | Partially | Not yet |
|---|---|---|---|
| Auth | 45 | 0 | 17 |
| Client | 7 | 1 | 1 |
| Database | 50 | 1 | 4 |
| Functions | 6 | 1 | 0 |
| Realtime | 31 | 2 | 3 |
| Storage | 27 | 0 | 20 |
| **Total** | **166** | **5** | **45** |

### Notable gaps documented

- `database.using_modifiers.maybe_single_row` — `.maybeSingle()` not implemented (only `.single()` exists)
- `realtime.presence.presence_state` — no synchronous presence query method
- `functions.invocation.timeout` — idle timeout is a hardcoded constant, not configurable per-call
- `storage.vector_buckets.*` / `storage.analytics.*` — 19 features not yet implemented
- `auth.passkey_admin.*` — user-level passkey CRUD exists; admin-level passkey management does not

### Partially implemented

- `database.using_modifiers.relationship_embed` — supported via query-string syntax in `select()` (e.g. `"user(*)"`) but no dedicated builder API
- `client.request_configuration.custom_http_client` — custom `URLSession` can be supplied; full HTTP client adapter protocol not exposed
- `functions.invocation.timeout` — fixed 150 s constant, not configurable per invocation
- `realtime.client.is_connected` / `is_connecting` — derivable from the `status` enum; no dedicated boolean properties

## Reviewer checklist

- [ ] Spot-check a few `partially_implemented` entries against the source
- [ ] Confirm the `not_implemented` gaps look accurate
- [ ] The CI workflow only runs on changes to `sdk-compliance.yaml`; no other workflows are affected