### PR TITLE
docs(postgrest): add DocC documentation to PostgREST public API

### DIFF
--- a/Sources/PostgREST/Defaults.swift
+++ b/Sources/PostgREST/Defaults.swift
@@ -11,17 +11,25 @@ import Foundation
 let version = Helpers.version
 
 extension PostgrestClient.Configuration {
-  /// The default `JSONDecoder` instance for ``PostgrestClient`` responses.
+  /// The default `JSONDecoder` used for decoding PostgREST responses.
+  ///
+  /// Pre-configured with Supabase-compatible date decoding and key strategies.
+  /// Use this as a starting point if you need a custom decoder.
   public static let jsonDecoder: JSONDecoder = {
     JSONDecoder.supabase()
   }()
 
-  /// The default `JSONEncoder` instance for ``PostgrestClient`` requests.
+  /// The default `JSONEncoder` used for encoding PostgREST request bodies.
+  ///
+  /// Pre-configured with Supabase-compatible date encoding and key strategies.
+  /// Use this as a starting point if you need a custom encoder.
   public static let jsonEncoder: JSONEncoder = {
     JSONEncoder.supabase()
   }()
 
-  /// The default headers for ``PostgrestClient`` requests.
+  /// The default HTTP headers added to every request from a ``PostgrestClient``.
+  ///
+  /// Includes an `X-Client-Info` header that identifies the SDK name and version.
   public static let defaultHeaders: [String: String] = [
     "X-Client-Info": "postgrest-swift/\(version)"
   ]

--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -6,13 +6,33 @@ import HTTPTypes
   import FoundationNetworking
 #endif
 
-/// The builder class for creating and executing requests to a PostgREST server.
+/// The base builder class for all PostgREST requests.
 ///
-/// - Note: Thread Safety: This class is `@unchecked Sendable` because all mutable state
-///   is protected by `LockIsolated`. Access to `mutableState` is always through `withValue`.
+/// ``PostgrestBuilder`` holds the shared HTTP request state and provides the ``execute(options:)-96tpd``
+/// methods that send the request to the PostgREST server. You typically interact with one of its
+/// subclasses — ``PostgrestQueryBuilder``, ``PostgrestFilterBuilder``, or
+/// ``PostgrestTransformBuilder`` — rather than instantiating ``PostgrestBuilder`` directly.
 ///
-/// - Important: While this class is `Sendable`, individual builder instances should not be
-///   modified concurrently from multiple tasks. Create separate builder chains for concurrent operations.
+/// > Note: Thread Safety: This class is `@unchecked Sendable` because all mutable state
+/// > is protected by `LockIsolated`. Access to `mutableState` is always through its `withValue` API.
+///
+/// > Important: While this class is `Sendable`, individual builder instances should not be
+/// > modified concurrently from multiple tasks. Create separate builder chains for concurrent operations.
+///
+/// ## Topics
+///
+/// ### Setting Headers
+///
+/// - ``setHeader(name:value:)``
+///
+/// ### Configuring Retries
+///
+/// - ``retry(enabled:)``
+///
+/// ### Executing the Request
+///
+/// - ``execute(options:)-96tpd``
+/// - ``execute(options:)-6mk2u``
 public class PostgrestBuilder: @unchecked Sendable {
   /// The configuration for the PostgREST client.
   let configuration: PostgrestClient.Configuration
@@ -59,7 +79,15 @@ public class PostgrestBuilder: @unchecked Sendable {
     mutableState.withValue { $0.retryEnabled = other.mutableState.value.retryEnabled }
   }
 
-  /// Set a HTTP header for the request.
+  /// Adds or replaces a custom HTTP header on the request.
+  ///
+  /// Use this method to attach arbitrary headers — for example, to pass custom PostgREST
+  /// `Prefer` values or to forward user-supplied metadata.
+  ///
+  /// - Parameters:
+  ///   - name: The header field name.
+  ///   - value: The header field value.
+  /// - Returns: The same builder instance so calls can be chained.
   @discardableResult
   public func setHeader(name: String, value: String) -> Self {
     return self.setHeader(name: .init(name)!, value: value)
@@ -74,21 +102,30 @@ public class PostgrestBuilder: @unchecked Sendable {
     return self
   }
 
-  /// Controls whether automatic retries are enabled for this request.
+  /// Controls whether automatic retries are enabled for this specific request.
   ///
-  /// When enabled, the request will be retried up to 3 times with exponential backoff on
-  /// transient errors (HTTP 503, 520, network errors) for idempotent methods (GET, HEAD).
+  /// When enabled, GET and HEAD requests that receive an HTTP 503 or 520 response, or encounter a
+  /// network error, are retried up to three times with exponential back-off. The global default is
+  /// set via ``PostgrestClient/Configuration/retryEnabled``; this method overrides it per request.
+  ///
   /// - Parameter enabled: Pass `false` to disable retries for this request.
+  /// - Returns: The same builder instance so calls can be chained.
   @discardableResult
   public func retry(enabled: Bool) -> Self {
     mutableState.withValue { $0.retryEnabled = enabled }
     return self
   }
 
-  /// Executes the request and returns a response of type Void.
-  /// - Parameters:
-  ///   - options: Options for querying Supabase.
-  /// - Returns: A `PostgrestResponse<Void>` instance representing the response.
+  /// Executes the request and discards the response body.
+  ///
+  /// Use this overload for mutations (INSERT, UPDATE, DELETE) when you do not need the
+  /// affected rows, or when you have already called ``PostgrestTransformBuilder/csv()`` or
+  /// a similar method that changes the response format.
+  ///
+  /// - Parameter options: Options controlling whether to include a row count and whether to
+  ///   use the HEAD method. Defaults to ``FetchOptions/init(head:count:)``.
+  /// - Returns: A ``PostgrestResponse`` whose `value` is `Void`.
+  /// - Throws: ``PostgrestError`` if PostgREST returns an error response, or any error thrown by the fetch handler.
   @discardableResult
   public func execute(
     options: FetchOptions = FetchOptions()
@@ -96,10 +133,21 @@ public class PostgrestBuilder: @unchecked Sendable {
     try await execute(options: options) { _ in () }
   }
 
-  /// Executes the request and returns a response of the specified type.
-  /// - Parameters:
-  ///   - options: Options for querying Supabase.
-  /// - Returns: A `PostgrestResponse<T>` instance representing the response.
+  /// Executes the request and decodes the response body into the inferred type.
+  ///
+  /// ```swift
+  /// let todos: [Todo] = try await client
+  ///   .from("todos")
+  ///   .select()
+  ///   .execute()
+  ///   .value
+  /// ```
+  ///
+  /// - Parameter options: Options controlling whether to include a row count and whether to
+  ///   use the HEAD method. Defaults to ``FetchOptions/init(head:count:)``.
+  /// - Returns: A ``PostgrestResponse`` whose `value` is the decoded `T`.
+  /// - Throws: ``PostgrestError`` if PostgREST returns an error response, a decoding error if the
+  ///   response body cannot be decoded as `T`, or any error thrown by the fetch handler.
   @discardableResult
   public func execute<T: Decodable>(
     options: FetchOptions = FetchOptions()

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -6,36 +6,137 @@ import HTTPTypes
   import FoundationNetworking
 #endif
 
-/// PostgREST client.
+/// The main entry point for interacting with a PostgREST server.
+///
+/// ``PostgrestClient`` lets you query and mutate data exposed by PostgREST. Start by calling
+/// ``from(_:)`` to target a table or view, or ``rpc(_:params:head:get:count:)`` to invoke a
+/// stored function.
+///
+/// ```swift
+/// let client = PostgrestClient(
+///   url: URL(string: "https://<project>.supabase.co/rest/v1")!,
+///   headers: ["apikey": "<anon-key>"]
+/// )
+///
+/// // SELECT * FROM todos
+/// let todos: [Todo] = try await client
+///   .from("todos")
+///   .select()
+///   .execute()
+///   .value
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating a Client
+///
+/// - ``init(configuration:)``
+/// - ``init(url:schema:headers:logger:fetch:encoder:decoder:retryEnabled:)``
+/// - ``Configuration``
+/// - ``FetchHandler``
+///
+/// ### Querying and Mutating Data
+///
+/// - ``from(_:)``
+/// - ``rpc(_:params:head:get:count:)``
+/// - ``rpc(_:head:get:count:)``
+///
+/// ### Managing Authentication
+///
+/// - ``setAuth(_:)``
+///
+/// ### Switching the Schema
+///
+/// - ``schema(_:)``
+///
+/// ### Inspecting Configuration
+///
+/// - ``configuration``
 public final class PostgrestClient: Sendable {
+  /// A closure that performs an HTTP request and returns the raw response data and metadata.
+  ///
+  /// Provide a custom ``FetchHandler`` through ``Configuration`` when you need to intercept,
+  /// mock, or otherwise customise the HTTP transport layer. The default implementation uses
+  /// `URLSession.shared`.
   public typealias FetchHandler =
     @Sendable (_ request: URLRequest) async throws -> (
       Data, URLResponse
     )
 
-  /// The configuration struct for the PostgREST client.
+  /// Configuration options for a ``PostgrestClient`` instance.
+  ///
+  /// Create a ``Configuration`` value and pass it to ``PostgrestClient/init(configuration:)`` when
+  /// you need fine-grained control over the client, such as supplying a custom ``FetchHandler`` or
+  /// ``JSONEncoder``/``JSONDecoder``.
+  ///
+  /// ## Topics
+  ///
+  /// ### Creating Configuration
+  ///
+  /// - ``init(url:schema:headers:logger:fetch:encoder:decoder:retryEnabled:)``
+  ///
+  /// ### Configuration Properties
+  ///
+  /// - ``url``
+  /// - ``schema``
+  /// - ``headers``
+  /// - ``fetch``
+  /// - ``encoder``
+  /// - ``decoder``
+  /// - ``retryEnabled``
+  ///
+  /// ### Defaults
+  ///
+  /// - ``jsonEncoder``
+  /// - ``jsonDecoder``
+  /// - ``defaultHeaders``
   public struct Configuration: Sendable {
+    /// The base URL of the PostgREST endpoint.
     public var url: URL
+
+    /// The PostgreSQL schema to query, or `nil` to use the PostgREST default (`public`).
     public var schema: String?
+
+    /// Additional HTTP headers sent with every request.
     public var headers: [String: String]
+
+    /// The closure used to perform HTTP requests.
+    ///
+    /// Defaults to `URLSession.shared.data(for:)`. Supply a custom handler for
+    /// testing or when you need to add authentication, logging, or other middleware.
     public var fetch: FetchHandler
+
+    /// The `JSONEncoder` used to serialise request bodies.
+    ///
+    /// Defaults to ``jsonEncoder``, which is pre-configured with Supabase-compatible settings.
     public var encoder: JSONEncoder
+
+    /// The `JSONDecoder` used to deserialise response bodies.
+    ///
+    /// Defaults to ``jsonDecoder``, which is pre-configured with Supabase-compatible settings.
     public var decoder: JSONDecoder
-    /// Whether automatic retries are enabled for transient errors. Defaults to `true`.
+
+    /// Whether the client should automatically retry transient errors.
+    ///
+    /// When `true` (the default), GET and HEAD requests that receive an HTTP 503 or 520
+    /// response, or encounter a network error, are retried up to three times with
+    /// exponential back-off. Set to `false` to disable retries globally; individual
+    /// requests can also override this via ``PostgrestBuilder/retry(enabled:)``.
     public var retryEnabled: Bool
 
     let logger: (any SupabaseLogger)?
 
-    /// Creates a PostgREST client.
+    /// Creates a new ``Configuration``.
+    ///
     /// - Parameters:
-    ///   - url: URL of the PostgREST endpoint.
-    ///   - schema: Postgres schema to switch to.
-    ///   - headers: Custom headers.
-    ///   - logger: The logger to use.
-    ///   - fetch: Custom fetch.
-    ///   - encoder: The JSONEncoder to use for encoding.
-    ///   - decoder: The JSONDecoder to use for decoding.
-    ///   - retryEnabled: Whether to automatically retry on transient errors (HTTP 503, 520, network errors). Defaults to `true`.
+    ///   - url: The base URL of the PostgREST endpoint.
+    ///   - schema: The PostgreSQL schema to use. Defaults to `nil` (PostgREST default).
+    ///   - headers: Additional HTTP headers sent with every request.
+    ///   - logger: A logger for diagnostic output. Defaults to `nil`.
+    ///   - fetch: The HTTP transport closure. Defaults to `URLSession.shared.data(for:)`.
+    ///   - encoder: The `JSONEncoder` used for request bodies. Defaults to ``jsonEncoder``.
+    ///   - decoder: The `JSONDecoder` used for response bodies. Defaults to ``jsonDecoder``.
+    ///   - retryEnabled: Whether to retry transient errors. Defaults to `true`.
     public init(
       url: URL,
       schema: String? = nil,
@@ -58,10 +159,17 @@ public final class PostgrestClient: Sendable {
   }
 
   private let _configuration: LockIsolated<Configuration>
+
+  /// The current configuration of this client.
+  ///
+  /// The configuration may change at runtime — for example, when ``setAuth(_:)`` updates the
+  /// `Authorization` header. Always read this property rather than caching a copy if you need
+  /// the most up-to-date values.
   public var configuration: Configuration { _configuration.value }
 
-  /// Creates a PostgREST client with the specified configuration.
-  /// - Parameter configuration: The configuration for the client.
+  /// Creates a ``PostgrestClient`` from an existing ``Configuration``.
+  ///
+  /// - Parameter configuration: The configuration to use.
   public init(configuration: Configuration) {
     _configuration = LockIsolated(configuration)
     _configuration.withValue {
@@ -69,16 +177,20 @@ public final class PostgrestClient: Sendable {
     }
   }
 
-  /// Creates a PostgREST client with the specified parameters.
+  /// Creates a ``PostgrestClient`` with individual configuration parameters.
+  ///
+  /// This is a convenience initialiser that constructs a ``Configuration`` internally.
+  /// Use ``init(configuration:)`` when you need to share or reuse a configuration value.
+  ///
   /// - Parameters:
-  ///   - url: URL of the PostgREST endpoint.
-  ///   - schema: Postgres schema to switch to.
-  ///   - headers: Custom headers.
-  ///   - logger: The logger to use.
-  ///   - fetch: Custom fetch.
-  ///   - encoder: The JSONEncoder to use for encoding.
-  ///   - decoder: The JSONDecoder to use for decoding.
-  ///   - retryEnabled: Whether to automatically retry on transient errors (HTTP 503, 520, network errors). Defaults to `true`.
+  ///   - url: The base URL of the PostgREST endpoint.
+  ///   - schema: The PostgreSQL schema to use. Defaults to `nil` (PostgREST default).
+  ///   - headers: Additional HTTP headers sent with every request.
+  ///   - logger: A logger for diagnostic output. Defaults to `nil`.
+  ///   - fetch: The HTTP transport closure. Defaults to `URLSession.shared.data(for:)`.
+  ///   - encoder: The `JSONEncoder` used for request bodies. Defaults to ``Configuration/jsonEncoder``.
+  ///   - decoder: The `JSONDecoder` used for response bodies. Defaults to ``Configuration/jsonDecoder``.
+  ///   - retryEnabled: Whether to retry transient errors. Defaults to `true`.
   public convenience init(
     url: URL,
     schema: String? = nil,
@@ -103,9 +215,13 @@ public final class PostgrestClient: Sendable {
     )
   }
 
-  /// Sets the authorization token for the client.
-  /// - Parameter token: The authorization token.
-  /// - Returns: The PostgrestClient instance.
+  /// Sets or clears the JWT used for row-level security.
+  ///
+  /// When `token` is non-`nil`, the client adds an `Authorization: Bearer <token>` header to all
+  /// subsequent requests. Passing `nil` removes the header.
+  ///
+  /// - Parameter token: A JWT string, or `nil` to remove the authorization header.
+  /// - Returns: The same ``PostgrestClient`` instance so calls can be chained.
   @discardableResult
   public func setAuth(_ token: String?) -> PostgrestClient {
     if let token {
@@ -116,8 +232,16 @@ public final class PostgrestClient: Sendable {
     return self
   }
 
-  /// Perform a query on a table or a view.
-  /// - Parameter table: The table or view name to query.
+  /// Returns a query builder targeting the specified table or view.
+  ///
+  /// Call ``PostgrestQueryBuilder/select(_:head:count:)`` on the returned builder to begin a
+  /// `SELECT`, or use ``PostgrestQueryBuilder/insert(_:returning:count:)``,
+  /// ``PostgrestQueryBuilder/update(_:returning:count:)``,
+  /// ``PostgrestQueryBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``, or
+  /// ``PostgrestQueryBuilder/delete(returning:count:)`` for write operations.
+  ///
+  /// - Parameter table: The name of the table or view to query.
+  /// - Returns: A ``PostgrestQueryBuilder`` for the specified table or view.
   public func from(_ table: String) -> PostgrestQueryBuilder {
     PostgrestQueryBuilder(
       configuration: configuration,
@@ -129,13 +253,24 @@ public final class PostgrestClient: Sendable {
     )
   }
 
-  /// Perform a function call.
+  /// Calls a PostgreSQL stored function (RPC) with parameters.
+  ///
+  /// ```swift
+  /// // Call a function that accepts a parameter
+  /// let result: [String] = try await client
+  ///   .rpc("search_todos", params: ["keyword": "groceries"])
+  ///   .execute()
+  ///   .value
+  /// ```
+  ///
   /// - Parameters:
-  ///   - fn: The function name to call.
-  ///   - params: The parameters to pass to the function call.
-  ///   - head: When set to `true`, `data`, will not be returned. Useful if you only need the count.
-  ///   - get: When set to `true`, the function will be called with read-only access mode.
-  ///   - count: Count algorithm to use to count rows returned by the function. Only applicable for [set-returning functions](https://www.postgresql.org/docs/current/functions-srf.html).
+  ///   - fn: The name of the function to invoke.
+  ///   - params: An `Encodable` value whose properties are passed as function arguments.
+  ///   - head: When `true`, the response body is omitted (HEAD request). Useful for retrieving only the count.
+  ///   - get: When `true`, parameters are sent as query string items and the function runs in read-only mode.
+  ///   - count: The row-count algorithm to use for [set-returning functions](https://www.postgresql.org/docs/current/functions-srf.html), or `nil` to skip counting.
+  /// - Returns: A ``PostgrestFilterBuilder`` that you can further filter or execute.
+  /// - Throws: ``PostgrestError`` if `params` cannot be serialised to a key-value JSON object when using `head` or `get`.
   public func rpc(
     _ fn: String,
     params: some Encodable,
@@ -184,12 +319,24 @@ public final class PostgrestClient: Sendable {
     )
   }
 
-  /// Perform a function call.
+  /// Calls a PostgreSQL stored function (RPC) with no parameters.
+  ///
+  /// Use this overload when the function takes no arguments.
+  ///
+  /// ```swift
+  /// let count: Int = try await client
+  ///   .rpc("active_user_count")
+  ///   .execute()
+  ///   .value
+  /// ```
+  ///
   /// - Parameters:
-  ///   - fn: The function name to call.
-  ///   - head: When set to `true`, `data`, will not be returned. Useful if you only need the count.
-  ///   - get: When set to `true`, the function will be called with read-only access mode.
-  ///   - count: Count algorithm to use to count rows returned by the function. Only applicable for [set-returning functions](https://www.postgresql.org/docs/current/functions-srf.html).
+  ///   - fn: The name of the function to invoke.
+  ///   - head: When `true`, the response body is omitted (HEAD request). Useful for retrieving only the count.
+  ///   - get: When `true`, the function runs in read-only mode.
+  ///   - count: The row-count algorithm to use for [set-returning functions](https://www.postgresql.org/docs/current/functions-srf.html), or `nil` to skip counting.
+  /// - Returns: A ``PostgrestFilterBuilder`` that you can further filter or execute.
+  /// - Throws: ``PostgrestError`` if the request cannot be constructed.
   public func rpc(
     _ fn: String,
     head: Bool = false,
@@ -199,10 +346,18 @@ public final class PostgrestClient: Sendable {
     try rpc(fn, params: NoParams(), head: head, get: get, count: count)
   }
 
-  /// Select a schema to query or perform an function (rpc) call.
+  /// Returns a new client that queries the specified PostgreSQL schema.
   ///
-  /// The schema needs to be on the list of exposed schemas inside Supabase.
-  /// - Parameter schema: The schema to query.
+  /// The schema must be listed in the PostgREST `db-schemas` configuration. Calling this method
+  /// does not mutate the receiver; it returns a fresh ``PostgrestClient`` with the schema applied.
+  ///
+  /// ```swift
+  /// let privateClient = client.schema("private")
+  /// let rows = try await privateClient.from("secrets").select().execute().value
+  /// ```
+  ///
+  /// - Parameter schema: The PostgreSQL schema name.
+  /// - Returns: A new ``PostgrestClient`` configured to use the given schema.
   public func schema(_ schema: String) -> PostgrestClient {
     var configuration = configuration
     configuration.schema = schema

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -56,7 +56,7 @@ public final class PostgrestClient: Sendable {
   /// A closure that performs an HTTP request and returns the raw response data and metadata.
   ///
   /// Provide a custom ``FetchHandler`` through ``Configuration`` when you need to intercept,
-  /// mock, or otherwise customise the HTTP transport layer. The default implementation uses
+  /// mock, or otherwise customize the HTTP transport layer. The default implementation uses
   /// `URLSession.shared`.
   public typealias FetchHandler =
     @Sendable (_ request: URLRequest) async throws -> (
@@ -106,12 +106,12 @@ public final class PostgrestClient: Sendable {
     /// testing or when you need to add authentication, logging, or other middleware.
     public var fetch: FetchHandler
 
-    /// The `JSONEncoder` used to serialise request bodies.
+    /// The `JSONEncoder` used to serialize request bodies.
     ///
     /// Defaults to ``jsonEncoder``, which is pre-configured with Supabase-compatible settings.
     public var encoder: JSONEncoder
 
-    /// The `JSONDecoder` used to deserialise response bodies.
+    /// The `JSONDecoder` used to deserialize response bodies.
     ///
     /// Defaults to ``jsonDecoder``, which is pre-configured with Supabase-compatible settings.
     public var decoder: JSONDecoder
@@ -179,7 +179,7 @@ public final class PostgrestClient: Sendable {
 
   /// Creates a ``PostgrestClient`` with individual configuration parameters.
   ///
-  /// This is a convenience initialiser that constructs a ``Configuration`` internally.
+  /// This is a convenience initializer that constructs a ``Configuration`` internally.
   /// Use ``init(configuration:)`` when you need to share or reuse a configuration value.
   ///
   /// - Parameters:
@@ -270,7 +270,7 @@ public final class PostgrestClient: Sendable {
   ///   - get: When `true`, parameters are sent as query string items and the function runs in read-only mode.
   ///   - count: The row-count algorithm to use for [set-returning functions](https://www.postgresql.org/docs/current/functions-srf.html), or `nil` to skip counting.
   /// - Returns: A ``PostgrestFilterBuilder`` that you can further filter or execute.
-  /// - Throws: ``PostgrestError`` if `params` cannot be serialised to a key-value JSON object when using `head` or `get`.
+  /// - Throws: ``PostgrestError`` if `params` cannot be serialized to a key-value JSON object when using `head` or `get`.
   public func rpc(
     _ fn: String,
     params: some Encodable,

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -804,7 +804,7 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// .textSearch("content", query: "swift programming")
   ///
   /// // Web-search syntax with a specific language configuration
-  /// .textSearch("content", query: "swift OR kotlin", config: "english", type: .websearch)
+  /// .textSearch("content", query: "swift OR ios", config: "english", type: .websearch)
   /// ```
   ///
   /// - Parameters:
@@ -859,7 +859,7 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// This is an escape hatch for filters not covered by the typed convenience methods. The
   /// `operator` and `value` strings are sent to PostgREST as-is and must follow
   /// [PostgREST syntax](https://postgrest.org/en/stable/api.html#operators). You are responsible
-  /// for sanitising user-supplied values to prevent injection.
+  /// for sanitizing user-supplied values to prevent injection.
   ///
   /// ```swift
   /// // Equivalent to .eq("status", value: "active")

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -202,7 +202,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
 
   /// Matches only rows where `column` equals `value`.
   ///
-  /// To test for NULL, use ``is(_:value:)`` instead, because `NULL = NULL` is false in SQL.
+  /// To test for NULL, use ``is(_:value:)`` instead — `NULL = NULL` is false in SQL.
+  ///
+  /// ```swift
+  /// // Rows where status equals "active"
+  /// .eq("status", value: "active")
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The column to filter on.
@@ -221,6 +226,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
 
   /// Matches only rows where `column` is not equal to `value`.
   ///
+  /// ```swift
+  /// // Rows where status is not "inactive"
+  /// .neq("status", value: "inactive")
+  /// ```
+  ///
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
@@ -237,6 +247,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   }
 
   /// Matches only rows where `column` is greater than `value`.
+  ///
+  /// ```swift
+  /// // Rows where score is greater than 100
+  /// .gt("score", value: 100)
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The column to filter on.
@@ -255,6 +270,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
 
   /// Matches only rows where `column` is greater than or equal to `value`.
   ///
+  /// ```swift
+  /// // Rows where score is at least 100
+  /// .gte("score", value: 100)
+  /// ```
+  ///
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
@@ -272,6 +292,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
 
   /// Matches only rows where `column` is less than `value`.
   ///
+  /// ```swift
+  /// // Rows where age is under 18
+  /// .lt("age", value: 18)
+  /// ```
+  ///
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
@@ -288,6 +313,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   }
 
   /// Matches only rows where `column` is less than or equal to `value`.
+  ///
+  /// ```swift
+  /// // Rows where age is 18 or under
+  /// .lte("age", value: 18)
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The column to filter on.
@@ -330,6 +360,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
 
   /// Matches only rows where `column` matches **all** of the supplied LIKE `patterns` case-sensitively.
   ///
+  /// ```swift
+  /// // Rows where name starts with "J" and ends with "n"
+  /// .likeAllOf("name", patterns: ["J%", "%n"])
+  /// ```
+  ///
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - patterns: The LIKE patterns that must all match.
@@ -346,6 +381,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   }
 
   /// Matches only rows where `column` matches **any** of the supplied LIKE `patterns` case-sensitively.
+  ///
+  /// ```swift
+  /// // Rows where name starts with "Jo" or "Ma"
+  /// .likeAnyOf("name", patterns: ["Jo%", "Ma%"])
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The column to filter on.
@@ -388,6 +428,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
 
   /// Matches only rows where `column` matches **all** of the supplied ILIKE `patterns` case-insensitively.
   ///
+  /// ```swift
+  /// // Rows where name starts with "j" and ends with "n" (case-insensitive)
+  /// .iLikeAllOf("name", patterns: ["j%", "%n"])
+  /// ```
+  ///
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - patterns: The ILIKE patterns that must all match.
@@ -404,6 +449,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   }
 
   /// Matches only rows where `column` matches **any** of the supplied ILIKE `patterns` case-insensitively.
+  ///
+  /// ```swift
+  /// // Rows where name starts with "jo" or "ma" (case-insensitive)
+  /// .iLikeAnyOf("name", patterns: ["jo%", "ma%"])
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The column to filter on.
@@ -447,6 +497,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// Matches only rows where `column` matches the regular expression `pattern` case-insensitively.
   ///
   /// Uses PostgreSQL's `~*` operator. The pattern must be a valid POSIX regular expression.
+  ///
+  /// ```swift
+  /// // Rows where email ends with "@supabase.io" (case-insensitive)
+  /// .imatch("email", pattern: "@supabase\\.io$")
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The column to filter on.
@@ -495,6 +550,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///
   /// Unlike ``neq(_:value:)``, this operator treats `NULL` as a comparable value: `NULL IS DISTINCT
   /// FROM NULL` evaluates to `false`, whereas `NULL != NULL` evaluates to `true` (unknown).
+  ///
+  /// ```swift
+  /// // Rows where deleted_at IS DISTINCT FROM NULL (i.e. has a value)
+  /// .isDistinct("deleted_at", value: "null")
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The column to filter on.
@@ -568,6 +628,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///
   /// Applies the `<@` containment operator. Only relevant for `jsonb`, array, and range columns.
   ///
+  /// ```swift
+  /// // Rows where the tags array is a subset of ["swift", "ios", "macos"]
+  /// .containedBy("tags", value: ["swift", "ios", "macos"])
+  /// ```
+  ///
   /// - Parameters:
   ///   - column: The `jsonb`, array, or range column to filter on.
   ///   - value: The `jsonb`, array, or range value that must contain every element in `column`.
@@ -586,6 +651,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// Matches only rows where every element in `column` is strictly less than every element in `range`.
   ///
   /// Applies the `<<` (strictly left of) range operator. Only relevant for range columns.
+  ///
+  /// ```swift
+  /// // Rows where the scheduled range is entirely before [2024-01-01, 2024-06-01)
+  /// .rangeLt("scheduled", range: "[2024-01-01,2024-06-01)")
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The range column to filter on.
@@ -606,6 +676,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///
   /// Applies the `>>` (strictly right of) range operator. Only relevant for range columns.
   ///
+  /// ```swift
+  /// // Rows where the scheduled range is entirely after [2024-01-01, 2024-06-01)
+  /// .rangeGt("scheduled", range: "[2024-01-01,2024-06-01)")
+  /// ```
+  ///
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - range: The range value to compare against.
@@ -624,6 +699,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// Matches only rows where `column` does not extend to the left of `range`.
   ///
   /// Applies the `&>` (does not extend to left) range operator. Only relevant for range columns.
+  ///
+  /// ```swift
+  /// // Rows where the scheduled range does not extend before 2024-01-01
+  /// .rangeGte("scheduled", range: "[2024-01-01,)")
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The range column to filter on.
@@ -644,6 +724,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///
   /// Applies the `&<` (does not extend to right) range operator. Only relevant for range columns.
   ///
+  /// ```swift
+  /// // Rows where the scheduled range does not extend past 2024-12-31
+  /// .rangeLte("scheduled", range: "[,2024-12-31]")
+  /// ```
+  ///
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - range: The range value to compare against.
@@ -663,6 +748,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///
   /// Applies the `-|-` (adjacent to) range operator. There must be no element that lies between
   /// the two ranges. Only relevant for range columns.
+  ///
+  /// ```swift
+  /// // Rows where the scheduled range is adjacent to [2024-01-01, 2024-06-01)
+  /// .rangeAdjacent("scheduled", range: "[2024-01-01,2024-06-01)")
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The range column to filter on.
@@ -745,6 +835,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// Matches only rows where `column` matches the full-text search `query` using `to_tsquery`.
   ///
   /// This is a convenience wrapper around ``textSearch(_:query:config:type:)`` with no ``TextSearchType``.
+  ///
+  /// ```swift
+  /// // Rows where content matches the full-text query "swift & programming"
+  /// .fts("content", query: "swift & programming", config: "english")
+  /// ```
   ///
   /// - Parameters:
   ///   - column: The `text` or `tsvector` column to search.

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -1,18 +1,160 @@
 import Foundation
 import Helpers
 
-/// Filter builder for applying WHERE clauses to queries.
+/// Builder for applying WHERE-clause filters to a PostgREST query.
 ///
-/// - Note: Thread Safety: Inherits thread-safe mutable state management from `PostgrestBuilder`.
-/// - Important: Do not modify the same builder instance from multiple concurrent tasks.
+/// Obtain a ``PostgrestFilterBuilder`` from ``PostgrestQueryBuilder/select(_:head:count:)``,
+/// ``PostgrestQueryBuilder/insert(_:returning:count:)``, ``PostgrestQueryBuilder/update(_:returning:count:)``,
+/// or other write methods. Chain one or more filter methods, then call
+/// ``PostgrestBuilder/execute(options:)-96tpd`` to send the request.
+///
+/// All filter methods return `self` so they can be freely chained:
+///
+/// ```swift
+/// let results: [Todo] = try await client
+///   .from("todos")
+///   .select()
+///   .eq("done", value: false)
+///   .order("created_at", ascending: false)
+///   .limit(20)
+///   .execute()
+///   .value
+/// ```
+///
+/// > Note: Thread Safety: Inherits thread-safe mutable state management from ``PostgrestBuilder``.
+///
+/// > Important: Do not modify the same builder instance from multiple concurrent tasks.
+///
+/// ## Topics
+///
+/// ### Equality Filters
+///
+/// - ``eq(_:value:)``
+/// - ``neq(_:value:)``
+/// - ``is(_:value:)``
+/// - ``isDistinct(_:value:)``
+/// - ``in(_:values:)``
+/// - ``match(_:)-6h9ou``
+///
+/// ### Comparison Filters
+///
+/// - ``gt(_:value:)``
+/// - ``gte(_:value:)``
+/// - ``lt(_:value:)``
+/// - ``lte(_:value:)``
+///
+/// ### Pattern Matching Filters
+///
+/// - ``like(_:pattern:)``
+/// - ``likeAllOf(_:patterns:)``
+/// - ``likeAnyOf(_:patterns:)``
+/// - ``ilike(_:pattern:)``
+/// - ``iLikeAllOf(_:patterns:)``
+/// - ``iLikeAnyOf(_:patterns:)``
+/// - ``match(_:pattern:)-9qlv5``
+/// - ``imatch(_:pattern:)``
+///
+/// ### Array and Range Filters
+///
+/// - ``contains(_:value:)``
+/// - ``containedBy(_:value:)``
+/// - ``overlaps(_:value:)``
+/// - ``rangeLt(_:range:)``
+/// - ``rangeGt(_:range:)``
+/// - ``rangeGte(_:range:)``
+/// - ``rangeLte(_:range:)``
+/// - ``rangeAdjacent(_:range:)``
+///
+/// ### Full-Text Search
+///
+/// - ``textSearch(_:query:config:type:)``
+/// - ``fts(_:query:config:)``
+///
+/// ### Logical Operators
+///
+/// - ``not(_:operator:value:)``
+/// - ``or(_:referencedTable:)``
+/// - ``filter(_:operator:value:)``
+///
+/// ### Operators
+///
+/// - ``Operator``
 public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Sendable {
+  /// The set of PostgREST comparison operators available for use with ``not(_:operator:value:)``
+  /// and ``filter(_:operator:value:)``.
+  ///
+  /// Most operators have dedicated convenience methods (e.g., ``eq(_:value:)``, ``gt(_:value:)``).
+  /// Use ``Operator`` directly only when you need ``not(_:operator:value:)`` or the raw
+  /// ``filter(_:operator:value:)`` escape hatch.
   public enum Operator: String, CaseIterable, Sendable {
-    case eq, neq, gt, gte, lt, lte, like, ilike, match, imatch, `is`, isdistinct, `in`, cs, cd, sl,
-      sr, nxl, nxr, adj, ov, fts, plfts, phfts, wfts
+    /// Equals (`=`).
+    case eq
+    /// Not equals (`!=`).
+    case neq
+    /// Greater than (`>`).
+    case gt
+    /// Greater than or equal (`>=`).
+    case gte
+    /// Less than (`<`).
+    case lt
+    /// Less than or equal (`<=`).
+    case lte
+    /// Case-sensitive LIKE pattern match.
+    case like
+    /// Case-insensitive ILIKE pattern match.
+    case ilike
+    /// Case-sensitive regex match.
+    case match
+    /// Case-insensitive regex match.
+    case imatch
+    /// IS (for NULL / boolean checks).
+    case `is`
+    /// IS DISTINCT FROM.
+    case isdistinct
+    /// IN — value is in a list.
+    case `in`
+    /// Contains (`@>`).
+    case cs
+    /// Contained by (`<@`).
+    case cd
+    /// Range strictly left of (`<<`).
+    case sl
+    /// Range strictly right of (`>>`).
+    case sr
+    /// Range does not extend to the left (`&>`).
+    case nxl
+    /// Range does not extend to the right (`&<`).
+    case nxr
+    /// Range is adjacent (`-|-`).
+    case adj
+    /// Overlaps (`&&`).
+    case ov
+    /// Full-text search using `to_tsquery`.
+    case fts
+    /// Full-text search using `plainto_tsquery`.
+    case plfts
+    /// Full-text search using `phraseto_tsquery`.
+    case phfts
+    /// Full-text search using `websearch_to_tsquery`.
+    case wfts
   }
 
   // MARK: - Filters
 
+  /// Negates the specified filter using the PostgREST `not.<operator>` syntax.
+  ///
+  /// Use this to invert any of the standard comparison operators defined in ``Operator``.
+  ///
+  /// ```swift
+  /// // Rows where status is NOT 'active'
+  /// .not("status", operator: .eq, value: "active")
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - column: The column to filter on.
+  ///   - op: The ``Operator`` to negate.
+  ///   - value: The filter value.
+  /// - Returns: The same builder instance so calls can be chained.
   public func not(
     _ column: String,
     operator op: Operator,
@@ -31,6 +173,21 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
+  /// Combines multiple filters with an OR condition.
+  ///
+  /// The `filters` value must be a raw PostgREST filter string, for example
+  /// `"done.eq.true,priority.gt.3"`. To target an embedded (referenced) table, pass its
+  /// name via `referencedTable`.
+  ///
+  /// ```swift
+  /// // Rows where done is true OR priority > 3
+  /// .or("done.eq.true,priority.gt.3")
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - filters: A comma-separated list of PostgREST filter expressions combined with OR logic.
+  ///   - referencedTable: The name of an embedded table to apply the OR filter on. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func or(
     _ filters: any PostgrestFilterValue,
     referencedTable: String? = nil
@@ -43,13 +200,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` is equal to `value`.
+  /// Matches only rows where `column` equals `value`.
   ///
-  /// To check if the value of `column` is NULL, you should use `is()` instead.
+  /// To test for NULL, use ``is(_:value:)`` instead, because `NULL = NULL` is false in SQL.
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The value to filter with
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func eq(
     _ column: String,
     value: any PostgrestFilterValue
@@ -61,11 +219,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` is not equal to `value`.
+  /// Matches only rows where `column` is not equal to `value`.
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The value to filter with
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func neq(
     _ column: String,
     value: any PostgrestFilterValue
@@ -77,11 +236,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` is greater than `value`.
+  /// Matches only rows where `column` is greater than `value`.
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The value to filter with
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func gt(
     _ column: String,
     value: any PostgrestFilterValue
@@ -93,11 +253,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` is greater than or equal to `value`.
+  /// Matches only rows where `column` is greater than or equal to `value`.
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The value to filter with
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func gte(
     _ column: String,
     value: any PostgrestFilterValue
@@ -109,11 +270,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` is less than `value`.
+  /// Matches only rows where `column` is less than `value`.
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The value to filter with
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func lt(
     _ column: String,
     value: any PostgrestFilterValue
@@ -125,11 +287,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` is less than or equal to `value`.
+  /// Matches only rows where `column` is less than or equal to `value`.
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The value to filter with
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func lte(
     _ column: String,
     value: any PostgrestFilterValue
@@ -141,11 +304,19 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches `pattern` case-sensitively.
+  /// Matches only rows where `column` matches `pattern` case-sensitively using SQL LIKE.
+  ///
+  /// Use `%` as a wildcard for any sequence of characters and `_` for a single character.
+  ///
+  /// ```swift
+  /// // Rows where name starts with "Jo"
+  /// .like("name", pattern: "Jo%")
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - pattern: The pattern to match with
+  ///   - column: The column to filter on.
+  ///   - pattern: The LIKE pattern to match against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func like(
     _ column: String,
     pattern: any PostgrestFilterValue
@@ -157,10 +328,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches all of `patterns` case-sensitively.
+  /// Matches only rows where `column` matches **all** of the supplied LIKE `patterns` case-sensitively.
+  ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - patterns: The patterns to match with
+  ///   - column: The column to filter on.
+  ///   - patterns: The LIKE patterns that must all match.
+  /// - Returns: The same builder instance so calls can be chained.
   public func likeAllOf(
     _ column: String,
     patterns: [some PostgrestFilterValue]
@@ -172,10 +345,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches any of `patterns` case-sensitively.
+  /// Matches only rows where `column` matches **any** of the supplied LIKE `patterns` case-sensitively.
+  ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - patterns: The patterns to match with
+  ///   - column: The column to filter on.
+  ///   - patterns: The LIKE patterns, at least one of which must match.
+  /// - Returns: The same builder instance so calls can be chained.
   public func likeAnyOf(
     _ column: String,
     patterns: [some PostgrestFilterValue]
@@ -187,11 +362,19 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches `pattern` case-insensitively.
+  /// Matches only rows where `column` matches `pattern` case-insensitively using SQL ILIKE.
+  ///
+  /// Use `%` as a wildcard for any sequence of characters and `_` for a single character.
+  ///
+  /// ```swift
+  /// // Rows where name starts with "jo" (case-insensitive)
+  /// .ilike("name", pattern: "jo%")
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - pattern: The pattern to match with
+  ///   - column: The column to filter on.
+  ///   - pattern: The ILIKE pattern to match against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func ilike(
     _ column: String,
     pattern: any PostgrestFilterValue
@@ -203,10 +386,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches all of `patterns` case-insensitively.
+  /// Matches only rows where `column` matches **all** of the supplied ILIKE `patterns` case-insensitively.
+  ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - patterns: The patterns to match with
+  ///   - column: The column to filter on.
+  ///   - patterns: The ILIKE patterns that must all match.
+  /// - Returns: The same builder instance so calls can be chained.
   public func iLikeAllOf(
     _ column: String,
     patterns: [some PostgrestFilterValue]
@@ -218,10 +403,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches any of `patterns` case-insensitively.
+  /// Matches only rows where `column` matches **any** of the supplied ILIKE `patterns` case-insensitively.
+  ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - patterns: The patterns to match with
+  ///   - column: The column to filter on.
+  ///   - patterns: The ILIKE patterns, at least one of which must match.
+  /// - Returns: The same builder instance so calls can be chained.
   public func iLikeAnyOf(
     _ column: String,
     patterns: [some PostgrestFilterValue]
@@ -233,11 +420,19 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches the regex `pattern` case-sensitively.
+  /// Matches only rows where `column` matches the regular expression `pattern` case-sensitively.
+  ///
+  /// Uses PostgreSQL's `~` operator. The pattern must be a valid POSIX regular expression.
+  ///
+  /// ```swift
+  /// // Rows where email ends with "@supabase.io"
+  /// .match("email", pattern: "@supabase\\.io$")
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - pattern: The regex pattern to match with
+  ///   - column: The column to filter on.
+  ///   - pattern: The POSIX regular expression to match against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func match(
     _ column: String,
     pattern: any PostgrestFilterValue
@@ -249,11 +444,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches the regex `pattern` case-insensitively.
+  /// Matches only rows where `column` matches the regular expression `pattern` case-insensitively.
+  ///
+  /// Uses PostgreSQL's `~*` operator. The pattern must be a valid POSIX regular expression.
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - pattern: The regex pattern to match with
+  ///   - column: The column to filter on.
+  ///   - pattern: The POSIX regular expression to match against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func imatch(
     _ column: String,
     pattern: any PostgrestFilterValue
@@ -265,14 +463,23 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` IS `value`.
+  /// Matches only rows where `column` IS `value`.
   ///
-  /// For non-boolean columns, this is only relevant for checking if the value of `column` is NULL by setting `value` to `null`.
-  /// For boolean columns, you can also set `value` to `true` or `false` and it will behave the same way as `.eq()`.
+  /// Use this filter to check for `NULL` or boolean values. Unlike ``eq(_:value:)``, this filter
+  /// correctly handles `NULL` comparisons because it uses the SQL `IS` operator rather than `=`.
+  ///
+  /// ```swift
+  /// // Rows where deleted_at IS NULL
+  /// .is("deleted_at", value: nil)
+  ///
+  /// // Rows where active IS TRUE
+  /// .is("active", value: true)
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The value to filter with
+  ///   - column: The column to filter on.
+  ///   - value: `true`, `false`, or `nil` (for NULL).
+  /// - Returns: The same builder instance so calls can be chained.
   public func `is`(
     _ column: String,
     value: Bool?
@@ -284,13 +491,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` IS DISTINCT FROM `value`.
+  /// Matches only rows where `column` IS DISTINCT FROM `value`.
   ///
-  /// Unlike `.neq()`, this treats NULL as a comparable value. NULL IS DISTINCT FROM NULL is false, while NULL != NULL is true.
+  /// Unlike ``neq(_:value:)``, this operator treats `NULL` as a comparable value: `NULL IS DISTINCT
+  /// FROM NULL` evaluates to `false`, whereas `NULL != NULL` evaluates to `true` (unknown).
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The value to filter with
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against using IS DISTINCT FROM.
+  /// - Returns: The same builder instance so calls can be chained.
   public func isDistinct(
     _ column: String,
     value: any PostgrestFilterValue
@@ -302,11 +511,19 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` is included in the `values` array.
+  /// Matches only rows where `column` is one of the values in `values`.
+  ///
+  /// Equivalent to a SQL `IN (...)` clause.
+  ///
+  /// ```swift
+  /// // Rows where status is "active" or "pending"
+  /// .in("status", values: ["active", "pending"])
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - value: The values array to filter with
+  ///   - column: The column to filter on.
+  ///   - values: The list of acceptable values.
+  /// - Returns: The same builder instance so calls can be chained.
   public func `in`(
     _ column: String,
     values: [any PostgrestFilterValue]
@@ -323,13 +540,19 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` contains every element appearing in `value`.
+  /// Matches only rows where `column` contains every element in `value`.
   ///
-  /// Only relevant for jsonb, array, and range columns.
+  /// Applies the `@>` containment operator. Only relevant for `jsonb`, array, and range columns.
+  ///
+  /// ```swift
+  /// // Rows where the tags array contains both "swift" and "ios"
+  /// .contains("tags", value: ["swift", "ios"])
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The jsonb, array, or range column to filter on
-  ///   - value: The jsonb, array, or range value to filter with
+  ///   - column: The `jsonb`, array, or range column to filter on.
+  ///   - value: The `jsonb`, array, or range value that `column` must contain.
+  /// - Returns: The same builder instance so calls can be chained.
   public func contains(
     _ column: String,
     value: any PostgrestFilterValue
@@ -341,13 +564,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where every element appearing in `column` is contained by `value`.
+  /// Matches only rows where `column` is contained by `value`.
   ///
-  /// Only relevant for jsonb, array, and range columns.
+  /// Applies the `<@` containment operator. Only relevant for `jsonb`, array, and range columns.
   ///
   /// - Parameters:
-  ///   - column: The jsonb, array, or range column to filter on
-  ///   - value: The jsonb, array, or range value to filter with
+  ///   - column: The `jsonb`, array, or range column to filter on.
+  ///   - value: The `jsonb`, array, or range value that must contain every element in `column`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func containedBy(
     _ column: String,
     value: some PostgrestFilterValue
@@ -359,13 +583,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where every element in `column` is less than any element in `range`.
+  /// Matches only rows where every element in `column` is strictly less than every element in `range`.
   ///
-  /// Only relevant for range columns.
+  /// Applies the `<<` (strictly left of) range operator. Only relevant for range columns.
   ///
   /// - Parameters:
-  ///   - column: The range column to filter on
-  ///   - range: The range to filter with
+  ///   - column: The range column to filter on.
+  ///   - range: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeLt(
     _ column: String,
     range: any PostgrestFilterValue
@@ -377,13 +602,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where every element in `column` is greater than any element in `range`.
+  /// Matches only rows where every element in `column` is strictly greater than every element in `range`.
   ///
-  /// Only relevant for range columns.
+  /// Applies the `>>` (strictly right of) range operator. Only relevant for range columns.
   ///
   /// - Parameters:
-  ///   - column: The range column to filter on
-  ///   - range: The range to filter with
+  ///   - column: The range column to filter on.
+  ///   - range: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeGt(
     _ column: String,
     range: any PostgrestFilterValue
@@ -395,13 +621,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where every element in `column` is either contained in `range` or greater than any element in `range`.
+  /// Matches only rows where `column` does not extend to the left of `range`.
   ///
-  /// Only relevant for range columns.
+  /// Applies the `&>` (does not extend to left) range operator. Only relevant for range columns.
   ///
   /// - Parameters:
-  ///   - column: The range column to filter on
-  ///   - range: The range to filter with
+  ///   - column: The range column to filter on.
+  ///   - range: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeGte(
     _ column: String,
     range: any PostgrestFilterValue
@@ -413,13 +640,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where every element in `column` is either contained in `range` or less than any element in `range`.
+  /// Matches only rows where `column` does not extend to the right of `range`.
   ///
-  /// Only relevant for range columns.
+  /// Applies the `&<` (does not extend to right) range operator. Only relevant for range columns.
   ///
   /// - Parameters:
-  ///   - column: The range column to filter on
-  ///   - range: The range to filter with
+  ///   - column: The range column to filter on.
+  ///   - range: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeLte(
     _ column: String,
     range: any PostgrestFilterValue
@@ -431,13 +659,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` is mutually exclusive to `range` and there can be no element between the two ranges.
+  /// Matches only rows where `column` and `range` are adjacent (no gap between them).
   ///
-  /// Only relevant for range columns.
+  /// Applies the `-|-` (adjacent to) range operator. There must be no element that lies between
+  /// the two ranges. Only relevant for range columns.
   ///
   /// - Parameters:
-  ///   - column: The range column to filter on
-  ///   - range: The range to filter with
+  ///   - column: The range column to filter on.
+  ///   - range: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeAdjacent(
     _ column: String,
     range: any PostgrestFilterValue
@@ -449,13 +679,19 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` and `value` have an element in common.
+  /// Matches only rows where `column` and `value` share at least one element.
   ///
-  /// Only relevant for array and range columns.
+  /// Applies the `&&` overlap operator. Only relevant for array and range columns.
+  ///
+  /// ```swift
+  /// // Rows where the tags array overlaps with ["swift", "ios"]
+  /// .overlaps("tags", value: ["swift", "ios"])
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The array or range column to filter on
-  ///   - value: The array or range value to filter with
+  ///   - column: The array or range column to filter on.
+  ///   - value: The array or range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func overlaps(
     _ column: String,
     value: any PostgrestFilterValue
@@ -467,15 +703,26 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where `column` matches the query string in `query`.
+  /// Matches only rows where `column` matches the full-text search `query`.
   ///
-  /// Only relevant for text and tsvector columns.
+  /// Only relevant for `text` and `tsvector` columns. The `config` parameter selects the
+  /// text search configuration (dictionary) to use; omit it to use the database default.
+  /// The `type` parameter controls how the query text is converted to a `tsquery` expression.
+  ///
+  /// ```swift
+  /// // Basic full-text search
+  /// .textSearch("content", query: "swift programming")
+  ///
+  /// // Web-search syntax with a specific language configuration
+  /// .textSearch("content", query: "swift OR kotlin", config: "english", type: .websearch)
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The text or tsvector column to filter on
-  ///   - query: The query text to match with
-  ///   - config: The text search configuration to use
-  ///   - type: Change how the `query` text is interpreted
+  ///   - column: The `text` or `tsvector` column to search.
+  ///   - query: The search query text.
+  ///   - config: The text search configuration name (e.g., `"english"`). Defaults to `nil`.
+  ///   - type: The query conversion strategy. See ``TextSearchType``. Defaults to `nil` (uses `to_tsquery`).
+  /// - Returns: The same builder instance so calls can be chained.
   public func textSearch(
     _ column: String,
     query: any PostgrestFilterValue,
@@ -495,6 +742,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
+  /// Matches only rows where `column` matches the full-text search `query` using `to_tsquery`.
+  ///
+  /// This is a convenience wrapper around ``textSearch(_:query:config:type:)`` with no ``TextSearchType``.
+  ///
+  /// - Parameters:
+  ///   - column: The `text` or `tsvector` column to search.
+  ///   - query: The search query text.
+  ///   - config: The text search configuration name. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func fts(
     _ column: String,
     query: any PostgrestFilterValue,
@@ -503,14 +759,23 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     textSearch(column, query: query, config: config, type: nil)
   }
 
-  /// Match only rows which satisfy the filter. This is an escape hatch - you should use the specific filter methods wherever possible.
+  /// Matches only rows that satisfy a raw PostgREST filter expression.
   ///
-  /// Unlike most filters, `operator` and `value` are used as-is and need to follow [PostgREST syntax](https://postgrest.org/en/stable/api.html#operators). You also need to make sure they are properly sanitized.
+  /// This is an escape hatch for filters not covered by the typed convenience methods. The
+  /// `operator` and `value` strings are sent to PostgREST as-is and must follow
+  /// [PostgREST syntax](https://postgrest.org/en/stable/api.html#operators). You are responsible
+  /// for sanitising user-supplied values to prevent injection.
+  ///
+  /// ```swift
+  /// // Equivalent to .eq("status", value: "active")
+  /// .filter("status", operator: "eq", value: "active")
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The column to filter on
-  ///   - operator: The operator to filter with, following PostgREST syntax
-  ///   - value: The value to filter with, following PostgREST syntax
+  ///   - column: The column to filter on.
+  ///   - operator: The PostgREST operator string (e.g., `"eq"`, `"gt"`, `"cs"`).
+  ///   - value: The filter value string, already formatted for PostgREST.
+  /// - Returns: The same builder instance so calls can be chained.
   public func filter(
     _ column: String,
     operator: String,
@@ -526,9 +791,17 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     return self
   }
 
-  /// Match only rows where each column in `query` keys is equal to its associated value. Shorthand for multiple `.eq()`s.
+  /// Matches only rows where each key in `query` equals its associated value.
   ///
-  /// - Parameter query: The object to filter with, with column names as keys mapped to their filter values
+  /// This is shorthand for chaining multiple ``eq(_:value:)`` calls with AND logic.
+  ///
+  /// ```swift
+  /// // Rows where done is false AND priority is 1
+  /// .match(["done": false, "priority": 1])
+  /// ```
+  ///
+  /// - Parameter query: A dictionary mapping column names to filter values.
+  /// - Returns: The same builder instance so calls can be chained.
   public func match(
     _ query: [String: any PostgrestFilterValue]
   ) -> PostgrestFilterBuilder {
@@ -547,6 +820,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
 
   // MARK: - Filter Semantic Improvements
 
+  /// Matches only rows where `column` equals `value`.
+  ///
+  /// This is a semantic alias for ``eq(_:value:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func equals(
     _ column: String,
     value: String
@@ -554,6 +835,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     eq(column, value: value)
   }
 
+  /// Matches only rows where `column` is not equal to `value`.
+  ///
+  /// This is a semantic alias for ``neq(_:value:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func notEquals(
     _ column: String,
     value: String
@@ -561,6 +850,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     neq(column, value: value)
   }
 
+  /// Matches only rows where `column` is greater than `value`.
+  ///
+  /// This is a semantic alias for ``gt(_:value:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func greaterThan(
     _ column: String,
     value: String
@@ -568,6 +865,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     gt(column, value: value)
   }
 
+  /// Matches only rows where `column` is greater than or equal to `value`.
+  ///
+  /// This is a semantic alias for ``gte(_:value:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func greaterThanOrEquals(
     _ column: String,
     value: String
@@ -575,6 +880,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     gte(column, value: value)
   }
 
+  /// Matches only rows where `column` is less than `value`.
+  ///
+  /// This is a semantic alias for ``lt(_:value:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func lowerThan(
     _ column: String,
     value: String
@@ -582,6 +895,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     lt(column, value: value)
   }
 
+  /// Matches only rows where `column` is less than or equal to `value`.
+  ///
+  /// This is a semantic alias for ``lte(_:value:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The column to filter on.
+  ///   - value: The value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func lowerThanOrEquals(
     _ column: String,
     value: String
@@ -589,6 +910,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     lte(column, value: value)
   }
 
+  /// Matches only rows where `column` is strictly less than `range`.
+  ///
+  /// This is a semantic alias for ``rangeLt(_:range:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The range column to filter on.
+  ///   - range: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeLowerThan(
     _ column: String,
     range: String
@@ -596,6 +925,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     rangeLt(column, range: range)
   }
 
+  /// Matches only rows where `column` is strictly greater than `value`.
+  ///
+  /// This is a semantic alias for ``rangeGt(_:range:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The range column to filter on.
+  ///   - value: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeGreaterThan(
     _ column: String,
     value: String
@@ -603,6 +940,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     rangeGt(column, range: value)
   }
 
+  /// Matches only rows where `column` does not extend to the left of `value`.
+  ///
+  /// This is a semantic alias for ``rangeGte(_:range:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The range column to filter on.
+  ///   - value: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeGreaterThanOrEquals(
     _ column: String,
     value: String
@@ -610,6 +955,14 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     rangeGte(column, range: value)
   }
 
+  /// Matches only rows where `column` does not extend to the right of `value`.
+  ///
+  /// This is a semantic alias for ``rangeLte(_:range:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The range column to filter on.
+  ///   - value: The range value to compare against.
+  /// - Returns: The same builder instance so calls can be chained.
   public func rangeLowerThanOrEquals(
     _ column: String,
     value: String
@@ -617,6 +970,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     rangeLte(column, range: value)
   }
 
+  /// Matches only rows where `column` matches the full-text search `query` using `to_tsquery`.
+  ///
+  /// This is a semantic alias for ``fts(_:query:config:)``.
+  ///
+  /// - Parameters:
+  ///   - column: The `text` or `tsvector` column to search.
+  ///   - query: The search query text.
+  ///   - config: The text search configuration name. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func fullTextSearch(
     _ column: String,
     query: String,
@@ -625,6 +987,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     fts(column, query: query, config: config)
   }
 
+  /// Matches only rows where `column` matches the full-text search `query` using `plainto_tsquery`.
+  ///
+  /// This is a semantic alias for ``textSearch(_:query:config:type:)`` with ``TextSearchType/plain``.
+  ///
+  /// - Parameters:
+  ///   - column: The `text` or `tsvector` column to search.
+  ///   - query: The search query text.
+  ///   - config: The text search configuration name. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func plainToFullTextSearch(
     _ column: String,
     query: String,
@@ -633,6 +1004,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     textSearch(column, query: query, config: config, type: .plain)
   }
 
+  /// Matches only rows where `column` matches the full-text search `query` using `phraseto_tsquery`.
+  ///
+  /// This is a semantic alias for ``textSearch(_:query:config:type:)`` with ``TextSearchType/phrase``.
+  ///
+  /// - Parameters:
+  ///   - column: The `text` or `tsvector` column to search.
+  ///   - query: The search query text.
+  ///   - config: The text search configuration name. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func phraseToFullTextSearch(
     _ column: String,
     query: String,
@@ -641,6 +1021,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     textSearch(column, query: query, config: config, type: .phrase)
   }
 
+  /// Matches only rows where `column` matches the full-text search `query` using `websearch_to_tsquery`.
+  ///
+  /// This is a semantic alias for ``textSearch(_:query:config:type:)`` with ``TextSearchType/websearch``.
+  ///
+  /// - Parameters:
+  ///   - column: The `text` or `tsvector` column to search.
+  ///   - query: The search query text.
+  ///   - config: The text search configuration name. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func webFullTextSearch(
     _ column: String,
     query: String,

--- a/Sources/PostgREST/PostgrestFilterValue.swift
+++ b/Sources/PostgREST/PostgrestFilterValue.swift
@@ -1,7 +1,25 @@
 import Foundation
 
-/// A value that can be used to filter Postgrest queries.
+/// A value that can be used as a filter operand in PostgREST queries.
+///
+/// Types conforming to ``PostgrestFilterValue`` provide a ``rawValue`` string that is appended
+/// directly to the PostgREST query string. The SDK ships with conformances for the most common
+/// Swift types; you can add your own by conforming any `Encodable` type to this protocol.
+///
+/// ## Built-in Conformances
+///
+/// | Swift type | Example `rawValue` |
+/// |---|---|
+/// | `String` | `"hello"` |
+/// | `Int` | `"42"` |
+/// | `Double` | `"3.14"` |
+/// | `Bool` | `"true"` |
+/// | `UUID` | `"123e4567-e89b-..."` |
+/// | `Date` | `"2024-01-15T12:00:00.000Z"` |
+/// | `[Element]` | `"{a,b,c}"` |
+/// | `Optional<Wrapped>` | `"NULL"` when `nil` |
 public protocol PostgrestFilterValue {
+  /// The string representation sent to PostgREST as the filter value.
   var rawValue: String { get }
 }
 
@@ -10,26 +28,32 @@ extension PostgrestFilterValue {
   public var queryValue: String { rawValue }
 }
 
+/// `String` can be used directly as a PostgREST filter value.
 extension String: PostgrestFilterValue {
   public var rawValue: String { self }
 }
 
+/// `Int` can be used directly as a PostgREST filter value.
 extension Int: PostgrestFilterValue {
   public var rawValue: String { "\(self)" }
 }
 
+/// `Double` can be used directly as a PostgREST filter value.
 extension Double: PostgrestFilterValue {
   public var rawValue: String { "\(self)" }
 }
 
+/// `Bool` can be used directly as a PostgREST filter value.
 extension Bool: PostgrestFilterValue {
   public var rawValue: String { "\(self)" }
 }
 
+/// `UUID` can be used directly as a PostgREST filter value.
 extension UUID: PostgrestFilterValue {
   public var rawValue: String { uuidString }
 }
 
+/// `Date` can be used directly as a PostgREST filter value, formatted as an ISO 8601 string.
 extension Date: PostgrestFilterValue {
   public var rawValue: String {
     let formatter = ISO8601DateFormatter()
@@ -38,12 +62,16 @@ extension Date: PostgrestFilterValue {
   }
 }
 
+/// An array of ``PostgrestFilterValue`` elements is itself a ``PostgrestFilterValue``.
+///
+/// The raw value is a PostgreSQL array literal, e.g. `{a,b,c}`.
 extension Array: PostgrestFilterValue where Element: PostgrestFilterValue {
   public var rawValue: String {
     "{\(map(\.rawValue).joined(separator: ","))}"
   }
 }
 
+/// `AnyJSON` can be used directly as a PostgREST filter value.
 extension AnyJSON: PostgrestFilterValue {
   public var rawValue: String {
     switch self {
@@ -58,6 +86,9 @@ extension AnyJSON: PostgrestFilterValue {
   }
 }
 
+/// An optional ``PostgrestFilterValue`` is itself a ``PostgrestFilterValue``.
+///
+/// When the optional is `nil`, the raw value is `"NULL"`.
 extension Optional: PostgrestFilterValue where Wrapped: PostgrestFilterValue {
   public var rawValue: String {
     if let value = self {
@@ -68,6 +99,7 @@ extension Optional: PostgrestFilterValue where Wrapped: PostgrestFilterValue {
   }
 }
 
+/// `JSONObject` can be used directly as a PostgREST filter value.
 extension JSONObject: PostgrestFilterValue {
   public var rawValue: String {
     let value = mapValues(\.value)

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -1,15 +1,79 @@
 import Foundation
 
-/// Query builder for SELECT, INSERT, UPDATE, DELETE, and UPSERT operations.
+/// Builder for SELECT, INSERT, UPDATE, UPSERT, and DELETE operations on a table or view.
 ///
-/// - Note: Thread Safety: Inherits thread-safe mutable state management from `PostgrestBuilder`.
-/// - Important: Do not modify the same builder instance from multiple concurrent tasks.
+/// Obtain a ``PostgrestQueryBuilder`` by calling ``PostgrestClient/from(_:)`` and then chain one
+/// of the operation methods. Most methods return a ``PostgrestFilterBuilder`` so you can narrow the
+/// affected rows with WHERE clauses before executing.
+///
+/// ```swift
+/// // INSERT a single row
+/// try await client
+///   .from("todos")
+///   .insert(["task": "Buy milk", "done": false])
+///   .execute()
+///
+/// // SELECT with a filter
+/// let todos: [Todo] = try await client
+///   .from("todos")
+///   .select()
+///   .eq("done", value: false)
+///   .execute()
+///   .value
+/// ```
+///
+/// > Note: Thread Safety: Inherits thread-safe mutable state management from ``PostgrestBuilder``.
+///
+/// > Important: Do not modify the same builder instance from multiple concurrent tasks.
+///
+/// ## Topics
+///
+/// ### Querying Rows
+///
+/// - ``select(_:head:count:)``
+///
+/// ### Inserting Rows
+///
+/// - ``insert(_:returning:count:)``
+///
+/// ### Updating Rows
+///
+/// - ``update(_:returning:count:)``
+///
+/// ### Upserting Rows
+///
+/// - ``upsert(_:onConflict:returning:count:ignoreDuplicates:)``
+///
+/// ### Deleting Rows
+///
+/// - ``delete(returning:count:)``
 public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable {
-  /// Perform a SELECT query on the table or view.
+  /// Performs a SELECT query on the table or view.
+  ///
+  /// By default all columns are returned (`*`). You can request specific columns, rename them,
+  /// and embed related rows in a single call using PostgREST's column-selection syntax.
+  ///
+  /// ```swift
+  /// // All columns
+  /// .select()
+  ///
+  /// // Specific columns
+  /// .select("id, task, done")
+  ///
+  /// // Column alias
+  /// .select("taskName:task")
+  ///
+  /// // Embed related table
+  /// .select("*, comments(*)")
+  /// ```
+  ///
   /// - Parameters:
-  ///   - columns: The columns to retrieve, separated by commas. Columns can be renamed when returned with `customName:columnName`
-  ///   - head: When set to `true`, `data` will not be returned. Useful if you only need the count.
-  ///   - count: Count algorithm to use to count rows in the table or view.
+  ///   - columns: A comma-separated list of columns to retrieve. Columns may be aliased using
+  ///     `alias:column` syntax. Defaults to `"*"` (all columns).
+  ///   - head: When `true`, the request uses the HEAD method and no rows are returned.
+  ///     Useful when combined with `count` to retrieve only the total row count.
+  ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
+  /// - Returns: A ``PostgrestFilterBuilder`` for applying WHERE clauses and executing the query.
   public func select(
     _ columns: String = "*",
     head: Bool = false,
@@ -43,13 +107,33 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
     return PostgrestFilterBuilder(self)
   }
 
-  /// Performs an INSERT into the table or view.
+  /// Inserts one or more rows into the table or view.
   ///
-  /// By default, inserted rows are not returned. To return it, chain the call with `.select()`.
+  /// By default, inserted rows are not returned. To receive the inserted data, chain with
+  /// ``PostgrestTransformBuilder/select(_:)`` after calling this method.
+  ///
+  /// ```swift
+  /// // Insert a single row
+  /// try await client
+  ///   .from("todos")
+  ///   .insert(["task": "Buy groceries", "done": false])
+  ///   .execute()
+  ///
+  /// // Insert multiple rows and return them
+  /// let inserted: [Todo] = try await client
+  ///   .from("todos")
+  ///   .insert([Todo(task: "A"), Todo(task: "B")])
+  ///   .select()
+  ///   .execute()
+  ///   .value
+  /// ```
   ///
   /// - Parameters:
-  ///   - values: The values to insert. Pass an object to insert a single row or an array to insert multiple rows.
-  ///   - count: Count algorithm to use to count inserted rows.
+  ///   - values: An `Encodable` value representing a single row or an array of rows to insert.
+  ///   - returning: Controls which rows PostgREST returns. Defaults to `nil` (server decides).
+  ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
+  /// - Returns: A ``PostgrestFilterBuilder`` for applying additional constraints or executing the request.
+  /// - Throws: An encoding error if `values` cannot be serialised, or ``PostgrestError`` on server error.
   public func insert(
     _ values: some Encodable,
     returning: PostgrestReturningOptions? = nil,
@@ -90,17 +174,35 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
     return PostgrestFilterBuilder(self)
   }
 
-  /// Perform an UPDATE on the table or view.
+  /// Inserts rows, updating existing rows on conflict (upsert).
   ///
-  /// Depending on the column(s) passed to `onConflict`, `.upsert()` allows you to perform the equivalent of `.insert()` if a row with the corresponding `onConflict` columns doesn't exist, or if it does exist, perform an alternative action depending on `ignoreDuplicates`.
+  /// Depending on `onConflict`, this is equivalent to an INSERT … ON CONFLICT DO UPDATE. If the
+  /// conflict column(s) match an existing row, the row is merged or ignored depending on
+  /// `ignoreDuplicates`.
   ///
-  /// By default, upserted rows are not returned. To return it, chain the call with `.select()`.
+  /// By default, upserted rows are returned. To suppress this, pass `.minimal` as `returning`.
+  ///
+  /// ```swift
+  /// // Upsert a row, merging on the "id" column
+  /// let upserted: Todo = try await client
+  ///   .from("todos")
+  ///   .upsert(Todo(id: 1, task: "Buy milk"))
+  ///   .select()
+  ///   .single()
+  ///   .execute()
+  ///   .value
+  /// ```
   ///
   /// - Parameters:
-  ///   - values: The values to upsert with. Pass an object to upsert a single row or an array to upsert multiple rows.
-  ///   - onConflict: Comma-separated UNIQUE column(s) to specify how duplicate rows are determined. Two rows are duplicates if all the `onConflict` columns are equal.
-  ///   - count: Count algorithm to use to count upserted rows.
-  ///   - ignoreDuplicates: If `true`, duplicate rows are ignored. If `false`, duplicate rows are merged with existing rows.
+  ///   - values: An `Encodable` value representing a single row or an array of rows.
+  ///   - onConflict: Comma-separated UNIQUE column(s) that determine whether a row is a duplicate.
+  ///     When `nil`, PostgREST uses the table's primary key.
+  ///   - returning: Controls which rows PostgREST returns after the upsert. Defaults to ``PostgrestReturningOptions/representation``.
+  ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
+  ///   - ignoreDuplicates: When `true`, conflicting rows are silently ignored. When `false` (the
+  ///     default), conflicting rows are merged with the supplied values.
+  /// - Returns: A ``PostgrestFilterBuilder`` for applying additional constraints or executing the request.
+  /// - Throws: An encoding error if `values` cannot be serialised, or ``PostgrestError`` on server error.
   public func upsert(
     _ values: some Encodable,
     onConflict: String? = nil,
@@ -146,13 +248,28 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
     return PostgrestFilterBuilder(self)
   }
 
-  /// Perform an UPDATE on the table or view.
+  /// Performs a partial UPDATE on rows that match subsequent filters.
   ///
-  /// By default, updated rows are not returned. To return it, chain the call with `.select()` after filters.
+  /// By default, updated rows are returned as ``PostgrestReturningOptions/representation``. To
+  /// suppress this, pass `.minimal` as `returning`.
+  ///
+  /// > Important: Omitting a filter will update **all rows** in the table. Always chain
+  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestBuilder/execute(options:)-96tpd``.
+  ///
+  /// ```swift
+  /// try await client
+  ///   .from("todos")
+  ///   .update(["done": true])
+  ///   .eq("id", value: 42)
+  ///   .execute()
+  /// ```
   ///
   /// - Parameters:
-  ///   - values: The values to update with.
-  ///   - count: Count algorithm to use to count rows in a table.
+  ///   - values: An `Encodable` value with the columns to update.
+  ///   - returning: Controls which rows PostgREST returns after the update. Defaults to ``PostgrestReturningOptions/representation``.
+  ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
+  /// - Returns: A ``PostgrestFilterBuilder`` for scoping which rows are affected.
+  /// - Throws: An encoding error if `values` cannot be serialised, or ``PostgrestError`` on server error.
   public func update(
     _ values: some Encodable,
     returning: PostgrestReturningOptions = .representation,
@@ -176,12 +293,26 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
     return PostgrestFilterBuilder(self)
   }
 
-  /// Perform a DELETE on the table or view.
+  /// Performs a DELETE on rows that match subsequent filters.
   ///
-  /// By default, deleted rows are not returned. To return it, chain the call with `.select()` after filters.
+  /// By default, deleted rows are returned as ``PostgrestReturningOptions/representation``. To
+  /// suppress this, pass `.minimal` as `returning`.
+  ///
+  /// > Important: Omitting a filter will delete **all rows** in the table. Always chain
+  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestBuilder/execute(options:)-96tpd``.
+  ///
+  /// ```swift
+  /// try await client
+  ///   .from("todos")
+  ///   .delete()
+  ///   .eq("id", value: 42)
+  ///   .execute()
+  /// ```
   ///
   /// - Parameters:
-  ///   - count: Count algorithm to use to count deleted rows.
+  ///   - returning: Controls which rows PostgREST returns after the delete. Defaults to ``PostgrestReturningOptions/representation``.
+  ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
+  /// - Returns: A ``PostgrestFilterBuilder`` for scoping which rows are deleted.
   public func delete(
     returning: PostgrestReturningOptions = .representation,
     count: CountOption? = nil

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -40,7 +40,7 @@ import Foundation
 ///
 /// - ``update(_:returning:count:)``
 ///
-/// ### Upserting Rows
+/// ### Upsert Rows
 ///
 /// - ``upsert(_:onConflict:returning:count:ignoreDuplicates:)``
 ///
@@ -133,7 +133,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   ///   - returning: Controls which rows PostgREST returns. Defaults to `nil` (server decides).
   ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
   /// - Returns: A ``PostgrestFilterBuilder`` for applying additional constraints or executing the request.
-  /// - Throws: An encoding error if `values` cannot be serialised, or ``PostgrestError`` on server error.
+  /// - Throws: An encoding error if `values` cannot be serialized, or ``PostgrestError`` on server error.
   public func insert(
     _ values: some Encodable,
     returning: PostgrestReturningOptions? = nil,
@@ -202,7 +202,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   ///   - ignoreDuplicates: When `true`, conflicting rows are silently ignored. When `false` (the
   ///     default), conflicting rows are merged with the supplied values.
   /// - Returns: A ``PostgrestFilterBuilder`` for applying additional constraints or executing the request.
-  /// - Throws: An encoding error if `values` cannot be serialised, or ``PostgrestError`` on server error.
+  /// - Throws: An encoding error if `values` cannot be serialized, or ``PostgrestError`` on server error.
   public func upsert(
     _ values: some Encodable,
     onConflict: String? = nil,
@@ -269,7 +269,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   ///   - returning: Controls which rows PostgREST returns after the update. Defaults to ``PostgrestReturningOptions/representation``.
   ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
   /// - Returns: A ``PostgrestFilterBuilder`` for scoping which rows are affected.
-  /// - Throws: An encoding error if `values` cannot be serialised, or ``PostgrestError`` on server error.
+  /// - Throws: An encoding error if `values` cannot be serialized, or ``PostgrestError`` on server error.
   public func update(
     _ values: some Encodable,
     returning: PostgrestReturningOptions = .representation,

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -1,16 +1,60 @@
 import Foundation
 
-/// Transform builder for applying ORDER BY, LIMIT, and other transformations.
+/// Builder for applying result transformations such as ordering, pagination, and response format.
 ///
-/// - Note: Thread Safety: Inherits thread-safe mutable state management from `PostgrestBuilder`.
-/// - Important: Do not modify the same builder instance from multiple concurrent tasks.
+/// ``PostgrestTransformBuilder`` sits between ``PostgrestFilterBuilder`` (WHERE clauses) and
+/// ``PostgrestBuilder/execute(options:)-96tpd`` (sending the request). All transformation methods
+/// return `self` so they can be chained freely.
+///
+/// > Note: Thread Safety: Inherits thread-safe mutable state management from ``PostgrestBuilder``.
+///
+/// > Important: Do not modify the same builder instance from multiple concurrent tasks.
+///
+/// ## Topics
+///
+/// ### Returning Modified Rows
+///
+/// - ``select(_:)``
+///
+/// ### Ordering and Pagination
+///
+/// - ``order(_:ascending:nullsFirst:referencedTable:)``
+/// - ``limit(_:referencedTable:)``
+/// - ``range(from:to:referencedTable:)``
+///
+/// ### Response Format
+///
+/// - ``single()``
+/// - ``csv()``
+/// - ``geojson()``
+/// - ``stripNulls()``
+///
+/// ### Query Analysis
+///
+/// - ``explain(analyze:verbose:settings:buffers:wal:format:)``
+///
+/// ### Limiting Affected Rows
+///
+/// - ``maxAffected(_:)``
 public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
-  /// Perform a SELECT on the query result.
+  /// Requests that the server return the modified rows from a write operation.
   ///
-  /// By default, `.insert()`, `.update()`, `.upsert()`, and `.delete()` do not return modified rows. By calling this method, modified rows are returned in `value`.
+  /// By default, INSERT, UPDATE, UPSERT, and DELETE operations do not return the affected rows.
+  /// Calling this method adds a `return=representation` preference and sets the `select` query
+  /// parameter, so the modified rows appear in ``PostgrestResponse/value``.
   ///
-  /// - Parameters:
-  ///   - columns: The columns to retrieve, separated by commas.
+  /// ```swift
+  /// let updated: [Todo] = try await client
+  ///   .from("todos")
+  ///   .update(["done": true])
+  ///   .eq("id", value: 1)
+  ///   .select("id, task, done")
+  ///   .execute()
+  ///   .value
+  /// ```
+  ///
+  /// - Parameter columns: A comma-separated list of columns to retrieve. Defaults to `"*"` (all columns).
+  /// - Returns: The same builder instance so calls can be chained.
   public func select(_ columns: String = "*") -> PostgrestTransformBuilder {
     // remove whitespaces except when quoted.
     var quoted = false
@@ -31,16 +75,24 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// Order the query result by `column`.
+  /// Sorts the query result by the specified column.
   ///
-  /// You can call this method multiple times to order by multiple columns.
-  /// You can order referenced tables, but it only affects the ordering of the parent table if you use `!inner` in the query.
+  /// Call this method multiple times to sort by multiple columns. When sorting a referenced
+  /// (embedded) table, pass the table name via `referencedTable`; note that this only affects
+  /// the ordering of the parent table's rows when the join uses `!inner`.
+  ///
+  /// ```swift
+  /// // Order by created_at descending, then by id ascending
+  /// .order("created_at", ascending: false)
+  /// .order("id")
+  /// ```
   ///
   /// - Parameters:
-  ///   - column: The column to order by.
-  ///   - ascending: If `true`, the result will be in ascending order.
-  ///   - nullsFirst: If `true`, `null`s appear first. If `false`, `null`s appear last.
-  ///   - referencedTable: Set this to order a referenced table by its columns.
+  ///   - column: The column to sort by.
+  ///   - ascending: When `true` (the default), results are sorted ascending (`ASC`).
+  ///   - nullsFirst: When `true`, `NULL` values appear before non-null values. Defaults to `false`.
+  ///   - referencedTable: The name of an embedded table to order by its columns. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func order(
     _ column: String,
     ascending: Bool = true,
@@ -68,10 +120,12 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// Limits the query result by `count`.
+  /// Limits the number of rows returned by the query.
+  ///
   /// - Parameters:
   ///   - count: The maximum number of rows to return.
-  ///   - referencedTable: Set this to limit rows of referenced tables instead of the parent table.
+  ///   - referencedTable: The name of an embedded table to limit instead of the parent table. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func limit(_ count: Int, referencedTable: String? = nil) -> PostgrestTransformBuilder {
     mutableState.withValue {
       let key = referencedTable.map { "\($0).limit" } ?? "limit"
@@ -80,16 +134,26 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// Limit the query result by starting at an offset (`from`) and ending at the offset (`from + to`).
+  /// Returns only the rows within the specified zero-based, inclusive index range.
   ///
-  /// Only records within this range are returned.
-  /// This respects the query order and if there is no order clause the range could behave unexpectedly.
-  /// The `from` and `to` values are 0-based and inclusive: `range(from: 1, to: 3)` will include the second, third and fourth rows of the query.
+  /// The range is applied after any ORDER BY clause. Both `from` and `to` are inclusive, so
+  /// `range(from: 0, to: 9)` returns the first 10 rows.
+  ///
+  /// > Important: Without an ORDER BY clause, the range may return rows in an unpredictable order.
+  /// > Chain ``order(_:ascending:nullsFirst:referencedTable:)`` before ``range(from:to:referencedTable:)``
+  /// > for deterministic pagination.
+  ///
+  /// ```swift
+  /// // Second page of 10 items
+  /// .order("id")
+  /// .range(from: 10, to: 19)
+  /// ```
   ///
   /// - Parameters:
-  ///   - from: The starting index from which to limit the result.
-  ///   - to: The last index to which to limit the result.
-  ///   - referencedTable: Set this to limit rows of referenced tables instead of the parent table.
+  ///   - from: The zero-based index of the first row to return.
+  ///   - to: The zero-based index of the last row to return (inclusive).
+  ///   - referencedTable: The name of an embedded table to paginate instead of the parent table. Defaults to `nil`.
+  /// - Returns: The same builder instance so calls can be chained.
   public func range(
     from: Int,
     to: Int,
@@ -108,9 +172,22 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// Return `value` as a single object instead of an array of objects.
+  /// Instructs PostgREST to return a single JSON object instead of an array.
   ///
-  /// Query result must be one row (e.g. using `.limit(1)`), otherwise this returns an error.
+  /// The query must return exactly one row; otherwise PostgREST returns an error. Pair this
+  /// with ``limit(_:referencedTable:)`` (limit 1) or a unique filter to guarantee a single result.
+  ///
+  /// ```swift
+  /// let todo: Todo = try await client
+  ///   .from("todos")
+  ///   .select()
+  ///   .eq("id", value: 42)
+  ///   .single()
+  ///   .execute()
+  ///   .value
+  /// ```
+  ///
+  /// - Returns: The same builder instance so calls can be chained.
   public func single() -> PostgrestTransformBuilder {
     mutableState.withValue {
       $0.request.headers[.accept] = "application/vnd.pgrst.object+json"
@@ -118,7 +195,14 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  ///  Return `value` as a string in CSV format.
+  /// Sets the response format to CSV.
+  ///
+  /// The raw CSV text is available in ``PostgrestResponse/data``. Convert it to a `String`
+  /// using ``PostgrestResponse/string(encoding:)``.
+  ///
+  /// > Note: ``csv()`` cannot be combined with ``stripNulls()``.
+  ///
+  /// - Returns: The same builder instance so calls can be chained.
   public func csv() -> PostgrestTransformBuilder {
     mutableState.withValue {
       let preferComponents = $0.request.headers[.prefer]?.components(separatedBy: ",") ?? []
@@ -130,9 +214,13 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// Strip null values from the response.
+  /// Instructs PostgREST to omit `null` values from the JSON response.
   ///
-  /// Requires PostgREST 11.2.0+. Not compatible with ``csv()``.
+  /// Requires PostgREST 11.2.0 or later.
+  ///
+  /// > Note: ``stripNulls()`` cannot be combined with ``csv()``.
+  ///
+  /// - Returns: The same builder instance so calls can be chained.
   public func stripNulls() -> PostgrestTransformBuilder {
     mutableState.withValue {
       if $0.request.headers[.accept] == "text/csv" {
@@ -143,7 +231,12 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// Return `value` as an object in [GeoJSON](https://geojson.org) format.
+  /// Sets the response format to [GeoJSON](https://geojson.org).
+  ///
+  /// Use this when querying geometry or geography columns from a PostGIS-enabled table.
+  /// The response is a GeoJSON `FeatureCollection`.
+  ///
+  /// - Returns: The same builder instance so calls can be chained.
   public func geojson() -> PostgrestTransformBuilder {
     mutableState.withValue {
       $0.request.headers[.accept] = "application/geo+json"
@@ -151,21 +244,29 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// Return `data` as the EXPLAIN plan for the query.
+  /// Returns the PostgreSQL EXPLAIN plan for the query instead of the query results.
   ///
-  /// You need to enable the [db_plan_enabled](https://supabase.com/docs/guides/database/debugging-performance#enabling-explain)
-  /// setting before using this method.
+  /// Use this to understand and debug query performance. You must enable the
+  /// [`db_plan_enabled`](https://supabase.com/docs/guides/database/debugging-performance#enabling-explain)
+  /// setting in your Supabase project before calling this method.
+  ///
+  /// ```swift
+  /// let plan = try await client
+  ///   .from("todos")
+  ///   .select()
+  ///   .explain(analyze: true, format: .json)
+  ///   .execute()
+  ///   .string()
+  /// ```
   ///
   /// - Parameters:
-  ///   - analyze: If `true`, the query will be executed and the actual run time will be returned
-  ///   - verbose: If `true`, the query identifier will be returned and `data` will include the
-  /// output columns of the query
-  ///   - settings: If `true`, include information on configuration parameters that affect query
-  /// planning
-  ///   - buffers: If `true`, include information on buffer usage
-  ///   - wal: If `true`, include information on WAL record generation
-  ///   - format: The format of the output, either ``ExplainFormat/text`` (default) or
-  /// ``ExplainFormat/json``
+  ///   - analyze: When `true`, the query is actually executed and actual run time statistics are included.
+  ///   - verbose: When `true`, the query identifier and output column names are included.
+  ///   - settings: When `true`, planner configuration parameters that affect the plan are included.
+  ///   - buffers: When `true`, buffer usage statistics are included (requires `analyze: true`).
+  ///   - wal: When `true`, WAL record generation statistics are included (requires `analyze: true`).
+  ///   - format: The output format. See ``ExplainFormat``. Defaults to ``ExplainFormat/text``.
+  /// - Returns: The same builder instance so calls can be chained.
   public func explain(
     analyze: Bool = false,
     verbose: Bool = false,
@@ -192,13 +293,21 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
-  /// Set the maximum number of rows that can be affected by the query.
+  /// Limits the maximum number of rows that a write operation may affect.
   ///
-  /// Only available in PostgREST v13+ and only works with PATCH, DELETE methods and RPC calls.
-  /// Note: This method doesn't validate the HTTP method - ensure you only use it with compatible operations.
+  /// When the number of affected rows would exceed `value`, PostgREST returns an error and
+  /// rolls back the transaction. This is a safety mechanism to prevent accidental mass updates
+  /// or deletes.
   ///
-  /// - Parameters:
-  ///   - value: The maximum number of rows that can be affected
+  /// Requires PostgREST v13 or later. Compatible with PATCH, DELETE, and RPC calls only.
+  ///
+  /// > Note: This method does not validate the HTTP method. Ensure you only use it with
+  /// > ``PostgrestQueryBuilder/update(_:returning:count:)``,
+  /// > ``PostgrestQueryBuilder/delete(returning:count:)``, or
+  /// > ``PostgrestClient/rpc(_:params:head:get:count:)``.
+  ///
+  /// - Parameter value: The maximum number of rows that the operation may affect.
+  /// - Returns: The same builder instance so calls can be chained.
   public func maxAffected(_ value: Int) -> PostgrestTransformBuilder {
     mutableState.withValue {
       $0.request.headers.appendOrUpdate(.prefer, value: "handling=strict")

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -4,16 +4,64 @@ import Foundation
   import FoundationNetworking
 #endif
 
+/// The response returned by a PostgREST query, containing the raw data, HTTP response, row count, and decoded value.
+///
+/// ``PostgrestResponse`` wraps the raw network response from PostgREST and provides decoded access
+/// to the returned rows alongside metadata such as the total row count (when requested via
+/// ``CountOption``) and the HTTP status code.
+///
+/// ```swift
+/// let response: PostgrestResponse<[Todo]> = try await client
+///   .from("todos")
+///   .select()
+///   .execute()
+///
+/// print(response.value)  // [Todo]
+/// print(response.count)  // optional total count
+/// print(response.status) // HTTP status code
+/// ```
+///
+/// ## Topics
+///
+/// ### Response Data
+///
+/// - ``data``
+/// - ``value``
+/// - ``count``
+/// - ``status``
+/// - ``response``
+///
+/// ### Converting the Response
+///
+/// - ``string(encoding:)``
 public struct PostgrestResponse<T> {
+  /// The raw response body as `Data`.
   public let data: Data
+
+  /// The underlying HTTP URL response.
   public let response: HTTPURLResponse
+
+  /// The total number of rows matching the query, or `nil` if no count was requested.
+  ///
+  /// This value is populated from the `Content-Range` response header when a ``CountOption`` is
+  /// passed to the query. It respects any applied filters but ignores modifiers such as `limit`
+  /// and `range`.
   public let count: Int?
+
+  /// The decoded response value.
   public let value: T
 
+  /// The HTTP status code of the response.
   public var status: Int {
     response.statusCode
   }
 
+  /// Creates a ``PostgrestResponse`` from raw response data.
+  ///
+  /// - Parameters:
+  ///   - data: The raw response body.
+  ///   - response: The HTTP URL response.
+  ///   - value: The decoded value.
   public init(
     data: Data,
     response: HTTPURLResponse,
@@ -33,68 +81,175 @@ public struct PostgrestResponse<T> {
     self.value = value
   }
 
-  /// Returns the response converting the returned Data into Unicode characters using a given encoding.
+  /// Returns the response body as a string using the specified encoding.
+  ///
+  /// - Parameter encoding: The string encoding to use. Defaults to `.utf8`.
+  /// - Returns: A `String` decoded from ``data``, or `nil` if the data cannot be decoded with the given encoding.
   public func string(encoding: String.Encoding = .utf8) -> String? {
     String(data: data, encoding: encoding)
   }
 }
 
-/// Returns count as part of the response when specified.
+/// The algorithm PostgREST uses to count the total number of rows matching a query.
+///
+/// Pass a ``CountOption`` to query methods such as ``PostgrestQueryBuilder/select(_:head:count:)``
+/// or ``PostgrestClient/rpc(_:params:head:get:count:)`` to include a row count in the response.
+///
+/// The chosen algorithm determines the accuracy vs. performance trade-off:
+///
+/// | Option | Accuracy | Speed |
+/// |--------|----------|-------|
+/// | ``exact`` | Exact | Slow |
+/// | ``planned`` | Approximate | Fast |
+/// | ``estimated`` | Adaptive | Moderate |
 public enum CountOption: String, Sendable {
-  /// Exact but slow count algorithm. Performs a `COUNT(*)` under the hood.
+  /// Performs a `COUNT(*)` under the hood for an exact row count.
+  ///
+  /// Use this when you need a precise total. It can be slow on large tables.
   case exact
-  /// Approximated but fast count algorithm. Uses the Postgres statistics under the hood.
+
+  /// Uses PostgreSQL statistics for a fast but approximate row count.
+  ///
+  /// The estimate is derived from `pg_class.reltuples` and may be inaccurate
+  /// if the table statistics are stale.
   case planned
+
   /// Uses exact count for low numbers and planned count for high numbers.
+  ///
+  /// PostgREST switches to the approximate algorithm automatically when the
+  /// estimated count exceeds a threshold, trading accuracy for performance
+  /// on large result sets.
   case estimated
 }
 
-/// Enum of options representing the ways PostgREST can return values from the server.
+/// Controls which rows PostgREST returns after a write operation.
 ///
-/// https://postgrest.org/en/v9.0/api.html?highlight=PREFER#insertions-updates
+/// Pass a ``PostgrestReturningOptions`` value to ``PostgrestQueryBuilder/insert(_:returning:count:)``,
+/// ``PostgrestQueryBuilder/update(_:returning:count:)``, ``PostgrestQueryBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``,
+/// or ``PostgrestQueryBuilder/delete(returning:count:)`` to specify what the server sends back.
+///
+/// See the [PostgREST documentation](https://postgrest.org/en/v9.0/api.html?highlight=PREFER#insertions-updates)
+/// for more detail.
 public enum PostgrestReturningOptions: String, Sendable {
-  /// Returns nothing from the server
+  /// Returns nothing from the server after the write.
+  ///
+  /// Use this option when you do not need the affected rows, as it avoids
+  /// the overhead of serialising and transmitting them.
   case minimal
-  /// Returns a copy of the updated data.
+
+  /// Returns a copy of the written rows.
+  ///
+  /// Use this option (or chain `.select()` after the call) when you need the
+  /// server-generated values such as `id`, `created_at`, or computed columns.
   case representation
 }
 
-/// The type of tsquery conversion to use on query.
+/// The conversion strategy used to turn a plain-text search query into a `tsquery` expression.
+///
+/// Pass a ``TextSearchType`` to ``PostgrestFilterBuilder/textSearch(_:query:config:type:)`` to
+/// control how user-supplied text is interpreted by PostgreSQL's full-text search engine.
 public enum TextSearchType: String, Sendable {
-  /// Uses PostgreSQL's plainto_tsquery function.
+  /// Converts the query using PostgreSQL's `plainto_tsquery` function.
+  ///
+  /// Words in the query are combined with the `&` (AND) operator. Punctuation
+  /// and special characters are ignored.
   case plain = "pl"
-  /// Uses PostgreSQL's phraseto_tsquery function.
+
+  /// Converts the query using PostgreSQL's `phraseto_tsquery` function.
+  ///
+  /// Words must appear in the specified order, making this suitable for
+  /// exact phrase searches.
   case phrase = "ph"
-  /// Uses PostgreSQL's websearch_to_tsquery function.
-  /// This function will never raise syntax errors, which makes it possible to use raw user-supplied
-  /// input for search, and can be used with advanced operators.
+
+  /// Converts the query using PostgreSQL's `websearch_to_tsquery` function.
+  ///
+  /// This function accepts a web-search–style syntax (`"exact phrase"`, `-exclude`,
+  /// `OR`) and never raises syntax errors, making it safe to use with raw
+  /// user-supplied input.
   case websearch = "w"
 }
 
-/// The output format of an EXPLAIN plan.
+/// The output format of a PostgREST EXPLAIN plan.
+///
+/// Pass an ``ExplainFormat`` value to ``PostgrestTransformBuilder/explain(analyze:verbose:settings:buffers:wal:format:)``
+/// to choose how the query plan is serialised in the response.
+///
+/// ## Topics
+///
+/// ### Built-in Formats
+///
+/// - ``text``
+/// - ``json``
+///
+/// ### Creating a Custom Format
+///
+/// - ``init(rawValue:)``
 public struct ExplainFormat: RawRepresentable, Hashable, Sendable {
+  /// The raw PostgREST format string (e.g., `"text"` or `"json"`).
   public let rawValue: String
 
+  /// Creates an ``ExplainFormat`` with a custom raw format string.
+  ///
+  /// Prefer the static members ``text`` and ``json`` for standard usage.
+  ///
+  /// - Parameter rawValue: The raw format string accepted by PostgREST.
   public init(rawValue: String) {
     self.rawValue = rawValue
   }
 
-  /// Human-readable text output (default).
+  /// Human-readable text output (the default).
+  ///
+  /// Produces the same indented text that `EXPLAIN` prints in `psql`.
   public static let text = ExplainFormat(rawValue: "text")
+
   /// Machine-readable JSON output.
+  ///
+  /// Useful when you want to programmatically inspect or visualise the query plan.
   public static let json = ExplainFormat(rawValue: "json")
 }
 
-/// Options for querying Supabase.
+/// Options for controlling whether the response body is returned and how rows are counted.
+///
+/// Pass a ``FetchOptions`` value to ``PostgrestBuilder/execute(options:)-96tpd`` (or the typed
+/// overload) to request a count without fetching data, or to fetch data and a count simultaneously.
+///
+/// ```swift
+/// // Fetch only the count, no rows
+/// let response = try await client
+///   .from("todos")
+///   .select()
+///   .execute(options: FetchOptions(head: true, count: .exact))
+///
+/// print(response.count) // total rows matching the query
+/// ```
+///
+/// ## Topics
+///
+/// ### Configuring the Request
+///
+/// - ``head``
+/// - ``count``
+///
+/// ### Creating Options
+///
+/// - ``init(head:count:)``
 public struct FetchOptions: Sendable {
-  /// Set head to true if you only want the count value and not the underlying data.
+  /// When `true`, the request uses the HTTP HEAD method and the response body is omitted.
+  ///
+  /// Combine with ``count`` to retrieve a total row count without fetching data.
   public let head: Bool
 
-  /// count options can be used to retrieve the total number of rows that satisfies the
-  /// query. The value for count respects any filters (e.g. eq, gt), but ignores
-  /// modifiers (e.g. limit, range).
+  /// The algorithm to use for counting rows, or `nil` to skip counting.
+  ///
+  /// The returned count respects any applied filters but ignores modifiers
+  /// such as `limit` and `range`. See ``CountOption`` for the available algorithms.
   public let count: CountOption?
 
+  /// Creates a ``FetchOptions`` value.
+  ///
+  /// - Parameters:
+  ///   - head: Pass `true` to suppress the response body (HEAD request). Defaults to `false`.
+  ///   - count: The row-count algorithm to use, or `nil` to skip counting. Defaults to `nil`.
   public init(head: Bool = false, count: CountOption? = nil) {
     self.head = head
     self.count = count

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -110,7 +110,7 @@ public enum CountOption: String, Sendable {
 
   /// Uses PostgreSQL statistics for a fast but approximate row count.
   ///
-  /// The estimate is derived from `pg_class.reltuples` and may be inaccurate
+  /// The estimate is derived from `pg_class.reltuples` and may be inaccurate  // cspell:ignore reltuples
   /// if the table statistics are stale.
   case planned
 
@@ -134,7 +134,7 @@ public enum PostgrestReturningOptions: String, Sendable {
   /// Returns nothing from the server after the write.
   ///
   /// Use this option when you do not need the affected rows, as it avoids
-  /// the overhead of serialising and transmitting them.
+  /// the overhead of serializing and transmitting them.
   case minimal
 
   /// Returns a copy of the written rows.
@@ -172,7 +172,7 @@ public enum TextSearchType: String, Sendable {
 /// The output format of a PostgREST EXPLAIN plan.
 ///
 /// Pass an ``ExplainFormat`` value to ``PostgrestTransformBuilder/explain(analyze:verbose:settings:buffers:wal:format:)``
-/// to choose how the query plan is serialised in the response.
+/// to choose how the query plan is serialized in the response.
 ///
 /// ## Topics
 ///
@@ -199,12 +199,12 @@ public struct ExplainFormat: RawRepresentable, Hashable, Sendable {
 
   /// Human-readable text output (the default).
   ///
-  /// Produces the same indented text that `EXPLAIN` prints in `psql`.
+  /// Produces the same indented text that `EXPLAIN` prints in `psql`. // cspell:ignore psql
   public static let text = ExplainFormat(rawValue: "text")
 
   /// Machine-readable JSON output.
   ///
-  /// Useful when you want to programmatically inspect or visualise the query plan.
+  /// Useful when you want to programmatically inspect or visualize the query plan.
   public static let json = ExplainFormat(rawValue: "json")
 }
 


### PR DESCRIPTION
## Summary

Adds comprehensive DocC documentation to all public symbols in `Sources/PostgREST/`, following the project's DocC conventions.

### Files Updated

- **`Types.swift`** — Full documentation for `PostgrestResponse<T>`, `CountOption`, `PostgrestReturningOptions`, `TextSearchType`, `ExplainFormat`, and `FetchOptions`, including `## Topics` sections and a comparison table for `CountOption`.
- **`PostgrestClient.swift`** — Documented `PostgrestClient`, `Configuration`, `FetchHandler` typealias, and all public methods (`from`, `rpc`, `schema`, `setAuth`). Includes code examples and cross-references.
- **`PostgrestBuilder.swift`** — Documented `setHeader(name:value:)`, `retry(enabled:)`, and both `execute` overloads with usage examples, throws documentation, and `## Topics`.
- **`PostgrestQueryBuilder.swift`** — Documented `select`, `insert`, `update`, `upsert`, and `delete` with parameter docs, safety warnings (mass-update/delete), and code examples.
- **`PostgrestTransformBuilder.swift`** — Documented `select`, `order`, `limit`, `range`, `single`, `csv`, `stripNulls`, `geojson`, `explain`, and `maxAffected` with usage examples and cross-references to `ExplainFormat`.
- **`PostgrestFilterBuilder.swift`** — Documented all filter methods (equality, comparison, pattern matching, range, array, full-text search, logical operators) and the `Operator` enum with case-level descriptions. Added `## Topics` grouping.
- **`PostgrestFilterValue.swift`** — Documented the `PostgrestFilterValue` protocol and all built-in conformances with a summary table.
- **`Defaults.swift`** — Documented the `jsonDecoder`, `jsonEncoder`, and `defaultHeaders` static properties.

### Verification

`make test-docs` passes with no warnings.