### PR TITLE
ci: use per-language SDK compliance workflow

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -11,6 +11,4 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main
-    with:
-      language: swift
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@main


### PR DESCRIPTION
## Summary

Updates the SDK compliance check to use the new **per-language** reusable workflow from `supabase/sdk`. The single `validate-sdk-compliance.yml` (which took a `language:` input and gated every step on it) has been split into one workflow per language ([supabase/sdk#49](https://github.com/supabase/sdk/pull/49)).

This drops the `language:` input and points at the language-specific file.

> [!IMPORTANT]
> Merge only **after** supabase/sdk#49 lands on `main`, since the new workflow file must exist at `@main` for this reference to resolve.