### PR TITLE
docs(auth): add DocC documentation to Auth public API

### DIFF
--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -8,11 +8,11 @@
 import Foundation
 import HTTPTypes
 
-/// Admin-only Auth operations that require the service-role key.
+/// Admin-only Auth operations that require the secret key.
 ///
 /// Access this namespace via ``AuthClient/admin``.
 ///
-/// > Warning: These methods require the service-role (`secret`) key. Never expose this key
+/// > Warning: These methods require the secret key. Never expose this key
 /// > in a browser or mobile app — call these methods from a secure server-side environment only.
 ///
 /// ## Topics

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -8,6 +8,25 @@
 import Foundation
 import HTTPTypes
 
+/// Admin-only Auth operations that require the service-role key.
+///
+/// Access this namespace via ``AuthClient/admin``.
+///
+/// > Warning: These methods require the service-role (`secret`) key. Never expose this key
+/// > in a browser or mobile app — call these methods from a secure server-side environment only.
+///
+/// ## Topics
+///
+/// ### User management
+/// - ``getUserById(_:)``
+/// - ``updateUserById(_:attributes:)``
+/// - ``createUser(attributes:)``
+/// - ``inviteUserByEmail(_:data:redirectTo:)``
+/// - ``deleteUser(id:shouldSoftDelete:)``
+/// - ``listUsers(params:)``
+///
+/// ### OAuth 2.1 clients
+/// - ``oauth``
 public struct AuthAdmin: Sendable {
   let clientID: AuthClientID
 
@@ -178,7 +197,7 @@ public struct AuthAdmin: Sendable {
   /*
    Generate link is commented out temporarily due issues with they Auth's decoding is configured.
    Will revisit it later.
-
+  
   /// Generates email links and OTPs to be sent via a custom email provider.
   ///
   /// - Parameter params: The parameters for the link generation.

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -197,7 +197,7 @@ public struct AuthAdmin: Sendable {
   /*
    Generate link is commented out temporarily due issues with they Auth's decoding is configured.
    Will revisit it later.
-  
+
   /// Generates email links and OTPs to be sent via a custom email provider.
   ///
   /// - Parameter params: The parameters for the link generation.

--- a/Sources/Auth/AuthAdminOAuth.swift
+++ b/Sources/Auth/AuthAdminOAuth.swift
@@ -8,8 +8,23 @@
 import Foundation
 import HTTPTypes
 
-/// Contains all OAuth client administration methods.
-/// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+/// Admin operations for managing OAuth 2.1 clients registered in Supabase Auth.
+///
+/// Only relevant when the OAuth 2.1 server feature is enabled in Supabase Auth.
+/// Access this namespace via ``AuthAdmin/oauth``.
+///
+/// > Warning: These methods require the service-role (`secret`) key. Never expose this key
+/// > in a browser or mobile app — call these methods from a secure server-side environment only.
+///
+/// ## Topics
+///
+/// ### Managing clients
+/// - ``listClients(params:)``
+/// - ``createClient(params:)``
+/// - ``getClient(clientId:)``
+/// - ``updateClient(clientId:params:)``
+/// - ``deleteClient(clientId:)``
+/// - ``regenerateClientSecret(clientId:)``
 public struct AuthAdminOAuth: Sendable {
   let clientID: AuthClientID
 

--- a/Sources/Auth/AuthAdminOAuth.swift
+++ b/Sources/Auth/AuthAdminOAuth.swift
@@ -13,7 +13,7 @@ import HTTPTypes
 /// Only relevant when the OAuth 2.1 server feature is enabled in Supabase Auth.
 /// Access this namespace via ``AuthAdmin/oauth``.
 ///
-/// > Warning: These methods require the service-role (`secret`) key. Never expose this key
+/// > Warning: These methods require the secret key. Never expose this key
 /// > in a browser or mobile app — call these methods from a secure server-side environment only.
 ///
 /// ## Topics

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -59,6 +59,93 @@ private actor GlobalJWKSCache {
 
 private let globalJWKSCache = GlobalJWKSCache()
 
+/// The primary interface to Supabase Auth.
+///
+/// Use `AuthClient` to sign users up, sign them in, manage sessions, and subscribe to
+/// authentication-state changes. It is an `actor`, so all mutable state is protected by Swift
+/// concurrency.
+///
+/// ```swift
+/// let auth = AuthClient(
+///   url: URL(string: "https://<project>.supabase.co/auth/v1")!,
+///   headers: ["apikey": "<anon-key>"],
+///   localStorage: KeychainLocalStorage()
+/// )
+///
+/// // Sign in
+/// let session = try await auth.signIn(email: "user@example.com", password: "secret")
+///
+/// // Listen for state changes
+/// for await (event, session) in auth.authStateChanges {
+///   print(event, session?.user.email ?? "signed out")
+/// }
+/// ```
+///
+/// ## Topics
+///
+/// ### Observing state
+/// - ``onAuthStateChange(_:)``
+/// - ``authStateChanges``
+/// - ``currentSession``
+/// - ``currentUser``
+/// - ``session``
+///
+/// ### Signing up
+/// - ``signUp(email:password:data:redirectTo:captchaToken:)``
+/// - ``signUp(phone:password:channel:data:captchaToken:)``
+/// - ``signInAnonymously(data:captchaToken:)``
+///
+/// ### Signing in
+/// - ``signIn(email:password:captchaToken:)``
+/// - ``signIn(phone:password:captchaToken:)``
+/// - ``signInWithIdToken(credentials:)``
+/// - ``signInWithOTP(email:redirectTo:shouldCreateUser:data:captchaToken:)``
+/// - ``signInWithOTP(phone:channel:shouldCreateUser:data:captchaToken:)``
+/// - ``signInWithSSO(domain:redirectTo:captchaToken:)``
+/// - ``signInWithSSO(providerId:redirectTo:captchaToken:)``
+/// - ``signInWithOAuth(provider:redirectTo:scopes:queryParams:launchFlow:)``
+///
+/// ### Session management
+/// - ``exchangeCodeForSession(authCode:)``
+/// - ``session(from:)``
+/// - ``setSession(accessToken:refreshToken:)``
+/// - ``refreshSession(refreshToken:)``
+/// - ``startAutoRefresh()``
+/// - ``stopAutoRefresh()``
+///
+/// ### Signing out
+/// - ``signOut(scope:)``
+///
+/// ### User management
+/// - ``user(jwt:)``
+/// - ``update(user:redirectTo:)``
+/// - ``verifyOTP(email:token:type:redirectTo:captchaToken:)``
+/// - ``verifyOTP(phone:token:type:captchaToken:)``
+/// - ``verifyOTP(tokenHash:type:)``
+/// - ``resend(email:type:emailRedirectTo:captchaToken:)``
+/// - ``resend(phone:type:captchaToken:)``
+/// - ``reauthenticate()``
+/// - ``resetPasswordForEmail(_:redirectTo:captchaToken:)``
+///
+/// ### Identities
+/// - ``userIdentities()``
+/// - ``linkIdentity(provider:scopes:redirectTo:queryParams:launchURL:)``
+/// - ``linkIdentity(provider:scopes:redirectTo:queryParams:)``
+/// - ``linkIdentityWithIdToken(credentials:)``
+/// - ``getLinkIdentityURL(provider:scopes:redirectTo:queryParams:)``
+/// - ``unlinkIdentity(_:)``
+///
+/// ### JWT claims
+/// - ``getClaims(jwt:options:)``
+///
+/// ### Namespaces
+/// - ``mfa``
+/// - ``admin``
+///
+/// ### Notifications
+/// - ``didChangeAuthStateNotification``
+/// - ``authChangeEventInfoKey``
+/// - ``authChangeSessionInfoKey``
 public actor AuthClient {
   private static let _globalClientID = LockIsolated(0)
 

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -68,7 +68,7 @@ private let globalJWKSCache = GlobalJWKSCache()
 /// ```swift
 /// let auth = AuthClient(
 ///   url: URL(string: "https://<project>.supabase.co/auth/v1")!,
-///   headers: ["apikey": "<anon-key>"],
+///   headers: ["apikey": "<publishable-key>"],
 ///   localStorage: KeychainLocalStorage()
 /// )
 ///

--- a/Sources/Auth/AuthClientConfiguration.swift
+++ b/Sources/Auth/AuthClientConfiguration.swift
@@ -18,13 +18,43 @@ extension AuthClient {
       _ request: URLRequest
     ) async throws -> (Data, URLResponse)
 
-  /// Configuration struct represents the client configuration.
+  /// Configuration options for ``AuthClient``.
+  ///
+  /// ## Topics
+  ///
+  /// ### Networking
+  /// - ``url``
+  /// - ``headers``
+  /// - ``flowType``
+  /// - ``redirectToURL``
+  /// - ``fetch``
+  ///
+  /// ### Storage
+  /// - ``localStorage``
+  /// - ``storageKey``
+  ///
+  /// ### Encoding / decoding
+  /// - ``encoder``
+  /// - ``decoder``
+  /// - ``jsonEncoder``
+  /// - ``jsonDecoder``
+  ///
+  /// ### Token refresh
+  /// - ``autoRefreshToken``
+  /// - ``defaultAutoRefreshToken``
+  /// - ``emitLocalSessionAsInitialSession``
+  ///
+  /// ### Defaults
+  /// - ``defaultFlowType``
+  /// - ``defaultHeaders``
   public struct Configuration: Sendable {
     /// The URL of the Auth server.
     public let url: URL
 
     /// Any additional headers to send to the Auth server.
     public var headers: [String: String]
+
+    /// The OAuth / sign-in flow type to use (``AuthFlowType/implicit`` or ``AuthFlowType/pkce``).
     public let flowType: AuthFlowType
 
     /// Default URL to be used for redirect on the flows that requires it.
@@ -38,7 +68,11 @@ extension AuthClient {
 
     /// Custom SupabaseLogger implementation used to inspecting log messages from the Auth library.
     public let logger: (any SupabaseLogger)?
+
+    /// The JSON encoder used to serialize request bodies sent to the Auth server.
     public let encoder: JSONEncoder
+
+    /// The JSON decoder used to deserialize responses received from the Auth server.
     public let decoder: JSONDecoder
 
     /// A custom fetch implementation.

--- a/Sources/Auth/AuthError.swift
+++ b/Sources/Auth/AuthError.swift
@@ -27,87 +27,165 @@ extension ErrorCode {
   /// ErrorCodeUnexpectedFailure signals an unexpected failure such as a 500 Internal Server Error.
   public static let unexpectedFailure = ErrorCode("unexpected_failure")
 
+  /// One or more request fields failed server-side validation.
   public static let validationFailed = ErrorCode("validation_failed")
+  /// The request body could not be parsed as JSON.
   public static let badJSON = ErrorCode("bad_json")
+  /// The supplied email address is already associated with an account.
   public static let emailExists = ErrorCode("email_exists")
+  /// The supplied phone number is already associated with an account.
   public static let phoneExists = ErrorCode("phone_exists")
+  /// The supplied JWT is malformed or uses an unsupported algorithm.
   public static let badJWT = ErrorCode("bad_jwt")
+  /// The operation requires admin privileges but the caller is not an admin.
   public static let notAdmin = ErrorCode("not_admin")
+  /// The request does not contain a valid `Authorization` header.
   public static let noAuthorization = ErrorCode("no_authorization")
+  /// No user exists with the given identifier.
   public static let userNotFound = ErrorCode("user_not_found")
+  /// The session referenced by the token does not exist.
   public static let sessionNotFound = ErrorCode("session_not_found")
+  /// The session has expired and must be refreshed.
   public static let sessionExpired = ErrorCode("session_expired")
+  /// The provided refresh token does not exist.
   public static let refreshTokenNotFound = ErrorCode("refresh_token_not_found")
+  /// The provided refresh token has already been used and cannot be reused.
   public static let refreshTokenAlreadyUsed = ErrorCode("refresh_token_already_used")
+  /// The PKCE or magic-link flow state referenced was not found.
   public static let flowStateNotFound = ErrorCode("flow_state_not_found")
+  /// The PKCE or magic-link flow state has expired.
   public static let flowStateExpired = ErrorCode("flow_state_expired")
+  /// New user sign-ups are disabled for this project.
   public static let signupDisabled = ErrorCode("signup_disabled")
+  /// The user account has been banned and cannot sign in.
   public static let userBanned = ErrorCode("user_banned")
+  /// The OAuth provider returned an email address that must be verified before it can be used.
   public static let providerEmailNeedsVerification = ErrorCode(
     "provider_email_needs_verification")
+  /// No invite was found for the supplied email/token combination.
   public static let inviteNotFound = ErrorCode("invite_not_found")
+  /// The OAuth state parameter is invalid or has been tampered with.
   public static let badOAuthState = ErrorCode("bad_oauth_state")
+  /// The OAuth provider returned an invalid or unexpected callback.
   public static let badOAuthCallback = ErrorCode("bad_oauth_callback")
+  /// The requested OAuth provider is not supported or not enabled.
   public static let oauthProviderNotSupported = ErrorCode("oauth_provider_not_supported")
+  /// The JWT audience (`aud`) claim does not match the expected audience.
   public static let unexpectedAudience = ErrorCode("unexpected_audience")
+  /// The identity cannot be deleted because it is the only identity linked to the user.
   public static let singleIdentityNotDeletable = ErrorCode("single_identity_not_deletable")
+  /// The identity cannot be deleted because doing so would create an email conflict.
   public static let emailConflictIdentityNotDeletable = ErrorCode(
     "email_conflict_identity_not_deletable")
+  /// The identity is already linked to another user.
   public static let identityAlreadyExists = ErrorCode("identity_already_exists")
+  /// The email provider is disabled for this project.
   public static let emailProviderDisabled = ErrorCode("email_provider_disabled")
+  /// The phone provider is disabled for this project.
   public static let phoneProviderDisabled = ErrorCode("phone_provider_disabled")
+  /// The user has already enrolled the maximum number of MFA factors.
   public static let tooManyEnrolledMFAFactors = ErrorCode("too_many_enrolled_mfa_factors")
+  /// Another MFA factor with the same name already exists for this user.
   public static let mfaFactorNameConflict = ErrorCode("mfa_factor_name_conflict")
+  /// No MFA factor was found with the given ID.
   public static let mfaFactorNotFound = ErrorCode("mfa_factor_not_found")
+  /// The MFA challenge request originated from a different IP address than the sign-in request.
   public static let mfaIPAddressMismatch = ErrorCode("mfa_ip_address_mismatch")
+  /// The MFA challenge has expired and a new one must be requested.
   public static let mfaChallengeExpired = ErrorCode("mfa_challenge_expired")
+  /// The MFA verification code was incorrect.
   public static let mfaVerificationFailed = ErrorCode("mfa_verification_failed")
+  /// The MFA verification was rejected by the server (e.g. too many attempts).
   public static let mfaVerificationRejected = ErrorCode("mfa_verification_rejected")
+  /// The session does not meet the required Authenticator Assurance Level (AAL).
   public static let insufficientAAL = ErrorCode("insufficient_aal")
+  /// The captcha verification token failed validation.
   public static let captchaFailed = ErrorCode("captcha_failed")
+  /// The SAML provider is disabled for this project.
   public static let samlProviderDisabled = ErrorCode("saml_provider_disabled")
+  /// Manual identity linking is disabled for this project.
   public static let manualLinkingDisabled = ErrorCode("manual_linking_disabled")
+  /// The SMS provider failed to send the message.
   public static let smsSendFailed = ErrorCode("sms_send_failed")
+  /// The user's email address has not been confirmed.
   public static let emailNotConfirmed = ErrorCode("email_not_confirmed")
+  /// The user's phone number has not been confirmed.
   public static let phoneNotConfirmed = ErrorCode("phone_not_confirmed")
+  /// The SAML relay state referenced was not found.
   public static let samlRelayStateNotFound = ErrorCode("saml_relay_state_not_found")
+  /// The SAML relay state has expired.
   public static let samlRelayStateExpired = ErrorCode("saml_relay_state_expired")
+  /// No SAML identity provider was found for the given domain or ID.
   public static let samlIdPNotFound = ErrorCode("saml_idp_not_found")
+  /// The SAML assertion does not contain a user ID.
   public static let samlAssertionNoUserID = ErrorCode("saml_assertion_no_user_id")
+  /// The SAML assertion does not contain an email address.
   public static let samlAssertionNoEmail = ErrorCode("saml_assertion_no_email")
+  /// A user with the given attributes already exists.
   public static let userAlreadyExists = ErrorCode("user_already_exists")
+  /// No SSO provider was found for the given domain or ID.
   public static let ssoProviderNotFound = ErrorCode("sso_provider_not_found")
+  /// Failed to fetch SAML metadata from the identity provider.
   public static let samlMetadataFetchFailed = ErrorCode("saml_metadata_fetch_failed")
+  /// A SAML identity provider with the same entity ID already exists.
   public static let samlIdPAlreadyExists = ErrorCode("saml_idp_already_exists")
+  /// An SSO domain with the same name is already registered.
   public static let ssoDomainAlreadyExists = ErrorCode("sso_domain_already_exists")
+  /// The SAML entity ID in the metadata does not match what was expected.
   public static let samlEntityIDMismatch = ErrorCode("saml_entity_id_mismatch")
+  /// A conflicting resource already exists (generic conflict).
   public static let conflict = ErrorCode("conflict")
+  /// The requested provider is disabled for this project.
   public static let providerDisabled = ErrorCode("provider_disabled")
+  /// The user is managed by an SSO provider and cannot be modified directly.
   public static let userSSOManaged = ErrorCode("user_sso_managed")
+  /// Reauthentication is required before performing this action.
   public static let reauthenticationNeeded = ErrorCode("reauthentication_needed")
+  /// The new password is the same as the current password.
   public static let samePassword = ErrorCode("same_password")
+  /// The reauthentication nonce has expired or is invalid.
   public static let reauthenticationNotValid = ErrorCode("reauthentication_not_valid")
+  /// The OTP has expired and a new one must be requested.
   public static let otpExpired = ErrorCode("otp_expired")
+  /// OTP sign-in is disabled for this project.
   public static let otpDisabled = ErrorCode("otp_disabled")
+  /// The identity referenced was not found.
   public static let identityNotFound = ErrorCode("identity_not_found")
+  /// The password does not meet the project's strength requirements.
   public static let weakPassword = ErrorCode("weak_password")
+  /// The caller has exceeded the global request rate limit.
   public static let overRequestRateLimit = ErrorCode("over_request_rate_limit")
+  /// The caller has exceeded the email-send rate limit.
   public static let overEmailSendRateLimit = ErrorCode("over_email_send_rate_limit")
+  /// The caller has exceeded the SMS-send rate limit.
   public static let overSMSSendRateLimit = ErrorCode("over_sms_send_rate_limit")
+  /// The PKCE code verifier does not match the stored code challenge.
   public static let badCodeVerifier = ErrorCode("bad_code_verifier")
+  /// Anonymous sign-in is disabled for this project.
   public static let anonymousProviderDisabled = ErrorCode("anonymous_provider_disabled")
+  /// A server-side hook timed out.
   public static let hookTimeout = ErrorCode("hook_timeout")
+  /// A server-side hook timed out on all retry attempts.
   public static let hookTimeoutAfterRetry = ErrorCode("hook_timeout_after_retry")
+  /// The hook payload exceeds the size limit.
   public static let hookPayloadOverSizeLimit = ErrorCode("hook_payload_over_size_limit")
+  /// The hook payload has an invalid `Content-Type`.
   public static let hookPayloadInvalidContentType = ErrorCode(
     "hook_payload_invalid_content_type")
+  /// The upstream request timed out.
   public static let requestTimeout = ErrorCode("request_timeout")
+  /// Phone factor enrollment is not enabled for this project.
   public static let mfaPhoneEnrollDisabled = ErrorCode("mfa_phone_enroll_not_enabled")
+  /// Phone factor verification is not enabled for this project.
   public static let mfaPhoneVerifyDisabled = ErrorCode("mfa_phone_verify_not_enabled")
+  /// TOTP factor enrollment is not enabled for this project.
   public static let mfaTOTPEnrollDisabled = ErrorCode("mfa_totp_enroll_not_enabled")
+  /// TOTP factor verification is not enabled for this project.
   public static let mfaTOTPVerifyDisabled = ErrorCode("mfa_totp_verify_not_enabled")
+  /// WebAuthn factor enrollment is not enabled for this project.
   public static let mfaWebAuthnEnrollDisabled = ErrorCode(
     "mfa_webauthn_enroll_not_enabled")
+  /// WebAuthn factor verification is not enabled for this project.
   public static let mfaWebAuthnVerifyDisabled = ErrorCode(
     "mfa_webauthn_verify_not_enabled")
   @_spi(Experimental) public static let webAuthnChallengeNotFound = ErrorCode(
@@ -119,13 +197,32 @@ extension ErrorCode {
   @_spi(Experimental) public static let webAuthnCredentialExists = ErrorCode(
     "webauthn_credential_exists")
   @_spi(Experimental) public static let tooManyPasskeys = ErrorCode("too_many_passkeys")
+  /// The user already has a verified MFA factor; unenroll it before enrolling a new one.
   public static let mfaVerifiedFactorExists = ErrorCode("mfa_verified_factor_exists")
   //#nosec G101 -- Not a secret value.
+  /// The provided credentials (email/password or phone/password) are incorrect.
   public static let invalidCredentials = ErrorCode("invalid_credentials")
+  /// The email address is not on the allow-list for this project.
   public static let emailAddressNotAuthorized = ErrorCode("email_address_not_authorized")
+  /// The provided JWT is invalid (malformed, bad signature, or expired).
   public static let invalidJWT = ErrorCode("invalid_jwt")
 }
 
+/// Errors that can be thrown by ``AuthClient`` and related Auth types.
+///
+/// ## Topics
+///
+/// ### Common errors
+/// - ``sessionMissing``
+/// - ``weakPassword(message:reasons:)``
+/// - ``api(message:errorCode:underlyingData:underlyingResponse:)``
+///
+/// ### OAuth flow errors
+/// - ``pkceGrantCodeExchange(message:error:code:)``
+/// - ``implicitGrantRedirect(message:)``
+///
+/// ### JWT errors
+/// - ``jwtVerificationFailed(message:)``
 public enum AuthError: LocalizedError, Equatable {
   @available(
     *,

--- a/Sources/Auth/AuthMFA.swift
+++ b/Sources/Auth/AuthMFA.swift
@@ -1,6 +1,23 @@
 import Foundation
 
 /// Contains the full multi-factor authentication API.
+///
+/// Access this namespace via ``AuthClient/mfa``.
+///
+/// ## Topics
+///
+/// ### Enrolling factors
+/// - ``enroll(params:)``
+/// - ``unenroll(params:)``
+///
+/// ### Verifying factors
+/// - ``challenge(params:)``
+/// - ``verify(params:)``
+/// - ``challengeAndVerify(params:)``
+///
+/// ### Listing factors
+/// - ``listFactors()``
+/// - ``getAuthenticatorAssuranceLevel()``
 public struct AuthMFA: Sendable {
   let clientID: AuthClientID
 

--- a/Sources/Auth/AuthStateChangeListener.swift
+++ b/Sources/Auth/AuthStateChangeListener.swift
@@ -18,6 +18,11 @@ public protocol AuthStateChangeListenerRegistration: Sendable {
 
 extension ObservationToken: AuthStateChangeListenerRegistration {}
 
+/// A closure called whenever the authentication state changes.
+///
+/// - Parameters:
+///   - event: The ``AuthChangeEvent`` that triggered this invocation.
+///   - session: The current ``Session``, or `nil` when the user has signed out.
 public typealias AuthStateChangeListener =
   @Sendable (
     _ event: AuthChangeEvent,

--- a/Sources/Auth/Storage/AuthLocalStorage.swift
+++ b/Sources/Auth/Storage/AuthLocalStorage.swift
@@ -1,12 +1,45 @@
 import Foundation
 
+/// A type that can persist, retrieve, and remove Auth session data on the local device.
+///
+/// Implement this protocol to provide a custom storage back-end for ``AuthClient``.
+/// The default implementation uses the Keychain on Apple platforms and Windows Credential
+/// Manager on Windows.
+///
+/// ## Topics
+///
+/// ### Implementing storage
+/// - ``store(key:value:)``
+/// - ``retrieve(key:)``
+/// - ``remove(key:)``
 public protocol AuthLocalStorage: Sendable {
+  /// Persists `value` under `key`, replacing any existing value.
+  ///
+  /// - Parameters:
+  ///   - key: The storage key.
+  ///   - value: The raw bytes to persist.
+  /// - Throws: An error if the write fails.
   func store(key: String, value: Data) throws
+
+  /// Returns the value previously stored under `key`, or `nil` if none exists.
+  ///
+  /// - Parameter key: The storage key.
+  /// - Returns: The stored bytes, or `nil` if the key is absent.
+  /// - Throws: An error if the read fails.
   func retrieve(key: String) throws -> Data?
+
+  /// Deletes the value stored under `key`, if any.
+  ///
+  /// - Parameter key: The storage key to delete.
+  /// - Throws: An error if the delete fails.
   func remove(key: String) throws
 }
 
 extension AuthClient.Configuration {
+  /// The platform-appropriate default local storage implementation.
+  ///
+  /// On Apple platforms this is a ``KeychainLocalStorage`` instance.
+  /// On Windows this is a ``WinCredLocalStorage`` instance.
   #if !os(Linux) && !os(Windows) && !os(Android)
     public static let defaultLocalStorage: any AuthLocalStorage = KeychainLocalStorage()
   #elseif os(Windows)

--- a/Sources/Auth/Storage/KeychainLocalStorage.swift
+++ b/Sources/Auth/Storage/KeychainLocalStorage.swift
@@ -5,18 +5,39 @@
   public struct KeychainLocalStorage: AuthLocalStorage {
     private let keychain: Keychain
 
+    /// Creates a Keychain-backed storage instance.
+    ///
+    /// - Parameters:
+    ///   - service: The Keychain service name used to namespace stored items.
+    ///     Defaults to `"supabase.gotrue.swift"`.
+    ///   - accessGroup: An optional Keychain access group for sharing items between apps.
     public init(service: String? = "supabase.gotrue.swift", accessGroup: String? = nil) {
       keychain = Keychain(service: service, accessGroup: accessGroup)
     }
 
+    /// Stores `value` in the Keychain under `key`.
+    ///
+    /// - Parameters:
+    ///   - key: The Keychain item key.
+    ///   - value: The raw bytes to store.
+    /// - Throws: A Keychain error if the write fails.
     public func store(key: String, value: Data) throws {
       try keychain.set(value, forKey: key)
     }
 
+    /// Returns the data stored in the Keychain for `key`, or `nil` if not present.
+    ///
+    /// - Parameter key: The Keychain item key.
+    /// - Returns: The stored bytes, or `nil` if the item does not exist.
+    /// - Throws: A Keychain error if the read fails.
     public func retrieve(key: String) throws -> Data? {
       try keychain.data(forKey: key)
     }
 
+    /// Removes the Keychain item for `key`.
+    ///
+    /// - Parameter key: The Keychain item key to delete.
+    /// - Throws: A Keychain error if the delete fails.
     public func remove(key: String) throws {
       try keychain.deleteItem(forKey: key)
     }

--- a/Sources/Auth/Storage/WinCredLocalStorage.swift
+++ b/Sources/Auth/Storage/WinCredLocalStorage.swift
@@ -7,18 +7,32 @@
     case other(Int)
   }
 
+  /// ``AuthLocalStorage`` implementation backed by Windows Credential Manager.
+  ///
+  /// This is the default local storage on Windows. Items are stored as generic credentials
+  /// scoped to the current machine (`CRED_PERSIST_LOCAL_MACHINE`).
   public struct WinCredLocalStorage: AuthLocalStorage {
     private let service: String
 
     private let credentialType: DWORD
     private let credentialPersistence: DWORD
 
+    /// Creates a Windows Credential Manager–backed storage instance.
+    ///
+    /// - Parameter service: A namespace string prepended to every credential target name.
+    ///   Defaults to `"supabase.gotrue.swift"`.
     public init(service: String = "supabase.gotrue.swift") {
       self.service = service
       credentialType = DWORD(CRED_TYPE_GENERIC)
       credentialPersistence = DWORD(CRED_PERSIST_LOCAL_MACHINE)
     }
 
+    /// Stores `value` in the Windows Credential Manager under `key`.
+    ///
+    /// - Parameters:
+    ///   - key: The credential target name suffix.
+    ///   - value: The raw bytes to store.
+    /// - Throws: ``WinCredLocalStorageError/windows(_:)`` if `CredWriteW` fails.
     public func store(key: String, value: Data) throws {
       var valueData = value
 
@@ -43,6 +57,11 @@
       }
     }
 
+    /// Returns the credential stored under `key`, or `nil` if not present.
+    ///
+    /// - Parameter key: The credential target name suffix.
+    /// - Returns: The stored bytes, or `nil` if the credential does not exist.
+    /// - Throws: ``WinCredLocalStorageError/windows(_:)`` if `CredReadW` fails.
     public func retrieve(key: String) throws -> Data? {
       var credential: PCREDENTIALW?
 
@@ -70,6 +89,10 @@
       return data
     }
 
+    /// Removes the credential stored under `key`.
+    ///
+    /// - Parameter key: The credential target name suffix.
+    /// - Throws: ``WinCredLocalStorageError/windows(_:)`` if `CredDeleteW` fails.
     public func remove(key: String) throws {
       let targetName = "\(service)\\\(key))".withCString(encodedAs: UTF16.self) { $0 }
 

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -208,7 +208,7 @@ public struct User: Codable, Hashable, Identifiable, Sendable {
   /// Third-party provider identities linked to this user.
   public var identities: [UserIdentity]?
 
-  /// Whether this is an anonymous (unauthenticated) user.
+  /// Whether this is an anonymous user.
   public var isAnonymous: Bool
 
   /// MFA factors registered for this user.

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1,13 +1,29 @@
 import Foundation
 
+/// An event emitted when the authentication state of the current user changes.
 public enum AuthChangeEvent: String, Sendable {
+  /// Emitted when an initial session is loaded from local storage on startup.
   case initialSession = "INITIAL_SESSION"
+
+  /// Emitted when a password-recovery email link is clicked, making the session available.
   case passwordRecovery = "PASSWORD_RECOVERY"
+
+  /// Emitted when a user signs in or a new session is established.
   case signedIn = "SIGNED_IN"
+
+  /// Emitted when a user signs out.
   case signedOut = "SIGNED_OUT"
+
+  /// Emitted when the access token is refreshed.
   case tokenRefreshed = "TOKEN_REFRESHED"
+
+  /// Emitted when the user's data is updated.
   case userUpdated = "USER_UPDATED"
+
+  /// Emitted when the user's account is deleted.
   case userDeleted = "USER_DELETED"
+
+  /// Emitted when an MFA challenge is successfully verified.
   case mfaChallengeVerified = "MFA_CHALLENGE_VERIFIED"
 }
 
@@ -49,22 +65,24 @@ struct SignUpRequest: Codable, Hashable, Sendable {
   var codeChallengeMethod: String?
 }
 
+/// An active authentication session containing the tokens and user details.
 public struct Session: Codable, Hashable, Sendable {
-  /// The oauth provider token. If present, this can be used to make external API requests to the
-  /// oauth provider used.
+  /// The OAuth provider token. If present, this can be used to make external API requests to the
+  /// OAuth provider used.
   public var providerToken: String?
 
-  /// The oauth provider refresh token. If present, this can be used to refresh the provider_token
-  /// via the oauth provider's API. Not all oauth providers return a provider refresh token. If the
-  /// provider_refresh_token is missing, please refer to the oauth provider's documentation for
+  /// The OAuth provider refresh token. If present, this can be used to refresh the provider_token
+  /// via the OAuth provider's API. Not all OAuth providers return a provider refresh token. If the
+  /// provider_refresh_token is missing, please refer to the OAuth provider's documentation for
   /// information on how to obtain the provider refresh token.
   public var providerRefreshToken: String?
 
   /// A valid JWT that will expire in ``Session/expiresIn`` seconds.
+  ///
   /// It is recommended to set the `JWT_EXPIRY` to a shorter expiry value.
   public var accessToken: String
 
-  /// What type of token this is. Only `bearer` returned, may change in the future.
+  /// The token type. Currently only `bearer` is returned; this may change in the future.
   public var tokenType: String
 
   /// Number of seconds after which the ``Session/accessToken`` should be renewed by using the
@@ -82,8 +100,21 @@ public struct Session: Codable, Hashable, Sendable {
   /// the password used is weak. Inspect the ``WeakPassword/reasons`` property to identify why.
   public var weakPassword: WeakPassword?
 
+  /// The authenticated user associated with this session.
   public var user: User
 
+  /// Creates a new session value.
+  ///
+  /// - Parameters:
+  ///   - providerToken: The OAuth provider token.
+  ///   - providerRefreshToken: The OAuth provider refresh token.
+  ///   - accessToken: A valid JWT access token.
+  ///   - tokenType: The token type (e.g. `bearer`).
+  ///   - expiresIn: Number of seconds until the access token expires.
+  ///   - expiresAt: UNIX timestamp at which the access token expires.
+  ///   - refreshToken: Opaque refresh token string.
+  ///   - weakPassword: Weak-password information returned by the server, if any.
+  ///   - user: The authenticated user.
   public init(
     providerToken: String? = nil,
     providerRefreshToken: String? = nil,
@@ -106,39 +137,108 @@ public struct Session: Codable, Hashable, Sendable {
     self.user = user
   }
 
-  /// Returns `true` if the token is expired or will expire in the next 30 seconds.
+  /// Returns `true` if the access token is expired or will expire within the next 30 seconds.
   ///
-  /// The 30 second buffer is to account for latency issues.
+  /// The 30-second buffer accounts for network latency.
   public var isExpired: Bool {
     let expiresAt = Date(timeIntervalSince1970: expiresAt)
     return expiresAt.timeIntervalSinceNow < defaultExpiryMargin
   }
 }
 
+/// A Supabase Auth user record.
 public struct User: Codable, Hashable, Identifiable, Sendable {
+  /// The unique identifier of the user.
   public var id: UUID
+
+  /// Application-specific metadata stored by the administrator in `auth.users.app_metadata`.
   public var appMetadata: [String: AnyJSON]
+
+  /// User-supplied metadata stored in `auth.users.raw_user_meta_data`.
   public var userMetadata: [String: AnyJSON]
+
+  /// The audience claim (`aud`) of the user's JWT.
   public var aud: String
+
+  /// Timestamp when a confirmation email was last sent to this user.
   public var confirmationSentAt: Date?
+
+  /// Timestamp when a recovery email was last sent to this user.
   public var recoverySentAt: Date?
+
+  /// Timestamp when an email-change confirmation was last sent to this user.
   public var emailChangeSentAt: Date?
+
+  /// The new email address the user has requested, pending confirmation.
   public var newEmail: String?
+
+  /// Timestamp when the user was invited.
   public var invitedAt: Date?
+
+  /// A one-time action link, if one was generated for this user.
   public var actionLink: String?
+
+  /// The user's email address.
   public var email: String?
+
+  /// The user's phone number in E.164 format.
   public var phone: String?
+
+  /// Timestamp when the user account was created.
   public var createdAt: Date
+
+  /// Timestamp when the user account was confirmed (email or phone).
   public var confirmedAt: Date?
+
+  /// Timestamp when the user's email address was confirmed.
   public var emailConfirmedAt: Date?
+
+  /// Timestamp when the user's phone number was confirmed.
   public var phoneConfirmedAt: Date?
+
+  /// Timestamp of the user's last sign-in.
   public var lastSignInAt: Date?
+
+  /// The role assigned to the user (appears in the JWT `role` claim).
   public var role: String?
+
+  /// Timestamp when the user record was last updated.
   public var updatedAt: Date
+
+  /// Third-party provider identities linked to this user.
   public var identities: [UserIdentity]?
+
+  /// Whether this is an anonymous (unauthenticated) user.
   public var isAnonymous: Bool
+
+  /// MFA factors registered for this user.
   public var factors: [Factor]?
 
+  /// Creates a new user value with the given properties.
+  ///
+  /// - Parameters:
+  ///   - id: The unique identifier.
+  ///   - appMetadata: Application-level metadata.
+  ///   - userMetadata: User-supplied metadata.
+  ///   - aud: The JWT audience claim.
+  ///   - confirmationSentAt: Timestamp a confirmation email was sent.
+  ///   - recoverySentAt: Timestamp a recovery email was sent.
+  ///   - emailChangeSentAt: Timestamp an email-change email was sent.
+  ///   - newEmail: Pending new email address.
+  ///   - invitedAt: Timestamp the user was invited.
+  ///   - actionLink: A one-time action link.
+  ///   - email: The user's email address.
+  ///   - phone: The user's phone number.
+  ///   - createdAt: Timestamp the account was created.
+  ///   - confirmedAt: Timestamp the account was confirmed.
+  ///   - emailConfirmedAt: Timestamp the email was confirmed.
+  ///   - phoneConfirmedAt: Timestamp the phone was confirmed.
+  ///   - lastSignInAt: Timestamp of the last sign-in.
+  ///   - role: The user's role.
+  ///   - updatedAt: Timestamp the record was last updated.
+  ///   - identities: Linked third-party identities.
+  ///   - isAnonymous: Whether the user is anonymous.
+  ///   - factors: Registered MFA factors.
   public init(
     id: UUID,
     appMetadata: [String: AnyJSON],
@@ -215,16 +315,43 @@ public struct User: Codable, Hashable, Identifiable, Sendable {
   }
 }
 
+/// A third-party identity linked to a ``User``.
 public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
+  /// Provider-specific identifier of this identity.
   public var id: String
+
+  /// Unique identifier of the identity record within Supabase.
   public var identityId: UUID
+
+  /// The user this identity belongs to.
   public var userId: UUID
+
+  /// Provider-specific identity data returned by the third-party.
   public var identityData: [String: AnyJSON]?
+
+  /// The name of the provider (e.g. `google`, `github`).
   public var provider: String
+
+  /// Timestamp when this identity was created.
   public var createdAt: Date?
+
+  /// Timestamp of the last sign-in with this identity.
   public var lastSignInAt: Date?
+
+  /// Timestamp when this identity record was last updated.
   public var updatedAt: Date?
 
+  /// Creates a new user identity value.
+  ///
+  /// - Parameters:
+  ///   - id: The provider-specific identity ID.
+  ///   - identityId: The Supabase identity UUID.
+  ///   - userId: The owning user's UUID.
+  ///   - identityData: Provider-specific identity data.
+  ///   - provider: The provider name.
+  ///   - createdAt: Timestamp the identity was created.
+  ///   - lastSignInAt: Timestamp of the last sign-in via this identity.
+  ///   - updatedAt: Timestamp the identity was last updated.
   public init(
     id: String,
     identityId: UUID,
@@ -314,9 +441,11 @@ public enum Provider: String, Identifiable, Codable, CaseIterable, Sendable {
   case zoom
   case fly
 
+  /// The raw string value of the provider, used as the stable identifier.
   public var id: RawValue { rawValue }
 }
 
+/// Credentials for signing in with an OpenID Connect (OIDC) ID token issued by a third-party.
 public struct OpenIDConnectCredentials: Codable, Hashable, Sendable {
   /// Provider name or OIDC `iss` value identifying which provider should be used to verify the
   /// provided token. Supported names: `google`, `apple`, `azure`, `facebook`.
@@ -341,6 +470,14 @@ public struct OpenIDConnectCredentials: Codable, Hashable, Sendable {
 
   var linkIdentity: Bool = false
 
+  /// Creates OIDC credentials for sign-in.
+  ///
+  /// - Parameters:
+  ///   - provider: The OIDC provider.
+  ///   - idToken: The ID token issued by the provider.
+  ///   - accessToken: Optional access token, required when the ID token contains an `at_hash` claim.
+  ///   - nonce: Optional nonce, required when the ID token contains a `nonce` claim.
+  ///   - gotrueMetaSecurity: Optional captcha verification token.
   public init(
     provider: Provider,
     idToken: String,
@@ -355,14 +492,20 @@ public struct OpenIDConnectCredentials: Codable, Hashable, Sendable {
     self.gotrueMetaSecurity = gotrueMetaSecurity
   }
 
+  /// Providers supported by the OIDC sign-in flow.
   public enum Provider: String, Codable, Hashable, Sendable {
     case google, apple, azure, facebook
   }
 }
 
+/// A captcha verification token used to secure Auth endpoints.
 public struct AuthMetaSecurity: Codable, Hashable, Sendable {
+  /// The captcha token obtained after the user completes a captcha challenge.
   public var captchaToken: String
 
+  /// Creates an ``AuthMetaSecurity`` value with the given captcha token.
+  ///
+  /// - Parameter captchaToken: The captcha token.
   public init(captchaToken: String) {
     self.captchaToken = captchaToken
   }
@@ -416,22 +559,43 @@ struct VerifyMobileOTPParams: Encodable, Hashable {
   var gotrueMetaSecurity: AuthMetaSecurity?
 }
 
+/// The OTP type used when verifying a mobile (SMS/WhatsApp) one-time password.
 public enum MobileOTPType: String, Encodable, Sendable {
+  /// A standard SMS OTP sent to the phone number.
   case sms
+
+  /// An OTP used when confirming a phone number change.
   case phoneChange = "phone_change"
 }
 
+/// The OTP type used when verifying an email one-time password.
 public enum EmailOTPType: String, Encodable, CaseIterable, Sendable {
+  /// OTP sent during initial sign-up email confirmation.
   case signup
+
+  /// OTP sent when an admin invites a user by email.
   case invite
+
+  /// OTP sent as part of a magic-link sign-in flow.
   case magiclink
+
+  /// OTP sent when the user requests a password reset.
   case recovery
+
+  /// OTP sent when the user requests an email address change.
   case emailChange = "email_change"
+
+  /// Generic email OTP.
   case email
 }
 
+/// The response from sign-up and OTP-verification calls that may return either a session or a
+/// user depending on whether email confirmation is required.
 public enum AuthResponse: Codable, Hashable, Sendable {
+  /// A full session was created, meaning the user is immediately signed in.
   case session(Session)
+
+  /// Only a user record was returned, meaning email confirmation is still pending.
   case user(User)
 
   public init(from decoder: any Decoder) throws {
@@ -456,6 +620,7 @@ public enum AuthResponse: Codable, Hashable, Sendable {
     }
   }
 
+  /// The user in either case of the response.
   public var user: User {
     switch self {
     case .session(let session): session.user
@@ -463,28 +628,33 @@ public enum AuthResponse: Codable, Hashable, Sendable {
     }
   }
 
+  /// The session, or `nil` if only a user was returned (confirmation pending).
   public var session: Session? {
     if case .session(let session) = self { return session }
     return nil
   }
 }
 
+/// Attributes that a user can update for their own account.
 public struct UserAttributes: Codable, Hashable, Sendable {
   /// The user's email.
   public var email: String?
+
   /// The user's phone.
   public var phone: String?
+
   /// The user's password.
   public var password: String?
 
   /// The nonce sent for reauthentication if the user's password is to be updated.
   ///
-  /// Note: Call ``AuthClient/reauthenticate()`` to obtain the nonce first.
+  /// > Note: Call ``AuthClient/reauthenticate()`` to obtain the nonce first.
   public var nonce: String?
 
   /// An email change token.
   @available(*, deprecated, message: "This is an old field, stop relying on it.")
   public var emailChangeToken: String?
+
   /// A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata`
   /// column. The `data` should be a JSON object that includes user-specific info, such as their
   /// first and last name.
@@ -493,6 +663,15 @@ public struct UserAttributes: Codable, Hashable, Sendable {
   var codeChallenge: String?
   var codeChallengeMethod: String?
 
+  /// Creates user attributes for an update call.
+  ///
+  /// - Parameters:
+  ///   - email: New email address.
+  ///   - phone: New phone number.
+  ///   - password: New password.
+  ///   - nonce: Reauthentication nonce, required when updating the password.
+  ///   - emailChangeToken: Deprecated email-change token.
+  ///   - data: Additional user metadata to merge.
   public init(
     email: String? = nil,
     phone: String? = nil,
@@ -510,18 +689,21 @@ public struct UserAttributes: Codable, Hashable, Sendable {
   }
 }
 
+/// Attributes that an administrator can set when creating or updating a user.
 public struct AdminUserAttributes: Encodable, Hashable, Sendable {
 
   /// A custom data object to store the user's application specific metadata. This maps to the `auth.users.app_metadata` column.
   public var appMetadata: [String: AnyJSON]?
 
   /// Determines how long a user is banned for.
+  ///
+  /// Pass `none` to remove an existing ban.
   public var banDuration: String?
 
   /// The user's email.
   public var email: String?
 
-  /// Confirms the user's email address if set to true.
+  /// Confirms the user's email address if set to `true`.
   public var emailConfirm: Bool?
 
   /// The `id` for the user.
@@ -539,7 +721,7 @@ public struct AdminUserAttributes: Encodable, Hashable, Sendable {
   /// The user's phone.
   public var phone: String?
 
-  /// Confirms the user's phone number if set to true.
+  /// Confirms the user's phone number if set to `true`.
   public var phoneConfirm: Bool?
 
   /// The role claim set in the user's access token JWT.
@@ -548,6 +730,21 @@ public struct AdminUserAttributes: Encodable, Hashable, Sendable {
   /// A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
   public var userMetadata: [String: AnyJSON]?
 
+  /// Creates admin user attributes.
+  ///
+  /// - Parameters:
+  ///   - appMetadata: Application-level metadata.
+  ///   - banDuration: Ban duration string, e.g. `"24h"`, or `"none"` to lift a ban.
+  ///   - email: The user's email address.
+  ///   - emailConfirm: Whether to mark the email as confirmed.
+  ///   - id: The user's UUID (string form).
+  ///   - nonce: Reauthentication nonce for password updates.
+  ///   - password: Plain-text password.
+  ///   - passwordHash: Pre-hashed password.
+  ///   - phone: The user's phone number.
+  ///   - phoneConfirm: Whether to mark the phone as confirmed.
+  ///   - role: The JWT role claim.
+  ///   - userMetadata: User-supplied metadata.
   public init(
     appMetadata: [String: AnyJSON]? = nil,
     banDuration: String? = nil,
@@ -584,15 +781,29 @@ struct RecoverParams: Codable, Hashable, Sendable {
   var codeChallengeMethod: String?
 }
 
+/// The OAuth / sign-in flow type used by ``AuthClient``.
 public enum AuthFlowType: Sendable {
+  /// The implicit grant flow — tokens are returned in the URL fragment.
+  ///
+  /// > Warning: This flow is less secure than PKCE and should only be used when PKCE is not
+  /// > supported by the environment.
   case implicit
+
+  /// The Proof Key for Code Exchange (PKCE) flow — an authorization code is exchanged for tokens.
+  ///
+  /// This is the recommended flow for mobile and desktop applications.
   case pkce
 }
 
+/// The string type used to identify an MFA factor type (e.g. `"totp"`, `"phone"`, `"webauthn"`).
 public typealias FactorType = String
 
+/// The enrollment status of an MFA factor.
 public enum FactorStatus: String, Codable, Sendable {
+  /// The factor has been verified and is active.
   case verified
+
+  /// The factor has been enrolled but not yet verified.
   case unverified
 }
 
@@ -610,21 +821,35 @@ public struct Factor: Identifiable, Codable, Hashable, Sendable {
   /// Factor's status.
   public let status: FactorStatus
 
+  /// Timestamp when the factor was created.
   public let createdAt: Date
+
+  /// Timestamp when the factor was last updated.
   public let updatedAt: Date
 }
 
+/// The protocol that MFA enrollment parameter types must conform to.
 public protocol MFAEnrollParamsType: Encodable, Hashable, Sendable {
+  /// The factor type identifier (e.g. `"totp"`, `"phone"`, `"webauthn"`).
   var factorType: FactorType { get }
 }
 
+/// Parameters for enrolling a TOTP (Time-based One-Time Password) MFA factor.
 public struct MFATotpEnrollParams: MFAEnrollParamsType {
+  /// The factor type, always `"totp"`.
   public let factorType: FactorType = "totp"
+
   /// Domain which the user is enrolled with.
   public let issuer: String?
+
   /// Human readable name assigned to the factor.
   public let friendlyName: String?
 
+  /// Creates TOTP enrollment parameters.
+  ///
+  /// - Parameters:
+  ///   - issuer: The issuer domain shown in authenticator apps.
+  ///   - friendlyName: A human-readable label for the factor.
   public init(issuer: String? = nil, friendlyName: String? = nil) {
     self.issuer = issuer
     self.friendlyName = friendlyName
@@ -632,12 +857,19 @@ public struct MFATotpEnrollParams: MFAEnrollParamsType {
 }
 
 extension MFAEnrollParamsType where Self == MFATotpEnrollParams {
+  /// Creates parameters for enrolling a TOTP factor.
+  ///
+  /// - Parameters:
+  ///   - issuer: The issuer domain shown in authenticator apps.
+  ///   - friendlyName: A human-readable label for the factor.
   public static func totp(issuer: String? = nil, friendlyName: String? = nil) -> Self {
     MFATotpEnrollParams(issuer: issuer, friendlyName: friendlyName)
   }
 }
 
+/// Parameters for enrolling a phone (SMS/WhatsApp) MFA factor.
 public struct MFAPhoneEnrollParams: MFAEnrollParamsType {
+  /// The factor type, always `"phone"`.
   public let factorType: FactorType = "phone"
 
   /// Human readable name assigned to the factor.
@@ -646,6 +878,11 @@ public struct MFAPhoneEnrollParams: MFAEnrollParamsType {
   /// Phone number to be enrolled. Number should conform to E.164 standard.
   public let phone: String
 
+  /// Creates phone enrollment parameters.
+  ///
+  /// - Parameters:
+  ///   - friendlyName: A human-readable label for the factor.
+  ///   - phone: The phone number in E.164 format.
   public init(friendlyName: String? = nil, phone: String) {
     self.friendlyName = friendlyName
     self.phone = phone
@@ -653,11 +890,17 @@ public struct MFAPhoneEnrollParams: MFAEnrollParamsType {
 }
 
 extension MFAEnrollParamsType where Self == MFAPhoneEnrollParams {
+  /// Creates parameters for enrolling a phone factor.
+  ///
+  /// - Parameters:
+  ///   - friendlyName: A human-readable label for the factor.
+  ///   - phone: The phone number in E.164 format.
   public static func phone(friendlyName: String? = nil, phone: String) -> Self {
     MFAPhoneEnrollParams(friendlyName: friendlyName, phone: phone)
   }
 }
 
+/// The response returned after successfully enrolling a new MFA factor.
 public struct AuthMFAEnrollResponse: Decodable, Hashable, Sendable {
   /// ID of the factor that was just enrolled (in an unverified state).
   public let id: String
@@ -674,6 +917,7 @@ public struct AuthMFAEnrollResponse: Decodable, Hashable, Sendable {
   /// Phone number of the MFA factor in E.164 format. Used to send messages. Available only if the ``type`` is `phone`.
   public var phone: String?
 
+  /// TOTP-specific enrollment data, including the QR code and shared secret.
   public struct TOTP: Decodable, Hashable, Sendable {
     /// Contains a QR code encoding the authenticator URI. You can convert it to a URL by prepending
     /// `data:image/svg+xml;utf-8,` to the value. Avoid logging this value to the console.
@@ -690,6 +934,7 @@ public struct AuthMFAEnrollResponse: Decodable, Hashable, Sendable {
   }
 }
 
+/// Parameters for creating an MFA challenge.
 public struct MFAChallengeParams: Encodable, Hashable {
   /// ID of the factor to be challenged. Returned in ``AuthMFA/enroll(params:)``.
   public let factorId: String
@@ -700,12 +945,23 @@ public struct MFAChallengeParams: Encodable, Hashable {
   /// Relying-party options. Only relevant for WebAuthn factors.
   @_spi(Experimental) public let webAuthn: WebAuthnChallengeOptions?
 
+  /// Creates challenge parameters for a TOTP or phone factor.
+  ///
+  /// - Parameters:
+  ///   - factorId: The factor ID to challenge.
+  ///   - channel: The messaging channel for phone factors.
   public init(factorId: String, channel: MessagingChannel? = nil) {
     self.factorId = factorId
     self.channel = channel
     self.webAuthn = nil
   }
 
+  /// Creates challenge parameters including WebAuthn relying-party options.
+  ///
+  /// - Parameters:
+  ///   - factorId: The factor ID to challenge.
+  ///   - channel: The messaging channel for phone factors.
+  ///   - webAuthn: WebAuthn-specific options.
   @_spi(Experimental)
   public init(
     factorId: String,
@@ -718,6 +974,7 @@ public struct MFAChallengeParams: Encodable, Hashable {
   }
 }
 
+/// Parameters for verifying an MFA challenge.
 public struct MFAVerifyParams: Encodable, Hashable {
   /// ID of the factor being verified. Returned in ``AuthMFA/enroll(params:)``.
   public let factorId: String
@@ -734,6 +991,11 @@ public struct MFAVerifyParams: Encodable, Hashable {
   @_spi(Experimental) public let credentialResponse: AnyJSON?
 
   /// Verifies a `totp` or `phone` factor using a user-provided code.
+  ///
+  /// - Parameters:
+  ///   - factorId: The factor ID being verified.
+  ///   - challengeId: The challenge ID being verified.
+  ///   - code: The verification code from the authenticator app or SMS.
   public init(factorId: String, challengeId: String, code: String) {
     self.factorId = factorId
     self.challengeId = challengeId
@@ -742,6 +1004,11 @@ public struct MFAVerifyParams: Encodable, Hashable {
   }
 
   /// Verifies a `webauthn` factor using the credential response produced by the authenticator.
+  ///
+  /// - Parameters:
+  ///   - factorId: The factor ID being verified.
+  ///   - challengeId: The challenge ID being verified.
+  ///   - credentialResponse: The W3C assertion produced by the platform authenticator.
   @_spi(Experimental)
   public init(factorId: String, challengeId: String, credentialResponse: AnyJSON) {
     self.factorId = factorId
@@ -751,15 +1018,20 @@ public struct MFAVerifyParams: Encodable, Hashable {
   }
 }
 
+/// Parameters for unenrolling an MFA factor.
 public struct MFAUnenrollParams: Encodable, Hashable, Sendable {
   /// ID of the factor to unenroll. Returned in ``AuthMFA/enroll(params:)``.
   public let factorId: String
 
+  /// Creates unenroll parameters.
+  ///
+  /// - Parameter factorId: The factor ID to unenroll.
   public init(factorId: String) {
     self.factorId = factorId
   }
 }
 
+/// Parameters for the combined challenge-and-verify operation.
 public struct MFAChallengeAndVerifyParams: Encodable, Hashable, Sendable {
   /// ID of the factor to be challenged. Returned in ``AuthMFA/enroll(params:)``.
   public let factorId: String
@@ -767,12 +1039,18 @@ public struct MFAChallengeAndVerifyParams: Encodable, Hashable, Sendable {
   /// Verification code provided by the user.
   public let code: String
 
+  /// Creates challenge-and-verify parameters.
+  ///
+  /// - Parameters:
+  ///   - factorId: The factor ID to challenge and verify.
+  ///   - code: The verification code from the user.
   public init(factorId: String, code: String) {
     self.factorId = factorId
     self.code = code
   }
 }
 
+/// The response returned after creating an MFA challenge.
 public struct AuthMFAChallengeResponse: Decodable, Hashable, Sendable {
   /// ID of the newly created challenge.
   public let id: String
@@ -787,13 +1065,16 @@ public struct AuthMFAChallengeResponse: Decodable, Hashable, Sendable {
   @_spi(Experimental) public var webauthn: WebAuthnChallengeResponseData? = nil
 }
 
+/// A type alias that maps an MFA verify response to a ``Session``.
 public typealias AuthMFAVerifyResponse = Session
 
+/// The response returned after successfully unenrolling an MFA factor.
 public struct AuthMFAUnenrollResponse: Decodable, Hashable, Sendable {
   /// ID of the factor that was successfully unenrolled.
   public let id: String
 }
 
+/// The response returned by ``AuthMFA/listFactors()``.
 public struct AuthMFAListFactorsResponse: Decodable, Hashable, Sendable {
   /// All available factors (verified and unverified).
   public let all: [Factor]
@@ -808,6 +1089,7 @@ public struct AuthMFAListFactorsResponse: Decodable, Hashable, Sendable {
   @_spi(Experimental) public let webauthn: [Factor]
 }
 
+/// A string representing an Authenticator Assurance Level (`aal1` or `aal2`).
 public typealias AuthenticatorAssuranceLevels = String
 
 /// An authentication method reference (AMR) entry.
@@ -820,6 +1102,7 @@ public struct AMREntry: Decodable, Hashable, Sendable {
   /// Timestamp when the method was successfully used.
   public let timestamp: TimeInterval
 
+  /// The string type used for authentication method names.
   public typealias Method = String
 }
 
@@ -837,6 +1120,7 @@ extension AMREntry {
   }
 }
 
+/// The response returned by ``AuthMFA/getAuthenticatorAssuranceLevel()``.
 public struct AuthMFAGetAuthenticatorAssuranceLevelResponse: Decodable, Hashable, Sendable {
   /// Current AAL level of the session.
   public let currentLevel: AuthenticatorAssuranceLevels?
@@ -850,19 +1134,26 @@ public struct AuthMFAGetAuthenticatorAssuranceLevelResponse: Decodable, Hashable
   public let currentAuthenticationMethods: [AMREntry]
 }
 
+/// The scope of a sign-out operation.
 public enum SignOutScope: String, Sendable {
   /// All sessions by this account will be signed out.
   case global
+
   /// Only this session will be signed out.
   case local
+
   /// All other sessions except the current one will be signed out. When using
   /// ``SignOutScope/others``, there is no ``AuthChangeEvent/signedOut`` event fired on the current
   /// session.
   case others
 }
 
+/// The type of email to resend when calling ``AuthClient/resend(email:type:emailRedirectTo:captchaToken:)``.
 public enum ResendEmailType: String, Hashable, Sendable, Encodable {
+  /// Resends the initial sign-up confirmation email.
   case signup
+
+  /// Resends the email-change confirmation email.
   case emailChange = "email_change"
 }
 
@@ -872,8 +1163,12 @@ struct ResendEmailParams: Encodable {
   let gotrueMetaSecurity: AuthMetaSecurity?
 }
 
+/// The type of mobile OTP to resend when calling ``AuthClient/resend(phone:type:captchaToken:)``.
 public enum ResendMobileType: String, Hashable, Sendable, Encodable {
+  /// Resends the SMS OTP for the current phone sign-in.
   case sms
+
+  /// Resends the OTP for confirming a phone number change.
   case phoneChange = "phone_change"
 }
 
@@ -883,16 +1178,21 @@ struct ResendMobileParams: Encodable {
   let gotrueMetaSecurity: AuthMetaSecurity?
 }
 
+/// The response returned when resending an SMS OTP.
 public struct ResendMobileResponse: Decodable, Hashable, Sendable {
   /// Unique ID of the message as reported by the SMS sending provider. Useful for tracking
   /// deliverability problems.
   public let messageId: String?
 
+  /// Creates a resend mobile response.
+  ///
+  /// - Parameter messageId: The provider-assigned message ID.
   public init(messageId: String?) {
     self.messageId = messageId
   }
 }
 
+/// Information about why a password is considered weak.
 public struct WeakPassword: Codable, Hashable, Sendable {
   /// List of reasons the password is too weak, could be any of `length`, `characters`, or `pwned`.
   public let reasons: [String]
@@ -902,8 +1202,12 @@ struct DeleteUserRequest: Encodable {
   let shouldSoftDelete: Bool
 }
 
+/// The messaging channel used to deliver OTPs.
 public enum MessagingChannel: String, Codable, Sendable {
+  /// Deliver the OTP via SMS.
   case sms
+
+  /// Deliver the OTP via WhatsApp.
   case whatsapp
 }
 
@@ -916,34 +1220,56 @@ struct SignInWithSSORequest: Encodable {
   let codeChallengeMethod: String?
 }
 
+/// The response from a single sign-on (SSO) initiation request.
 public struct SSOResponse: Codable, Hashable, Sendable {
   /// URL to open in a browser which will complete the sign-in flow by taking the user to the
   /// identity provider's authentication flow.
   public let url: URL
 }
 
+/// The URL and provider returned when building an OAuth sign-in URL.
 public struct OAuthResponse: Codable, Hashable, Sendable {
+  /// The OAuth provider.
   public let provider: Provider
+
+  /// The URL to open in order to start the OAuth flow.
   public let url: URL
 }
 
+/// Pagination parameters for list endpoints.
 public struct PageParams {
   /// The page number.
   public let page: Int?
+
   /// Number of items returned per page.
   public let perPage: Int?
 
+  /// Creates pagination parameters.
+  ///
+  /// - Parameters:
+  ///   - page: The page number (1-indexed).
+  ///   - perPage: The number of items per page.
   public init(page: Int? = nil, perPage: Int? = nil) {
     self.page = page
     self.perPage = perPage
   }
 }
 
+/// A paginated list of users returned by ``AuthAdmin/listUsers(params:)``.
 public struct ListUsersPaginatedResponse: Hashable, Sendable {
+  /// The users on the current page.
   public let users: [User]
+
+  /// The audience the users belong to.
   public let aud: String
+
+  /// The page number of the next page, if one exists.
   public var nextPage: Int?
+
+  /// The page number of the last page.
   public var lastPage: Int
+
+  /// The total number of users matching the query.
   public var total: Int
 }
 
@@ -1075,15 +1401,23 @@ public struct ListUsersPaginatedResponse: Hashable, Sendable {
 public struct OAuthClientGrantType: RawRepresentable, Codable, Hashable, Sendable,
   ExpressibleByStringLiteral
 {
+  /// The raw string value of the grant type.
   public let rawValue: String
+
+  /// Creates an ``OAuthClientGrantType`` from a raw string value.
   public init(rawValue: String) {
     self.rawValue = rawValue
   }
+
+  /// Creates an ``OAuthClientGrantType`` from a string literal.
   public init(stringLiteral value: String) {
     self.init(rawValue: value)
   }
 
+  /// The `authorization_code` grant type.
   public static let authorizationCode: OAuthClientGrantType = "authorization_code"
+
+  /// The `refresh_token` grant type.
   public static let refreshToken: OAuthClientGrantType = "refresh_token"
 }
 
@@ -1092,14 +1426,20 @@ public struct OAuthClientGrantType: RawRepresentable, Codable, Hashable, Sendabl
 public struct OAuthClientResponseType: RawRepresentable, Codable, Hashable, Sendable,
   ExpressibleByStringLiteral
 {
+  /// The raw string value of the response type.
   public let rawValue: String
+
+  /// Creates an ``OAuthClientResponseType`` from a raw string value.
   public init(rawValue: String) {
     self.rawValue = rawValue
   }
+
+  /// Creates an ``OAuthClientResponseType`` from a string literal.
   public init(stringLiteral value: String) {
     self.init(rawValue: value)
   }
 
+  /// The `code` response type.
   public static let code: OAuthClientResponseType = "code"
 }
 
@@ -1108,14 +1448,23 @@ public struct OAuthClientResponseType: RawRepresentable, Codable, Hashable, Send
 public struct OAuthClientType: RawRepresentable, Codable, Hashable, Sendable,
   ExpressibleByStringLiteral
 {
+  /// The raw string value of the client type.
   public let rawValue: String
+
+  /// Creates an ``OAuthClientType`` from a raw string value.
   public init(rawValue: String) {
     self.rawValue = rawValue
   }
+
+  /// Creates an ``OAuthClientType`` from a string literal.
   public init(stringLiteral value: String) {
     self.init(rawValue: value)
   }
+
+  /// A public client that cannot keep credentials confidential (e.g. a browser or mobile app).
   public static let `public`: OAuthClientType = "public"
+
+  /// A confidential client that can securely store credentials (e.g. a server-side app).
   public static let confidential: OAuthClientType = "confidential"
 }
 
@@ -1124,14 +1473,23 @@ public struct OAuthClientType: RawRepresentable, Codable, Hashable, Sendable,
 public struct OAuthClientRegistrationType: RawRepresentable, Codable, Hashable, Sendable,
   ExpressibleByStringLiteral
 {
+  /// The raw string value of the registration type.
   public let rawValue: String
+
+  /// Creates an ``OAuthClientRegistrationType`` from a raw string value.
   public init(rawValue: String) {
     self.rawValue = rawValue
   }
+
+  /// Creates an ``OAuthClientRegistrationType`` from a string literal.
   public init(stringLiteral value: String) {
     self.init(rawValue: value)
   }
+
+  /// The client was registered using dynamic client registration.
   public static let dynamic: OAuthClientRegistrationType = "dynamic"
+
+  /// The client was registered manually via the dashboard or admin API.
   public static let manual: OAuthClientRegistrationType = "manual"
 }
 
@@ -1140,30 +1498,43 @@ public struct OAuthClientRegistrationType: RawRepresentable, Codable, Hashable, 
 public struct OAuthClient: Codable, Hashable, Sendable {
   /// Unique identifier for the OAuth client
   public let clientId: UUID
+
   /// Human-readable name of the OAuth client
   public let clientName: String
+
   /// Client secret (only returned on registration and regeneration)
   public let clientSecret: String?
+
   /// Type of OAuth client
   public let clientType: OAuthClientType
+
   /// Token endpoint authentication method
   public let tokenEndpointAuthMethod: String
+
   /// Registration type of the client
   public let registrationType: OAuthClientRegistrationType
+
   /// URI of the OAuth client
   public let clientUri: String?
+
   /// URL of the client application's logo
   public let logoUri: String?
+
   /// Array of allowed redirect URIs
   public let redirectUris: [String]
+
   /// Array of allowed grant types
   public let grantTypes: [OAuthClientGrantType]
+
   /// Array of allowed response types
   public let responseTypes: [OAuthClientResponseType]
+
   /// Scope of the OAuth client
   public let scope: String?
+
   /// Timestamp when the client was created
   public let createdAt: Date
+
   /// Timestamp when the client was last updated
   public let updatedAt: Date
 }
@@ -1173,17 +1544,31 @@ public struct OAuthClient: Codable, Hashable, Sendable {
 public struct CreateOAuthClientParams: Encodable, Hashable, Sendable {
   /// Human-readable name of the OAuth client
   public let clientName: String
+
   /// URI of the OAuth client
   public let clientUri: String?
+
   /// Array of allowed redirect URIs
   public let redirectUris: [String]
+
   /// Array of allowed grant types (optional, defaults to authorization_code and refresh_token)
   public let grantTypes: [OAuthClientGrantType]?
+
   /// Array of allowed response types (optional, defaults to code)
   public let responseTypes: [OAuthClientResponseType]?
+
   /// Scope of the OAuth client
   public let scope: String?
 
+  /// Creates parameters for a new OAuth client.
+  ///
+  /// - Parameters:
+  ///   - clientName: Human-readable name for the client.
+  ///   - clientUri: URI of the client application's homepage.
+  ///   - redirectUris: Allowed redirect URIs.
+  ///   - grantTypes: Allowed grant types; defaults to `authorization_code` and `refresh_token`.
+  ///   - responseTypes: Allowed response types; defaults to `code`.
+  ///   - scope: Requested scope.
   public init(
     clientName: String,
     clientUri: String? = nil,
@@ -1206,15 +1591,27 @@ public struct CreateOAuthClientParams: Encodable, Hashable, Sendable {
 public struct UpdateOAuthClientParams: Encodable, Hashable, Sendable {
   /// Human-readable name of the client application
   public let clientName: String?
+
   /// URL of the client application's homepage
   public let clientUri: String?
+
   /// URL of the client application's logo
   public let logoUri: String?
+
   /// Array of redirect URIs used by the client
   public let redirectUris: [String]?
+
   /// OAuth grant types the client is authorized to use
   public let grantTypes: [OAuthClientGrantType]?
 
+  /// Creates parameters for updating an existing OAuth client.
+  ///
+  /// - Parameters:
+  ///   - clientName: New human-readable name.
+  ///   - clientUri: New URI for the client application.
+  ///   - logoUri: New logo URI.
+  ///   - redirectUris: Replacement list of redirect URIs.
+  ///   - grantTypes: Replacement list of grant types.
   public init(
     clientName: String? = nil,
     clientUri: String? = nil,
@@ -1230,45 +1627,60 @@ public struct UpdateOAuthClientParams: Encodable, Hashable, Sendable {
   }
 }
 
-/// Response type for listing OAuth clients.
+/// A paginated list of OAuth clients returned by ``AuthAdminOAuth/listClients(params:)``.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 public struct ListOAuthClientsPaginatedResponse: Hashable, Sendable {
+  /// The OAuth clients on the current page.
   public let clients: [OAuthClient]
+
+  /// The audience the clients belong to.
   public let aud: String
+
+  /// The page number of the next page, if one exists.
   public var nextPage: Int?
+
+  /// The page number of the last page.
   public var lastPage: Int
+
+  /// The total number of OAuth clients.
   public var total: Int
 }
 
 // MARK: - JWT Claims
 
-/// JSON Web Key (JWK) representation
+/// JSON Web Key (JWK) representation.
 public struct JWK: Codable, Hashable, Sendable {
-  /// Key type (e.g., "RSA", "EC", "oct")
+  /// Key type (e.g., `"RSA"`, `"EC"`, `"oct"`).
   public let kty: String
-  /// Key operations (e.g., ["sign", "verify"])
+
+  /// Key operations (e.g., `["sign", "verify"]`).
   public let keyOps: [String]?
-  /// Algorithm (e.g., "RS256", "ES256", "HS256")
+
+  /// Algorithm (e.g., `"RS256"`, `"ES256"`, `"HS256"`).
   public let alg: String?
-  /// Key ID
+
+  /// Key ID.
   public let kid: String?
 
   // RSA-specific fields
-  /// RSA modulus (base64url-encoded)
+  /// RSA modulus (base64url-encoded).
   public let n: String?
-  /// RSA exponent (base64url-encoded)
+
+  /// RSA exponent (base64url-encoded).
   public let e: String?
 
   // EC-specific fields
-  /// EC curve name (e.g., "P-256")
+  /// EC curve name (e.g., `"P-256"`).
   public let crv: String?
-  /// EC x coordinate (base64url-encoded)
+
+  /// EC x coordinate (base64url-encoded).
   public let x: String?
-  /// EC y coordinate (base64url-encoded)
+
+  /// EC y coordinate (base64url-encoded).
   public let y: String?
 
   // Symmetric key field
-  /// Symmetric key value (base64url-encoded)
+  /// Symmetric key value (base64url-encoded).
   public let k: String?
 
   enum CodingKeys: String, CodingKey {
@@ -1285,52 +1697,69 @@ public struct JWK: Codable, Hashable, Sendable {
   }
 }
 
-/// JSON Web Key Set (JWKS)
+/// A JSON Web Key Set (JWKS) containing one or more JWKs.
 public struct JWKS: Codable, Hashable, Sendable {
+  /// The set of JSON Web Keys.
   public let keys: [JWK]
 }
 
-/// JWT Header
+/// The header portion of a decoded JSON Web Token.
 public struct JWTHeader: Codable, Hashable, Sendable {
-  /// Algorithm (e.g., "RS256", "ES256", "HS256")
+  /// Algorithm (e.g., `"RS256"`, `"ES256"`, `"HS256"`).
   public let alg: String
-  /// Key ID
+
+  /// Key ID used to select the signing key.
   public let kid: String?
-  /// Type (typically "JWT")
+
+  /// Token type (typically `"JWT"`).
   public let typ: String?
 }
 
-/// JWT Claims
+/// The decoded claims from a JSON Web Token.
 public struct JWTClaims: Codable, Hashable, Sendable {
-  /// Issuer
+  /// Issuer (`iss` claim).
   public let iss: String?
-  /// Subject
+
+  /// Subject (`sub` claim) — typically the user's UUID.
   public let sub: String?
-  /// Audience
+
+  /// Audience (`aud` claim) — can be a single string or an array of strings.
   public let aud: AudienceClaim?
-  /// Expiration time
+
+  /// Expiration time (`exp` claim) as a UNIX timestamp.
   public let exp: TimeInterval?
-  /// Issued at
+
+  /// Issued-at time (`iat` claim) as a UNIX timestamp.
   public let iat: TimeInterval?
-  /// Not before
+
+  /// Not-before time (`nbf` claim) as a UNIX timestamp.
   public let nbf: TimeInterval?
-  /// JWT ID
+
+  /// JWT ID (`jti` claim).
   public let jti: String?
-  /// Role
+
+  /// Role claim.
   public let role: String?
-  /// Authenticator Assurance Level
+
+  /// Authenticator Assurance Level (`aal` claim).
   public let aal: String?
-  /// Session ID
+
+  /// Session ID.
   public let sessionId: String?
-  /// Email
+
+  /// Email claim.
   public let email: String?
-  /// Phone
+
+  /// Phone claim.
   public let phone: String?
-  /// App metadata
+
+  /// Application metadata.
   public let appMetadata: [String: AnyJSON]?
-  /// User metadata
+
+  /// User metadata.
   public let userMetadata: [String: AnyJSON]?
-  /// Additional claims
+
+  /// Any claims not recognized by the standard set of ``CodingKeys``.
   public var additionalClaims: [String: AnyJSON] = [:]
 
   enum CodingKeys: String, CodingKey {
@@ -1402,9 +1831,12 @@ public struct JWTClaims: Codable, Hashable, Sendable {
   }
 }
 
-/// Audience claim can be either a string or an array of strings
+/// A JWT `aud` (audience) claim that may be either a single string or an array of strings.
 public enum AudienceClaim: Codable, Hashable, Sendable {
+  /// A single audience string.
   case string(String)
+
+  /// Multiple audience strings.
   case array([String])
 
   public init(from decoder: any Decoder) throws {
@@ -1450,21 +1882,31 @@ private struct AnyCodingKey: CodingKey {
   }
 }
 
-/// Response from getClaims method
+/// The result returned by ``AuthClient/getClaims(jwt:options:)``.
 public struct JWTClaimsResponse: Sendable {
+  /// The decoded JWT claims.
   public let claims: JWTClaims
+
+  /// The decoded JWT header.
   public let header: JWTHeader
+
+  /// The raw JWT signature bytes.
   public let signature: Data
 }
 
-/// Options for the getClaims method
+/// Options for ``AuthClient/getClaims(jwt:options:)``.
 public struct GetClaimsOptions: Sendable {
-  /// If set to `true` the `exp` claim will not be validated against the current time.
+  /// When `true`, the `exp` claim is not validated against the current time, allowing expired tokens to be decoded.
   public let allowExpired: Bool
 
-  /// If set, this JSON Web Key Set is going to have precedence over the cached value available on the server.
+  /// When set, this JSON Web Key Set takes precedence over any cached JWKS from the server.
   public let jwks: JWKS?
 
+  /// Creates claim-decoding options.
+  ///
+  /// - Parameters:
+  ///   - allowExpired: Pass `true` to skip expiration validation.
+  ///   - jwks: An explicit JWKS to use instead of the cached server JWKS.
   public init(allowExpired: Bool = false, jwks: JWKS? = nil) {
     self.allowExpired = allowExpired
     self.jwks = jwks


### PR DESCRIPTION
## Summary

- Added `///` triple-slash DocC documentation to every public symbol in `Sources/Auth/`
- Covered all types in `Types.swift` (60+ types including `Session`, `User`, `UserIdentity`, `Factor`, MFA response types, OAuth client types, JWT types, and more)
- Added abstracts to `AuthClient` (actor), `AuthAdmin`, `AuthMFA`, `AuthAdminOAuth`, `AuthClientConfiguration.Configuration`
- Documented `AuthLocalStorage` protocol methods, `KeychainLocalStorage` init/methods, and `WinCredLocalStorage` init/methods
- Added one-line abstracts to all 70+ known `ErrorCode` static members; added abstract and `## Topics` to `AuthError` enum
- Added `AuthStateChangeListener` typealias doc
- Added `## Topics` groupings to `AuthClient`, `AuthAdmin`, `AuthMFA`, `AuthAdminOAuth`, and `AuthClient.Configuration`
- Fixed missing docs on `Configuration.flowType`, `.encoder`, `.decoder`
- Ran `make test-docs` — zero warnings

## Test plan

- [x] `make test-docs` passes with no warnings
- [x] All changed files formatted with `swift-format`
- [x] No functional code changes — documentation only