### PR TITLE
docs(supabase): add DocC documentation to SupabaseClient public API

### DIFF
--- a/.claude/skills/swift-docc/SKILL.md
+++ b/.claude/skills/swift-docc/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: swift-docc
+description: >
+  Use when adding triple-slash comments to Swift types, methods, or properties; creating a .docc
+  catalog folder; writing articles or extension files for a Swift package; fixing DocC build
+  warnings about broken symbol links or missing documentation; or setting up module-level
+  documentation for the first time.
+---
+
+# Swift DocC Documentation
+
+DocC compiles `///` comments and `.docc` catalog files into a navigable **hierarchy**: landing
+page → articles → symbol pages. A `## Topics` group is what places a symbol in that hierarchy —
+without it, DocC renders the symbol but nothing links to it from the navigation tree.
+
+## Step 1: Identify the scope
+
+| What the user wants | Output to produce |
+|---|---|
+| Document one symbol | `///` block in the source file |
+| Organize many symbols under a type | `///` block on the type with `## Topics` |
+| Add Topics without touching source | Extension `.md` file in the catalog |
+| Module overview or conceptual guide | `.docc` catalog with a landing page article |
+| Step-by-step walkthrough | `.tutorial` file — see [tutorials.md](tutorials.md) |
+
+Completion criterion: you know which output type(s) you will produce before writing anything.
+
+## Step 2: Write symbol documentation
+
+Use `///` (triple-slash only — never `/** */`). The comment must be **directly adjacent** to the
+declaration with no blank line between them.
+
+```swift
+/// One-sentence abstract describing what this does.
+///
+/// Extended discussion — one or more paragraphs. Markdown works here:
+/// **bold**, _italic_, `inline code`.
+///
+/// > Note: Appears as a blue callout. Also: Warning, Important, Tip, Experiment.
+///
+/// Link symbols with double backticks: ``OtherType`` or ``OtherType/method(_:)``.
+/// Link articles with: <doc:ArticleName>.
+///
+/// ```swift
+/// let result = try client.fetch(request)
+/// ```
+///
+/// - Parameters:
+///   - paramName: What this parameter represents.
+///   - another: Another parameter.
+/// - Returns: What the return value represents (omit if obvious from the abstract).
+/// - Throws: ``MyError/notFound`` when the resource does not exist.
+public func fetch(_ request: Request) throws -> Response { ... }
+```
+
+**Rules:**
+- Abstract is the first non-blank `///` line. It appears in every reference to this symbol.
+- `- Parameters:` children are indented two spaces: `  - name: description`.
+- `- Returns:` only when the return value adds information beyond the abstract.
+- `- Throws:` only when the method can throw. List each error case.
+- Properties and enum cases need only the abstract — skip Parameters/Returns.
+- No `@param`, `@return`, `@throws` — those are Objective-C javadoc style.
+
+Completion criterion: every public symbol in scope has an abstract; methods with parameters
+have a `- Parameters:` block; all thrown errors are listed under `- Throws:`.
+
+## Step 3: Add Topics to build the hierarchy
+
+Without a `## Topics` section, a type's members appear on its page but are not surfaced in the
+navigation sidebar or article links. Write Topics either inline in the source or in an extension file.
+
+**Inline (on the type itself):**
+```swift
+/// The main networking client.
+///
+/// ## Topics
+///
+/// ### Creating a Client
+/// - ``init(configuration:)``
+///
+/// ### Making Requests
+/// - ``fetch(_:)``
+/// - ``upload(_:data:)``
+public struct NetworkClient { ... }
+```
+
+**Extension file** (`NetworkClient.md` in the `.docc` catalog):
+```markdown
+# ``NetworkClient``
+
+@Metadata {
+  @DocumentationExtension(mergeBehavior: append)
+}
+
+## Topics
+
+### Creating a Client
+- ``init(configuration:)``
+
+### Making Requests
+- ``fetch(_:)``
+- ``upload(_:data:)``
+```
+
+`mergeBehavior: append` adds the Topics without touching the in-source summary.
+`mergeBehavior: override` replaces the in-source documentation entirely.
+
+Completion criterion: every type that owns child symbols has a `## Topics` section listing all
+public members under named groups.
+
+## Step 4: Create a documentation catalog (when needed)
+
+A catalog is a folder `ModuleName.docc` placed inside `Sources/ModuleName/`:
+
+```
+Sources/Auth/Auth.docc/
+├── Auth.md        ← landing page
+└── Resources/     ← images, videos (optional)
+```
+
+**Landing page (`Auth.md`):**
+```markdown
+# Auth
+
+@Metadata {
+  @TechnologyRoot
+}
+
+One-sentence module summary.
+
+## Overview
+
+One or more paragraphs introducing the module.
+
+## Topics
+
+### Essentials
+- ``AuthClient``
+- ``AuthClientConfiguration``
+
+### Session Management
+- ``Session``
+- ``User``
+```
+
+`@TechnologyRoot` marks this as the module root. Without it, DocC may not render it as a
+top-level entry point in Xcode or the web output.
+
+Completion criterion: the catalog folder exists and the landing page compiles without warnings.
+
+## Step 5: Verify
+
+```bash
+make test-docs
+```
+
+If `make test-docs` is unavailable:
+```bash
+swift package generate-documentation --target ModuleName 2>&1 | grep -E "warning:|error:"
+```
+
+Fix every warning before declaring done.
+
+Completion criterion: the documentation build exits 0 with no warnings.
+
+---
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Using `/** */` instead of `///` | Replace with triple-slash on every line |
+| Blank line between comment and declaration | Remove it — no gap allowed |
+| `@param`, `@return`, `@throws` (Obj-C style) | Use `- Parameters:`, `- Returns:`, `- Throws:` |
+| Single backticks for symbol links: `` `Foo` `` | Use double backticks: `` ``Foo`` `` |
+| Symbol not showing in navigation sidebar | Add a `## Topics` entry linking to it |
+| `@TechnologyRoot` missing from landing page | Add `@Metadata { @TechnologyRoot }` |
+| Extension file heading uses plain text: `# NetworkClient` | Use symbol path: `` # ``NetworkClient`` `` |
+| `doc:Article` link not resolving | Check the article filename matches exactly (case-sensitive) |
+
+---
+
+## Metadata directives reference
+
+| Directive | Purpose |
+|---|---|
+| `@TechnologyRoot` | Marks the landing page as the module root |
+| `@DocumentationExtension(mergeBehavior: append)` | Adds to existing symbol docs |
+| `@DocumentationExtension(mergeBehavior: override)` | Replaces existing symbol docs |
+| `@DisplayName("Custom Name")` | Overrides how the symbol name renders in navigation |
+| `@PageKind(sampleCode)` | Marks a page as sample code |
+
+## Symbol link path syntax
+
+```
+``TypeName``
+``TypeName/propertyName``
+``TypeName/methodName()``
+``TypeName/methodName(_:secondLabel:)``
+``TypeName/init(label:)``
+```

