### PR TITLE
ci: fix API stability check output and PR comment failure

### DIFF
--- a/.github/workflows/api-stability.yml
+++ b/.github/workflows/api-stability.yml
@@ -33,13 +33,13 @@ jobs:
 
           echo "Checking for breaking API changes against $BASELINE_TREEISH"
 
-          # Run the breaking changes check and capture output
+          # Run the breaking changes check.
+          # stdout receives only the filtered "API breakage:" lines (see the script).
+          # stderr (full build log) flows directly to the CI log for debugging.
           set +e
-          API_OUTPUT=$(bash scripts/check-for-breaking-api-changes.sh 2>&1)
+          API_OUTPUT=$(bash scripts/check-for-breaking-api-changes.sh)
           API_EXIT_CODE=$?
           set -e
-
-          echo "$API_OUTPUT"
 
           if [ $API_EXIT_CODE -eq 0 ]; then
             echo "✅ No breaking API changes detected"
@@ -92,11 +92,13 @@ jobs:
               echo "⚠️ Breaking API changes detected but not acknowledged"
               echo "has_breaking_changes=true" >> $GITHUB_OUTPUT
 
-              # Save the API output for the comment (escape for multiline)
+              # Save the API output for the comment.
+              # Use a random delimiter to prevent injection if output contains "EOF".
+              API_OUTPUT_DELIMITER="$(openssl rand -hex 8)"
               {
-                echo 'api_output<<EOF'
+                echo "api_output<<${API_OUTPUT_DELIMITER}"
                 echo "$API_OUTPUT"
-                echo 'EOF'
+                echo "${API_OUTPUT_DELIMITER}"
               } >> $GITHUB_OUTPUT
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - release/*
-      - v3
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - release/*
+      - v3
   workflow_dispatch:
 
 permissions:

--- a/scripts/check-for-breaking-api-changes.sh
+++ b/scripts/check-for-breaking-api-changes.sh
@@ -31,12 +31,15 @@ git -C "${REPO_ROOT}" fetch "${BASELINE_REPO_URL}" "${BASELINE_TREEISH}"
 BASELINE_COMMIT=$(git -C "${REPO_ROOT}" rev-parse FETCH_HEAD)
 
 log "Checking for API changes since ${BASELINE_REPO_URL}#${BASELINE_TREEISH} (${BASELINE_COMMIT})..."
-swift package --package-path "${REPO_ROOT}" diagnose-api-breaking-changes \
-  "${BASELINE_COMMIT}" \
-  && RC=$? || RC=$?
+SWIFT_OUTPUT=$(swift package --package-path "${REPO_ROOT}" diagnose-api-breaking-changes \
+  "${BASELINE_COMMIT}" 2>&1) && RC=0 || RC=$?
+
+# Print full output to stderr so it appears in CI logs for debugging
+echo "$SWIFT_OUTPUT" >&2
 
 if [ "${RC}" -ne 0 ]; then
+  # Print only the breaking change lines to stdout (captured by the caller)
+  echo "$SWIFT_OUTPUT" | grep "API breakage:" || true
   fatal "❌ Breaking API changes detected."
-  exit "${RC}"
 fi
 log "✅ No breaking API changes detected."


### PR DESCRIPTION
## What changed

- **`scripts/check-for-breaking-api-changes.sh`**: The script now captures the full `swift package diagnose-api-breaking-changes` output internally, pipes it to **stderr** (so it still appears in CI logs for debugging), and only writes the filtered `API breakage:` lines to **stdout**.
- **`.github/workflows/api-stability.yml`**:
  - Removed `2>&1` from the `API_OUTPUT` capture — only the filtered stdout (the actual breakage lines) is stored in the variable; the full build log streams naturally via stderr.
  - Removed the `echo "$API_OUTPUT"` that was re-printing the full log.
  - Replaced the unsafe `EOF` heredoc delimiter with `openssl rand -hex 8` to prevent `$GITHUB_OUTPUT` corruption if the output ever contains a bare `EOF` line.

## Why

The previous implementation captured the **entire build log** into `API_OUTPUT` — thousands of lines of package fetching, dependency resolution, and compilation warnings. This caused two failures:

1. **"Argument list too long"** — the `peter-evans/create-or-update-comment` action passed `api_output` as an environment variable to a Node.js process, which exceeded the OS argument length limit, making the step fail entirely.
2. **Unreadable output** — even when it didn't crash, the PR comment embedded the full build log, burying the ~15 actual `💔 API breakage:` lines in thousands of lines of noise.

## Reviewer notes

- The full build log is still visible in the CI step output (via stderr), so debugging information is not lost.
- The PR comment will now show only the compact list of breaking changes, e.g.:
  ```
  API breakage: var BucketOptions.fileSizeLimit has declared type change from Swift.String? to Storage.StorageByteCount?
  API breakage: var TransformOptions.resize has declared type change from Swift.String? to Storage.ResizeMode?
  ...
  ```