### PR TITLE
fix(postgrest): remove invalid quotes from explain() plan media type

### DIFF
--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -185,7 +185,7 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
       .joined(separator: "|")
       let forMediaType = $0.request.headers[.accept] ?? "application/json"
       $0.request.headers[.accept] =
-        "application/vnd.pgrst.plan+\(format); for=\(forMediaType); options=\(options);"
+        "application/vnd.pgrst.plan+\(format); for=\"\(forMediaType)\"; options=\(options);"
     }
 
     return self

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -185,7 +185,7 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
       .joined(separator: "|")
       let forMediaType = $0.request.headers[.accept] ?? "application/json"
       $0.request.headers[.accept] =
-        "application/vnd.pgrst.plan+\"\(format)\"; for=\(forMediaType); options=\(options);"
+        "application/vnd.pgrst.plan+\(format); for=\(forMediaType); options=\(options);"
     }
 
     return self

--- a/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
@@ -396,7 +396,7 @@ final class PostgrestTransformBuilderTests: PostgrestQueryTests {
     .snapshotRequest {
       #"""
       curl \
-      	--header "Accept: application/vnd.pgrst.plan+text; for=application/json; options=analyze|verbose;" \
+      	--header "Accept: application/vnd.pgrst.plan+text; for=\"application/json\"; options=analyze|verbose;" \
       	--header "Content-Type: application/json" \
       	--header "X-Client-Info: postgrest-swift/0.0.0" \
       	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
@@ -414,6 +414,35 @@ final class PostgrestTransformBuilderTests: PostgrestQueryTests {
       .string() ?? ""
 
     XCTAssertTrue(explain.contains("Aggregate"))
+  }
+
+  func testExplainWithJSONFormat() async throws {
+    Mock(
+      url: url.appendingPathComponent("countries"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .get: Data("[]".utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "Accept: application/vnd.pgrst.plan+json; for=\"application/json\"; options=analyze;" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/countries?select=*"
+      """#
+    }
+    .register()
+
+    _ =
+      try await sut
+      .from("countries")
+      .select()
+      .explain(analyze: true, format: "json")
+      .execute()
   }
 
   func testMaxAffectedOnUpdate() async throws {

--- a/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
@@ -396,7 +396,7 @@ final class PostgrestTransformBuilderTests: PostgrestQueryTests {
     .snapshotRequest {
       #"""
       curl \
-      	--header "Accept: application/vnd.pgrst.plan+\"text\"; for=application/json; options=analyze|verbose;" \
+      	--header "Accept: application/vnd.pgrst.plan+text; for=application/json; options=analyze|verbose;" \
       	--header "Content-Type: application/json" \
       	--header "X-Client-Info: postgrest-swift/0.0.0" \
       	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \


### PR DESCRIPTION
When building the `Accept` header for `.explain()`, the plan format is wrapped in literal double quotes:

```
Accept: application/vnd.pgrst.plan+"text"; for=application/json; options=analyze|verbose;
```

Double quotes are not valid in the structured-syntax suffix of a media type, so PostgREST does not recognize `application/vnd.pgrst.plan+"text"` as the plan media type and the request does not behave as an EXPLAIN.

### Fix
Drop the quotes so the header matches the spec and the reference implementation. `postgrest-js` emits `application/vnd.pgrst.plan+${format}` (no quotes):

```
Accept: application/vnd.pgrst.plan+text; for=application/json; options=analyze|verbose;
```

### Notes
- The existing snapshot test `testExplain` had frozen the buggy `+"text"` output; it is updated in the same commit. Snapshot tests never hit a server, so it recorded the defect rather than validating it.
- All `PostgRESTTests` pass (93 tests, 0 failures).