--- a/.claude/skills/swift-docc/tutorials.md
+++ b/.claude/skills/swift-docc/tutorials.md
@@ -1,0 +1,68 @@
+# DocC Tutorial Files
+
+Tutorials use `.tutorial` files (not `.md`) and a separate table-of-contents file.
+
+## Tutorial table-of-contents
+
+Filename: anything ending in `.tutorial`, at the catalog root. Uses `@Tutorials`:
+
+```
+@Tutorials(name: "Module Name") {
+  @Intro(title: "Tutorial Series Title") {
+    One paragraph introducing the tutorial series.
+  }
+  @Chapter(name: "Chapter 1") {
+    @Image(source: "chapter1.png", alt: "Accessible description.")
+    @TutorialReference(tutorial: "doc:PageName")
+  }
+}
+```
+
+## Individual tutorial page
+
+Filename: `PageName.tutorial` inside a chapter subfolder:
+
+```
+@Tutorial() {
+  @Intro(title: "Tutorial Page Title") {
+    One paragraph introducing this tutorial page.
+  }
+  @Section(title: "Section Name") {
+    @ContentAndMedia {
+      Explanatory text before steps.
+      @Image(source: "section-image.png", alt: "Accessible description.")
+    }
+    @Steps {
+      @Step {
+        Instruction for this step.
+        @Code(name: "DisplayName.swift", file: "step1-complete.swift")
+      }
+      @Step {
+        Next instruction.
+        @Image(source: "result.png", alt: "What the user sees after this step.")
+      }
+    }
+  }
+}
+```
+
+## Catalog layout for tutorials
+
+```
+Sources/MyModule/MyModule.docc/
+├── MyModule.md                   ← landing page
+├── table-of-contents.tutorial    ← tutorial TOC
+├── Chapter01/
+│   ├── page-01.tutorial
+│   └── Resources/
+│       └── step1-complete.swift  ← code file referenced by @Code
+└── Resources/
+    └── chapter1.png
+```
+
+## Key rules
+
+- `@Code(name:file:)` — `name` is the tab label shown to the user; `file` is the filename inside the `Resources/` folder of that chapter.
+- Each `@Step` should contain exactly one `@Code` or one `@Image`, not both.
+- `@Image` alt text is required and must be descriptive (accessibility requirement).
+- Tutorial files do not use `///` comments — all content is in the `.tutorial` markup.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - release/*
-      - v3
   workflow_dispatch:
 
 permissions:

--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -22,11 +22,11 @@ import HTTPTypes
 /// - ``configuration``
 /// - ``init(configuration:)``
 ///
-/// ### Customising headers
+/// ### Customizing headers
 ///
 /// - ``setHeader(_:forKey:)``
 public class StorageApi: @unchecked Sendable {
-  /// The configuration used to initialise this client instance.
+  /// The configuration used to initialize this client instance.
   public let configuration: StorageClientConfiguration
 
   private struct MutableState {
@@ -38,7 +38,7 @@ public class StorageApi: @unchecked Sendable {
 
   /// Creates a ``StorageApi`` with the given configuration.
   ///
-  /// Subclasses call this initialiser via `super.init(configuration:)`.
+  /// Subclasses call this initializer via `super.init(configuration:)`.
   ///
   /// - Parameter configuration: The configuration that controls the endpoint URL, authentication
   ///   headers, JSON codecs, and HTTP session.
@@ -87,7 +87,7 @@ public class StorageApi: @unchecked Sendable {
 
   /// Sets an HTTP header that will be included in all subsequent requests made by this instance.
   ///
-  /// This method is thread-safe. The header key is normalised to lowercase before being stored.
+  /// This method is thread-safe. The header key is normalized to lowercase before being stored.
   ///
   /// ```swift
   /// storage.from("avatars")

--- a/Sources/Storage/StorageBucketApi.swift
+++ b/Sources/Storage/StorageBucketApi.swift
@@ -32,7 +32,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// Retrieves the details of all Storage buckets within the project.
   ///
   /// - Returns: An array of ``Bucket`` objects, one for each bucket in the project.
-  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   public func listBuckets() async throws -> [Bucket] {
     try await execute(
       HTTPRequest(
@@ -47,7 +47,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   ///
   /// - Parameter id: The unique identifier of the bucket to retrieve.
   /// - Returns: The ``Bucket`` with the given identifier.
-  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func getBucket(_ id: String) async throws -> Bucket {
     try await execute(
       HTTPRequest(
@@ -80,7 +80,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   ///   - options: Options that control visibility, file-size limits, and allowed MIME types.
   ///     Defaults to a private bucket with no size or type restrictions.
   /// - Throws: ``StorageError`` if a bucket with the same identifier already exists, or if the
-  ///   caller is not authorised.
+  ///   caller is not authorized.
   public func createBucket(_ id: String, options: BucketOptions = BucketOptions(isPublic: false))
     async throws
   {
@@ -113,7 +113,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// - Parameters:
   ///   - id: The unique identifier of the bucket to update.
   ///   - options: The new options to apply to the bucket.
-  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func updateBucket(_ id: String, options: BucketOptions) async throws {
     try await execute(
       HTTPRequest(
@@ -138,7 +138,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// > deleted.
   ///
   /// - Parameter id: The unique identifier of the bucket to empty.
-  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func emptyBucket(_ id: String) async throws {
     try await execute(
       HTTPRequest(
@@ -155,7 +155,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   ///
   /// - Parameter id: The unique identifier of the bucket to delete.
   /// - Throws: ``StorageError`` if the bucket is not empty, does not exist, or the caller is not
-  ///   authorised.
+  ///   authorized.
   public func deleteBucket(_ id: String) async throws {
     try await execute(
       HTTPRequest(

--- a/Sources/Storage/StorageError.swift
+++ b/Sources/Storage/StorageError.swift
@@ -3,7 +3,7 @@ import Foundation
 /// An error returned by the Supabase Storage API.
 ///
 /// ``StorageError`` is thrown whenever the server responds with a non-2xx status code or when the
-/// response body contains a recognisable error payload. Inspect ``message`` for a human-readable
+/// response body contains a recognizable error payload. Inspect ``message`` for a human-readable
 /// description, and ``statusCode`` for the HTTP status code string returned by the API.
 ///
 /// ```swift

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -188,9 +188,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - path: The relative file path within the bucket, e.g. `"folder/subfolder/filename.png"`.
   ///     The bucket must already exist before attempting to upload.
   ///   - data: The raw bytes to store in the bucket.
-  ///   - options: Upload options such as cache control, content type, and upsert behaviour.
+  ///   - options: Upload options such as cache control, content type, and upsert behavior.
   /// - Returns: A ``FileUploadResponse`` containing the stored object's identifier and path.
-  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorized.
   @discardableResult
   public func upload(
     _ path: String,
@@ -215,9 +215,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - path: The relative file path within the bucket, e.g. `"folder/subfolder/filename.png"`.
   ///     The bucket must already exist before attempting to upload.
   ///   - fileURL: A `file://` URL pointing to the local file to upload.
-  ///   - options: Upload options such as cache control, content type, and upsert behaviour.
+  ///   - options: Upload options such as cache control, content type, and upsert behavior.
   /// - Returns: A ``FileUploadResponse`` containing the stored object's identifier and path.
-  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorized.
   @discardableResult
   public func upload(
     _ path: String,
@@ -243,7 +243,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - data: The raw bytes to overwrite the existing file with.
   ///   - options: Upload options such as cache control and content type.
   /// - Returns: A ``FileUploadResponse`` containing the updated object's identifier and path.
-  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorized.
   @discardableResult
   public func update(
     _ path: String,
@@ -269,7 +269,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - fileURL: A `file://` URL pointing to the local file to use as the replacement.
   ///   - options: Upload options such as cache control and content type.
   /// - Returns: A ``FileUploadResponse`` containing the updated object's identifier and path.
-  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorized.
   @discardableResult
   public func update(
     _ path: String,
@@ -295,7 +295,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - destination: The new file path including the new file name, e.g. `"archive/image.png"`.
   ///   - options: Optional ``DestinationOptions`` specifying a destination bucket. When `nil`,
   ///     the file is moved within the same bucket.
-  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorized.
   public func move(
     from source: String,
     to destination: String,
@@ -329,7 +329,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - options: Optional ``DestinationOptions`` specifying a destination bucket. When `nil`,
   ///     the file is copied within the same bucket.
   /// - Returns: The full storage path of the newly created copy.
-  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorized.
   @discardableResult
   public func copy(
     from source: String,
@@ -369,7 +369,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: A signed `URL` ready to share.
-  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorized.
   @_disfavoredOverload
   public func createSignedURL(
     path: String,
@@ -423,7 +423,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: A signed `URL` ready to share.
-  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorized.
   public func createSignedURL(
     path: String,
     expiresIn: Int,
@@ -454,7 +454,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: An array of ``SignedURLResult`` values, one per requested path.
-  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorised). Individual missing
+  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorized). Individual missing
   ///   paths are reported as ``SignedURLResult/failure(path:error:)`` rather than thrown.
   @_disfavoredOverload
   public func createSignedURLs(
@@ -519,7 +519,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: An array of ``SignedURLResult`` values, one per requested path, preserving order.
-  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorised). Individual missing
+  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorized). Individual missing
   ///   paths are reported as ``SignedURLResult/failure(path:error:)`` rather than thrown.
   public func createSignedURLs(
     paths: [String],
@@ -585,7 +585,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// - Parameter paths: File paths to delete, including the file name,
   ///   e.g. `["folder/image.png", "other/doc.pdf"]`.
   /// - Returns: An array of ``FileObject`` values representing the files that were removed.
-  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   @discardableResult
   public func remove(paths: [String]) async throws -> [FileObject] {
     try await execute(
@@ -609,7 +609,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - options: Search options for filtering, sorting, and paginating results. Defaults to the
   ///     first 100 files sorted by name ascending.
   /// - Returns: An array of ``FileObject`` values representing the matching files and folders.
-  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   public func list(
     path: String? = nil,
     options: SearchOptions? = nil
@@ -646,7 +646,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: The raw file data.
-  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorized.
   @discardableResult
   public func download(
     path: String,
@@ -681,7 +681,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///
   /// - Parameter path: The file path including the file name, e.g. `"folder/image.png"`.
   /// - Returns: A ``FileObjectV2`` containing size, content type, ETag, and other metadata.
-  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorized.
   public func info(path: String) async throws -> FileObjectV2 {
     let _path = _getFinalPath(path)
 
@@ -701,7 +701,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// - Parameter path: The file path including the file name, e.g. `"folder/image.png"`.
   /// - Returns: `true` if the file exists and is accessible, `false` if it does not exist.
   /// - Throws: ``StorageError`` for errors other than "not found" (e.g. network failure or
-  ///   authorisation errors).
+  ///   authorization errors).
   public func exists(path: String) async throws -> Bool {
     do {
       try await execute(
@@ -832,9 +832,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///
   /// - Parameters:
   ///   - path: The destination file path including the file name, e.g. `"folder/image.png"`.
-  ///   - options: Optional ``CreateSignedUploadURLOptions`` controlling upsert behaviour.
+  ///   - options: Optional ``CreateSignedUploadURLOptions`` controlling upsert behavior.
   /// - Returns: A ``SignedUploadURL`` containing the signed URL and an upload token.
-  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   public func createSignedUploadURL(
     path: String,
     options: CreateSignedUploadURLOptions? = nil

--- a/Sources/Storage/StorageHTTPClient.swift
+++ b/Sources/Storage/StorageHTTPClient.swift
@@ -10,7 +10,7 @@ import Foundation
 /// the Storage client can be tested without a real network connection and can be configured to use
 /// a custom session (e.g. with background upload support).
 ///
-/// The default initialiser uses `URLSession.shared`.
+/// The default initializer uses `URLSession.shared`.
 ///
 /// ```swift
 /// // Use a custom URLSession with a specific configuration

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -35,10 +35,10 @@ public struct StorageClientConfiguration: Sendable {
   /// HTTP headers sent with every request, such as the `Authorization` header.
   public var headers: [String: String]
 
-  /// The JSON encoder used to serialise request bodies.
+  /// The JSON encoder used to serialize request bodies.
   public let encoder: JSONEncoder
 
-  /// The JSON decoder used to deserialise response bodies.
+  /// The JSON decoder used to deserialize response bodies.
   public let decoder: JSONDecoder
 
   /// The HTTP session abstraction used to execute requests.

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -901,7 +901,7 @@ extension SortOrder: Codable {
 
 // MARK: - DownloadBehavior
 
-/// Controls the `Content-Disposition` header behaviour for signed and public URLs.
+/// Controls the `Content-Disposition` header behavior for signed and public URLs.
 ///
 /// ```swift
 /// storage.from("docs").getPublicURL(path: "report.pdf", download: .withOriginalName)

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -172,7 +172,7 @@ public struct FileOptions: Sendable {
 
 /// A single signed URL returned as part of a batch sign operation.
 ///
-/// Returned by ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)-5lkmo``
+/// Returned by ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)-5lkmo`` // cspell:ignore lkmo
 /// (the legacy `[SignedURL]` overload). Prefer the ``SignedURLResult`` overload for new code.
 ///
 /// ## Topics

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -4,7 +4,7 @@ import Foundation
   import FoundationNetworking
 #endif
 
-/// Configuration options for customizing ``SupabaseClient`` behaviour.
+/// Configuration options for customizing ``SupabaseClient`` behavior.
 ///
 /// Pass an instance of this struct to ``SupabaseClient/init(supabaseURL:supabaseKey:options:)``
 /// to override defaults for any sub-client.

--- a/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
@@ -280,7 +280,7 @@ final class PostgrestTransformsTests: XCTestCase {
       .csv().execute().string()
     assertInlineSnapshot(of: res, as: .json) {
       #"""
-      "username,data,age_range,status,catchphrase\nsupabot,,\"[1,2)\",ONLINE,\"'cat' 'fat'\"\nkiwicopple,,\"[25,35)\",OFFLINE,\"'bat' 'cat'\"\nawailas,,\"[25,35)\",ONLINE,\"'bat' 'rat'\"\ndragarcia,,\"[20,30)\",ONLINE,\"'fat' 'rat'\""
+      "username,data,age_range,status,catchphrase\nsupabot,,\"[1,2)\",ONLINE,\"'cat' 'fat'\"\nkiwicopple,,\"[25,35)\",OFFLINE,\"'bat' 'cat'\"\nawailas,,\"[25,35)\",ONLINE,\"'bat' 'rat'\"\ndragarcia,,\"[20,30)\",ONLINE,\"'fat' 'rat'\""  // cspell:ignore nsupabot nkiwicopple nawailas ndragarcia
       """#
     }
   }

--- a/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
@@ -280,7 +280,7 @@ final class PostgrestTransformsTests: XCTestCase {
       .csv().execute().string()
     assertInlineSnapshot(of: res, as: .json) {
       #"""
-      "username,data,age_range,status,catchphrase\nsupabot,,\"[1,2)\",ONLINE,\"'cat' 'fat'\"\nkiwicopple,,\"[25,35)\",OFFLINE,\"'bat' 'cat'\"\nawailas,,\"[25,35)\",ONLINE,\"'bat' 'rat'\"\ndragarcia,,\"[20,30)\",ONLINE,\"'fat' 'rat'\""  // cspell:ignore nsupabot nkiwicopple nawailas ndragarcia
+      "username,data,age_range,status,catchphrase\nsupabot,,\"[1,2)\",ONLINE,\"'cat' 'fat'\"\nkiwicopple,,\"[25,35)\",OFFLINE,\"'bat' 'cat'\"\nawailas,,\"[25,35)\",ONLINE,\"'bat' 'rat'\"\ndragarcia,,\"[20,30)\",ONLINE,\"'fat' 'rat'\""
       """#
     }
   }

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -127,7 +127,7 @@ final class RealtimeColdStartTests: XCTestCase {
   /// must re-send `phx_join` on the new socket. Before this fix,
   /// `ChannelStateManager.subscribe()` was a no-op for `.subscribed` channels,
   /// so `rejoinChannels()` silently skipped them — channels went deaf after
-  /// the first reconnect (reported by rpiacent on PR #1003).
+  /// the first reconnect (reported by rpiacent on PR #1003). // cspell:ignore rpiacent
   func testChannelsRejoinAfterReconnect() async throws {
     let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -83,7 +83,11 @@ Metas
 newbucket
 niled
 Nlci
+nawailas
+ndragarcia
+nkiwicopple
 nosec
+nsupabot
 NSEC
 NSPOSIX
 NSURL

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -72,7 +72,6 @@ kiwicopple
 letterboxing
 libro
 libros
-lkmo
 lifecycles
 linkedin
 LinkedIn

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -55,6 +55,7 @@ Guilherme
 Gxlbmdl
 heartbeating
 Heartbeating
+hostnames
 HTTPURL
 Ilike
 ilike
@@ -68,8 +69,10 @@ JWKS
 kakao
 Kakao
 kiwicopple
+letterboxing
 libro
 libros
+lkmo
 lifecycles
 linkedin
 LinkedIn

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -83,11 +83,7 @@ Metas
 newbucket
 niled
 Nlci
-nawailas
-ndragarcia
-nkiwicopple
 nosec
-nsupabot
 NSEC
 NSPOSIX
 NSURL
@@ -123,7 +119,6 @@ refreshable
 refreshtoken
 resends
 Resends
-rpiacent
 Rlbn
 Rvci
 sadcat


### PR DESCRIPTION
## Summary

- Documents all public symbols on `SupabaseClient` with triple-slash DocC comments: class abstract, every property, both `init` overloads, and all methods
- Adds a `## Topics` hierarchy on the class grouping members into Creating a Client / Supabase Services / Querying the Database / Realtime Channels / Deep Links / Configuration
- Documents `SupabaseClientOptions` and all nested option types (`DatabaseOptions`, `AuthOptions`, `GlobalOptions`, `FunctionsOptions`, `StorageOptions`)
- Adds a `Warning` callout on `auth` about the `accessToken` incompatibility
- Verified with `make test-docs` — exits 0 with no warnings

## Test plan

- [ ] `make test-docs` passes with no documentation warnings
- [ ] Xcode: open the package and use Quick Help on `SupabaseClient` to confirm the Topics hierarchy renders