### PR TITLE
test: E2E failure case — unregistered symbol

### DIFF
--- a/.github/workflows/check-api-compliance.yml
+++ b/.github/workflows/check-api-compliance.yml
@@ -9,3 +9,5 @@ permissions:
 jobs:
   check:
     uses: supabase/sdk/.github/workflows/check-api-compliance.yml@claude/elegant-ptolemy-c2121d
+    with:
+      sdk-ref: refs/heads/claude/elegant-ptolemy-c2121d

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -1687,3 +1687,8 @@ extension AuthClient {
     }
   }
 #endif
+
+  /// E2E test symbol — NOT registered in capability matrix.
+  public func signInWithMagicLink(email: String) async throws {
+    fatalError("E2E test only")
+  }


### PR DESCRIPTION
This PR adds `AuthClient.signInWithMagicLink` which is NOT in `sdk-compliance.yaml`. The compliance check should hard-fail. **Delete after E2E testing.**