### PR TITLE
ci: consolidate SDK compliance workflows into one

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -1,10 +1,7 @@
-name: Validate SDK Compliance
+name: SDK Compliance
 
 on:
   pull_request:
-    paths:
-      - 'sdk-compliance.yaml'
-      - '.github/workflows/validate-capabilities.yml'
 
 permissions:
   contents: read
@@ -12,3 +9,5 @@ permissions:
 jobs:
   validate:
     uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main
+    with:
+      language: swift


### PR DESCRIPTION
## Summary

- `supabase/sdk` merged `validate-sdk-compliance.yml` and `check-api-compliance.yml` into a single reusable workflow (`validate-sdk-compliance.yml`) that now requires a `language` input and always runs both a `validate` job and a `check` job.
- This PR consolidates the two local workflow files into one: updates `validate-capabilities.yml` to call the merged reusable workflow with `language: swift`.
- The `paths` filter is removed so the API symbol check runs on every PR, matching the previous behavior of the separate `check-api-compliance.yml` workflow.

## Changes

- Updated `.github/workflows/validate-capabilities.yml`: renamed to `SDK Compliance`, removed paths filter, added `language: swift` input to the reusable workflow call.
- No `check-api-compliance.yml` existed on `main` yet, so nothing to delete here — the single updated file covers both jobs going forward.