### PR TITLE
feat(functions): builder-style invoke API + public FunctionInvokeOptions fields

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -161,22 +161,77 @@ public final class FunctionsClient: Sendable {
     }
   }
 
+  // MARK: - New builder-style API
+
+  /// Invokes a function and returns the raw response data and HTTP response.
+  ///
+  /// - Parameters:
+  ///   - functionName: The name of the function to invoke.
+  ///   - applyOptions: A closure to configure the invocation options.
+  /// - Returns: The raw response data and HTTP response.
+  @discardableResult
+  public func invoke(
+    _ functionName: String,
+    options applyOptions: (inout FunctionInvokeOptions) -> Void = { _ in }
+  ) async throws -> (Data, HTTPURLResponse) {
+    var options = FunctionInvokeOptions()
+    applyOptions(&options)
+    let response = try await rawInvoke(functionName: functionName, invokeOptions: options)
+    return (response.data, response.underlyingResponse)
+  }
+
+  /// Invokes a function and decodes the response as a specific type.
+  ///
+  /// - Parameters:
+  ///   - functionName: The name of the function to invoke.
+  ///   - type: The type to decode the response as.
+  ///   - decoder: The JSON decoder to use. If `nil`, uses the client's decoder.
+  ///   - applyOptions: A closure to configure the invocation options.
+  /// - Returns: The decoded value and HTTP response.
+  public func invokeDecodable<T: Decodable>(
+    _ functionName: String,
+    as _: T.Type = T.self,
+    decoder: JSONDecoder? = nil,
+    options applyOptions: (inout FunctionInvokeOptions) -> Void = { _ in }
+  ) async throws -> (T, HTTPURLResponse) {
+    let (data, response) = try await invoke(functionName, options: applyOptions)
+    let value = try (decoder ?? self.decoder).decode(T.self, from: data)
+    return (value, response)
+  }
+
+  /// Invokes a function with a streamed response.
+  ///
+  /// The invoked function must return a `text/event-stream` content type.
+  ///
+  /// - Parameters:
+  ///   - functionName: The name of the function to invoke.
+  ///   - applyOptions: A closure to configure the invocation options.
+  /// - Returns: A stream of `Data` chunks from the response.
+  public func invokeStream(
+    _ functionName: String,
+    options applyOptions: (inout FunctionInvokeOptions) -> Void = { _ in }
+  ) -> AsyncThrowingStream<Data, any Error> {
+    var opts = FunctionInvokeOptions()
+    applyOptions(&opts)
+    return makeStreamedResponse(functionName: functionName, options: opts)
+  }
+
+  // MARK: - Deprecated API
+
   /// Invokes a function and decodes the response.
   ///
   /// - Parameters:
   ///   - functionName: The name of the function to invoke.
-  ///   - options: Options for invoking the function. (Default: empty `FunctionInvokeOptions`)
-  ///   - decode: A closure to decode the response data and HTTPURLResponse into a `Response`
-  /// object.
+  ///   - options: Options for invoking the function.
+  ///   - decode: A closure to decode the response data and HTTPURLResponse into a `Response` object.
   /// - Returns: The decoded `Response` object.
+  @available(*, deprecated, message: "Use invoke(_:options:) with a closure instead.")
   public func invoke<Response>(
     _ functionName: String,
     options: FunctionInvokeOptions = .init(),
     decode: (Data, HTTPURLResponse) throws -> Response
   ) async throws -> Response {
-    let response = try await rawInvoke(
-      functionName: functionName, invokeOptions: options
-    )
+    let response = try await rawInvoke(functionName: functionName, invokeOptions: options)
     return try decode(response.data, response.underlyingResponse)
   }
 
