### PR TITLE
fix(realtime): backport Swift 6 strict concurrency fixes from v3

### DIFF
--- a/Sources/Helpers/Task+withTimeout.swift
+++ b/Sources/Helpers/Task+withTimeout.swift
@@ -10,7 +10,7 @@ import Foundation
 @discardableResult
 package func withTimeout<R: Sendable>(
   interval: TimeInterval,
-  @_inheritActorContext operation: @escaping @Sendable () async -> R
+  @_inheritActorContext operation: @escaping @Sendable () async throws -> R
 ) async throws -> R {
   try await withThrowingTaskGroup(of: R.self) { group in
     defer {
@@ -20,7 +20,7 @@ package func withTimeout<R: Sendable>(
     let deadline = Date(timeIntervalSinceNow: interval)
 
     group.addTask {
-      await operation()
+      try await operation()
     }
 
     group.addTask {

--- a/Sources/Realtime/ChannelStateManager.swift
+++ b/Sources/Realtime/ChannelStateManager.swift
@@ -282,9 +282,9 @@ actor ChannelStateManager {
           "Subscribe attempt \(attempts)/\(maxRetryAttempts) for channel '\(topic)'"
         )
 
-        try await withTimeout(interval: timeoutInterval) { [self] in
-          await Result { try await runOneSubscribeAttempt() }
-        }.get()
+        try await withTimeout(interval: timeoutInterval) {
+          [self] in try await runOneSubscribeAttempt()
+        }
 
         logger?.debug("Subscribe succeeded for channel '\(topic)'")
         return

--- a/Sources/Realtime/RealtimeChannelV2.swift
+++ b/Sources/Realtime/RealtimeChannelV2.swift
@@ -270,11 +270,8 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     )
 
     let response = try await withTimeout(interval: timeout ?? socket.options.timeoutInterval) {
-      [self] in
-      await Result {
-        try await socket.http.send(request)
-      }
-    }.get()
+      [self] in try await socket.http.send(request)
+    }
 
     guard response.statusCode == 202 else {
       // Try to parse error message from response body

--- a/Sources/Realtime/RealtimeClientV2.swift
+++ b/Sources/Realtime/RealtimeClientV2.swift
@@ -64,7 +64,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     /// Retains the optional app-lifecycle observer for the client's lifetime.
     /// Stored as `AnyObject?` so this type remains available on platforms where
     /// the concrete `RealtimeLifecycleManager` is not compiled.
-    var lifecycleManager: AnyObject?
+    var lifecycleManager: (any Sendable & AnyObject)?
 
     /// Whether the socket was `.connected` the last time the app entered the
     /// background. `handleAppForeground` only attempts recovery when this is

--- a/Sources/Realtime/RealtimeSerializer.swift
+++ b/Sources/Realtime/RealtimeSerializer.swift
@@ -44,7 +44,7 @@ struct RealtimeSerializer: Sendable {
 
   /// Encodes a ``RealtimeMessageV2`` as a JSON array string: `[joinRef, ref, topic, event, payload]`.
   func encodeText(_ message: RealtimeMessageV2) throws -> String {
-    var array: [AnyJSON] = [
+    let array: [AnyJSON] = [
       message.joinRef.map { .string($0) } ?? .null,
       message.ref.map { .string($0) } ?? .null,
       .string(message.topic),

--- a/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
@@ -21,7 +21,7 @@ import XCTest
 #else
 
   @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-  final class RealtimeChannelBroadcastTests: XCTestCase {
+  final class RealtimeChannelBroadcastTests: XCTestCase, @unchecked Sendable {
     let url = URL(string: "http://localhost:54321/realtime/v1")!
     let apiKey = "publishable.api.key"
 


### PR DESCRIPTION
## Summary

Cherry-picks two commits from `release/v3` that fix Swift 6 strict concurrency issues in the Realtime module. Both apply cleanly to main with no conflicts.

**Commit 1** (`2088a21`): `lifecycleManager` Sendable constraint
- `var lifecycleManager: AnyObject?` → `var lifecycleManager: (any Sendable & AnyObject)?`
- Private property inside `MutableState` — zero public API impact
- Fixes a Swift 6 strict concurrency warning on `RealtimeClientV2`
- Also adds `@unchecked Sendable` to `RealtimeChannelBroadcastTests`

**Commit 2** (`bdca0f9`): `withTimeout` throwing + `Result` anti-pattern removal
- `withTimeout` now accepts `() async throws -> R` (was `() async -> R`), removing the need for `Result`-wrapping at call sites
- Removes `await Result { try await ... }.get()` pattern in `RealtimeChannelV2` and `ChannelStateManager`
- Fixes a `var → let` for an immutable array in `RealtimeSerializer`
- Non-throwing closures passed to `withTimeout` are still valid (backward compatible)

## Test plan

- [ ] All existing Realtime tests pass
- [ ] No new warnings under strict concurrency checking