### PR TITLE
docs(storage): add DocC documentation to Storage public API

### DIFF
--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -8,10 +8,25 @@ import HTTPTypes
 
 /// Base class for Storage API operations.
 ///
-/// - Note: Thread Safety: This class is `@unchecked Sendable` because all mutable state
-///   is protected by `LockIsolated`. The `configuration` property is immutable (`let`),
-///   while mutable headers are managed separately via `mutableState`.
+/// ``StorageApi`` holds the ``StorageClientConfiguration`` and manages mutable per-instance HTTP
+/// headers behind a lock. Both ``StorageBucketApi`` and ``StorageFileApi`` inherit from this class.
+///
+/// > Note: This class is `@unchecked Sendable` because all mutable state is protected by
+/// > `LockIsolated`. The ``configuration`` property is immutable (`let`), while mutable headers are
+/// > managed separately.
+///
+/// ## Topics
+///
+/// ### Configuration
+///
+/// - ``configuration``
+/// - ``init(configuration:)``
+///
+/// ### Customising headers
+///
+/// - ``setHeader(_:forKey:)``
 public class StorageApi: @unchecked Sendable {
+  /// The configuration used to initialise this client instance.
   public let configuration: StorageClientConfiguration
 
   private struct MutableState {
@@ -21,6 +36,12 @@ public class StorageApi: @unchecked Sendable {
   private let mutableState: LockIsolated<MutableState>
   private let http: any HTTPClientType
 
+  /// Creates a ``StorageApi`` with the given configuration.
+  ///
+  /// Subclasses call this initialiser via `super.init(configuration:)`.
+  ///
+  /// - Parameter configuration: The configuration that controls the endpoint URL, authentication
+  ///   headers, JSON codecs, and HTTP session.
   public init(configuration: StorageClientConfiguration) {
     var configuration = configuration
     if configuration.headers["X-Client-Info"] == nil {
@@ -64,14 +85,19 @@ public class StorageApi: @unchecked Sendable {
     )
   }
 
-  /// Sets an HTTP header for subsequent requests.
+  /// Sets an HTTP header that will be included in all subsequent requests made by this instance.
   ///
-  /// This method is thread-safe and updates the instance's headers using a `LockIsolated`-backed store.
+  /// This method is thread-safe. The header key is normalised to lowercase before being stored.
+  ///
+  /// ```swift
+  /// storage.from("avatars")
+  ///   .setHeader("x-custom-header", forKey: "X-Custom-Header")
+  /// ```
   ///
   /// - Parameters:
-  ///   - value: The value of the header.
-  ///   - key: The name of the header field.
-  /// - Returns: `self` to allow method chaining.
+  ///   - value: The value of the header field.
+  ///   - key: The name of the header field. The key is case-insensitively stored as lowercase.
+  /// - Returns: `self`, enabling method chaining.
   @discardableResult
   public func setHeader(_ value: String, forKey key: String) -> Self {
     mutableState.withValue { $0.headers[key.lowercased()] = value }

--- a/Sources/Storage/StorageBucketApi.swift
+++ b/Sources/Storage/StorageBucketApi.swift
@@ -4,11 +4,35 @@ import Foundation
   import FoundationNetworking
 #endif
 
-/// Storage Bucket API for bucket management operations.
+/// Storage API for bucket management operations.
 ///
-/// - Note: Thread Safety: Inherits immutable design from `StorageApi`. No additional mutable state.
+/// ``StorageBucketApi`` provides methods to list, create, update, empty, and delete Storage
+/// buckets. It is the superclass of ``SupabaseStorageClient``.
+///
+/// > Note: This class is `@unchecked Sendable` and inherits the thread-safe design of
+/// > ``StorageApi``. No additional mutable state is introduced.
+///
+/// ## Topics
+///
+/// ### Listing and inspecting buckets
+///
+/// - ``listBuckets()``
+/// - ``getBucket(_:)``
+///
+/// ### Creating and updating buckets
+///
+/// - ``createBucket(_:options:)``
+/// - ``updateBucket(_:options:)``
+///
+/// ### Removing buckets
+///
+/// - ``emptyBucket(_:)``
+/// - ``deleteBucket(_:)``
 public class StorageBucketApi: StorageApi, @unchecked Sendable {
-  /// Retrieves the details of all Storage buckets within an existing project.
+  /// Retrieves the details of all Storage buckets within the project.
+  ///
+  /// - Returns: An array of ``Bucket`` objects, one for each bucket in the project.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
   public func listBuckets() async throws -> [Bucket] {
     try await execute(
       HTTPRequest(
@@ -20,8 +44,10 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   }
 
   /// Retrieves the details of an existing Storage bucket.
-  /// - Parameters:
-  ///   - id: The unique identifier of the bucket you would like to retrieve.
+  ///
+  /// - Parameter id: The unique identifier of the bucket to retrieve.
+  /// - Returns: The ``Bucket`` with the given identifier.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
   public func getBucket(_ id: String) async throws -> Bucket {
     try await execute(
       HTTPRequest(
@@ -41,9 +67,20 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   }
 
   /// Creates a new Storage bucket.
+  ///
+  /// ```swift
+  /// try await storage.createBucket(
+  ///   "avatars",
+  ///   options: BucketOptions(isPublic: true, fileSizeLimit: .megabytes(5))
+  /// )
+  /// ```
+  ///
   /// - Parameters:
-  ///   - id: A unique identifier for the bucket you are creating.
-  ///   - options: Options for creating the bucket.
+  ///   - id: A unique identifier for the bucket. This also becomes the bucket name.
+  ///   - options: Options that control visibility, file-size limits, and allowed MIME types.
+  ///     Defaults to a private bucket with no size or type restrictions.
+  /// - Throws: ``StorageError`` if a bucket with the same identifier already exists, or if the
+  ///   caller is not authorised.
   public func createBucket(_ id: String, options: BucketOptions = BucketOptions(isPublic: false))
     async throws
   {
@@ -64,10 +101,19 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Updates a Storage bucket.
+  /// Updates an existing Storage bucket's settings.
+  ///
+  /// ```swift
+  /// try await storage.updateBucket(
+  ///   "avatars",
+  ///   options: BucketOptions(isPublic: false, allowedMimeTypes: ["image/png", "image/jpeg"])
+  /// )
+  /// ```
+  ///
   /// - Parameters:
-  ///   - id: A unique identifier for the bucket you are updating.
-  ///   - options: Options for updating the bucket.
+  ///   - id: The unique identifier of the bucket to update.
+  ///   - options: The new options to apply to the bucket.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
   public func updateBucket(_ id: String, options: BucketOptions) async throws {
     try await execute(
       HTTPRequest(
@@ -86,9 +132,13 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Removes all objects inside a single bucket.
-  /// - Parameters:
-  ///   - id: The unique identifier of the bucket you would like to empty.
+  /// Removes all objects inside a bucket without deleting the bucket itself.
+  ///
+  /// > Important: This operation is irreversible. All files in the bucket will be permanently
+  /// > deleted.
+  ///
+  /// - Parameter id: The unique identifier of the bucket to empty.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
   public func emptyBucket(_ id: String) async throws {
     try await execute(
       HTTPRequest(
@@ -98,10 +148,14 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Deletes an existing bucket. A bucket can't be deleted with existing objects inside it.
-  /// You must first `empty()` the bucket.
-  /// - Parameters:
-  ///   - id: The unique identifier of the bucket you would like to delete.
+  /// Deletes an existing bucket.
+  ///
+  /// > Important: A bucket cannot be deleted while it contains objects. Call ``emptyBucket(_:)``
+  /// > first to remove all files, then delete the bucket.
+  ///
+  /// - Parameter id: The unique identifier of the bucket to delete.
+  /// - Throws: ``StorageError`` if the bucket is not empty, does not exist, or the caller is not
+  ///   authorised.
   public func deleteBucket(_ id: String) async throws {
     try await execute(
       HTTPRequest(

--- a/Sources/Storage/StorageError.swift
+++ b/Sources/Storage/StorageError.swift
@@ -1,10 +1,34 @@
 import Foundation
 
+/// An error returned by the Supabase Storage API.
+///
+/// ``StorageError`` is thrown whenever the server responds with a non-2xx status code or when the
+/// response body contains a recognisable error payload. Inspect ``message`` for a human-readable
+/// description, and ``statusCode`` for the HTTP status code string returned by the API.
+///
+/// ```swift
+/// do {
+///   try await storage.from("avatars").download(path: "missing.png")
+/// } catch let error as StorageError {
+///   print(error.statusCode ?? "unknown", error.message)
+/// }
+/// ```
 public struct StorageError: Error, Decodable, Sendable {
+  /// The HTTP status code returned by the API, represented as a string (e.g. `"404"`).
   public var statusCode: String?
+
+  /// A human-readable description of the error.
   public var message: String
+
+  /// A short error identifier string returned by the API, if available.
   public var error: String?
 
+  /// Creates a ``StorageError``.
+  ///
+  /// - Parameters:
+  ///   - statusCode: The HTTP status code string, if known.
+  ///   - message: A human-readable description of the error.
+  ///   - error: A short error identifier string, if available.
   public init(statusCode: String? = nil, message: String, error: String? = nil) {
     self.statusCode = statusCode
     self.message = message
@@ -13,6 +37,7 @@ public struct StorageError: Error, Decodable, Sendable {
 }
 
 extension StorageError: LocalizedError {
+  /// A localized description of the error, equal to ``message``.
   public var errorDescription: String? {
     message
   }

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -54,12 +54,59 @@ enum FileUpload {
   let testingBoundary = LockIsolated<String?>(nil)
 #endif
 
-/// Supabase Storage File API for file operations within a bucket.
+/// Supabase Storage File API for file operations within a specific bucket.
 ///
-/// - Note: Thread Safety: Inherits immutable design from `StorageApi`. The additional `bucketId`
-///   property is also immutable (`let`).
+/// Obtain a ``StorageFileApi`` by calling ``SupabaseStorageClient/from(_:)`` with the bucket
+/// identifier you want to operate on:
+///
+/// ```swift
+/// let fileApi = storage.from("avatars")
+///
+/// // Upload a PNG
+/// try await fileApi.upload("user123.png", data: imageData)
+///
+/// // Generate a signed URL valid for 60 seconds
+/// let url = try await fileApi.createSignedURL(path: "user123.png", expiresIn: 60)
+/// ```
+///
+/// > Note: This class is `@unchecked Sendable`. The ``bucketId`` property is immutable (`let`), and
+/// > all mutable header state is protected by the lock inherited from ``StorageApi``.
+///
+/// ## Topics
+///
+/// ### Uploading files
+///
+/// - ``upload(_:data:options:)``
+/// - ``upload(_:fileURL:options:)``
+/// - ``update(_:data:options:)``
+/// - ``update(_:fileURL:options:)``
+///
+/// ### Uploading via signed URLs
+///
+/// - ``createSignedUploadURL(path:options:)``
+/// - ``uploadToSignedURL(_:token:data:options:)``
+/// - ``uploadToSignedURL(_:token:fileURL:options:)``
+///
+/// ### Downloading files
+///
+/// - ``download(path:options:query:cacheNonce:)``
+/// - ``getPublicURL(path:download:options:cacheNonce:)``
+///
+/// ### Managing files
+///
+/// - ``move(from:to:options:)``
+/// - ``copy(from:to:options:)``
+/// - ``remove(paths:)``
+/// - ``list(path:options:)``
+/// - ``info(path:)``
+/// - ``exists(path:)``
+///
+/// ### Creating signed URLs
+///
+/// - ``createSignedURL(path:expiresIn:download:transform:cacheNonce:)``
+/// - ``createSignedURLs(paths:expiresIn:download:cacheNonce:)``
 public class StorageFileApi: StorageApi, @unchecked Sendable {
-  /// The bucket id to operate on.
+  /// The identifier of the bucket this instance operates on.
   let bucketId: String
 
   init(bucketId: String, configuration: StorageClientConfiguration) {
@@ -131,10 +178,19 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   }
 
   /// Uploads a file to an existing bucket.
+  ///
+  /// ```swift
+  /// let response = try await storage.from("avatars").upload("user123.png", data: imageData)
+  /// print(response.fullPath) // "avatars/user123.png"
+  /// ```
+  ///
   /// - Parameters:
-  ///   - path: The relative file path. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
-  ///   - data: The Data to be stored in the bucket.
-  ///   - options: The options for the uploaded file.
+  ///   - path: The relative file path within the bucket, e.g. `"folder/subfolder/filename.png"`.
+  ///     The bucket must already exist before attempting to upload.
+  ///   - data: The raw bytes to store in the bucket.
+  ///   - options: Upload options such as cache control, content type, and upsert behaviour.
+  /// - Returns: A ``FileUploadResponse`` containing the stored object's identifier and path.
+  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorised.
   @discardableResult
   public func upload(
     _ path: String,
@@ -149,11 +205,19 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Uploads a file to an existing bucket.
+  /// Uploads a file from a local file URL to an existing bucket.
+  ///
+  /// Use this overload when you have a `URL` pointing to a file on disk rather than raw `Data`
+  /// already loaded in memory. This is preferable for large files because the data is streamed
+  /// rather than read entirely into memory first.
+  ///
   /// - Parameters:
-  ///   - path: The relative file path. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
-  ///   - fileURL: The file URL to be stored in the bucket.
-  ///   - options: The options for the uploaded file.
+  ///   - path: The relative file path within the bucket, e.g. `"folder/subfolder/filename.png"`.
+  ///     The bucket must already exist before attempting to upload.
+  ///   - fileURL: A `file://` URL pointing to the local file to upload.
+  ///   - options: Upload options such as cache control, content type, and upsert behaviour.
+  /// - Returns: A ``FileUploadResponse`` containing the stored object's identifier and path.
+  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorised.
   @discardableResult
   public func upload(
     _ path: String,
@@ -168,11 +232,18 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Replaces an existing file at the specified path with a new one.
+  /// Replaces an existing file at the specified path with new data.
+  ///
+  /// Unlike ``upload(_:data:options:)`` with `upsert: true`, this method always targets an
+  /// existing object and will throw if the path does not exist.
+  ///
   /// - Parameters:
-  ///   - path: The relative file path. Should be of the format `folder/subfolder`. The bucket already exist before attempting to upload.
-  ///   - data: The Data to be stored in the bucket.
-  ///   - options: The options for the updated file.
+  ///   - path: The relative file path within the bucket, e.g. `"folder/subfolder/filename.png"`.
+  ///     The bucket must already exist before attempting to update.
+  ///   - data: The raw bytes to overwrite the existing file with.
+  ///   - options: Upload options such as cache control and content type.
+  /// - Returns: A ``FileUploadResponse`` containing the updated object's identifier and path.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
   @discardableResult
   public func update(
     _ path: String,
@@ -187,11 +258,18 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Replaces an existing file at the specified path with a new one.
+  /// Replaces an existing file at the specified path with a new local file.
+  ///
+  /// Use this overload when the replacement content is available as a `URL` pointing to a file on
+  /// disk rather than raw `Data`. Large files are streamed rather than fully loaded into memory.
+  ///
   /// - Parameters:
-  ///   - path: The relative file path. Should be of the format `folder/subfolder`. The bucket already exist before attempting to upload.
-  ///   - fileURL: The file URL to be stored in the bucket.
-  ///   - options: The options for the updated file.
+  ///   - path: The relative file path within the bucket, e.g. `"folder/subfolder/filename.png"`.
+  ///     The bucket must already exist before attempting to update.
+  ///   - fileURL: A `file://` URL pointing to the local file to use as the replacement.
+  ///   - options: Upload options such as cache control and content type.
+  /// - Returns: A ``FileUploadResponse`` containing the updated object's identifier and path.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
   @discardableResult
   public func update(
     _ path: String,
@@ -206,11 +284,18 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Moves an existing file to a new path.
+  /// Moves an existing file to a new path, optionally within a different bucket.
+  ///
+  /// ```swift
+  /// try await storage.from("docs").move(from: "draft.pdf", to: "published/report.pdf")
+  /// ```
+  ///
   /// - Parameters:
-  ///   - source: The original file path, including the current file name. For example `folder/image.png`.
-  ///   - destination: The new file path, including the new file name. For example `folder/image-new.png`.
-  ///   - options: The destination options.
+  ///   - source: The original file path including the file name, e.g. `"folder/image.png"`.
+  ///   - destination: The new file path including the new file name, e.g. `"archive/image.png"`.
+  ///   - options: Optional ``DestinationOptions`` specifying a destination bucket. When `nil`,
+  ///     the file is moved within the same bucket.
+  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorised.
   public func move(
     from source: String,
     to destination: String,
@@ -232,11 +317,19 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Copies an existing file to a new path.
+  /// Copies an existing file to a new path, optionally within a different bucket.
+  ///
+  /// ```swift
+  /// let newPath = try await storage.from("docs").copy(from: "original.pdf", to: "backup/original.pdf")
+  /// ```
+  ///
   /// - Parameters:
-  ///   - source: The original file path, including the current file name. For example `folder/image.png`.
-  ///   - destination: The new file path, including the new file name. For example `folder/image-copy.png`.
-  ///   - options: The destination options.
+  ///   - source: The original file path including the file name, e.g. `"folder/image.png"`.
+  ///   - destination: The destination path including the new file name, e.g. `"folder/image-copy.png"`.
+  ///   - options: Optional ``DestinationOptions`` specifying a destination bucket. When `nil`,
+  ///     the file is copied within the same bucket.
+  /// - Returns: The full storage path of the newly created copy.
+  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorised.
   @discardableResult
   public func copy(
     from source: String,
@@ -265,13 +358,18 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     .Key
   }
 
-  /// Creates a signed URL. Use a signed URL to share a file for a fixed amount of time.
+  /// Creates a signed URL for sharing a private file for a fixed period of time.
+  ///
   /// - Parameters:
-  ///   - path: The file path, including the current file name. For example `folder/image.png`.
-  ///   - expiresIn: The number of seconds until the signed URL expires. For example, `60` for a URL which is valid for one minute.
-  ///   - download: Trigger a download with the specified file name.
-  ///   - transform: Transform the asset before serving it to the client.
-  ///   - cacheNonce: A nonce value appended as a `cacheNonce` query parameter for cache invalidation.
+  ///   - path: The file path including the file name, e.g. `"folder/image.png"`.
+  ///   - expiresIn: Seconds until the URL expires, e.g. `60` for one minute.
+  ///   - download: An optional custom download filename. Pass a non-nil string to force a download
+  ///     with that filename in the `Content-Disposition` header, or `nil` for inline display.
+  ///   - transform: Optional image transformation options applied server-side before delivery.
+  ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
+  ///     cache-busting purposes.
+  /// - Returns: A signed `URL` ready to share.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
   @_disfavoredOverload
   public func createSignedURL(
     path: String,
@@ -301,13 +399,31 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     return try makeSignedURL(response.signedURL, download: download, cacheNonce: cacheNonce)
   }
 
-  /// Creates a signed URL. Use a signed URL to share a file for a fixed amount of time.
+  /// Creates a signed URL for sharing a private file for a fixed period of time.
+  ///
+  /// ```swift
+  /// // Inline preview URL, valid for 5 minutes
+  /// let url = try await storage.from("docs").createSignedURL(path: "report.pdf", expiresIn: 300)
+  ///
+  /// // Force download with original file name
+  /// let downloadURL = try await storage.from("docs").createSignedURL(
+  ///   path: "report.pdf",
+  ///   expiresIn: 60,
+  ///   download: .withOriginalName
+  /// )
+  /// ```
+  ///
   /// - Parameters:
-  ///   - path: The file path, including the current file name. For example `folder/image.png`.
-  ///   - expiresIn: The number of seconds until the signed URL expires. For example, `60` for a URL which is valid for one minute.
-  ///   - download: Trigger a download with the file's original name or a custom name.
-  ///   - transform: Transform the asset before serving it to the client.
-  ///   - cacheNonce: A nonce value appended as a `cacheNonce` query parameter for cache invalidation.
+  ///   - path: The file path including the file name, e.g. `"folder/image.png"`.
+  ///   - expiresIn: Seconds until the URL expires, e.g. `60` for one minute.
+  ///   - download: Controls whether the URL triggers a file download. Pass `.withOriginalName` to
+  ///     download using the file's original name, `.named("custom.pdf")` for a custom name, or
+  ///     `nil` for inline display.
+  ///   - transform: Optional image transformation options applied server-side before delivery.
+  ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
+  ///     cache-busting purposes.
+  /// - Returns: A signed `URL` ready to share.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
   public func createSignedURL(
     path: String,
     expiresIn: Int,
@@ -324,15 +440,22 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Creates multiple signed URLs. Use a signed URL to share a file for a fixed amount of time.
+  /// Creates signed URLs for multiple files in a single request.
   ///
-  /// Each item in the returned array is a ``SignedURLResult``: either `.success(path:signedURL:)` or
-  /// `.failure(path:error:)`. Exactly one case is guaranteed per item.
+  /// Each element in the returned array is a ``SignedURLResult``: either
+  /// `.success(path:signedURL:)` or `.failure(path:error:)`. Exactly one case applies per item.
+  /// Paths that do not exist produce a `.failure` result rather than throwing.
+  ///
   /// - Parameters:
-  ///   - paths: The file paths to be downloaded, including the current file names. For example `["folder/image.png", "folder2/image2.png"]`.
-  ///   - expiresIn: The number of seconds until the signed URLs expire. For example, `60` for URLs which are valid for one minute.
-  ///   - download: Trigger a download with the specified file name.
-  ///   - cacheNonce: A nonce value appended as a `cacheNonce` query parameter for cache invalidation.
+  ///   - paths: File paths to sign, e.g. `["folder/image.png", "folder2/image2.png"]`.
+  ///   - expiresIn: Seconds until the URLs expire, e.g. `60` for one minute.
+  ///   - download: An optional custom download filename. Pass a non-nil string to force a download,
+  ///     or `nil` for inline display.
+  ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
+  ///     cache-busting purposes.
+  /// - Returns: An array of ``SignedURLResult`` values, one per requested path.
+  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorised). Individual missing
+  ///   paths are reported as ``SignedURLResult/failure(path:error:)`` rather than thrown.
   @_disfavoredOverload
   public func createSignedURLs(
     paths: [String],
@@ -368,15 +491,36 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     }
   }
 
-  /// Creates multiple signed URLs. Use a signed URL to share a file for a fixed amount of time.
+  /// Creates signed URLs for multiple files in a single request.
   ///
-  /// Each item in the returned array is a ``SignedURLResult``: either `.success(path:signedURL:)` or
-  /// `.failure(path:error:)`. Exactly one case is guaranteed per item.
+  /// Each element in the returned array is a ``SignedURLResult``: either
+  /// `.success(path:signedURL:)` or `.failure(path:error:)`. Exactly one case applies per item.
+  /// Paths that do not exist produce a `.failure` result rather than throwing.
+  ///
+  /// ```swift
+  /// let results = try await storage.from("docs").createSignedURLs(
+  ///   paths: ["a.pdf", "b.pdf", "missing.pdf"],
+  ///   expiresIn: 3600
+  /// )
+  /// for result in results {
+  ///   switch result {
+  ///   case .success(let path, let url): print(path, url)
+  ///   case .failure(let path, let error): print(path, "failed:", error)
+  ///   }
+  /// }
+  /// ```
+  ///
   /// - Parameters:
-  ///   - paths: The file paths to be downloaded, including the current file names. For example `["folder/image.png", "folder2/image2.png"]`.
-  ///   - expiresIn: The number of seconds until the signed URLs expire. For example, `60` for URLs which are valid for one minute.
-  ///   - download: Trigger a download with the file's original name or a custom name.
-  ///   - cacheNonce: A nonce value appended as a `cacheNonce` query parameter for cache invalidation.
+  ///   - paths: File paths to sign, e.g. `["folder/image.png", "folder2/image2.png"]`.
+  ///   - expiresIn: Seconds until the URLs expire, e.g. `60` for one minute.
+  ///   - download: Controls whether the URLs trigger a file download. Pass `.withOriginalName` to
+  ///     download using each file's original name, `.named("custom")` for a custom name, or `nil`
+  ///     for inline display.
+  ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
+  ///     cache-busting purposes.
+  /// - Returns: An array of ``SignedURLResult`` values, one per requested path, preserving order.
+  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorised). Individual missing
+  ///   paths are reported as ``SignedURLResult/failure(path:error:)`` rather than thrown.
   public func createSignedURLs(
     paths: [String],
     expiresIn: Int,
@@ -432,10 +576,16 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     return signedURL
   }
 
-  /// Deletes files within the same bucket
-  /// - Parameters:
-  ///   - paths: An array of files to be deletes, including the path and file name. For example [`folder/image.png`].
-  /// - Returns: A list of removed ``FileObject``.
+  /// Deletes one or more files from the bucket.
+  ///
+  /// ```swift
+  /// let removed = try await storage.from("avatars").remove(paths: ["user123.png", "temp/draft.png"])
+  /// ```
+  ///
+  /// - Parameter paths: File paths to delete, including the file name,
+  ///   e.g. `["folder/image.png", "other/doc.pdf"]`.
+  /// - Returns: An array of ``FileObject`` values representing the files that were removed.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
   @discardableResult
   public func remove(paths: [String]) async throws -> [FileObject] {
     try await execute(
@@ -448,10 +598,18 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     .decoded(decoder: configuration.decoder)
   }
 
-  /// Lists all the files within a bucket.
+  /// Lists all files within a bucket folder.
+  ///
+  /// ```swift
+  /// let files = try await storage.from("avatars").list(path: "users/")
+  /// ```
+  ///
   /// - Parameters:
-  ///   - path: The folder path.
-  ///   - options: Search options, including `limit`, `offset`, and `sortBy`.
+  ///   - path: The folder prefix to list, e.g. `"users/"`. Pass `nil` to list the bucket root.
+  ///   - options: Search options for filtering, sorting, and paginating results. Defaults to the
+  ///     first 100 files sorted by name ascending.
+  /// - Returns: An array of ``FileObject`` values representing the matching files and folders.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
   public func list(
     path: String? = nil,
     options: SearchOptions? = nil
@@ -471,14 +629,24 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     .decoded(decoder: configuration.decoder)
   }
 
-  /// Downloads a file from a private bucket. For public buckets, make a request to the URL returned
-  /// from ``StorageFileApi/getPublicURL(path:download:fileName:options:)`` instead.
+  /// Downloads a file from a private bucket and returns its raw bytes.
+  ///
+  /// For public buckets, prefer requesting the URL returned by
+  /// ``getPublicURL(path:download:options:cacheNonce:)`` directly.
+  ///
+  /// ```swift
+  /// let data = try await storage.from("avatars").download(path: "user123.png")
+  /// let image = UIImage(data: data)
+  /// ```
+  ///
   /// - Parameters:
-  ///   - path: The file path to be downloaded, including the path and file name. For example `folder/image.png`.
-  ///   - options: Transform the asset before serving it to the client.
-  ///   - additionalQueryItems: Additional query items to be added to the request.
-  ///   - cacheNonce: A nonce value appended as a `cacheNonce` query parameter for cache invalidation.
-  /// - Returns: The data of the downloaded file.
+  ///   - path: The file path including the file name, e.g. `"folder/image.png"`.
+  ///   - options: Optional image transformation options applied server-side before delivery.
+  ///   - additionalQueryItems: Extra URL query items appended to the request.
+  ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
+  ///     cache-busting purposes.
+  /// - Returns: The raw file data.
+  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorised.
   @discardableResult
   public func download(
     path: String,
@@ -509,7 +677,11 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     .data
   }
 
-  /// Retrieves the details of an existing file.
+  /// Retrieves metadata about an existing file without downloading its content.
+  ///
+  /// - Parameter path: The file path including the file name, e.g. `"folder/image.png"`.
+  /// - Returns: A ``FileObjectV2`` containing size, content type, ETag, and other metadata.
+  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorised.
   public func info(path: String) async throws -> FileObjectV2 {
     let _path = _getFinalPath(path)
 
@@ -522,7 +694,14 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     .decoded(decoder: configuration.decoder)
   }
 
-  /// Checks the existence of file.
+  /// Checks whether a file exists in the bucket without downloading it.
+  ///
+  /// Returns `false` for HTTP 400 and 404 responses, and re-throws for any other error.
+  ///
+  /// - Parameter path: The file path including the file name, e.g. `"folder/image.png"`.
+  /// - Returns: `true` if the file exists and is accessible, `false` if it does not exist.
+  /// - Throws: ``StorageError`` for errors other than "not found" (e.g. network failure or
+  ///   authorisation errors).
   public func exists(path: String) async throws -> Bool {
     do {
       try await execute(
@@ -550,13 +729,18 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   }
 
   /// Returns the public URL for a file in a public bucket.
-  /// - Parameters:
-  ///  - path: The path and name of the file to generate the public URL for. For example `folder/image.png`.
-  ///  - download: Trigger a download with the specified file name.
-  ///  - options: Transform the asset before retrieving it on the client.
-  ///  - cacheNonce: A nonce value appended as a `cacheNonce` query parameter for cache invalidation.
   ///
-  ///  - Note: The bucket needs to be set to public.
+  /// > Note: The bucket must be set to public for this URL to be accessible without authentication.
+  ///
+  /// - Parameters:
+  ///   - path: The file path including the file name, e.g. `"folder/image.png"`.
+  ///   - download: An optional custom download filename. Pass a non-nil string to force a download
+  ///     with that name, or `nil` for inline display.
+  ///   - options: Optional image transformation options applied server-side before delivery.
+  ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
+  ///     cache-busting purposes.
+  /// - Returns: The publicly accessible `URL` for the file.
+  /// - Throws: `URLError` if the resulting URL cannot be constructed.
   @_disfavoredOverload
   public func getPublicURL(
     path: String,
@@ -596,13 +780,27 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   }
 
   /// Returns the public URL for a file in a public bucket.
-  /// - Parameters:
-  ///  - path: The path and name of the file to generate the public URL for. For example `folder/image.png`.
-  ///  - download: Trigger a download with the file's original name or a custom name.
-  ///  - options: Transform the asset before retrieving it on the client.
-  ///  - cacheNonce: A nonce value appended as a `cacheNonce` query parameter for cache invalidation.
   ///
-  ///  - Note: The bucket needs to be set to public.
+  /// ```swift
+  /// // Inline display URL
+  /// let url = try storage.from("avatars").getPublicURL(path: "user123.png")
+  ///
+  /// // Force download with original file name
+  /// let dlURL = try storage.from("docs").getPublicURL(path: "report.pdf", download: .withOriginalName)
+  /// ```
+  ///
+  /// > Note: The bucket must be set to public for this URL to be accessible without authentication.
+  ///
+  /// - Parameters:
+  ///   - path: The file path including the file name, e.g. `"folder/image.png"`.
+  ///   - download: Controls whether the URL triggers a file download. Pass `.withOriginalName` to
+  ///     download using the file's original name, `.named("custom.pdf")` for a custom name, or
+  ///     `nil` for inline display.
+  ///   - options: Optional image transformation options applied server-side before delivery.
+  ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
+  ///     cache-busting purposes.
+  /// - Returns: The publicly accessible `URL` for the file.
+  /// - Throws: `URLError` if the resulting URL cannot be constructed.
   public func getPublicURL(
     path: String,
     download: DownloadBehavior? = nil,
@@ -617,18 +815,26 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Returns the public URL for a file in a public bucket.
-  /// - Parameters:
-  ///  - path: The path and name of the file to generate the public URL for. For example `folder/image.png`.
-  ///  - download: Trigger a download with the default file name.
-  ///  - options: Transform the asset before retrieving it on the client.
-  ///  - cacheNonce: A nonce value appended as a `cacheNonce` query parameter for cache invalidation.
+  /// Creates a signed upload URL that allows uploading a file without further authentication.
   ///
-  ///  - Note: The bucket needs to be set to public.
-  /// Creates a signed upload URL. Signed upload URLs can be used to upload files to the bucket without further authentication. They are valid for 2 hours.
-  /// - Parameter path: The file path, including the current file name. For example `folder/image.png`.
-  /// - Returns: A URL that can be used to upload files to the bucket without further
-  /// authentication.
+  /// Signed upload URLs are valid for 2 hours. Pass the returned ``SignedUploadURL/token`` to
+  /// ``uploadToSignedURL(_:token:data:options:)`` (or the file-URL variant) to perform the upload.
+  ///
+  /// ```swift
+  /// let signedUpload = try await storage.from("avatars").createSignedUploadURL(path: "user123.png")
+  /// // Share signedUpload.token with the uploader
+  /// try await storage.from("avatars").uploadToSignedURL(
+  ///   "user123.png",
+  ///   token: signedUpload.token,
+  ///   data: imageData
+  /// )
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - path: The destination file path including the file name, e.g. `"folder/image.png"`.
+  ///   - options: Optional ``CreateSignedUploadURLOptions`` controlling upsert behaviour.
+  /// - Returns: A ``SignedUploadURL`` containing the signed URL and an upload token.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
   public func createSignedUploadURL(
     path: String,
     options: CreateSignedUploadURLOptions? = nil
@@ -672,13 +878,18 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Upload a file with a token generated from ``StorageFileApi/createSignedUploadURL(path:)``.
+  /// Uploads raw data to a pre-signed upload URL.
+  ///
+  /// Obtain the `token` from ``createSignedUploadURL(path:options:)`` before calling this method.
+  ///
   /// - Parameters:
-  ///   - path: The file path, including the file name. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
-  ///   - token: The token generated from ``StorageFileApi/createSignedUploadURL(path:)``.
-  ///   - data: The Data to be stored in the bucket.
-  ///   - options: HTTP headers, for example `cacheControl`.
-  /// - Returns: A key pointing to stored location.
+  ///   - path: The destination file path, e.g. `"folder/subfolder/filename.png"`.
+  ///     The bucket must already exist.
+  ///   - token: The upload token from ``createSignedUploadURL(path:options:)``.
+  ///   - data: The raw bytes to store in the bucket.
+  ///   - options: Optional upload options such as cache control and content type.
+  /// - Returns: A ``SignedURLUploadResponse`` containing the stored object path.
+  /// - Throws: ``StorageError`` if the token is invalid, expired, or the upload fails.
   @discardableResult
   public func uploadToSignedURL(
     _ path: String,
@@ -694,13 +905,20 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     )
   }
 
-  /// Upload a file with a token generated from ``StorageFileApi/createSignedUploadURL(path:)``.
+  /// Uploads a local file to a pre-signed upload URL.
+  ///
+  /// Obtain the `token` from ``createSignedUploadURL(path:options:)`` before calling this method.
+  /// Use this overload for large files where streaming from disk is preferable to loading all
+  /// content into memory.
+  ///
   /// - Parameters:
-  ///   - path: The file path, including the file name. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
-  ///   - token: The token generated from ``StorageFileApi/createSignedUploadURL(path:)``.
-  ///   - fileURL: The file URL to be stored in the bucket.
-  ///   - options: HTTP headers, for example `cacheControl`.
-  /// - Returns: A key pointing to stored location.
+  ///   - path: The destination file path, e.g. `"folder/subfolder/filename.png"`.
+  ///     The bucket must already exist.
+  ///   - token: The upload token from ``createSignedUploadURL(path:options:)``.
+  ///   - fileURL: A `file://` URL pointing to the local file to upload.
+  ///   - options: Optional upload options such as cache control and content type.
+  /// - Returns: A ``SignedURLUploadResponse`` containing the stored object path.
+  /// - Throws: ``StorageError`` if the token is invalid, expired, or the upload fails.
   @discardableResult
   public func uploadToSignedURL(
     _ path: String,

--- a/Sources/Storage/StorageHTTPClient.swift
+++ b/Sources/Storage/StorageHTTPClient.swift
@@ -4,11 +4,46 @@ import Foundation
   import FoundationNetworking
 #endif
 
+/// An HTTP session abstraction used by the Storage client to perform network requests.
+///
+/// ``StorageHTTPSession`` wraps a `URLSession` (or any custom async fetch/upload closures) so that
+/// the Storage client can be tested without a real network connection and can be configured to use
+/// a custom session (e.g. with background upload support).
+///
+/// The default initialiser uses `URLSession.shared`.
+///
+/// ```swift
+/// // Use a custom URLSession with a specific configuration
+/// let config = URLSessionConfiguration.default
+/// config.timeoutIntervalForRequest = 60
+/// let session = URLSession(configuration: config)
+/// let httpSession = StorageHTTPSession(session: session)
+///
+/// let storage = SupabaseStorageClient(
+///   configuration: StorageClientConfiguration(
+///     url: storageURL,
+///     headers: ["Authorization": "Bearer \(token)"],
+///     session: httpSession
+///   )
+/// )
+/// ```
 public struct StorageHTTPSession: Sendable {
+  /// A closure that performs a data fetch for a given `URLRequest`.
+  ///
+  /// Returns the raw response body and the `URLResponse`.
   public var fetch: @Sendable (_ request: URLRequest) async throws -> (Data, URLResponse)
+
+  /// A closure that performs a data upload for a given `URLRequest` and body `Data`.
+  ///
+  /// Returns the raw response body and the `URLResponse`.
   public var upload:
     @Sendable (_ request: URLRequest, _ data: Data) async throws -> (Data, URLResponse)
 
+  /// Creates a ``StorageHTTPSession`` with custom fetch and upload closures.
+  ///
+  /// - Parameters:
+  ///   - fetch: A closure that executes a network fetch request and returns the response data and metadata.
+  ///   - upload: A closure that uploads data for a request and returns the response data and metadata.
   public init(
     fetch: @escaping @Sendable (_ request: URLRequest) async throws -> (Data, URLResponse),
     upload:
@@ -20,6 +55,9 @@ public struct StorageHTTPSession: Sendable {
     self.upload = upload
   }
 
+  /// Creates a ``StorageHTTPSession`` backed by a `URLSession`.
+  ///
+  /// - Parameter session: The `URLSession` to use for network requests. Defaults to `URLSession.shared`.
   public init(session: URLSession = .shared) {
     self.init(
       fetch: { try await session.data(for: $0) },

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -1,14 +1,66 @@
 import Foundation
 
+/// Configuration for the Supabase Storage client.
+///
+/// Pass a ``StorageClientConfiguration`` to ``SupabaseStorageClient`` to control the Storage
+/// endpoint URL, authentication headers, JSON coding strategies, and the underlying HTTP session.
+///
+/// ```swift
+/// let configuration = StorageClientConfiguration(
+///   url: URL(string: "https://project.supabase.co/storage/v1")!,
+///   headers: ["Authorization": "Bearer \(accessToken)"]
+/// )
+/// let storage = SupabaseStorageClient(configuration: configuration)
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating a configuration
+///
+/// - ``init(url:headers:encoder:decoder:session:logger:useNewHostname:)``
+///
+/// ### Configuration properties
+///
+/// - ``url``
+/// - ``headers``
+/// - ``encoder``
+/// - ``decoder``
+/// - ``session``
+/// - ``logger``
+/// - ``useNewHostname``
 public struct StorageClientConfiguration: Sendable {
+  /// The base URL of the Storage API endpoint (e.g. `https://project.supabase.co/storage/v1`).
   public var url: URL
+
+  /// HTTP headers sent with every request, such as the `Authorization` header.
   public var headers: [String: String]
+
+  /// The JSON encoder used to serialise request bodies.
   public let encoder: JSONEncoder
+
+  /// The JSON decoder used to deserialise response bodies.
   public let decoder: JSONDecoder
+
+  /// The HTTP session abstraction used to execute requests.
   public let session: StorageHTTPSession
+
+  /// An optional logger for debugging HTTP interactions.
   public let logger: (any SupabaseLogger)?
+
+  /// When `true`, rewrites `project.supabase.co` hostnames to `project.storage.supabase.co`,
+  /// which disables request buffering and enables uploads larger than 50 GB.
   public let useNewHostname: Bool
 
+  /// Creates a ``StorageClientConfiguration``.
+  ///
+  /// - Parameters:
+  ///   - url: The base URL of the Storage API endpoint.
+  ///   - headers: HTTP headers sent with every request.
+  ///   - encoder: The JSON encoder for request bodies. Defaults to ``JSONEncoder/defaultStorageEncoder``.
+  ///   - decoder: The JSON decoder for response bodies. Defaults to ``JSONDecoder/defaultStorageDecoder``.
+  ///   - session: The HTTP session used for networking. Defaults to a session backed by `URLSession.shared`.
+  ///   - logger: An optional logger. Pass `nil` to disable logging.
+  ///   - useNewHostname: When `true`, the storage-specific hostname is used, enabling uploads over 50 GB.
   public init(
     url: URL,
     headers: [String: String],
@@ -28,14 +80,46 @@ public struct StorageClientConfiguration: Sendable {
   }
 }
 
-/// Supabase Storage client for managing buckets and files.
+/// The top-level Supabase Storage client for managing buckets and files.
 ///
-/// - Note: Thread Safety: Inherits immutable design from `StorageApi`. All state is set at
-///   initialization and never mutated.
+/// ``SupabaseStorageClient`` inherits all bucket-management operations from ``StorageBucketApi``
+/// and provides a ``from(_:)`` method to obtain a ``StorageFileApi`` scoped to a specific bucket.
+///
+/// Typically you obtain an instance via the main `SupabaseClient`:
+///
+/// ```swift
+/// let client = SupabaseClient(supabaseURL: url, supabaseKey: key)
+/// let storage = client.storage
+///
+/// // Upload a file
+/// try await storage.from("avatars").upload("user123.png", data: imageData)
+///
+/// // List all buckets
+/// let buckets = try await storage.listBuckets()
+/// ```
+///
+/// ## Topics
+///
+/// ### Accessing buckets
+///
+/// - ``from(_:)``
+///
+/// ### Bucket management
+///
+/// - ``StorageBucketApi/listBuckets()``
+/// - ``StorageBucketApi/getBucket(_:)``
+/// - ``StorageBucketApi/createBucket(_:options:)``
+/// - ``StorageBucketApi/updateBucket(_:options:)``
+/// - ``StorageBucketApi/emptyBucket(_:)``
+/// - ``StorageBucketApi/deleteBucket(_:)``
 public class SupabaseStorageClient: StorageBucketApi, @unchecked Sendable {
-  /// Perform file operation in a bucket.
-  /// - Parameter id: The bucket id to operate on.
-  /// - Returns: StorageFileApi object
+  /// Returns a ``StorageFileApi`` scoped to the given bucket.
+  ///
+  /// Use the returned object to upload, download, list, move, copy, or delete files within the
+  /// specified bucket.
+  ///
+  /// - Parameter id: The unique identifier of the bucket to operate on.
+  /// - Returns: A ``StorageFileApi`` configured for the given bucket.
   public func from(_ id: String) -> StorageFileApi {
     StorageFileApi(bucketId: id, configuration: configuration)
   }

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -913,12 +913,12 @@ extension SortOrder: Codable {
 /// - ``withOriginalName``
 /// - ``named(_:)``
 public enum DownloadBehavior: Sendable {
-  /// Triggers a browser download using the file's original name.
+  /// Triggers a download using the file's original name.
   case withOriginalName
 
-  /// Triggers a browser download using a custom filename.
+  /// Triggers a download using a custom filename.
   ///
-  /// - Parameter _: The filename the browser should suggest when saving the file.
+  /// - Parameter _: The filename to suggest when saving the file.
   case named(String)
 
   var queryValue: String {

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -1,20 +1,54 @@
 import Foundation
 
+/// Options for searching and paginating files within a bucket.
+///
+/// Pass a ``SearchOptions`` value to ``StorageFileApi/list(path:options:)`` to control which files
+/// are returned and how they are ordered.
+///
+/// ```swift
+/// let options = SearchOptions(
+///   limit: 50,
+///   offset: 0,
+///   sortBy: SortBy(column: "created_at", order: .descending),
+///   search: "avatar"
+/// )
+/// let files = try await storage.from("avatars").list(options: options)
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating search options
+///
+/// - ``init(limit:offset:sortBy:search:)``
+///
+/// ### Filter and sort properties
+///
+/// - ``limit``
+/// - ``offset``
+/// - ``sortBy``
+/// - ``search``
 public struct SearchOptions: Encodable, Sendable {
   var prefix: String
 
-  /// The number of files you want to be returned.
+  /// Maximum number of files to return. Defaults to `100`.
   public var limit: Int?
 
-  /// The starting position.
+  /// Zero-based offset used for paginating results. Defaults to `0`.
   public var offset: Int?
 
-  /// The column to sort by. Can be any column inside a ``FileObject``.
+  /// The column and direction to sort results by. Can be any column inside a ``FileObject``.
   public var sortBy: SortBy?
 
-  /// The search string to filter files by.
+  /// A substring filter applied to file names.
   public var search: String?
 
+  /// Creates a ``SearchOptions`` value.
+  ///
+  /// - Parameters:
+  ///   - limit: Maximum number of files to return.
+  ///   - offset: Zero-based offset for pagination.
+  ///   - sortBy: Column and direction to sort by.
+  ///   - search: A substring filter applied to file names.
   public init(
     limit: Int? = nil,
     offset: Int? = nil,
@@ -29,41 +63,96 @@ public struct SearchOptions: Encodable, Sendable {
   }
 }
 
+/// A column-and-direction pair used to sort ``StorageFileApi/list(path:options:)`` results.
+///
+/// ```swift
+/// SortBy(column: "name", order: .ascending)
+/// SortBy(column: "created_at", order: .descending)
+/// ```
+///
+/// ## Topics
+///
+/// ### Properties
+///
+/// - ``column``
+/// - ``order``
 public struct SortBy: Encodable, Sendable {
+  /// The name of the column to sort by, e.g. `"name"` or `"created_at"`.
   public var column: String?
+
+  /// The raw sort direction string (`"asc"` or `"desc"`).
   public var order: String?
 
+  /// Creates a ``SortBy`` value.
+  ///
+  /// - Parameters:
+  ///   - column: The column name to sort by.
+  ///   - order: The sort direction. Use ``SortOrder/ascending`` or ``SortOrder/descending``.
   public init(column: String? = nil, order: SortOrder? = nil) {
     self.column = column
     self.order = order?.rawValue
   }
 }
 
+/// Options applied when uploading or updating a file.
+///
+/// ```swift
+/// let options = FileOptions(
+///   cacheControl: "86400",
+///   contentType: "image/png",
+///   upsert: true
+/// )
+/// try await storage.from("avatars").upload("user123.png", data: imageData, options: options)
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating file options
+///
+/// - ``init(cacheControl:contentType:upsert:duplex:metadata:headers:)``
+///
+/// ### Upload configuration
+///
+/// - ``cacheControl``
+/// - ``contentType``
+/// - ``upsert``
+/// - ``duplex``
+/// - ``metadata``
+/// - ``headers``
 public struct FileOptions: Sendable {
-  /// The number of seconds the asset is cached in the browser and in the Supabase CDN. This is set
-  /// in the `Cache-Control: max-age=<seconds>` header. Defaults to 3600 seconds.
+  /// The number of seconds the asset is cached in the browser and in the Supabase CDN.
+  ///
+  /// This value is set in the `Cache-Control: max-age=<seconds>` header. Defaults to `"3600"`.
   public var cacheControl: String
 
-  /// The `Content-Type` header value.
+  /// The `Content-Type` header value, e.g. `"image/png"`. When `nil`, the type is inferred from
+  /// the file extension.
   public var contentType: String?
 
-  /// When upsert is set to `true`, the file is overwritten if it exists. When set to `false`, an error
-  /// is thrown if the object already exists. Defaults to `false`.
+  /// When `true`, overwrites an existing file at the same path. When `false` (the default), an
+  /// error is thrown if an object already exists at the destination path.
   public var upsert: Bool
 
-  /// The duplex option is a string parameter that enables or disables duplex streaming, allowing
-  /// for both reading and writing data in the same stream. It can be passed as an option to the
-  /// fetch() method.
+  /// Enables or disables duplex streaming on the underlying `fetch()` call, allowing simultaneous
+  /// reading and writing within the same stream.
   public var duplex: String?
 
-  /// The metadata option is an object that allows you to store additional information about the file.
-  /// This information can be used to filter and search for files.
-  /// The metadata object can contain any key-value pairs you want to store.
+  /// Arbitrary key-value metadata to attach to the uploaded object. You can later use this to
+  /// filter or search for files.
   public var metadata: [String: AnyJSON]?
 
-  /// Optionally add extra headers.
+  /// Extra HTTP headers to include with the upload request.
   public var headers: [String: String]?
 
+  /// Creates a ``FileOptions`` value.
+  ///
+  /// - Parameters:
+  ///   - cacheControl: Seconds for the `Cache-Control: max-age` header. Defaults to `"3600"`.
+  ///   - contentType: MIME type for the `Content-Type` header. Inferred from the extension when `nil`.
+  ///   - upsert: Whether to overwrite an existing file. Defaults to `false`.
+  ///   - duplex: Duplex streaming mode string, if needed.
+  ///   - metadata: Arbitrary metadata key-value pairs to attach to the object.
+  ///   - headers: Extra HTTP headers for the upload request.
   public init(
     cacheControl: String = "3600",
     contentType: String? = nil,
@@ -81,16 +170,34 @@ public struct FileOptions: Sendable {
   }
 }
 
+/// A single signed URL returned as part of a batch sign operation.
+///
+/// Returned by ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)-5lkmo``
+/// (the legacy `[SignedURL]` overload). Prefer the ``SignedURLResult`` overload for new code.
+///
+/// ## Topics
+///
+/// ### Properties
+///
+/// - ``error``
+/// - ``signedURL``
+/// - ``path``
 public struct SignedURL: Decodable, Sendable {
-  /// An optional error message.
+  /// An optional error message. Non-nil when the path could not be signed.
   public var error: String?
 
-  /// The signed url.
+  /// The signed URL.
   public var signedURL: URL
 
-  /// The path of the file.
+  /// The requested file path.
   public var path: String
 
+  /// Creates a ``SignedURL``.
+  ///
+  /// - Parameters:
+  ///   - error: An optional error message when signing failed.
+  ///   - signedURL: The resulting signed URL.
+  ///   - path: The requested file path.
   public init(error: String? = nil, signedURL: URL, path: String) {
     self.error = error
     self.signedURL = signedURL
@@ -98,18 +205,43 @@ public struct SignedURL: Decodable, Sendable {
   }
 }
 
-/// Represents the per-item result of a ``StorageFileApi/createSignedURLs(paths:expiresIn:download:)`` call.
+/// Represents the per-item result of a ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)`` call.
 ///
 /// It is guaranteed that exactly one case applies per item: either the URL was signed
-/// successfully, or the path did not exist / was inaccessible.
+/// successfully, or the path did not exist or was inaccessible.
+///
+/// ```swift
+/// let results = try await storage.from("docs").createSignedURLs(paths: paths, expiresIn: 3600)
+/// for result in results {
+///   switch result {
+///   case .success(let path, let url): print(path, url)
+///   case .failure(let path, let error): print(path, "failed:", error)
+///   }
+/// }
+/// ```
+///
+/// ## Topics
+///
+/// ### Cases
+///
+/// - ``success(path:signedURL:)``
+/// - ``failure(path:error:)``
+///
+/// ### Convenience accessors
+///
+/// - ``path``
+/// - ``signedURL``
+/// - ``error``
 public enum SignedURLResult: Sendable {
   /// The URL was signed successfully.
+  ///
   /// - Parameters:
   ///   - path: The requested file path.
   ///   - signedURL: The signed URL ready for use.
   case success(path: String, signedURL: URL)
 
   /// The path could not be signed.
+  ///
   /// - Parameters:
   ///   - path: The requested file path.
   ///   - error: The reason the URL could not be created.
@@ -136,50 +268,173 @@ public enum SignedURLResult: Sendable {
   }
 }
 
+/// A signed upload URL created by ``StorageFileApi/createSignedUploadURL(path:options:)``.
+///
+/// Pass ``token`` to ``StorageFileApi/uploadToSignedURL(_:token:data:options:)`` to perform the
+/// authenticated upload.
+///
+/// ## Topics
+///
+/// ### Properties
+///
+/// - ``signedURL``
+/// - ``path``
+/// - ``token``
 public struct SignedUploadURL: Sendable {
+  /// The fully constructed signed upload URL.
   public let signedURL: URL
+
+  /// The destination file path within the bucket.
   public let path: String
+
+  /// The upload authentication token extracted from ``signedURL``.
   public let token: String
 }
 
+/// The response returned after a successful file upload or update.
+///
+/// ## Topics
+///
+/// ### Properties
+///
+/// - ``id``
+/// - ``path``
+/// - ``fullPath``
 public struct FileUploadResponse: Sendable {
+  /// The unique identifier assigned to the uploaded object.
   public let id: String
+
+  /// The relative file path within the bucket, as provided to the upload call.
   public let path: String
+
+  /// The full storage key including the bucket name, e.g. `"avatars/user123.png"`.
   public let fullPath: String
 }
 
+/// The response returned after a successful upload via a signed URL.
+///
+/// ## Topics
+///
+/// ### Properties
+///
+/// - ``path``
+/// - ``fullPath``
 public struct SignedURLUploadResponse: Sendable {
+  /// The relative file path within the bucket, as provided to the upload call.
   public let path: String
+
+  /// The full storage key including the bucket name, e.g. `"avatars/user123.png"`.
   public let fullPath: String
 }
 
+/// Options for creating a signed upload URL.
+///
+/// Pass this to ``StorageFileApi/createSignedUploadURL(path:options:)`` to control whether an
+/// existing file at the destination path should be overwritten.
+///
+/// ## Topics
+///
+/// ### Properties
+///
+/// - ``upsert``
 public struct CreateSignedUploadURLOptions: Sendable {
+  /// When `true`, an existing file at the destination path is overwritten by the subsequent upload.
   public var upsert: Bool
 
+  /// Creates a ``CreateSignedUploadURLOptions`` value.
+  ///
+  /// - Parameter upsert: Whether to overwrite an existing object at the destination path.
   public init(upsert: Bool) {
     self.upsert = upsert
   }
 }
 
+/// Options for specifying a destination bucket when moving or copying files.
+///
+/// Pass to ``StorageFileApi/move(from:to:options:)`` or ``StorageFileApi/copy(from:to:options:)``
+/// to move or copy a file across buckets.
+///
+/// ## Topics
+///
+/// ### Properties
+///
+/// - ``destinationBucket``
 public struct DestinationOptions: Sendable {
+  /// The identifier of the destination bucket. When `nil`, the operation stays within the source bucket.
   public var destinationBucket: String?
 
+  /// Creates a ``DestinationOptions`` value.
+  ///
+  /// - Parameter destinationBucket: The destination bucket identifier, or `nil` to use the same bucket.
   public init(destinationBucket: String? = nil) {
     self.destinationBucket = destinationBucket
   }
 }
 
+/// Metadata about a file stored in a Supabase Storage bucket.
+///
+/// ``FileObject`` is returned by ``StorageFileApi/list(path:options:)`` and
+/// ``StorageFileApi/remove(paths:)``.
+///
+/// ## Topics
+///
+/// ### Identifying the file
+///
+/// - ``id``
+/// - ``name``
+/// - ``bucketId``
+/// - ``owner``
+///
+/// ### Timestamps
+///
+/// - ``createdAt``
+/// - ``updatedAt``
+/// - ``lastAccessedAt``
+///
+/// ### Metadata and associations
+///
+/// - ``metadata``
+/// - ``buckets``
 public struct FileObject: Identifiable, Hashable, Codable, Sendable {
+  /// The name of the file, including its extension.
   public var name: String
+
+  /// The identifier of the bucket that contains this file.
   public var bucketId: String?
+
+  /// The user ID of the file owner.
   public var owner: String?
+
+  /// The unique identifier of this file object.
   public var id: UUID?
+
+  /// The date and time the file was last updated.
   public var updatedAt: Date?
+
+  /// The date and time the file was created.
   public var createdAt: Date?
+
+  /// The date and time the file was last accessed.
   public var lastAccessedAt: Date?
+
+  /// Arbitrary key-value metadata attached to the file at upload time.
   public var metadata: [String: AnyJSON]?
+
+  /// The bucket associated with this file, if it was eagerly loaded.
   public var buckets: Bucket?
 
+  /// Creates a ``FileObject``.
+  ///
+  /// - Parameters:
+  ///   - name: The file name including its extension.
+  ///   - bucketId: The bucket identifier.
+  ///   - owner: The owner's user ID.
+  ///   - id: The unique object identifier.
+  ///   - updatedAt: Last-updated timestamp.
+  ///   - createdAt: Creation timestamp.
+  ///   - lastAccessedAt: Last-accessed timestamp.
+  ///   - metadata: Arbitrary key-value metadata.
+  ///   - buckets: The associated ``Bucket``, if available.
   public init(
     name: String,
     bucketId: String? = nil,
@@ -215,19 +470,75 @@ public struct FileObject: Identifiable, Hashable, Codable, Sendable {
   }
 }
 
+/// Extended metadata about a file stored in Supabase Storage, returned by the v2 API.
+///
+/// ``FileObjectV2`` is returned by ``StorageFileApi/info(path:)`` and provides richer metadata
+/// compared to ``FileObject``.
+///
+/// ## Topics
+///
+/// ### Identifying the file
+///
+/// - ``id``
+/// - ``version``
+/// - ``name``
+/// - ``bucketId``
+///
+/// ### Size and content type
+///
+/// - ``size``
+/// - ``contentType``
+/// - ``cacheControl``
+/// - ``etag``
+///
+/// ### Timestamps
+///
+/// - ``createdAt``
+/// - ``updatedAt``
+/// - ``lastAccessedAt``
+/// - ``lastModified``
+///
+/// ### Metadata
+///
+/// - ``metadata``
 public struct FileObjectV2: Identifiable, Hashable, Decodable, Sendable {
+  /// The unique identifier of this object.
   public let id: String
+
+  /// The storage version string for this object.
   public let version: String
+
+  /// The file name including its extension.
   public let name: String
+
+  /// The identifier of the bucket that contains this file.
   public let bucketId: String?
+
+  /// The date and time the file was last updated.
   public let updatedAt: Date?
+
+  /// The date and time the file was created.
   public let createdAt: Date?
+
+  /// The date and time the file was last accessed.
   public let lastAccessedAt: Date?
+
+  /// The file size in bytes.
   public let size: Int?
+
+  /// The `Cache-Control` header value associated with this file.
   public let cacheControl: String?
+
+  /// The MIME content type of the file.
   public let contentType: String?
+
+  /// The ETag of the stored object.
   public let etag: String?
+
+  /// The date and time the object was last modified.
   public let lastModified: Date?
+
+  /// Arbitrary key-value metadata attached to the file at upload time.
   public let metadata: [String: AnyJSON]?
 
   enum CodingKeys: String, CodingKey {
@@ -247,16 +558,65 @@ public struct FileObjectV2: Identifiable, Hashable, Decodable, Sendable {
   }
 }
 
+/// A Supabase Storage bucket.
+///
+/// Buckets are the top-level containers for files. Retrieve bucket details with
+/// ``StorageBucketApi/getBucket(_:)`` or ``StorageBucketApi/listBuckets()``.
+///
+/// ## Topics
+///
+/// ### Identifying the bucket
+///
+/// - ``id``
+/// - ``name``
+/// - ``owner``
+///
+/// ### Access and limits
+///
+/// - ``isPublic``
+/// - ``allowedMimeTypes``
+/// - ``fileSizeLimit``
+///
+/// ### Timestamps
+///
+/// - ``createdAt``
+/// - ``updatedAt``
 public struct Bucket: Identifiable, Hashable, Codable, Sendable {
+  /// The unique identifier of the bucket.
   public var id: String
+
+  /// The human-readable name of the bucket.
   public var name: String
+
+  /// The user ID of the bucket owner.
   public var owner: String
+
+  /// Whether the bucket is publicly accessible without an authorization token.
   public var isPublic: Bool
+
+  /// The date and time the bucket was created.
   public var createdAt: Date
+
+  /// The date and time the bucket was last updated.
   public var updatedAt: Date
+
+  /// MIME types accepted during upload, e.g. `["image/png", "image/*"]`. `nil` allows all types.
   public var allowedMimeTypes: [String]?
+
+  /// Maximum file size allowed for uploads to this bucket, in bytes.
   public var fileSizeLimit: Int64?
 
+  /// Creates a ``Bucket``.
+  ///
+  /// - Parameters:
+  ///   - id: Unique bucket identifier.
+  ///   - name: Human-readable bucket name.
+  ///   - owner: User ID of the bucket owner.
+  ///   - isPublic: Whether the bucket is publicly readable.
+  ///   - createdAt: Creation timestamp.
+  ///   - updatedAt: Last-updated timestamp.
+  ///   - allowedMimeTypes: Permitted MIME types for uploads. `nil` allows all types.
+  ///   - fileSizeLimit: Maximum upload size in bytes. `nil` means no limit.
   public init(
     id: String,
     name: String,
@@ -291,25 +651,49 @@ public struct Bucket: Identifiable, Hashable, Codable, Sendable {
 
 // MARK: - StorageByteCount
 
-/// A file size limit for a Storage bucket.
+/// A file size limit for a Storage bucket, expressed as an integer byte count or a human-readable string.
+///
+/// ``StorageByteCount`` is accepted wherever a file-size limit is required (e.g. ``BucketOptions``).
+/// You can create instances using the static factory methods, integer literals, or string literals.
 ///
 /// ```swift
 /// BucketOptions(fileSizeLimit: .megabytes(1.5))
 /// BucketOptions(fileSizeLimit: "500kb")
 /// BucketOptions(fileSizeLimit: 5_000_000)
 /// ```
+///
+/// ## Topics
+///
+/// ### Creating a byte count
+///
+/// - ``init(_:)``
+/// - ``init(stringValue:)``
+/// - ``kilobytes(_:)``
+/// - ``megabytes(_:)``
+/// - ``gigabytes(_:)``
+///
+/// ### Accessing the stored value
+///
+/// - ``intValue``
+/// - ``stringValue``
 public struct StorageByteCount: Sendable, Hashable {
-  /// The exact byte count, or `nil` when a string value is used.
+  /// The exact byte count, or `nil` when a human-readable string value is used.
   public let intValue: Int64?
 
   /// A human-readable size string (e.g. `"1.5mb"`, `"500kb"`), or `nil` when an integer is used.
   public let stringValue: String?
 
+  /// Creates a ``StorageByteCount`` from an exact byte count.
+  ///
+  /// - Parameter intValue: The number of bytes.
   public init(_ intValue: Int64) {
     self.intValue = intValue
     self.stringValue = nil
   }
 
+  /// Creates a ``StorageByteCount`` from a human-readable size string.
+  ///
+  /// - Parameter stringValue: A size string such as `"500kb"`, `"1.5mb"`, or `"2gb"`.
   public init(stringValue: String) {
     self.intValue = nil
     self.stringValue = stringValue
@@ -320,16 +704,22 @@ public struct StorageByteCount: Sendable, Hashable {
   }
 
   /// Creates a ``StorageByteCount`` from a number of kilobytes.
+  ///
+  /// - Parameter value: Size in kilobytes.
   public static func kilobytes(_ value: Double) -> Self {
     Self(stringValue: "\(formatValue(value))kb")
   }
 
   /// Creates a ``StorageByteCount`` from a number of megabytes.
+  ///
+  /// - Parameter value: Size in megabytes.
   public static func megabytes(_ value: Double) -> Self {
     Self(stringValue: "\(formatValue(value))mb")
   }
 
   /// Creates a ``StorageByteCount`` from a number of gigabytes.
+  ///
+  /// - Parameter value: Size in gigabytes.
   public static func gigabytes(_ value: Double) -> Self {
     Self(stringValue: "\(formatValue(value))gb")
   }
@@ -362,16 +752,36 @@ extension StorageByteCount: Encodable {
 
 // MARK: - ResizeMode
 
-/// Resize mode for on-the-fly image transformation.
+/// The strategy used to fit an image into the requested dimensions during server-side transformation.
+///
 /// ```swift
 /// TransformOptions(resize: .cover)
 /// ```
+///
+/// ## Topics
+///
+/// ### Predefined modes
+///
+/// - ``cover``
+/// - ``contain``
+/// - ``fill``
 public struct ResizeMode: RawRepresentable, Hashable, Sendable {
+  /// The raw string value sent to the API.
   public let rawValue: String
+
+  /// Creates a ``ResizeMode`` from a raw string value.
+  ///
+  /// - Parameter rawValue: The resize mode string understood by the Storage image API.
   public init(rawValue: String) { self.rawValue = rawValue }
 
+  /// Crops the image to fill the target dimensions while preserving the aspect ratio.
   public static let cover = ResizeMode(rawValue: "cover")
+
+  /// Scales the image to fit within the target dimensions while preserving the aspect ratio, adding
+  /// letterboxing if necessary.
   public static let contain = ResizeMode(rawValue: "contain")
+
+  /// Stretches the image to fill the target dimensions, ignoring the aspect ratio.
   public static let fill = ResizeMode(rawValue: "fill")
 }
 
@@ -393,16 +803,35 @@ extension ResizeMode: Codable {
 
 // MARK: - ImageFormat
 
-/// Output format for on-the-fly image transformation.
+/// The output image format produced by the server-side image transformation pipeline.
+///
 /// ```swift
 /// TransformOptions(format: .webp)
 /// ```
+///
+/// ## Topics
+///
+/// ### Predefined formats
+///
+/// - ``origin``
+/// - ``webp``
+/// - ``avif``
 public struct ImageFormat: RawRepresentable, Hashable, Sendable {
+  /// The raw string value sent to the API.
   public let rawValue: String
+
+  /// Creates an ``ImageFormat`` from a raw string value.
+  ///
+  /// - Parameter rawValue: The format string understood by the Storage image API.
   public init(rawValue: String) { self.rawValue = rawValue }
 
+  /// Returns the image in its original format without re-encoding.
   public static let origin = ImageFormat(rawValue: "origin")
+
+  /// Encodes the image as WebP, which typically offers better compression than JPEG or PNG.
   public static let webp = ImageFormat(rawValue: "webp")
+
+  /// Encodes the image as AVIF for superior compression at equivalent quality.
   public static let avif = ImageFormat(rawValue: "avif")
 }
 
@@ -425,14 +854,30 @@ extension ImageFormat: Codable {
 // MARK: - SortOrder
 
 /// Sort direction for ``StorageFileApi/list(path:options:)`` results.
+///
 /// ```swift
 /// SortBy(column: "name", order: .ascending)
 /// ```
+///
+/// ## Topics
+///
+/// ### Predefined orders
+///
+/// - ``ascending``
+/// - ``descending``
 public struct SortOrder: RawRepresentable, Hashable, Sendable {
+  /// The raw string value sent to the API (`"asc"` or `"desc"`).
   public let rawValue: String
+
+  /// Creates a ``SortOrder`` from a raw string value.
+  ///
+  /// - Parameter rawValue: The sort direction string (`"asc"` or `"desc"`).
   public init(rawValue: String) { self.rawValue = rawValue }
 
+  /// Sort results in ascending order (A → Z, oldest → newest).
   public static let ascending = SortOrder(rawValue: "asc")
+
+  /// Sort results in descending order (Z → A, newest → oldest).
   public static let descending = SortOrder(rawValue: "desc")
 }
 
@@ -454,16 +899,26 @@ extension SortOrder: Codable {
 
 // MARK: - DownloadBehavior
 
-/// Controls download behavior for signed and public URLs.
+/// Controls the `Content-Disposition` header behaviour for signed and public URLs.
 ///
 /// ```swift
 /// storage.from("docs").getPublicURL(path: "report.pdf", download: .withOriginalName)
 /// storage.from("docs").getPublicURL(path: "report.pdf", download: .named("annual-2024.pdf"))
 /// ```
+///
+/// ## Topics
+///
+/// ### Cases
+///
+/// - ``withOriginalName``
+/// - ``named(_:)``
 public enum DownloadBehavior: Sendable {
-  /// Trigger a download using the file's original name.
+  /// Triggers a browser download using the file's original name.
   case withOriginalName
-  /// Trigger a download with a custom filename.
+
+  /// Triggers a browser download using a custom filename.
+  ///
+  /// - Parameter _: The filename the browser should suggest when saving the file.
   case named(String)
 
   var queryValue: String {
@@ -477,16 +932,46 @@ public enum DownloadBehavior: Sendable {
 // MARK: - BucketOptions
 
 /// Options used when creating or updating a Storage bucket.
+///
+/// ```swift
+/// try await storage.createBucket(
+///   "user-uploads",
+///   options: BucketOptions(
+///     isPublic: false,
+///     fileSizeLimit: .megabytes(10),
+///     allowedMimeTypes: ["image/png", "image/jpeg"]
+///   )
+/// )
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating bucket options
+///
+/// - ``init(isPublic:fileSizeLimit:allowedMimeTypes:)``
+///
+/// ### Bucket settings
+///
+/// - ``isPublic``
+/// - ``fileSizeLimit``
+/// - ``allowedMimeTypes``
 public struct BucketOptions: Sendable {
   /// Whether the bucket is publicly accessible without an authorization token.
   public var isPublic: Bool
 
-  /// Maximum file size allowed for uploads to this bucket.
+  /// Maximum file size allowed for uploads, stored as a string for the API (e.g. `"10mb"`).
   public var fileSizeLimit: String?
 
   /// MIME types accepted during upload, e.g. `["image/png", "image/*"]`. `nil` allows all types.
   public var allowedMimeTypes: [String]?
 
+  /// Creates a ``BucketOptions`` value.
+  ///
+  /// - Parameters:
+  ///   - isPublic: Whether the bucket is publicly readable. Defaults to `false`.
+  ///   - fileSizeLimit: Maximum upload size. Use ``StorageByteCount`` factory methods for
+  ///     convenience, e.g. `.megabytes(10)`. Defaults to `nil` (no limit).
+  ///   - allowedMimeTypes: Permitted MIME types. `nil` allows all MIME types.
   public init(
     isPublic: Bool = false,
     fileSizeLimit: StorageByteCount? = nil,
@@ -500,19 +985,55 @@ public struct BucketOptions: Sendable {
 
 // MARK: - TransformOptions
 
-/// Transform the asset before serving it to the client.
+/// Options for server-side image transformation applied before the asset is served to the client.
+///
+/// Pass a ``TransformOptions`` value to ``StorageFileApi/download(path:options:query:cacheNonce:)``,
+/// ``StorageFileApi/getPublicURL(path:download:options:cacheNonce:)``, or
+/// ``StorageFileApi/createSignedURL(path:expiresIn:download:transform:cacheNonce:)`` to resize,
+/// reformat, or adjust the quality of images on the fly.
+///
+/// ```swift
+/// let options = TransformOptions(width: 200, height: 200, resize: .cover, quality: 80)
+/// let data = try await storage.from("avatars").download(path: "user.png", options: options)
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating transform options
+///
+/// - ``init(width:height:resize:quality:format:)``
+///
+/// ### Dimensions and format
+///
+/// - ``width``
+/// - ``height``
+/// - ``resize``
+/// - ``quality``
+/// - ``format``
 public struct TransformOptions: Encodable, Sendable {
-  /// The width of the image in pixels.
+  /// Target width in pixels.
   public var width: Int?
-  /// The height of the image in pixels.
+
+  /// Target height in pixels.
   public var height: Int?
+
   /// How the image is resized to fit the target dimensions. Defaults to `cover`.
   public var resize: String?
-  /// Quality of the returned image, from 20 to 100. Defaults to 80.
+
+  /// Output quality, from 20 to 100. Higher values produce larger files. Defaults to 80.
   public var quality: Int?
-  /// Output format of the image.
+
+  /// Output image format.
   public var format: String?
 
+  /// Creates a ``TransformOptions`` value.
+  ///
+  /// - Parameters:
+  ///   - width: Target width in pixels.
+  ///   - height: Target height in pixels.
+  ///   - resize: Resize strategy. Defaults to ``ResizeMode/cover`` when `nil`.
+  ///   - quality: Output quality from 20–100. Defaults to 80 when `nil`.
+  ///   - format: Output image format. Defaults to the source format when `nil`.
   public init(
     width: Int? = nil,
     height: Int? = nil,


### PR DESCRIPTION
## Summary

- **`StorageError`** — full DocC abstract and property docs with a usage example
- **`StorageHTTPSession`** — abstract, property docs, and two initialiser overloads documented
- **`StorageClientConfiguration`** — full property docs, `## Topics` section
- **`SupabaseStorageClient`** — main client abstract with usage example, `## Topics` for all operations
- **`StorageApi`** — base-class abstract, thread-safety note, `## Topics`, and improved `setHeader(_:forKey:)` docs
- **`StorageBucketApi`** — all six bucket CRUD methods documented with parameter, returns, and throws; important notes for `emptyBucket` and `deleteBucket`
- **`StorageFileApi`** — comprehensive class abstract with usage example and full `## Topics`; every public method documented with parameters, return values, throws, and code examples
- **`Types.swift`** — every public type documented: `SearchOptions`, `SortBy`, `FileOptions`, `SignedURL`, `SignedURLResult`, `SignedUploadURL`, `FileUploadResponse`, `SignedURLUploadResponse`, `CreateSignedUploadURLOptions`, `DestinationOptions`, `FileObject`, `FileObjectV2`, `Bucket`, `StorageByteCount`, `ResizeMode`, `ImageFormat`, `SortOrder`, `DownloadBehavior`, `BucketOptions`, `TransformOptions`; each includes a `## Topics` section grouping its members

All docs pass `make test-docs` with zero warnings.