### PR TITLE
feat(postgrest): add ExplainFormat enum for explain(format:)

### DIFF
--- a/Sources/PostgREST/Deprecated.swift
+++ b/Sources/PostgREST/Deprecated.swift
@@ -135,6 +135,30 @@ extension PostgrestFilterBuilder {
   }
 }
 
+extension PostgrestTransformBuilder {
+  /// Return `data` as the EXPLAIN plan for the query, using a string `format`.
+  @available(
+    *, deprecated, message: "Use the `ExplainFormat` overload, e.g. `explain(format: .json)`."
+  )
+  public func explain(
+    analyze: Bool = false,
+    verbose: Bool = false,
+    settings: Bool = false,
+    buffers: Bool = false,
+    wal: Bool = false,
+    format: String
+  ) -> PostgrestTransformBuilder {
+    explain(
+      analyze: analyze,
+      verbose: verbose,
+      settings: settings,
+      buffers: buffers,
+      wal: wal,
+      format: ExplainFormat(rawValue: format)
+    )
+  }
+}
+
 @available(
   *,
   deprecated,

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -174,46 +174,6 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     wal: Bool = false,
     format: ExplainFormat = .text
   ) -> PostgrestTransformBuilder {
-    explain(
-      analyze: analyze,
-      verbose: verbose,
-      settings: settings,
-      buffers: buffers,
-      wal: wal,
-      formatValue: format.rawValue
-    )
-  }
-
-  /// Return `data` as the EXPLAIN plan for the query, using a string `format`.
-  @available(
-    *, deprecated, message: "Use the `ExplainFormat` overload, e.g. `explain(format: .json)`."
-  )
-  public func explain(
-    analyze: Bool = false,
-    verbose: Bool = false,
-    settings: Bool = false,
-    buffers: Bool = false,
-    wal: Bool = false,
-    format: String
-  ) -> PostgrestTransformBuilder {
-    explain(
-      analyze: analyze,
-      verbose: verbose,
-      settings: settings,
-      buffers: buffers,
-      wal: wal,
-      formatValue: format
-    )
-  }
-
-  private func explain(
-    analyze: Bool,
-    verbose: Bool,
-    settings: Bool,
-    buffers: Bool,
-    wal: Bool,
-    formatValue: String
-  ) -> PostgrestTransformBuilder {
     mutableState.withValue {
       let options = [
         analyze ? "analyze" : nil,
@@ -226,7 +186,7 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
       .joined(separator: "|")
       let forMediaType = $0.request.headers[.accept] ?? "application/json"
       $0.request.headers[.accept] =
-        "application/vnd.pgrst.plan+\(formatValue); for=\"\(forMediaType)\"; options=\(options);"
+        "application/vnd.pgrst.plan+\(format.rawValue); for=\"\(forMediaType)\"; options=\(options);"
     }
 
     return self

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -151,14 +151,6 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// The output format of an ``explain(analyze:verbose:settings:buffers:wal:format:)`` plan.
-  public enum ExplainFormat: String, Sendable {
-    /// Human-readable text output (default).
-    case text
-    /// Machine-readable JSON output.
-    case json
-  }
-
   /// Return `data` as the EXPLAIN plan for the query.
   ///
   /// You need to enable the [db_plan_enabled](https://supabase.com/docs/guides/database/debugging-performance#enabling-explain)

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -151,6 +151,14 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
+  /// The output format of an ``explain(analyze:verbose:settings:buffers:wal:format:)`` plan.
+  public enum ExplainFormat: String, Sendable {
+    /// Human-readable text output (default).
+    case text
+    /// Machine-readable JSON output.
+    case json
+  }
+
   /// Return `data` as the EXPLAIN plan for the query.
   ///
   /// You need to enable the [db_plan_enabled](https://supabase.com/docs/guides/database/debugging-performance#enabling-explain)
@@ -164,14 +172,55 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   /// planning
   ///   - buffers: If `true`, include information on buffer usage
   ///   - wal: If `true`, include information on WAL record generation
-  ///   - format: The format of the output, can be `"text"` (default) or `"json"`
+  ///   - format: The format of the output, either ``ExplainFormat/text`` (default) or
+  /// ``ExplainFormat/json``
   public func explain(
     analyze: Bool = false,
     verbose: Bool = false,
     settings: Bool = false,
     buffers: Bool = false,
     wal: Bool = false,
-    format: String = "text"
+    format: ExplainFormat = .text
+  ) -> PostgrestTransformBuilder {
+    explain(
+      analyze: analyze,
+      verbose: verbose,
+      settings: settings,
+      buffers: buffers,
+      wal: wal,
+      formatValue: format.rawValue
+    )
+  }
+
+  /// Return `data` as the EXPLAIN plan for the query, using a string `format`.
+  @available(
+    *, deprecated, message: "Use the `ExplainFormat` overload, e.g. `explain(format: .json)`."
+  )
+  public func explain(
+    analyze: Bool = false,
+    verbose: Bool = false,
+    settings: Bool = false,
+    buffers: Bool = false,
+    wal: Bool = false,
+    format: String
+  ) -> PostgrestTransformBuilder {
+    explain(
+      analyze: analyze,
+      verbose: verbose,
+      settings: settings,
+      buffers: buffers,
+      wal: wal,
+      formatValue: format
+    )
+  }
+
+  private func explain(
+    analyze: Bool,
+    verbose: Bool,
+    settings: Bool,
+    buffers: Bool,
+    wal: Bool,
+    formatValue: String
   ) -> PostgrestTransformBuilder {
     mutableState.withValue {
       let options = [
@@ -185,7 +234,7 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
       .joined(separator: "|")
       let forMediaType = $0.request.headers[.accept] ?? "application/json"
       $0.request.headers[.accept] =
-        "application/vnd.pgrst.plan+\"\(format)\"; for=\(forMediaType); options=\(options);"
+        "application/vnd.pgrst.plan+\"\(formatValue)\"; for=\(forMediaType); options=\(options);"
     }
 
     return self

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -71,6 +71,20 @@ public enum TextSearchType: String, Sendable {
   case websearch = "w"
 }
 
+/// The output format of an EXPLAIN plan.
+public struct ExplainFormat: RawRepresentable, Hashable, Sendable {
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Human-readable text output (default).
+  public static let text = ExplainFormat(rawValue: "text")
+  /// Machine-readable JSON output.
+  public static let json = ExplainFormat(rawValue: "json")
+}
+
 /// Options for querying Supabase.
 public struct FetchOptions: Sendable {
   /// Set head to true if you only want the count value and not the underlying data.

--- a/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
@@ -416,6 +416,35 @@ final class PostgrestTransformBuilderTests: PostgrestQueryTests {
     XCTAssertTrue(explain.contains("Aggregate"))
   }
 
+  func testExplainWithJSONFormat() async throws {
+    Mock(
+      url: url.appendingPathComponent("countries"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .get: Data("[]".utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "Accept: application/vnd.pgrst.plan+\"json\"; for=application/json; options=analyze;" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/countries?select=*"
+      """#
+    }
+    .register()
+
+    _ =
+      try await sut
+      .from("countries")
+      .select()
+      .explain(analyze: true, format: .json)
+      .execute()
+  }
+
   func testMaxAffectedOnUpdate() async throws {
     Mock(
       url: url.appendingPathComponent("users"),

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -296,7 +296,10 @@ features:
   database.using_modifiers.strip_nulls: implemented
   database.using_modifiers.format_csv: implemented
   database.using_modifiers.format_geojson: implemented
-  database.using_modifiers.explain: implemented
+  database.using_modifiers.explain:
+    status: implemented
+    symbols:
+      - ExplainFormat
   database.using_modifiers.max_affected_rows: implemented
   database.using_modifiers.request_cancellation: implemented
   database.using_modifiers.relationship_embed:


### PR DESCRIPTION
Follow-up to #1048, as discussed with @grdsdev.

The `explain()` `format` parameter is currently an untyped `String`, so a typo like `format: "jsom"` silently produces an unrecognised media type. The postgrest-js reference types this as `'json' | 'text'`.

### Change
Introduces a type-safe `ExplainFormat` enum for compile-time safety:

```swift
public enum ExplainFormat: String, Sendable {
  case text
  case json
}

builder.explain(analyze: true, format: .json)
```

**This is non-breaking.** The existing `String`-based overload is kept and marked `@available(*, deprecated)`, so current callers keep compiling (with a deprecation warning steering them to the enum). Both public overloads forward to a single private implementation, so the emitted header is unchanged.

### Notes
- Adds `testExplainWithJSONFormat` covering the `.json` path.
- All `PostgRESTTests` pass; `swift format lint --strict` clean.
- Stacked on top of #1048 — based off `main`, so the snapshots here reflect the current header formatting. Once #1048 merges I'll rebase and reconcile the json-format test.