### PR TITLE
ci: test sdk compliance workflow from sdk#38 (swift package dump-symbol-graph)

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@claude/vigilant-wilson-62e91c
     with:
       language: swift
+      sdk-ref: claude/vigilant-wilson-62e91c


### PR DESCRIPTION
Test PR for [supabase/sdk#38](https://github.com/supabase/sdk/pull/38).

Exercises the updated `validate-sdk-compliance.yml` reusable workflow that replaces `swift-symbolgraph-extract` with `swift package dump-symbol-graph`. Points workflow reference and `sdk-ref` at the feature branch.

**Do not merge** — delete after CI passes.