### PR TITLE
chore: add symbols to auth.oauth_admin entries in sdk-compliance.yaml

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -201,12 +201,30 @@ features:
   auth.oauth_server.list_grants: not_implemented
   auth.oauth_server.revoke_grant: not_implemented
 
-  auth.oauth_admin.create_client: implemented
-  auth.oauth_admin.delete_client: implemented
-  auth.oauth_admin.get_client: implemented
-  auth.oauth_admin.list_clients: implemented
-  auth.oauth_admin.regenerate_client_secret: implemented
-  auth.oauth_admin.update_client: implemented
+  auth.oauth_admin.create_client:
+    status: implemented
+    symbols:
+      - AuthAdminOAuth.createClient
+  auth.oauth_admin.delete_client:
+    status: implemented
+    symbols:
+      - AuthAdminOAuth.deleteClient
+  auth.oauth_admin.get_client:
+    status: implemented
+    symbols:
+      - AuthAdminOAuth.getClient
+  auth.oauth_admin.list_clients:
+    status: implemented
+    symbols:
+      - AuthAdminOAuth.listClients
+  auth.oauth_admin.regenerate_client_secret:
+    status: implemented
+    symbols:
+      - AuthAdminOAuth.regenerateClientSecret
+  auth.oauth_admin.update_client:
+    status: implemented
+    symbols:
+      - AuthAdminOAuth.updateClient
 
   # ── Client ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What changed

The six `auth.oauth_admin.*` entries in `sdk-compliance.yaml` were using the bare `implemented` string value instead of the structured `status:`/`symbols:` mapping that every other implemented feature uses.

Before:
```yaml
auth.oauth_admin.create_client: implemented
```

After:
```yaml
auth.oauth_admin.create_client:
  status: implemented
  symbols:
    - AuthAdminOAuth.createClient
```

## Why

Discovered while auditing the yaml against the canonical [supabase/sdk](https://github.com/supabase/sdk) capability registry. All 212 features are present and correctly classified — this was the only format inconsistency. The symbols now point to `AuthAdminOAuth` methods, consistent with how all other implemented features document their symbols.

## Reviewer notes

No behaviour change — purely a yaml formatting fix. The compliance CI check should pass as before.