@@ -184,32 +239,48 @@ public final class FunctionsClient: Sendable {
   ///
   /// - Parameters:
   ///   - functionName: The name of the function to invoke.
-  ///   - options: Options for invoking the function. (Default: empty `FunctionInvokeOptions`)
-  ///   - decoder: The JSON decoder to use for decoding the response. If `nil`, uses the client's
-  ///     decoder.
+  ///   - options: Options for invoking the function.
+  ///   - decoder: The JSON decoder to use for decoding the response. If `nil`, uses the client's decoder.
   /// - Returns: The decoded object of type `T`.
+  @available(*, deprecated, message: "Use invokeDecodable(_:as:decoder:options:) instead.")
   public func invoke<T: Decodable>(
     _ functionName: String,
     options: FunctionInvokeOptions = .init(),
     decoder: JSONDecoder? = nil
   ) async throws -> T {
     let decoder = decoder ?? self.decoder
-    return try await invoke(functionName, options: options) { data, _ in
-      try decoder.decode(T.self, from: data)
-    }
+    let response = try await rawInvoke(functionName: functionName, invokeOptions: options)
+    return try decoder.decode(T.self, from: response.data)
   }
 
   /// Invokes a function without expecting a response.
   ///
   /// - Parameters:
   ///   - functionName: The name of the function to invoke.
-  ///   - options: Options for invoking the function. (Default: empty `FunctionInvokeOptions`)
+  ///   - options: Options for invoking the function.
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Use invoke(_:options:) with a closure instead.")
   public func invoke(
     _ functionName: String,
     options: FunctionInvokeOptions = .init()
   ) async throws {
-    try await invoke(functionName, options: options) { _, _ in () }
+    _ = try await rawInvoke(functionName: functionName, invokeOptions: options)
   }
+
+  /// Invokes a function with streamed response.
+  ///
+  /// Function MUST return a `text/event-stream` content type for this method to work.
+  ///
+  /// - Warning: Deprecated. Use ``invokeStream(_:options:)`` instead.
+  @available(*, deprecated, renamed: "invokeStream(_:options:)")
+  public func _invokeWithStreamedResponse(
+    _ functionName: String,
+    options invokeOptions: FunctionInvokeOptions = .init()
+  ) -> AsyncThrowingStream<Data, any Error> {
+    makeStreamedResponse(functionName: functionName, options: invokeOptions)
+  }
+
+  // MARK: - Private
 
   private func rawInvoke(
     functionName: String,
@@ -230,20 +301,8 @@ public final class FunctionsClient: Sendable {
     return response
   }
 
-  /// Invokes a function with streamed response.
-  ///
-  /// Function MUST return a `text/event-stream` content type for this method to work.
-  ///
-  /// - Parameters:
-  ///   - functionName: The name of the function to invoke.
-  ///   - invokeOptions: Options for invoking the function.
-  /// - Returns: A stream of Data.
-  ///
-  /// - Warning: Experimental method.
-  /// - Note: This method doesn't use the same underlying `URLSession` as the remaining methods in the library.
-  public func _invokeWithStreamedResponse(
-    _ functionName: String,
-    options invokeOptions: FunctionInvokeOptions = .init()
+  private func makeStreamedResponse(
+    functionName: String, options: FunctionInvokeOptions
   ) -> AsyncThrowingStream<Data, any Error> {
     let (stream, continuation) = AsyncThrowingStream<Data, any Error>.makeStream()
     let delegate = StreamResponseDelegate(continuation: continuation)
@@ -251,7 +310,7 @@ public final class FunctionsClient: Sendable {
     let session = URLSession(
       configuration: sessionConfiguration, delegate: delegate, delegateQueue: nil)
 
-    let urlRequest = buildRequest(functionName: functionName, options: invokeOptions).urlRequest
+    let urlRequest = buildRequest(functionName: functionName, options: options).urlRequest
 
     let task = session.dataTask(with: urlRequest)
     task.resume()
@@ -269,19 +328,20 @@ public final class FunctionsClient: Sendable {
   private func buildRequest(functionName: String, options: FunctionInvokeOptions)
     -> Helpers.HTTPRequest
   {
-    var query = options.query
+    var query = options.query.map { URLQueryItem(name: $0.key, value: $0.value) }
     var request = HTTPRequest(
       url: url.appendingPathComponent(functionName),
       method: FunctionInvokeOptions.httpMethod(options.method) ?? .post,
       query: query,
-      headers: mutableState.headers.merging(with: options.headers),
+      headers: mutableState.headers.merging(with: HTTPFields(options.headers)),
       body: options.body,
       timeoutInterval: FunctionsClient.requestIdleTimeout
     )
 
-    if let region = options.region ?? region {
-      request.headers[.xRegion] = region
-      query.appendOrUpdate(URLQueryItem(name: "forceFunctionRegion", value: region))
+    let regionString = options.region?.rawValue ?? region
+    if let regionString {
+      request.headers[.xRegion] = regionString
+      query.appendOrUpdate(URLQueryItem(name: "forceFunctionRegion", value: regionString))
       request.query = query
     }
 

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -117,21 +117,46 @@ public struct FunctionInvokeOptions: Sendable {
   }
 }
 
-public enum FunctionRegion: String, Sendable {
-  case apNortheast1 = "ap-northeast-1"
-  case apNortheast2 = "ap-northeast-2"
-  case apSouth1 = "ap-south-1"
-  case apSoutheast1 = "ap-southeast-1"
-  case apSoutheast2 = "ap-southeast-2"
-  case caCentral1 = "ca-central-1"
-  case euCentral1 = "eu-central-1"
-  case euWest1 = "eu-west-1"
-  case euWest2 = "eu-west-2"
-  case euWest3 = "eu-west-3"
-  case saEast1 = "sa-east-1"
-  case usEast1 = "us-east-1"
-  case usWest1 = "us-west-1"
-  case usWest2 = "us-west-2"
+/// A Supabase Edge Network region identifier.
+///
+/// Use the predefined static constants for known regions, or supply a custom value
+/// for regions not listed here:
+///
+/// ```swift
+/// // predefined
+/// options.region = .usEast1
+/// // custom region
+/// options.region = FunctionRegion(rawValue: "custom-region")
+/// options.region = "custom-region"
+/// ```
+public struct FunctionRegion: RawRepresentable, Hashable, Sendable {
+  /// The raw region string sent in the request.
+  public var rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public static let apNortheast1 = FunctionRegion(rawValue: "ap-northeast-1")
+  public static let apNortheast2 = FunctionRegion(rawValue: "ap-northeast-2")
+  public static let apSouth1 = FunctionRegion(rawValue: "ap-south-1")
+  public static let apSoutheast1 = FunctionRegion(rawValue: "ap-southeast-1")
+  public static let apSoutheast2 = FunctionRegion(rawValue: "ap-southeast-2")
+  public static let caCentral1 = FunctionRegion(rawValue: "ca-central-1")
+  public static let euCentral1 = FunctionRegion(rawValue: "eu-central-1")
+  public static let euWest1 = FunctionRegion(rawValue: "eu-west-1")
+  public static let euWest2 = FunctionRegion(rawValue: "eu-west-2")
+  public static let euWest3 = FunctionRegion(rawValue: "eu-west-3")
+  public static let saEast1 = FunctionRegion(rawValue: "sa-east-1")
+  public static let usEast1 = FunctionRegion(rawValue: "us-east-1")
+  public static let usWest1 = FunctionRegion(rawValue: "us-west-1")
+  public static let usWest2 = FunctionRegion(rawValue: "us-west-2")
+}
+
+extension FunctionRegion: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
 }
 
 extension FunctionInvokeOptions {

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -21,76 +21,21 @@ public enum FunctionsError: Error, LocalizedError {
 
 /// Options for invoking a function.
 public struct FunctionInvokeOptions: Sendable {
-  /// Method to use in the function invocation.
-  let method: Method?
+  /// HTTP method to use in the function invocation.
+  public var method: Method?
   /// Headers to be included in the function invocation.
-  let headers: HTTPFields
+  public var headers: [String: String] = [:]
   /// Body data to be sent with the function invocation.
-  let body: Data?
-  /// The Region to invoke the function in.
-  let region: String?
-  /// The query to be included in the function invocation.
-  let query: [URLQueryItem]
+  public var body: Data?
+  /// The region to invoke the function in.
+  public var region: FunctionRegion?
+  /// Query parameters to be included in the function invocation.
+  public var query: [String: String] = [:]
 
-  /// Initializes the `FunctionInvokeOptions` structure.
-  ///
-  /// - Parameters:
-  ///   - method: Method to use in the function invocation.
-  ///   - query: The query to be included in the function invocation.
-  ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
-  ///   - region: The Region to invoke the function in.
-  ///   - body: The body data to be sent with the function invocation.
-  ///   - encoder: The JSON encoder to use for encoding the body. (Default: `JSONEncoder()`)
-  @_disfavoredOverload
-  public init(
-    method: Method? = nil,
-    query: [URLQueryItem] = [],
-    headers: [String: String] = [:],
-    region: String? = nil,
-    body: some Encodable,
-    encoder: JSONEncoder = JSONEncoder()
-  ) {
-    var defaultHeaders = HTTPFields()
+  /// Creates a `FunctionInvokeOptions` with default values.
+  public init() {}
 
-    switch body {
-    case let string as String:
-      defaultHeaders[.contentType] = "text/plain"
-      self.body = string.data(using: .utf8)
-    case let data as Data:
-      defaultHeaders[.contentType] = "application/octet-stream"
-      self.body = data
-    default:
-      defaultHeaders[.contentType] = "application/json"
-      self.body = try? encoder.encode(body)
-    }
-
-    self.method = method
-    self.headers = defaultHeaders.merging(with: HTTPFields(headers))
-    self.region = region
-    self.query = query
-  }
-
-  /// Initializes the `FunctionInvokeOptions` structure.
-  ///
-  /// - Parameters:
-  ///   - method: Method to use in the function invocation.
-  ///   - query: The query to be included in the function invocation.
-  ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
-  ///   - region: The Region to invoke the function in.
-  @_disfavoredOverload
-  public init(
-    method: Method? = nil,
-    query: [URLQueryItem] = [],
-    headers: [String: String] = [:],
-    region: String? = nil
-  ) {
-    self.method = method
-    self.headers = HTTPFields(headers)
-    self.region = region
-    self.query = query
-    body = nil
-  }
-
+  /// HTTP methods available for function invocation.
   public enum Method: String, Sendable {
     case get = "GET"
     case post = "POST"
@@ -101,18 +46,12 @@ public struct FunctionInvokeOptions: Sendable {
 
   static func httpMethod(_ method: Method?) -> HTTPTypes.HTTPRequest.Method? {
     switch method {
-    case .get:
-      .get
-    case .post:
-      .post
-    case .put:
-      .put
-    case .patch:
-      .patch
-    case .delete:
-      .delete
-    case nil:
-      nil
+    case .get: .get
+    case .post: .post
+    case .put: .put
+    case .patch: .patch
+    case .delete: .delete
+    case nil: nil
     }
   }
 }
@@ -159,15 +98,58 @@ extension FunctionRegion: ExpressibleByStringLiteral {
   }
 }
 
+// MARK: - Deprecated initializers
+
 extension FunctionInvokeOptions {
-  /// Initializes the `FunctionInvokeOptions` structure.
-  ///
-  /// - Parameters:
-  ///   - method: Method to use in the function invocation.
-  ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
-  ///   - region: The Region to invoke the function in.
-  ///   - body: The body data to be sent with the function invocation.
-  ///   - encoder: The JSON encoder to use for encoding the body. (Default: `JSONEncoder()`)
+  @available(*, deprecated, message: "Use the builder-style invoke API instead.")
+  @_disfavoredOverload
+  public init(
+    method: Method? = nil,
+    query: [URLQueryItem] = [],
+    headers: [String: String] = [:],
+    region: String? = nil,
+    body: some Encodable,
+    encoder: JSONEncoder = JSONEncoder()
+  ) {
+    self.init()
+    self.method = method
+    self.region = region.map { FunctionRegion(rawValue: $0) }
+    self.query = query.reduce(into: [:]) { dict, item in
+      if let value = item.value { dict[item.name] = value }
+    }
+    var computedHeaders: [String: String] = [:]
+    switch body {
+    case let string as String:
+      computedHeaders["Content-Type"] = "text/plain"
+      self.body = string.data(using: .utf8)
+    case let data as Data:
+      computedHeaders["Content-Type"] = "application/octet-stream"
+      self.body = data
+    default:
+      computedHeaders["Content-Type"] = "application/json"
+      self.body = try? encoder.encode(body)
+    }
+    self.headers = computedHeaders.merging(headers) { _, new in new }
+  }
+
+  @available(*, deprecated, message: "Use the builder-style invoke API instead.")
+  @_disfavoredOverload
+  public init(
+    method: Method? = nil,
+    query: [URLQueryItem] = [],
+    headers: [String: String] = [:],
+    region: String? = nil
+  ) {
+    self.init()
+    self.method = method
+    self.headers = headers
+    self.region = region.map { FunctionRegion(rawValue: $0) }
+    self.query = query.reduce(into: [:]) { dict, item in
+      if let value = item.value { dict[item.name] = value }
+    }
+  }
+
+  @available(*, deprecated, message: "Use the builder-style invoke API instead.")
   public init(
     method: Method? = nil,
     headers: [String: String] = [:],
@@ -176,25 +158,16 @@ extension FunctionInvokeOptions {
     encoder: JSONEncoder = JSONEncoder()
   ) {
     self.init(
-      method: method,
-      headers: headers,
-      region: region?.rawValue,
-      body: body,
-      encoder: encoder
-    )
+      method: method, query: [], headers: headers, region: region?.rawValue, body: body,
+      encoder: encoder)
   }
 
-  /// Initializes the `FunctionInvokeOptions` structure.
-  ///
-  /// - Parameters:
-  ///   - method: Method to use in the function invocation.
-  ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
-  ///   - region: The Region to invoke the function in.
+  @available(*, deprecated, message: "Use the builder-style invoke API instead.")
   public init(
     method: Method? = nil,
     headers: [String: String] = [:],
     region: FunctionRegion? = nil
   ) {
-    self.init(method: method, headers: headers, region: region?.rawValue)
+    self.init(method: method, query: [], headers: headers, region: region?.rawValue)
   }
 }

--- a/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
+++ b/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
@@ -6,13 +6,13 @@ import XCTest
 final class FunctionInvokeOptionsTests: XCTestCase {
   func test_initWithStringBody() {
     let options = FunctionInvokeOptions(body: "string value")
-    XCTAssertEqual(options.headers[.contentType], "text/plain")
+    XCTAssertEqual(options.headers["Content-Type"], "text/plain")
     XCTAssertNotNil(options.body)
   }
 
   func test_initWithDataBody() {
     let options = FunctionInvokeOptions(body: "binary value".data(using: .utf8)!)
-    XCTAssertEqual(options.headers[.contentType], "application/octet-stream")
+    XCTAssertEqual(options.headers["Content-Type"], "application/octet-stream")
     XCTAssertNotNil(options.body)
   }
 
@@ -21,7 +21,7 @@ final class FunctionInvokeOptionsTests: XCTestCase {
       let value: String
     }
     let options = FunctionInvokeOptions(body: Body(value: "value"))
-    XCTAssertEqual(options.headers[.contentType], "application/json")
+    XCTAssertEqual(options.headers["Content-Type"], "application/json")
     XCTAssertNotNil(options.body)
   }
 
@@ -34,7 +34,7 @@ final class FunctionInvokeOptionsTests: XCTestCase {
     encoder.keyEncodingStrategy = .convertToSnakeCase
 
     let options = FunctionInvokeOptions(body: Body(userName: "test"), encoder: encoder)
-    XCTAssertEqual(options.headers[.contentType], "application/json")
+    XCTAssertEqual(options.headers["Content-Type"], "application/json")
 
     let json = try! JSONSerialization.jsonObject(with: options.body!) as! [String: Any]
     XCTAssertNotNil(json["user_name"])
@@ -48,7 +48,7 @@ final class FunctionInvokeOptionsTests: XCTestCase {
       headers: ["Content-Type": contentType],
       body: "binary value".data(using: .utf8)!
     )
-    XCTAssertEqual(options.headers[.contentType], contentType)
+    XCTAssertEqual(options.headers["Content-Type"], contentType)
     XCTAssertNotNil(options.body)
   }
 
@@ -64,5 +64,18 @@ final class FunctionInvokeOptionsTests: XCTestCase {
     for (method, expected) in testCases {
       XCTAssertEqual(FunctionInvokeOptions.httpMethod(method), expected)
     }
+  }
+
+  func test_builderInit() {
+    var options = FunctionInvokeOptions()
+    options.method = .post
+    options.headers["X-Custom"] = "value"
+    options.region = .usEast1
+    options.query["key"] = "val"
+
+    XCTAssertEqual(options.method, .post)
+    XCTAssertEqual(options.headers["X-Custom"], "value")
+    XCTAssertEqual(options.region, .usEast1)
+    XCTAssertEqual(options.query["key"], "val")
   }
 }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -312,10 +312,21 @@ features:
 
   # ── Functions ──────────────────────────────────────────────────────────────
 
-  functions.invocation.invoke: implemented
+  functions.invocation.invoke:
+    status: implemented
+    symbols:
+      - FunctionInvokeOptions.method
+      - FunctionInvokeOptions.headers
+      - FunctionInvokeOptions.body
+      - FunctionInvokeOptions.region
+      - FunctionInvokeOptions.query
+      - FunctionsClient.invokeDecodable
   functions.invocation.set_auth_token: implemented
   functions.invocation.method_override: implemented
-  functions.invocation.streaming_response: implemented
+  functions.invocation.streaming_response:
+    status: implemented
+    symbols:
+      - FunctionsClient.invokeStream
   functions.invocation.region_selection:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -316,7 +316,26 @@ features:
   functions.invocation.set_auth_token: implemented
   functions.invocation.method_override: implemented
   functions.invocation.streaming_response: implemented
-  functions.invocation.region_selection: implemented
+  functions.invocation.region_selection:
+    status: implemented
+    symbols:
+      - FunctionRegion
+      - FunctionRegion.init
+      - FunctionRegion.rawValue
+      - FunctionRegion.apNortheast1
+      - FunctionRegion.apNortheast2
+      - FunctionRegion.apSouth1
+      - FunctionRegion.apSoutheast1
+      - FunctionRegion.apSoutheast2
+      - FunctionRegion.caCentral1
+      - FunctionRegion.euCentral1
+      - FunctionRegion.euWest1
+      - FunctionRegion.euWest2
+      - FunctionRegion.euWest3
+      - FunctionRegion.saEast1
+      - FunctionRegion.usEast1
+      - FunctionRegion.usWest1
+      - FunctionRegion.usWest2
   functions.invocation.request_cancellation: implemented
   functions.invocation.timeout:
     status: partially_implemented


### PR DESCRIPTION
## Summary

Backport from `release/v3`: mutable `FunctionInvokeOptions` with user-friendly public fields and builder-closure invoke methods.

### Changes

**`FunctionInvokeOptions` restructured:**
- Fields promoted from `internal let` to `public var` with ergonomic types:
  - `headers: [String: String]` (was `HTTPFields`)
  - `region: FunctionRegion?` (was `String?`)
  - `query: [String: String]` (was `[URLQueryItem]`)
- Zero-arg `public init()` added to enable builder pattern
- All old init overloads deprecated (backward compatible — still compile and work)

**New `FunctionsClient` API:**
- `invoke(_:options:)` — builder closure `(inout FunctionInvokeOptions) -> Void`, returns `(Data, HTTPURLResponse)`
- `invokeDecodable(_:as:decoder:options:)` — typed decode, returns `(T, HTTPURLResponse)`
- `invokeStream(_:options:)` — public replacement for `_invokeWithStreamedResponse`
- Old `invoke` overloads and `_invokeWithStreamedResponse` deprecated

**Usage example:**
```swift
// new builder style
let (data, _) = try await client.invoke("hello") { opts in
    opts.method = .post
    opts.headers["X-Custom"] = "value"
    opts.region = .usEast1
    opts.body = try JSONEncoder().encode(payload)
}

// typed decode
let (result, _) = try await client.invokeDecodable("fn", as: MyResponse.self)
```

## Test plan

- [ ] `FunctionInvokeOptionsTests` updated — header assertions use `[String: String]` subscript
- [ ] New `test_builderInit` test added
- [ ] Existing `FunctionsClientTests` / `RequestTests` compile and pass (deprecated API still works)
- [ ] CI passes (sdk-compliance.yaml updated with new public symbols)

## Notes

- This PR depends on `feat/function-region-struct` (which introduced `FunctionRegion` struct) and cannot be merged before that PR.
- `invokeStream` returns `AsyncThrowingStream<Data, any Error>` (data chunks) matching the existing delegate-based implementation; the `UInt8`-byte stream from v3 requires further infrastructure work.