### PR TITLE
docs(functions): add DocC documentation to Functions public API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - release/*
-      - v3
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - release/*
+      - v3
   workflow_dispatch:
 
 permissions:

--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -9,17 +9,45 @@ import Helpers
 
 let version = Helpers.version
 
-/// An actor representing a client for invoking functions.
+/// A client for invoking Supabase Edge Functions.
+///
+/// Obtain an instance from ``SupabaseClient/functions`` rather than creating one directly.
+///
+/// ```swift
+/// // Invoke and decode a response
+/// let order: Order = try await supabase.functions.invoke("get-order")
+///
+/// // Invoke with a body and no return value
+/// try await supabase.functions.invoke(
+///   "send-email",
+///   options: FunctionInvokeOptions(body: ["to": "user@example.com"])
+/// )
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating a Client
+/// - ``init(url:headers:region:logger:fetch:decoder:)``
+/// - ``FetchHandler``
+///
+/// ### Invoking Functions
+/// - ``invoke(_:options:decode:)``
+/// - ``invoke(_:options:decoder:)``
+/// - ``invoke(_:options:)``
+/// - ``_invokeWithStreamedResponse(_:options:)``
+///
+/// ### Configuration
+/// - ``decoder``
+/// - ``requestIdleTimeout``
+/// - ``setAuth(token:)``
 public final class FunctionsClient: Sendable {
-  /// Fetch handler used to make requests.
+  /// A handler that performs the underlying HTTP request for a function invocation.
   public typealias FetchHandler =
     @Sendable (_ request: URLRequest) async throws -> (
       Data, URLResponse
     )
 
-  /// Request idle timeout: 150s (If an Edge Function doesn't send a response before the timeout, 504 Gateway Timeout will be returned)
-  ///
-  /// See more: https://supabase.com/docs/guides/functions/limits
+  /// The maximum time an Edge Function may run before the gateway returns a 504 error (150 seconds).
   public static let requestIdleTimeout: TimeInterval = 150
 
   /// The base URL for the functions.
@@ -28,7 +56,7 @@ public final class FunctionsClient: Sendable {
   /// The Region to invoke the functions in.
   let region: String?
 
-  /// The JSON decoder to use for decoding response bodies.
+  /// The JSON decoder used to decode function response bodies.
   public let decoder: JSONDecoder
 
   struct MutableState {
@@ -44,15 +72,14 @@ public final class FunctionsClient: Sendable {
     mutableState.headers
   }
 
-  /// Initializes a new instance of `FunctionsClient`.
-  ///
+  /// Creates a new Functions client.
   /// - Parameters:
-  ///   - url: The base URL for the functions.
-  ///   - headers: Headers to be included in the requests. (Default: empty dictionary)
-  ///   - region: The Region to invoke the functions in.
-  ///   - logger: SupabaseLogger instance to use.
-  ///   - fetch: The fetch handler used to make requests. (Default: URLSession.shared.data(for:))
-  ///   - decoder: The JSON decoder to use for decoding response bodies. (Default: `JSONDecoder()`)
+  ///   - url: The base URL of the Functions endpoint.
+  ///   - headers: Additional headers to include in every request.
+  ///   - region: The region string to invoke functions in.
+  ///   - logger: A logger for request and response diagnostics.
+  ///   - fetch: A custom fetch handler. Defaults to `URLSession.shared`.
+  ///   - decoder: The JSON decoder used to decode response bodies.
   @_disfavoredOverload
   public convenience init(
     url: URL,
@@ -121,15 +148,14 @@ public final class FunctionsClient: Sendable {
     }
   }
 
-  /// Initializes a new instance of `FunctionsClient`.
-  ///
+  /// Creates a new Functions client.
   /// - Parameters:
-  ///   - url: The base URL for the functions.
-  ///   - headers: Headers to be included in the requests. (Default: empty dictionary)
-  ///   - region: The Region to invoke the functions in.
-  ///   - logger: SupabaseLogger instance to use.
-  ///   - fetch: The fetch handler used to make requests. (Default: URLSession.shared.data(for:))
-  ///   - decoder: The JSON decoder to use for decoding response bodies. (Default: `JSONDecoder()`)
+  ///   - url: The base URL of the Functions endpoint.
+  ///   - headers: Additional headers to include in every request.
+  ///   - region: The region to invoke functions in.
+  ///   - logger: A logger for request and response diagnostics.
+  ///   - fetch: A custom fetch handler. Defaults to `URLSession.shared`.
+  ///   - decoder: The JSON decoder used to decode response bodies.
   public convenience init(
     url: URL,
     headers: [String: String] = [:],
@@ -148,9 +174,8 @@ public final class FunctionsClient: Sendable {
     )
   }
 
-  /// Updates the authorization header.
-  ///
-  /// - Parameter token: The new JWT token sent in the authorization header.
+  /// Sets or clears the JWT used in the Authorization header for subsequent requests.
+  /// - Parameter token: The JWT to send, or `nil` to remove the Authorization header.
   public func setAuth(token: String?) {
     mutableState.withValue {
       if let token {
@@ -161,14 +186,14 @@ public final class FunctionsClient: Sendable {
     }
   }
 
-  /// Invokes a function and decodes the response.
-  ///
+  /// Invokes a function and decodes the response with a custom closure.
   /// - Parameters:
   ///   - functionName: The name of the function to invoke.
-  ///   - options: Options for invoking the function. (Default: empty `FunctionInvokeOptions`)
-  ///   - decode: A closure to decode the response data and HTTPURLResponse into a `Response`
-  /// object.
-  /// - Returns: The decoded `Response` object.
+  ///   - options: Options for the invocation.
+  ///   - decode: A closure that receives the raw response data and HTTP response, and returns the
+  ///     decoded value.
+  /// - Returns: The value returned by `decode`.
+  /// - Throws: ``FunctionsError`` if the function returns a non-2xx status or a relay error.
   public func invoke<Response>(
     _ functionName: String,
     options: FunctionInvokeOptions = .init(),
@@ -180,14 +205,14 @@ public final class FunctionsClient: Sendable {
     return try decode(response.data, response.underlyingResponse)
   }
 
-  /// Invokes a function and decodes the response as a specific type.
-  ///
+  /// Invokes a function and JSON-decodes the response body into `T`.
   /// - Parameters:
   ///   - functionName: The name of the function to invoke.
-  ///   - options: Options for invoking the function. (Default: empty `FunctionInvokeOptions`)
-  ///   - decoder: The JSON decoder to use for decoding the response. If `nil`, uses the client's
-  ///     decoder.
-  /// - Returns: The decoded object of type `T`.
+  ///   - options: Options for the invocation.
+  ///   - decoder: The JSON decoder to use. Defaults to the client's ``decoder`` when `nil`.
+  /// - Returns: The decoded `T`.
+  /// - Throws: ``FunctionsError`` if the function returns a non-2xx status or a relay error, or
+  ///   a decoding error if the response body cannot be decoded as `T`.
   public func invoke<T: Decodable>(
     _ functionName: String,
     options: FunctionInvokeOptions = .init(),
@@ -199,11 +224,11 @@ public final class FunctionsClient: Sendable {
     }
   }
 
-  /// Invokes a function without expecting a response.
-  ///
+  /// Invokes a function and discards any response body.
   /// - Parameters:
   ///   - functionName: The name of the function to invoke.
-  ///   - options: Options for invoking the function. (Default: empty `FunctionInvokeOptions`)
+  ///   - options: Options for the invocation.
+  /// - Throws: ``FunctionsError`` if the function returns a non-2xx status or a relay error.
   public func invoke(
     _ functionName: String,
     options: FunctionInvokeOptions = .init()
@@ -230,17 +255,17 @@ public final class FunctionsClient: Sendable {
     return response
   }
 
-  /// Invokes a function with streamed response.
+  /// Invokes a function and returns its response as a stream of raw `Data` chunks.
   ///
-  /// Function MUST return a `text/event-stream` content type for this method to work.
+  /// The function must return a `text/event-stream` content type for this to work correctly.
   ///
+  /// > Warning: Experimental — the API may change without a major version bump.
+  ///
+  /// > Note: This method uses a separate `URLSession` from the rest of the client.
   /// - Parameters:
   ///   - functionName: The name of the function to invoke.
-  ///   - invokeOptions: Options for invoking the function.
-  /// - Returns: A stream of Data.
-  ///
-  /// - Warning: Experimental method.
-  /// - Note: This method doesn't use the same underlying `URLSession` as the remaining methods in the library.
+  ///   - options: Options for the invocation.
+  /// - Returns: An `AsyncThrowingStream` that yields response data chunks as they arrive.
   public func _invokeWithStreamedResponse(
     _ functionName: String,
     options invokeOptions: FunctionInvokeOptions = .init()

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -32,15 +32,15 @@ public struct FunctionInvokeOptions: Sendable {
   /// The query to be included in the function invocation.
   let query: [URLQueryItem]
 
-  /// Initializes the `FunctionInvokeOptions` structure.
-  ///
+  /// Creates options for a function invocation with an encodable body.
   /// - Parameters:
-  ///   - method: Method to use in the function invocation.
-  ///   - query: The query to be included in the function invocation.
-  ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
-  ///   - region: The Region to invoke the function in.
-  ///   - body: The body data to be sent with the function invocation.
-  ///   - encoder: The JSON encoder to use for encoding the body. (Default: `JSONEncoder()`)
+  ///   - method: The HTTP method to use. Defaults to POST when `nil`.
+  ///   - query: Query items appended to the function URL.
+  ///   - headers: Additional headers to include in the request.
+  ///   - region: The region string to invoke the function in.
+  ///   - body: The body to encode and send. Strings are sent as `text/plain`, `Data` as
+  ///     `application/octet-stream`, and all other `Encodable` values as JSON.
+  ///   - encoder: The JSON encoder used when `body` is encoded as JSON.
   @_disfavoredOverload
   public init(
     method: Method? = nil,
@@ -70,13 +70,12 @@ public struct FunctionInvokeOptions: Sendable {
     self.query = query
   }
 
-  /// Initializes the `FunctionInvokeOptions` structure.
-  ///
+  /// Creates options for a function invocation with no body.
   /// - Parameters:
-  ///   - method: Method to use in the function invocation.
-  ///   - query: The query to be included in the function invocation.
-  ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
-  ///   - region: The Region to invoke the function in.
+  ///   - method: The HTTP method to use. Defaults to POST when `nil`.
+  ///   - query: Query items appended to the function URL.
+  ///   - headers: Additional headers to include in the request.
+  ///   - region: The region string to invoke the function in.
   @_disfavoredOverload
   public init(
     method: Method? = nil,
@@ -91,11 +90,17 @@ public struct FunctionInvokeOptions: Sendable {
     body = nil
   }
 
+  /// The HTTP method to use when invoking a function.
   public enum Method: String, Sendable {
+    /// Performs an HTTP GET request.
     case get = "GET"
+    /// Performs an HTTP POST request.
     case post = "POST"
+    /// Performs an HTTP PUT request.
     case put = "PUT"
+    /// Performs an HTTP PATCH request.
     case patch = "PATCH"
+    /// Performs an HTTP DELETE request.
     case delete = "DELETE"
   }
 
@@ -117,32 +122,46 @@ public struct FunctionInvokeOptions: Sendable {
   }
 }
 
+/// A Supabase Edge Function deployment region.
 public enum FunctionRegion: String, Sendable {
+  /// Asia Pacific (Tokyo).
   case apNortheast1 = "ap-northeast-1"
+  /// Asia Pacific (Seoul).
   case apNortheast2 = "ap-northeast-2"
+  /// Asia Pacific (Mumbai).
   case apSouth1 = "ap-south-1"
+  /// Asia Pacific (Singapore).
   case apSoutheast1 = "ap-southeast-1"
+  /// Asia Pacific (Sydney).
   case apSoutheast2 = "ap-southeast-2"
+  /// Canada (Central).
   case caCentral1 = "ca-central-1"
+  /// Europe (Frankfurt).
   case euCentral1 = "eu-central-1"
+  /// Europe (Ireland).
   case euWest1 = "eu-west-1"
+  /// Europe (London).
   case euWest2 = "eu-west-2"
+  /// Europe (Paris).
   case euWest3 = "eu-west-3"
+  /// South America (São Paulo).
   case saEast1 = "sa-east-1"
+  /// US East (N. Virginia).
   case usEast1 = "us-east-1"
+  /// US West (N. California).
   case usWest1 = "us-west-1"
+  /// US West (Oregon).
   case usWest2 = "us-west-2"
 }
 
 extension FunctionInvokeOptions {
-  /// Initializes the `FunctionInvokeOptions` structure.
-  ///
+  /// Creates options for a function invocation with an encodable body and a typed region.
   /// - Parameters:
-  ///   - method: Method to use in the function invocation.
-  ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
-  ///   - region: The Region to invoke the function in.
-  ///   - body: The body data to be sent with the function invocation.
-  ///   - encoder: The JSON encoder to use for encoding the body. (Default: `JSONEncoder()`)
+  ///   - method: The HTTP method to use. Defaults to POST when `nil`.
+  ///   - headers: Additional headers to include in the request.
+  ///   - region: The region to invoke the function in.
+  ///   - body: The body to encode and send.
+  ///   - encoder: The JSON encoder used when `body` is encoded as JSON.
   public init(
     method: Method? = nil,
     headers: [String: String] = [:],
@@ -159,12 +178,11 @@ extension FunctionInvokeOptions {
     )
   }
 
-  /// Initializes the `FunctionInvokeOptions` structure.
-  ///
+  /// Creates options for a function invocation with no body and a typed region.
   /// - Parameters:
-  ///   - method: Method to use in the function invocation.
-  ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
-  ///   - region: The Region to invoke the function in.
+  ///   - method: The HTTP method to use. Defaults to POST when `nil`.
+  ///   - headers: Additional headers to include in the request.
+  ///   - region: The region to invoke the function in.
   public init(
     method: Method? = nil,
     headers: [String: String] = [:],

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -7,7 +7,46 @@ import IssueReporting
   import FoundationNetworking
 #endif
 
-/// Supabase Client.
+/// The unified client for all Supabase services.
+///
+/// Create one instance per Supabase project and share it across your app.
+///
+/// ```swift
+/// let supabase = SupabaseClient(
+///   supabaseURL: URL(string: "https://your-project.supabase.co")!,
+///   supabaseKey: "your-anon-key"
+/// )
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating a Client
+/// - ``init(supabaseURL:supabaseKey:)``
+/// - ``init(supabaseURL:supabaseKey:options:)``
+///
+/// ### Supabase Services
+/// - ``auth``
+/// - ``storage``
+/// - ``functions``
+/// - ``realtimeV2``
+///
+/// ### Querying the Database
+/// - ``from(_:)``
+/// - ``rpc(_:params:count:)``
+/// - ``rpc(_:count:)``
+/// - ``schema(_:)``
+///
+/// ### Realtime Channels
+/// - ``channels``
+/// - ``channel(_:options:)``
+/// - ``removeChannel(_:)``
+/// - ``removeAllChannels()``
+///
+/// ### Deep Links
+/// - ``handle(_:)``
+///
+/// ### Configuration
+/// - ``headers``
 public final class SupabaseClient: Sendable {
   let options: SupabaseClientOptions
   let supabaseURL: URL
@@ -18,7 +57,14 @@ public final class SupabaseClient: Sendable {
 
   private let _auth: AuthClient
 
-  /// Supabase Auth allows you to create and manage user sessions for access to data that is secured by access policies.
+  /// The Auth client for managing user sessions and authentication.
+  ///
+  /// Use this property to sign users in and out, retrieve the current session,
+  /// and listen for authentication state changes.
+  ///
+  /// > Warning: Do not access this property when ``SupabaseClientOptions/AuthOptions/accessToken``
+  /// > is configured — the client will emit a runtime issue. Use a separate ``SupabaseClient``
+  /// > without `accessToken` if you need both Supabase Auth and a third-party auth provider.
   public var auth: AuthClient {
     if options.auth.accessToken != nil {
       reportIssue(
@@ -49,7 +95,7 @@ public final class SupabaseClient: Sendable {
     }
   }
 
-  /// Supabase Storage allows you to manage user-generated content, such as photos or videos.
+  /// The Storage client for uploading, downloading, and managing files.
   public var storage: SupabaseStorageClient {
     mutableState.withValue {
       if $0.storage == nil {
@@ -70,7 +116,7 @@ public final class SupabaseClient: Sendable {
 
   let _realtime: UncheckedSendable<RealtimeClient>
 
-  /// Realtime client for Supabase
+  /// The Realtime client for subscribing to database changes and broadcasting presence events.
   public var realtimeV2: RealtimeClientV2 {
     mutableState.withValue {
       if $0.realtime == nil {
@@ -80,7 +126,7 @@ public final class SupabaseClient: Sendable {
     }
   }
 
-  /// Supabase Functions allows you to deploy and invoke edge functions.
+  /// The Functions client for invoking Supabase Edge Functions.
   public var functions: FunctionsClient {
     mutableState.withValue {
       if $0.functions == nil {
@@ -99,9 +145,10 @@ public final class SupabaseClient: Sendable {
   }
 
   let _headers: HTTPFields
-  /// Headers provided to the inner clients on initialization.
+  /// The HTTP headers included in every request made by sub-clients.
   ///
-  /// - Note: This collection is non-mutable, if you want to provide different headers, pass it in ``SupabaseClientOptions/GlobalOptions/headers``.
+  /// This dictionary is read-only. To supply custom headers, set
+  /// ``SupabaseClientOptions/GlobalOptions/headers`` when initializing the client.
   public var headers: [String: String] {
     _headers.dictionary
   }
@@ -123,10 +170,10 @@ public final class SupabaseClient: Sendable {
   }
 
   #if !os(Linux) && !os(Android)
-    /// Create a new client.
+    /// Creates a client with default options.
     /// - Parameters:
-    ///   - supabaseURL: The unique Supabase URL which is supplied when you create a new project in your project dashboard.
-    ///   - supabaseKey: The unique Supabase Key which is supplied when you create a new project in your project dashboard.
+    ///   - supabaseURL: Your Supabase project URL, found in the project dashboard.
+    ///   - supabaseKey: Your Supabase project anon key, found in the project dashboard.
     public convenience init(supabaseURL: URL, supabaseKey: String) {
       self.init(
         supabaseURL: supabaseURL,
@@ -136,11 +183,11 @@ public final class SupabaseClient: Sendable {
     }
   #endif
 
-  /// Create a new client.
+  /// Creates a client with custom options.
   /// - Parameters:
-  ///   - supabaseURL: The unique Supabase URL which is supplied when you create a new project in your project dashboard.
-  ///   - supabaseKey: The unique Supabase Key which is supplied when you create a new project in your project dashboard.
-  ///   - options: Custom options to configure client's behavior.
+  ///   - supabaseURL: Your Supabase project URL, found in the project dashboard.
+  ///   - supabaseKey: Your Supabase project anon key, found in the project dashboard.
+  ///   - options: Configuration options for the client and its sub-clients.
   public init(
     supabaseURL: URL,
     supabaseKey: String,
@@ -208,21 +255,20 @@ public final class SupabaseClient: Sendable {
     }
   }
 
-  /// Performs a query on a table or a view.
-  /// - Parameter table: The table or view name to query.
-  /// - Returns: A PostgrestQueryBuilder instance.
+  /// Creates a query builder targeting a table or view.
+  /// - Parameter table: The name of the table or view to query.
+  /// - Returns: A query builder for constructing and executing the query.
   public func from(_ table: String) -> PostgrestQueryBuilder {
     rest.from(table)
   }
 
-  /// Performs a function call.
+  /// Calls a Postgres function.
   /// - Parameters:
-  ///   - fn: The function name to call.
-  ///   - params: The parameters to pass to the function call.
-  ///   - count: Count algorithm to use to count rows returned by the function.
-  ///             Only applicable for set-returning functions.
-  /// - Returns: A PostgrestFilterBuilder instance.
-  /// - Throws: An error if the function call fails.
+  ///   - fn: The name of the function to call.
+  ///   - params: The parameters to pass to the function.
+  ///   - count: The count algorithm to apply to rows returned by set-returning functions.
+  /// - Returns: A filter builder for further narrowing the result set.
+  /// - Throws: If encoding `params` fails or the function call returns an error.
   public func rpc(
     _ fn: String,
     params: some Encodable,
@@ -231,13 +277,12 @@ public final class SupabaseClient: Sendable {
     try rest.rpc(fn, params: params, count: count)
   }
 
-  /// Performs a function call.
+  /// Calls a Postgres function with no parameters.
   /// - Parameters:
-  ///   - fn: The function name to call.
-  ///   - count: Count algorithm to use to count rows returned by the function.
-  ///            Only applicable for set-returning functions.
-  /// - Returns: A PostgrestFilterBuilder instance.
-  /// - Throws: An error if the function call fails.
+  ///   - fn: The name of the function to call.
+  ///   - count: The count algorithm to apply to rows returned by set-returning functions.
+  /// - Returns: A filter builder for further narrowing the result set.
+  /// - Throws: If the function call returns an error.
   public func rpc(
     _ fn: String,
     count: CountOption? = nil
@@ -245,23 +290,25 @@ public final class SupabaseClient: Sendable {
     try rest.rpc(fn, count: count)
   }
 
-  /// Select a schema to query or perform an function (rpc) call.
+  /// Returns a database client scoped to the given Postgres schema.
   ///
-  /// The schema needs to be on the list of exposed schemas inside Supabase.
+  /// The schema must be on the list of exposed schemas in your Supabase project dashboard.
   /// - Parameter schema: The schema to query.
+  /// - Returns: A ``PostgrestClient`` configured for the given schema.
   public func schema(_ schema: String) -> PostgrestClient {
     rest.schema(schema)
   }
 
-  /// Returns all Realtime channels.
+  /// All active Realtime channels.
   public var channels: [RealtimeChannelV2] {
     Array(realtimeV2.subscriptions.values)
   }
 
-  /// Creates a Realtime channel with Broadcast, Presence, and Postgres Changes.
+  /// Creates a Realtime channel with support for Broadcast, Presence, and Postgres Changes.
   /// - Parameters:
-  ///   - name: The name of the Realtime channel.
-  ///   - options: The options to pass to the Realtime channel.
+  ///   - name: A unique name for the channel.
+  ///   - options: A closure to configure broadcast, presence, and Postgres change options.
+  /// - Returns: A configured ``RealtimeChannelV2`` ready to subscribe.
   public func channel(
     _ name: String,
     options: @Sendable (inout RealtimeChannelConfig) -> Void = { _ in }
@@ -269,18 +316,21 @@ public final class SupabaseClient: Sendable {
     realtimeV2.channel(name, options: options)
   }
 
-  /// Unsubscribes and removes Realtime channel from Realtime client.
-  /// - Parameter channel: The Realtime channel to remove.
+  /// Unsubscribes from and removes a Realtime channel.
+  /// - Parameter channel: The channel to remove.
   public func removeChannel(_ channel: RealtimeChannelV2) async {
     await realtimeV2.removeChannel(channel)
   }
 
-  /// Unsubscribes and removes all Realtime channels from Realtime client.
+  /// Unsubscribes from and removes all active Realtime channels.
   public func removeAllChannels() async {
     await realtimeV2.removeAllChannels()
   }
 
-  /// Handles an incoming URL received by the app.
+  /// Passes an incoming URL to the Auth client for processing deep links and OAuth callbacks.
+  ///
+  /// Call this from your app's URL-handling entry points so Auth can complete OAuth and
+  /// magic-link flows.
   ///
   /// ## Usage example:
   ///

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -4,14 +4,25 @@ import Foundation
   import FoundationNetworking
 #endif
 
+/// Configuration options for customizing ``SupabaseClient`` behaviour.
+///
+/// Pass an instance of this struct to ``SupabaseClient/init(supabaseURL:supabaseKey:options:)``
+/// to override defaults for any sub-client.
 public struct SupabaseClientOptions: Sendable {
+  /// Options for the database (PostgREST) sub-client.
   public let db: DatabaseOptions
+  /// Options for the Auth sub-client.
   public let auth: AuthOptions
+  /// Options shared across all sub-clients.
   public let global: GlobalOptions
+  /// Options for the Edge Functions sub-client.
   public let functions: FunctionsOptions
+  /// Options for the Realtime sub-client.
   public let realtime: RealtimeClientOptions
+  /// Options for the Storage sub-client.
   public let storage: StorageOptions
 
+  /// Options for the database (PostgREST) sub-client.
   public struct DatabaseOptions: Sendable {
     /// The Postgres schema which your tables belong to. Must be on the list of exposed schemas in
     /// Supabase.
@@ -34,6 +45,7 @@ public struct SupabaseClientOptions: Sendable {
     }
   }
 
+  /// Options for the Auth sub-client.
   public struct AuthOptions: Sendable {
     /// A storage provider. Used to store the logged-in session.
     public let storage: any AuthLocalStorage
@@ -93,6 +105,7 @@ public struct SupabaseClientOptions: Sendable {
     }
   }
 
+  /// Options shared across all Supabase sub-clients.
   public struct GlobalOptions: Sendable {
     /// Optional headers for initializing the client, it will be passed down to all sub-clients.
     public let headers: [String: String]
@@ -114,6 +127,7 @@ public struct SupabaseClientOptions: Sendable {
     }
   }
 
+  /// Options for the Edge Functions sub-client.
   public struct FunctionsOptions: Sendable {
     /// The Region to invoke the functions in.
     public let region: String?
@@ -138,6 +152,7 @@ public struct SupabaseClientOptions: Sendable {
     }
   }
 
+  /// Options for the Storage sub-client.
   public struct StorageOptions: Sendable {
     /// Whether storage client should be initialized with the new hostname format, i.e. `project-ref.storage.supabase.co`
     public let useNewHostname: Bool
@@ -147,6 +162,14 @@ public struct SupabaseClientOptions: Sendable {
     }
   }
 
+  /// Creates a configuration with the given options.
+  /// - Parameters:
+  ///   - db: Options for the database (PostgREST) sub-client.
+  ///   - auth: Options for the Auth sub-client.
+  ///   - global: Options shared across all sub-clients.
+  ///   - functions: Options for the Edge Functions sub-client.
+  ///   - realtime: Options for the Realtime sub-client.
+  ///   - storage: Options for the Storage sub-client.
   public init(
     db: DatabaseOptions = .init(),
     auth: AuthOptions,


### PR DESCRIPTION
## Summary

- **`FunctionsClient`** — replaces the incorrect "actor" description with a proper abstract, adds a usage code example, and adds a `## Topics` hierarchy (Creating a Client / Invoking Functions / Configuration)
- **`FetchHandler`** — improves typealias doc
- **`requestIdleTimeout`** — removes the bare URL in favour of inline prose
- **`invoke` overloads** — each overload now has a distinct abstract and a `- Throws:` entry referencing `FunctionsError`
- **`_invokeWithStreamedResponse`** — converts bare Warning/Note to DocC callout directives
- **`setAuth(token:)`** — clarifies that passing `nil` removes the header
- **`FunctionRegion`** — adds struct doc and geographic descriptions for all 14 cases
- **`FunctionInvokeOptions.Method`** — adds enum doc and abstracts for all 5 cases
- All `init` docs rewritten for consistency (removes "(Default: ...)" style)

## Test plan

- [ ] `make test-docs` passes with no warnings
- [ ] Xcode Quick Help on `FunctionsClient` shows the Topics hierarchy