### PR TITLE
ci: trigger release-please for v3 branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - release/*
+      - v3
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Adds `v3` to the `workflow_run` trigger branches list in the Release workflow.

- Without this change, release-please only fires after CI passes on `main` or `release/*` branches
- With this change, release-please also runs when CI passes on the `v3` branch, producing beta pre-releases automatically

This is required for v3 beta release automation.