### PR TITLE
docs(realtime): add DocC documentation to Realtime public API

### DIFF
--- a/Sources/RealtimeV2/PostgresAction.swift
+++ b/Sources/RealtimeV2/PostgresAction.swift
@@ -147,10 +147,12 @@ public struct DeleteAction: PostgresAction, HasOldRecord, HasRawMessage {
 /// A Postgres change event that wraps any of the concrete action types.
 ///
 /// Use this type when you want to receive `INSERT`, `UPDATE`, and `DELETE` changes
-/// with a single callback. Pattern-match on the cases to access the underlying action.
+/// with a single async stream. Pattern-match on the cases to access the underlying action.
 ///
 /// ```swift
-/// channel.onPostgresChange(AnyAction.self, schema: "public", table: "messages") { action in
+/// let changes = channel.postgresChange(AnyAction.self, schema: "public", table: "messages")
+/// try await channel.subscribeWithError()
+/// for await action in changes {
 ///   switch action {
 ///   case .insert(let insert): print(insert.record)
 ///   case .update(let update): print(update.record)

--- a/Sources/RealtimeV2/PostgresAction.swift
+++ b/Sources/RealtimeV2/PostgresAction.swift
@@ -7,59 +7,176 @@
 
 import Foundation
 
+/// Describes a single column returned in a Postgres change event.
+///
+/// ## Topics
+/// ### Properties
+/// - ``name``
+/// - ``type``
 public struct Column: Equatable, Codable, Sendable {
+  /// The column name in the database.
   public let name: String
+
+  /// The PostgreSQL type of the column (e.g. `"int4"`, `"text"`, `"timestamptz"`).
   public let type: String
 }
 
+/// A Postgres row change event received from the Realtime server.
+///
+/// Concrete types conforming to this protocol are ``InsertAction``, ``UpdateAction``,
+/// ``DeleteAction``, and ``AnyAction``.
+///
+/// ## Topics
+/// ### Associated Event
+/// - ``eventType``
 public protocol PostgresAction: Equatable, Sendable {
+  /// The Postgres change event type this action represents.
   static var eventType: PostgresChangeEvent { get }
 }
 
+/// An action that carries the new row data after an `INSERT` or `UPDATE`.
+///
+/// Use ``decodeRecord(as:decoder:)`` to decode the ``record`` into a `Decodable` model.
 public protocol HasRecord {
+  /// The current row data as a ``JSONObject``, keyed by column name.
   var record: JSONObject { get }
 }
 
+/// An action that carries the previous row data before an `UPDATE` or `DELETE`.
+///
+/// Use ``decodeOldRecord(as:decoder:)`` to decode the ``oldRecord`` into a `Decodable` model.
 public protocol HasOldRecord {
+  /// The previous row data as a ``JSONObject``, keyed by column name, before the change was applied.
   var oldRecord: JSONObject { get }
 }
 
+/// An action that exposes the raw ``RealtimeMessageV2`` received from the server.
 public protocol HasRawMessage {
+  /// The underlying Realtime message that triggered this action.
   var rawMessage: RealtimeMessageV2 { get }
 }
 
+/// A Postgres `INSERT` change event.
+///
+/// Received when a new row is inserted into a tracked table.
+/// Contains the new row's data in ``record``.
+///
+/// ## Topics
+/// ### Properties
+/// - ``columns``
+/// - ``commitTimestamp``
+/// - ``record``
+/// - ``rawMessage``
 public struct InsertAction: PostgresAction, HasRecord, HasRawMessage {
+  /// The change event type, always ``PostgresChangeEvent/insert``.
   public static let eventType: PostgresChangeEvent = .insert
 
+  /// The column definitions for the affected table at the time of the change.
   public let columns: [Column]
+
+  /// The timestamp at which this change was committed in the database.
   public let commitTimestamp: Date
+
+  /// The newly-inserted row's data, keyed by column name.
   public let record: [String: AnyJSON]
+
+  /// The raw Realtime message that delivered this event.
   public let rawMessage: RealtimeMessageV2
 }
 
+/// A Postgres `UPDATE` change event.
+///
+/// Received when an existing row is updated in a tracked table.
+/// Contains both the new row data in ``record`` and the previous data in ``oldRecord``.
+///
+/// ## Topics
+/// ### Properties
+/// - ``columns``
+/// - ``commitTimestamp``
+/// - ``record``
+/// - ``oldRecord``
+/// - ``rawMessage``
 public struct UpdateAction: PostgresAction, HasRecord, HasOldRecord, HasRawMessage {
+  /// The change event type, always ``PostgresChangeEvent/update``.
   public static let eventType: PostgresChangeEvent = .update
 
+  /// The column definitions for the affected table at the time of the change.
   public let columns: [Column]
+
+  /// The timestamp at which this change was committed in the database.
   public let commitTimestamp: Date
-  public let record, oldRecord: [String: AnyJSON]
+
+  /// The updated row's new data, keyed by column name.
+  public let record: [String: AnyJSON]
+
+  /// The row's data before the update was applied, keyed by column name.
+  public let oldRecord: [String: AnyJSON]
+
+  /// The raw Realtime message that delivered this event.
   public let rawMessage: RealtimeMessageV2
 }
 
+/// A Postgres `DELETE` change event.
+///
+/// Received when a row is deleted from a tracked table.
+/// Contains the deleted row's previous data in ``oldRecord``.
+///
+/// ## Topics
+/// ### Properties
+/// - ``columns``
+/// - ``commitTimestamp``
+/// - ``oldRecord``
+/// - ``rawMessage``
 public struct DeleteAction: PostgresAction, HasOldRecord, HasRawMessage {
+  /// The change event type, always ``PostgresChangeEvent/delete``.
   public static let eventType: PostgresChangeEvent = .delete
 
+  /// The column definitions for the affected table at the time of the change.
   public let columns: [Column]
+
+  /// The timestamp at which this change was committed in the database.
   public let commitTimestamp: Date
+
+  /// The deleted row's data before removal, keyed by column name.
   public let oldRecord: [String: AnyJSON]
+
+  /// The raw Realtime message that delivered this event.
   public let rawMessage: RealtimeMessageV2
 }
 
+/// A Postgres change event that wraps any of the concrete action types.
+///
+/// Use this type when you want to receive `INSERT`, `UPDATE`, and `DELETE` changes
+/// with a single callback. Pattern-match on the cases to access the underlying action.
+///
+/// ```swift
+/// channel.onPostgresChange(AnyAction.self, schema: "public", table: "messages") { action in
+///   switch action {
+///   case .insert(let insert): print(insert.record)
+///   case .update(let update): print(update.record)
+///   case .delete(let delete): print(delete.oldRecord)
+///   }
+/// }
+/// ```
+///
+/// ## Topics
+/// ### Cases
+/// - ``insert(_:)``
+/// - ``update(_:)``
+/// - ``delete(_:)``
+/// ### Properties
+/// - ``rawMessage``
 public enum AnyAction: PostgresAction, HasRawMessage {
+  /// The event type for this enum, always ``PostgresChangeEvent/all``.
   public static let eventType: PostgresChangeEvent = .all
 
+  /// An `INSERT` event wrapping an ``InsertAction``.
   case insert(InsertAction)
+
+  /// An `UPDATE` event wrapping an ``UpdateAction``.
   case update(UpdateAction)
+
+  /// A `DELETE` event wrapping a ``DeleteAction``.
   case delete(DeleteAction)
 
   var wrappedAction: any PostgresAction & HasRawMessage {
@@ -70,18 +187,33 @@ public enum AnyAction: PostgresAction, HasRawMessage {
     }
   }
 
+  /// The raw Realtime message from the server that delivered this action.
   public var rawMessage: RealtimeMessageV2 {
     wrappedAction.rawMessage
   }
 }
 
 extension HasRecord {
+  /// Decodes the ``record`` dictionary into a `Decodable` model.
+  ///
+  /// - Parameters:
+  ///   - type: The target `Decodable` type. Can be inferred from context.
+  ///   - decoder: A `JSONDecoder` to use for decoding. Defaults to `AnyJSON.decoder`.
+  /// - Returns: An instance of `T` decoded from the record data.
+  /// - Throws: A `DecodingError` if the record cannot be decoded into `T`.
   public func decodeRecord<T: Decodable>(as _: T.Type = T.self, decoder: JSONDecoder) throws -> T {
     try record.decode(as: T.self, decoder: decoder)
   }
 }
 
 extension HasOldRecord {
+  /// Decodes the ``oldRecord`` dictionary into a `Decodable` model.
+  ///
+  /// - Parameters:
+  ///   - type: The target `Decodable` type. Can be inferred from context.
+  ///   - decoder: A `JSONDecoder` to use for decoding. Defaults to `AnyJSON.decoder`.
+  /// - Returns: An instance of `T` decoded from the old record data.
+  /// - Throws: A `DecodingError` if the old record cannot be decoded into `T`.
   public func decodeOldRecord<T: Decodable>(
     as _: T.Type = T.self,
     decoder: JSONDecoder

--- a/Sources/RealtimeV2/PresenceAction.swift
+++ b/Sources/RealtimeV2/PresenceAction.swift
@@ -7,12 +7,23 @@
 
 import Foundation
 
+/// The presence state of a single client tracked on a Realtime channel.
+///
+/// Instances are received via ``PresenceAction/joins`` and ``PresenceAction/leaves``
+/// when other clients call ``RealtimeChannelV2/track(_:)`` or ``RealtimeChannelV2/untrack()``.
+///
+/// ## Topics
+/// ### Properties
+/// - ``ref``
+/// - ``state``
+/// ### Decoding
+/// - ``decodeState(as:decoder:)``
 public struct PresenceV2: Hashable, Sendable {
-  /// The presence reference of the object.
+  /// The server-assigned presence reference string that uniquely identifies this presence entry.
   public let ref: String
 
-  /// The object the other client is tracking. Can be done via the
-  /// ``RealtimeChannelV2/track(state:)`` method.
+  /// The arbitrary state payload the client published via ``RealtimeChannelV2/track(_:)``,
+  /// stored as a ``JSONObject``.
   public let state: JSONObject
 }
 
@@ -77,10 +88,16 @@ extension PresenceV2: Codable {
     try container.encode(state, forKey: _StringCodingKey("state"))
   }
 
-  /// Decode ``state``.
+  /// Decodes the ``state`` dictionary into a `Decodable` model.
   ///
-  /// - Note: You can also receive your own presence, but without your state so be aware of
-  /// exceptions.
+  /// > Note: You may receive your own presence entry, but without your state payload,
+  /// > so be prepared to handle decoding failures gracefully.
+  ///
+  /// - Parameters:
+  ///   - type: The target `Decodable` type. Can be inferred from context.
+  ///   - decoder: A `JSONDecoder` to use. Defaults to `AnyJSON.decoder`.
+  /// - Returns: An instance of `T` decoded from the state data.
+  /// - Throws: A `DecodingError` if the state cannot be decoded into `T`.
   public func decodeState<T: Decodable>(
     as _: T.Type = T.self,
     decoder: JSONDecoder = AnyJSON.decoder
@@ -89,24 +106,38 @@ extension PresenceV2: Codable {
   }
 }
 
-/// Represents a presence action.
+/// An event describing clients joining and leaving a Realtime channel's presence set.
+///
+/// Received via ``RealtimeChannelV2/onPresenceChange(_:)`` or
+/// ``RealtimeChannelV2/presenceChange()``.
+///
+/// ## Topics
+/// ### Presence Maps
+/// - ``joins``
+/// - ``leaves``
+/// ### Decoding Helpers
+/// - ``decodeJoins(as:ignoreOtherTypes:decoder:)``
+/// - ``decodeLeaves(as:ignoreOtherTypes:decoder:)``
 public protocol PresenceAction: Sendable, HasRawMessage {
-  /// Represents a map of ``PresenceV2`` objects indexed by their key.
-  ///
-  /// Your own key can be customized when creating the channel within the presence config.
+  /// A map of presence entries that joined the channel since the last event, keyed by the
+  /// client-defined presence key (configured via ``PresenceJoinConfig/key``).
   var joins: [String: PresenceV2] { get }
 
-  /// Represents a map of ``PresenceV2`` objects indexed by their key.
-  ///
-  /// Your own key can be customized when creating the channel within the presence config.
+  /// A map of presence entries that left the channel since the last event, keyed by the
+  /// client-defined presence key.
   var leaves: [String: PresenceV2] { get }
 }
 
 extension PresenceAction {
-  /// Decode all ``PresenceAction/joins`` values.
+  /// Decodes all ``joins`` entries into an array of `Decodable` values.
+  ///
   /// - Parameters:
-  ///   - ignoreOtherTypes: Whether to ignore presences which cannot be decoded such as your own
-  /// presence.
+  ///   - type: The target `Decodable` type. Can be inferred from context.
+  ///   - ignoreOtherTypes: When `true`, presences whose state cannot be decoded to `T` are
+  ///     silently skipped (e.g. your own presence without a state payload). Defaults to `true`.
+  ///   - decoder: A `JSONDecoder` to use. Defaults to `AnyJSON.decoder`.
+  /// - Returns: An array of `T` values decoded from the joined presences.
+  /// - Throws: A `DecodingError` when `ignoreOtherTypes` is `false` and any presence cannot be decoded.
   public func decodeJoins<T: Decodable>(
     as _: T.Type = T.self,
     ignoreOtherTypes: Bool = true,
@@ -119,10 +150,15 @@ extension PresenceAction {
     return try joins.values.map { try $0.decodeState(as: T.self, decoder: decoder) }
   }
 
-  /// Decode all ``PresenceAction/leaves`` values.
+  /// Decodes all ``leaves`` entries into an array of `Decodable` values.
+  ///
   /// - Parameters:
-  ///   - ignoreOtherTypes: Whether to ignore presences which cannot be decoded such as your own
-  /// presence.
+  ///   - type: The target `Decodable` type. Can be inferred from context.
+  ///   - ignoreOtherTypes: When `true`, presences whose state cannot be decoded to `T` are
+  ///     silently skipped. Defaults to `true`.
+  ///   - decoder: A `JSONDecoder` to use. Defaults to `AnyJSON.decoder`.
+  /// - Returns: An array of `T` values decoded from the leaving presences.
+  /// - Throws: A `DecodingError` when `ignoreOtherTypes` is `false` and any presence cannot be decoded.
   public func decodeLeaves<T: Decodable>(
     as _: T.Type = T.self,
     ignoreOtherTypes: Bool = true,

--- a/Sources/RealtimeV2/RealtimeChannel+AsyncAwait.swift
+++ b/Sources/RealtimeV2/RealtimeChannel+AsyncAwait.swift
@@ -8,7 +8,12 @@
 import Foundation
 
 extension RealtimeChannelV2 {
-  /// Listen for clients joining / leaving the channel using presences.
+  /// Returns an async stream that emits a ``PresenceAction`` whenever clients join or leave.
+  ///
+  /// The stream terminates when the caller cancels the enclosing task or the channel is removed.
+  /// Register this stream before calling ``subscribeWithError()``.
+  ///
+  /// - Returns: An `AsyncStream` of ``PresenceAction`` values.
   public func presenceChange() -> AsyncStream<any PresenceAction> {
     let (stream, continuation) = AsyncStream<any PresenceAction>.makeStream()
 
@@ -23,7 +28,16 @@ extension RealtimeChannelV2 {
     return stream
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Returns an async stream of ``InsertAction`` values for the given table.
+  ///
+  /// Register this stream before calling ``subscribeWithError()``.
+  ///
+  /// - Parameters:
+  ///   - type: Pass `InsertAction.self`.
+  ///   - schema: The database schema. Defaults to `"public"`.
+  ///   - table: The table name, or `nil` to match all tables.
+  ///   - filter: An optional ``RealtimePostgresFilter`` to narrow the rows.
+  /// - Returns: An `AsyncStream<InsertAction>`.
   public func postgresChange(
     _: InsertAction.Type,
     schema: String = "public",
@@ -37,7 +51,9 @@ extension RealtimeChannelV2 {
     .compactErase()
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Returns an async stream of ``InsertAction`` values for the given table using a raw filter string.
+  ///
+  /// > Warning: Use the ``RealtimePostgresFilter``-based overload instead.
   @available(
     *,
     deprecated,
@@ -55,7 +71,16 @@ extension RealtimeChannelV2 {
       .compactErase()
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Returns an async stream of ``UpdateAction`` values for the given table.
+  ///
+  /// Register this stream before calling ``subscribeWithError()``.
+  ///
+  /// - Parameters:
+  ///   - type: Pass `UpdateAction.self`.
+  ///   - schema: The database schema. Defaults to `"public"`.
+  ///   - table: The table name, or `nil` to match all tables.
+  ///   - filter: An optional ``RealtimePostgresFilter`` to narrow the rows.
+  /// - Returns: An `AsyncStream<UpdateAction>`.
   public func postgresChange(
     _: UpdateAction.Type,
     schema: String = "public",
@@ -69,7 +94,9 @@ extension RealtimeChannelV2 {
     .compactErase()
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Returns an async stream of ``UpdateAction`` values for the given table using a raw filter string.
+  ///
+  /// > Warning: Use the ``RealtimePostgresFilter``-based overload instead.
   @available(
     *,
     deprecated,
@@ -87,7 +114,16 @@ extension RealtimeChannelV2 {
       .compactErase()
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Returns an async stream of ``DeleteAction`` values for the given table.
+  ///
+  /// Register this stream before calling ``subscribeWithError()``.
+  ///
+  /// - Parameters:
+  ///   - type: Pass `DeleteAction.self`.
+  ///   - schema: The database schema. Defaults to `"public"`.
+  ///   - table: The table name, or `nil` to match all tables.
+  ///   - filter: An optional ``RealtimePostgresFilter`` to narrow the rows.
+  /// - Returns: An `AsyncStream<DeleteAction>`.
   public func postgresChange(
     _: DeleteAction.Type,
     schema: String = "public",
@@ -101,7 +137,9 @@ extension RealtimeChannelV2 {
     .compactErase()
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Returns an async stream of ``DeleteAction`` values for the given table using a raw filter string.
+  ///
+  /// > Warning: Use the ``RealtimePostgresFilter``-based overload instead.
   @available(
     *,
     deprecated,
@@ -119,7 +157,16 @@ extension RealtimeChannelV2 {
       .compactErase()
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Returns an async stream of ``AnyAction`` values for all change types on the given table.
+  ///
+  /// Register this stream before calling ``subscribeWithError()``.
+  ///
+  /// - Parameters:
+  ///   - type: Pass `AnyAction.self`.
+  ///   - schema: The database schema. Defaults to `"public"`.
+  ///   - table: The table name, or `nil` to match all tables.
+  ///   - filter: An optional ``RealtimePostgresFilter`` to narrow the rows.
+  /// - Returns: An `AsyncStream<AnyAction>`.
   public func postgresChange(
     _: AnyAction.Type,
     schema: String = "public",
@@ -132,7 +179,9 @@ extension RealtimeChannelV2 {
     )
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Returns an async stream of ``AnyAction`` values using a raw filter string.
+  ///
+  /// > Warning: Use the ``RealtimePostgresFilter``-based overload instead.
   @available(
     *,
     deprecated,
@@ -172,7 +221,12 @@ extension RealtimeChannelV2 {
     return stream
   }
 
-  /// Listen for broadcast messages sent by other clients within the same channel under a specific `event`.
+  /// Returns an async stream of ``JSONObject`` broadcast payloads for the given event.
+  ///
+  /// The stream terminates when the caller cancels the enclosing task or the channel is removed.
+  ///
+  /// - Parameter event: The broadcast event name to listen for.
+  /// - Returns: An `AsyncStream<JSONObject>`.
   public func broadcastStream(event: String) -> AsyncStream<JSONObject> {
     let (stream, continuation) = AsyncStream<JSONObject>.makeStream()
 
@@ -187,7 +241,13 @@ extension RealtimeChannelV2 {
     return stream
   }
 
-  /// Listen for binary broadcast messages sent by other clients within the same channel under a specific `event`.
+  /// Returns an async stream of raw binary `Data` broadcast payloads for the given event.
+  ///
+  /// Use this when the sender is transmitting binary data via ``RealtimeChannelV2/broadcast(event:data:)``.
+  /// Requires protocol ``RealtimeProtocolVersion/v2``.
+  ///
+  /// - Parameter event: The broadcast event name to listen for.
+  /// - Returns: An `AsyncStream<Data>`.
   public func broadcastDataStream(event: String) -> AsyncStream<Data> {
     let (stream, continuation) = AsyncStream<Data>.makeStream()
 
@@ -202,7 +262,11 @@ extension RealtimeChannelV2 {
     return stream
   }
 
-  /// Listen for `system` event.
+  /// Returns an async stream that emits the ``RealtimeMessageV2`` for every `system` event.
+  ///
+  /// System events convey channel-level status information from the server.
+  ///
+  /// - Returns: An `AsyncStream<RealtimeMessageV2>`.
   public func system() -> AsyncStream<RealtimeMessageV2> {
     let (stream, continuation) = AsyncStream<RealtimeMessageV2>.makeStream()
 
@@ -217,7 +281,9 @@ extension RealtimeChannelV2 {
     return stream
   }
 
-  /// Listen for broadcast messages sent by other clients within the same channel under a specific `event`.
+  /// Returns an async stream of ``JSONObject`` broadcast payloads for the given event.
+  ///
+  /// > Warning: Renamed to ``broadcastStream(event:)``.
   @available(*, deprecated, renamed: "broadcastStream(event:)")
   public func broadcast(event: String) -> AsyncStream<JSONObject> {
     broadcastStream(event: event)

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -18,9 +18,26 @@ import IssueReporting
   }
 #endif
 
+/// Configuration for a ``RealtimeChannelV2``.
+///
+/// Pass a builder closure to ``RealtimeClientV2/channel(_:options:)`` to customise
+/// broadcast, presence, and privacy settings before subscribing.
+///
+/// ## Topics
+/// ### Configuration Properties
+/// - ``broadcast``
+/// - ``presence``
+/// - ``isPrivate``
 public struct RealtimeChannelConfig: Sendable {
+  /// Configuration for the broadcast feature of the channel.
   public var broadcast: BroadcastJoinConfig
+
+  /// Configuration for the presence feature of the channel.
   public var presence: PresenceJoinConfig
+
+  /// Whether the channel is private.
+  ///
+  /// Private channels restrict broadcast and presence to authenticated clients only.
   public var isPrivate: Bool
 }
 
@@ -32,13 +49,72 @@ protocol RealtimeChannelProtocol: AnyObject, Sendable {
   var socket: any RealtimeClientProtocol { get }
 }
 
+/// A Realtime channel that joins a topic and dispatches incoming events to registered callbacks.
+///
+/// Obtain an instance from ``RealtimeClientV2/channel(_:options:)`` and call
+/// ``subscribeWithError()`` to start receiving events. Register all callbacks
+/// **before** subscribing — adding callbacks after ``subscribe()``/``subscribeWithError()``
+/// returns triggers a runtime warning.
+///
+/// ```swift
+/// let channel = client.channel("room:lobby") { config in
+///   config.broadcast.receiveOwnBroadcasts = true
+/// }
+///
+/// _ = channel.onBroadcast(event: "message") { payload in
+///   print(payload)
+/// }
+///
+/// try await channel.subscribeWithError()
+/// ```
+///
+/// ## Topics
+/// ### Identity
+/// - ``topic``
+/// - ``config``
+/// ### Status
+/// - ``status``
+/// - ``statusChange``
+/// - ``onStatusChange(_:)``
+/// ### Lifecycle
+/// - ``subscribeWithError()``
+/// - ``subscribe()``
+/// - ``unsubscribe()``
+/// ### Broadcasting
+/// - ``broadcast(event:message:)-7xyf5``
+/// - ``broadcast(event:message:)-2pvzp``
+/// - ``broadcast(event:data:)``
+/// - ``httpSend(event:message:timeout:)-8v03n``
+/// - ``httpSend(event:message:timeout:)-5hhoc``
+/// ### Presence
+/// - ``track(_:)``
+/// - ``track(state:)``
+/// - ``untrack()``
+/// - ``onPresenceChange(_:)``
+/// ### Postgres Changes
+/// - ``onPostgresChange(_:schema:table:filter:callback:)-8kn76``
+/// - ``onPostgresChange(_:schema:table:filter:callback:)-1j0l6``
+/// - ``onPostgresChange(_:schema:table:filter:callback:)-9c5h2``
+/// - ``onPostgresChange(_:schema:table:filter:callback:)-7srl6``
+/// ### Broadcast Events
+/// - ``onBroadcast(event:callback:)``
+/// - ``onBroadcastData(event:callback:)``
+/// ### System Events
+/// - ``onSystem(callback:)-7cnrp``
+/// - ``onSystem(callback:)-7cno3``
+/// ### Deprecated
+/// - ``updateAuth(jwt:)``
 public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
+  /// The fully-qualified topic string sent to the Realtime server (e.g. `"realtime:room:lobby"`).
   public let topic: String
 
   /// The channel's topic without the `realtime:` prefix, as expected by the
   /// broadcast REST endpoint (WebSocket frames use the full ``topic``).
   let subTopic: String
 
+  /// The channel's current configuration.
+  ///
+  /// Reflects the options passed to ``RealtimeClientV2/channel(_:options:)``.
   @MainActor public private(set) var config: RealtimeChannelConfig
 
   let logger: (any SupabaseLogger)?
@@ -56,20 +132,26 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
 
   private let statusSubject = AsyncValueSubject<RealtimeChannelStatus>(.unsubscribed)
 
+  /// The current subscription status of the channel.
   public private(set) var status: RealtimeChannelStatus {
     get { statusSubject.value }
     set { statusSubject.yield(newValue) }
   }
 
+  /// An async stream that emits channel subscription status changes.
+  ///
+  /// The stream emits the current status immediately upon iteration and then each
+  /// subsequent change. Use ``onStatusChange(_:)`` for a closure-based alternative.
   public var statusChange: AsyncStream<RealtimeChannelStatus> {
     statusSubject.values
   }
 
-  /// Listen for connection status changes.
-  /// - Parameter listener: Closure that will be called when connection status changes.
-  /// - Returns: An observation handle that can be used to stop listening.
+  /// Registers a closure to be called whenever the channel subscription status changes.
   ///
-  /// - Note: Use ``statusChange`` if you prefer to use Async/Await.
+  /// - Parameter listener: A `@Sendable` closure called with the new ``RealtimeChannelStatus`` on every change.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
+  ///
+  /// > Note: Use ``statusChange`` if you prefer async iteration over closures.
   public func onStatusChange(
     _ listener: @escaping @Sendable (RealtimeChannelStatus) -> Void
   ) -> RealtimeSubscription {
@@ -145,19 +227,27 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Subscribes to the channel.
+  /// Joins the Realtime topic and suspends until the subscription is confirmed by the server.
+  ///
+  /// All callbacks (broadcast, presence, postgres changes) must be registered before calling
+  /// this method. Calling it more than once on an already-subscribed channel is a no-op.
+  ///
+  /// - Throws: A ``RealtimeError`` if the subscribe attempt fails or times out.
   public func subscribeWithError() async throws {
     logger?.debug("Subscribe requested for channel '\(topic)'")
     try await stateManager.subscribe()
   }
 
-  /// Subscribes to the channel.
+  /// Joins the Realtime topic, silently ignoring any errors.
+  ///
+  /// > Warning: Prefer ``subscribeWithError()`` so errors are surfaced to the caller.
   @available(*, deprecated, message: "Use `subscribeWithError` instead")
   @MainActor
   public func subscribe() async {
     try? await subscribeWithError()
   }
 
+  /// Leaves the Realtime topic and transitions the channel to ``RealtimeChannelStatus/unsubscribed``.
   public func unsubscribe() async {
     logger?.debug("Unsubscribe requested for channel '\(topic)'")
     await stateManager.unsubscribe()
@@ -196,6 +286,10 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     )
   }
 
+  /// Updates the JWT token for this channel directly.
+  ///
+  /// > Warning: Updating the token per-channel is deprecated. Use
+  /// > ``RealtimeClientV2/setAuth(_:)`` on the client instead.
   @available(
     *,
     deprecated,
@@ -210,17 +304,17 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     )
   }
 
-  /// Sends a broadcast message explicitly via REST API.
+  /// Sends a broadcast message via the REST API using a `Codable` payload.
   ///
-  /// This method always uses the REST API endpoint regardless of WebSocket connection state.
-  /// Useful when you want to guarantee REST delivery or when gradually migrating from implicit REST fallback.
+  /// This method always targets the REST broadcast endpoint regardless of the current
+  /// WebSocket state. Use it when you need guaranteed REST delivery or want to send
+  /// a broadcast before subscribing to the channel.
   ///
   /// - Parameters:
-  ///   - event: The name of the broadcast event.
-  ///   - message: Message payload (required).
-  ///   - timeout: Optional timeout interval. If not specified, uses the socket's default timeout.
-  /// - Returns: `true` if the message was accepted (HTTP 202), otherwise throws an error.
-  /// - Throws: An error if the access token is missing, payload is missing, or the request fails.
+  ///   - event: The broadcast event name.
+  ///   - message: A `Codable` value to send as the message payload.
+  ///   - timeout: An optional timeout in seconds. Defaults to the socket's configured timeout.
+  /// - Throws: A ``RealtimeError`` if the access token is missing or the request fails.
   public func httpSend(
     event: String,
     message: some Codable,
@@ -229,17 +323,17 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     try await httpSend(event: event, message: JSONObject(message), timeout: timeout)
   }
 
-  /// Sends a broadcast message explicitly via REST API.
+  /// Sends a broadcast message via the REST API using a raw `JSONObject` payload.
   ///
-  /// This method always uses the REST API endpoint regardless of WebSocket connection state.
-  /// Useful when you want to guarantee REST delivery or when gradually migrating from implicit REST fallback.
+  /// This method always targets the REST broadcast endpoint regardless of the current
+  /// WebSocket state. Use it when you need guaranteed REST delivery or want to send
+  /// a broadcast before subscribing to the channel.
   ///
   /// - Parameters:
-  ///   - event: The name of the broadcast event.
-  ///   - message: Message payload as a `JSONObject` (required).
-  ///   - timeout: Optional timeout interval. If not specified, uses the socket's default timeout.
-  /// - Returns: `true` if the message was accepted (HTTP 202), otherwise throws an error.
-  /// - Throws: An error if the access token is missing, payload is missing, or the request fails.
+  ///   - event: The broadcast event name.
+  ///   - message: A ``JSONObject`` to send as the message payload.
+  ///   - timeout: An optional timeout in seconds. Defaults to the socket's configured timeout.
+  /// - Throws: A ``RealtimeError`` if the access token is missing or the request fails.
   public func httpSend(
     event: String,
     message: JSONObject,
@@ -289,18 +383,28 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Send a broadcast message with `event` and a `Codable` payload.
+  /// Sends a broadcast message with a `Codable` payload over WebSocket (or falls back to REST).
+  ///
+  /// When the channel is subscribed, the message is sent over the existing WebSocket connection.
+  /// If not subscribed, the call falls back to the REST broadcast endpoint with a deprecation notice.
+  /// Prefer ``httpSend(event:message:timeout:)-8v03n`` for an explicit REST call.
+  ///
   /// - Parameters:
-  ///   - event: Broadcast message event.
-  ///   - message: Message payload.
+  ///   - event: The broadcast event name.
+  ///   - message: A `Codable` value to send as the message payload.
   public func broadcast(event: String, message: some Codable) async throws {
     try await broadcast(event: event, message: JSONObject(message))
   }
 
-  /// Send a broadcast message with `event` and a raw `JSON` payload.
+  /// Sends a broadcast message with a raw `JSONObject` payload over WebSocket (or falls back to REST).
+  ///
+  /// When the channel is subscribed, the message is sent over the existing WebSocket connection.
+  /// If not subscribed, the call falls back to the REST broadcast endpoint with a deprecation notice.
+  /// Prefer ``httpSend(event:message:timeout:)-5hhoc`` for an explicit REST call.
+  ///
   /// - Parameters:
-  ///   - event: Broadcast message event.
-  ///   - message: Message payload.
+  ///   - event: The broadcast event name.
+  ///   - message: A raw ``JSONObject`` payload.
   @MainActor
   public func broadcast(event: String, message: JSONObject) async {
     if status != .subscribed {
@@ -375,12 +479,15 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Send a broadcast message with `event` and a raw binary `Data` payload.
+  /// Sends a binary broadcast message over WebSocket.
   ///
-  /// Binary broadcasts require protocol version 2.0.0 (`vsn: .v2`).
+  /// Binary broadcasts require protocol version ``RealtimeProtocolVersion/v2`` and an active
+  /// subscription. An issue is reported (via `reportIssue`) if the channel is not subscribed or
+  /// if the client is running protocol 1.0.0.
+  ///
   /// - Parameters:
-  ///   - event: Broadcast message event.
-  ///   - data: Binary data payload.
+  ///   - event: The broadcast event name.
+  ///   - data: Raw binary data to send as the payload.
   @MainActor
   public func broadcast(event: String, data: Data) async {
     if status != .subscribed {
@@ -411,15 +518,21 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     )
   }
 
-  /// Tracks the given state in the channel.
-  /// - Parameter state: The state to be tracked, conforming to `Codable`.
-  /// - Throws: An error if the tracking fails.
+  /// Tracks the current client's presence state using a `Codable` value.
+  ///
+  /// The state is shared with all other clients on the same channel. Call this after subscribing.
+  ///
+  /// - Parameter state: A `Codable` value representing the client's presence state.
+  /// - Throws: An error if the state cannot be encoded.
   public func track(_ state: some Codable) async throws {
     try await track(state: JSONObject(state))
   }
 
-  /// Tracks the given state in the channel.
-  /// - Parameter state: The state to be tracked as a `JSONObject`.
+  /// Tracks the current client's presence state using a raw `JSONObject`.
+  ///
+  /// The state is shared with all other clients on the same channel. Call this after subscribing.
+  ///
+  /// - Parameter state: A ``JSONObject`` representing the client's presence state.
   public func track(state: JSONObject) async {
     if status != .subscribed {
       reportIssue(
@@ -437,7 +550,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     )
   }
 
-  /// Stops tracking the current state in the channel.
+  /// Stops tracking the current client's presence state on the channel.
   public func untrack() async {
     await push(
       ChannelEvent.presence,
@@ -601,7 +714,12 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for clients joining / leaving the channel using presences.
+  /// Registers a closure that is called when clients join or leave the channel's presence set.
+  ///
+  /// Register this callback before calling ``subscribeWithError()``.
+  ///
+  /// - Parameter callback: A `@Sendable` closure receiving a ``PresenceAction`` value.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onPresenceChange(
     _ callback: @escaping @Sendable (any PresenceAction) -> Void
   ) -> RealtimeSubscription {
@@ -623,14 +741,19 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Registers a closure that is called for every Postgres change event on the specified table.
+  ///
+  /// Use ``AnyAction`` to receive insert, update, and delete changes in one callback.
+  /// Register this callback before calling ``subscribeWithError()``.
   ///
   /// - Parameters:
-  ///   - schema: The database schema to listen to. Defaults to `"public"`.
-  ///   - table: The table to listen to. Listens to all tables when `nil`.
-  ///   - filter: A ``RealtimePostgresFilter`` restricting which changes are received.
-  ///   - select: Restricts the change payload to a subset of columns instead of
-  ///     the full row. Requires an explicit `schema` and `table`.
+  ///   - type: Pass `AnyAction.self` to match all change types.
+  ///   - schema: The database schema to listen on. Defaults to `"public"`.
+  ///   - table: The table name to filter changes, or `nil` to listen to all tables in the schema.
+  ///   - filter: A ``RealtimePostgresFilter`` restricting which rows are received.
+  ///   - select: Restricts the change payload to a subset of columns. Requires an explicit `schema` and `table`.
+  ///   - callback: A `@Sendable` closure receiving an ``AnyAction`` for each change.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onPostgresChange(
     _: AnyAction.Type,
     schema: String = "public",
@@ -671,14 +794,18 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Registers a closure that is called for every `INSERT` change on the specified table.
+  ///
+  /// Register this callback before calling ``subscribeWithError()``.
   ///
   /// - Parameters:
-  ///   - schema: The database schema to listen to. Defaults to `"public"`.
-  ///   - table: The table to listen to. Listens to all tables when `nil`.
-  ///   - filter: A ``RealtimePostgresFilter`` restricting which changes are received.
-  ///   - select: Restricts the change payload to a subset of columns instead of
-  ///     the full row. Requires an explicit `schema` and `table`.
+  ///   - type: Pass `InsertAction.self`.
+  ///   - schema: The database schema to listen on. Defaults to `"public"`.
+  ///   - table: The table name to filter changes, or `nil` to listen to all tables in the schema.
+  ///   - filter: A ``RealtimePostgresFilter`` restricting which rows are received.
+  ///   - select: Restricts the change payload to a subset of columns. Requires an explicit `schema` and `table`.
+  ///   - callback: A `@Sendable` closure receiving an ``InsertAction`` for each insert.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onPostgresChange(
     _: InsertAction.Type,
     schema: String = "public",
@@ -721,14 +848,18 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Registers a closure that is called for every `UPDATE` change on the specified table.
+  ///
+  /// Register this callback before calling ``subscribeWithError()``.
   ///
   /// - Parameters:
-  ///   - schema: The database schema to listen to. Defaults to `"public"`.
-  ///   - table: The table to listen to. Listens to all tables when `nil`.
-  ///   - filter: A ``RealtimePostgresFilter`` restricting which changes are received.
-  ///   - select: Restricts the change payload to a subset of columns instead of
-  ///     the full row. Requires an explicit `schema` and `table`.
+  ///   - type: Pass `UpdateAction.self`.
+  ///   - schema: The database schema to listen on. Defaults to `"public"`.
+  ///   - table: The table name to filter changes, or `nil` to listen to all tables in the schema.
+  ///   - filter: A ``RealtimePostgresFilter`` restricting which rows are received.
+  ///   - select: Restricts the change payload to a subset of columns. Requires an explicit `schema` and `table`.
+  ///   - callback: A `@Sendable` closure receiving an ``UpdateAction`` for each update.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onPostgresChange(
     _: UpdateAction.Type,
     schema: String = "public",
@@ -771,14 +902,18 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for postgres changes in a channel.
+  /// Registers a closure that is called for every `DELETE` change on the specified table.
+  ///
+  /// Register this callback before calling ``subscribeWithError()``.
   ///
   /// - Parameters:
-  ///   - schema: The database schema to listen to. Defaults to `"public"`.
-  ///   - table: The table to listen to. Listens to all tables when `nil`.
-  ///   - filter: A ``RealtimePostgresFilter`` restricting which changes are received.
-  ///   - select: Restricts the change payload to a subset of columns instead of
-  ///     the full row. Requires an explicit `schema` and `table`.
+  ///   - type: Pass `DeleteAction.self`.
+  ///   - schema: The database schema to listen on. Defaults to `"public"`.
+  ///   - table: The table name to filter changes, or `nil` to listen to all tables in the schema.
+  ///   - filter: A ``RealtimePostgresFilter`` restricting which rows are received.
+  ///   - select: Restricts the change payload to a subset of columns. Requires an explicit `schema` and `table`.
+  ///   - callback: A `@Sendable` closure receiving a ``DeleteAction`` for each deletion.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onPostgresChange(
     _: DeleteAction.Type,
     schema: String = "public",
@@ -860,7 +995,12 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for broadcast messages sent by other clients within the same channel under a specific `event`.
+  /// Registers a closure that is called when a JSON broadcast message arrives for the given event.
+  ///
+  /// - Parameters:
+  ///   - event: The broadcast event name to listen for.
+  ///   - callback: A `@Sendable` closure receiving the ``JSONObject`` payload.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onBroadcast(
     event: String,
     callback: @escaping @Sendable (JSONObject) -> Void
@@ -872,9 +1012,15 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for binary broadcast messages sent by other clients within the same channel under a specific `event`.
+  /// Registers a closure that is called when a binary broadcast message arrives for the given event.
   ///
-  /// Use this when you expect binary (non-JSON) broadcast payloads.
+  /// Use this when you expect binary (non-JSON) broadcast payloads sent via
+  /// ``broadcast(event:data:)``. Requires protocol ``RealtimeProtocolVersion/v2``.
+  ///
+  /// - Parameters:
+  ///   - event: The broadcast event name to listen for.
+  ///   - callback: A `@Sendable` closure receiving the raw `Data` payload.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onBroadcastData(
     event: String,
     callback: @escaping @Sendable (Data) -> Void
@@ -886,7 +1032,12 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for `system` event.
+  /// Registers a closure that is called when a `system` event is received, providing the full message.
+  ///
+  /// System events are emitted by the server to convey channel-level status information.
+  ///
+  /// - Parameter callback: A `@Sendable` closure receiving the ``RealtimeMessageV2``.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onSystem(
     callback: @escaping @Sendable (RealtimeMessageV2) -> Void
   ) -> RealtimeSubscription {
@@ -897,7 +1048,12 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     }
   }
 
-  /// Listen for `system` event.
+  /// Registers a no-argument closure that is called when a `system` event is received.
+  ///
+  /// Use this overload when you only need to know that a system event occurred, not its contents.
+  ///
+  /// - Parameter callback: A `@Sendable` closure called on each system event.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onSystem(
     callback: @escaping @Sendable () -> Void
   ) -> RealtimeSubscription {

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -18,9 +18,10 @@ import IssueReporting
   }
 #endif
 
+// cspell:ignore pvzp hhoc cnrp
 /// Configuration for a ``RealtimeChannelV2``.
 ///
-/// Pass a builder closure to ``RealtimeClientV2/channel(_:options:)`` to customise
+/// Pass a builder closure to ``RealtimeClientV2/channel(_:options:)`` to customize
 /// broadcast, presence, and privacy settings before subscribing.
 ///
 /// ## Topics

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -37,7 +37,9 @@ public struct RealtimeChannelConfig: Sendable {
 
   /// Whether the channel is private.
   ///
-  /// Private channels restrict broadcast and presence to authenticated clients only.
+  /// Private channels enforce access control via RLS policies defined in your database.
+  /// See the [Realtime authorization guide](https://supabase.com/docs/guides/realtime/authorization)
+  /// for details.
   public var isPrivate: Bool
 }
 
@@ -61,11 +63,12 @@ protocol RealtimeChannelProtocol: AnyObject, Sendable {
 ///   config.broadcast.receiveOwnBroadcasts = true
 /// }
 ///
-/// _ = channel.onBroadcast(event: "message") { payload in
+/// let messages = channel.broadcastStream(event: "message")
+/// try await channel.subscribeWithError()
+///
+/// for await payload in messages {
 ///   print(payload)
 /// }
-///
-/// try await channel.subscribeWithError()
 /// ```
 ///
 /// ## Topics
@@ -718,6 +721,14 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   ///
   /// Register this callback before calling ``subscribeWithError()``.
   ///
+  /// ```swift
+  /// let subscription = channel.onPresenceChange { action in
+  ///   print("joins:", action.joins, "leaves:", action.leaves)
+  /// }
+  /// ```
+  ///
+  /// > Note: Use ``presenceChange()`` if you prefer async iteration over closures.
+  ///
   /// - Parameter callback: A `@Sendable` closure receiving a ``PresenceAction`` value.
   /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
   public func onPresenceChange(
@@ -745,6 +756,18 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   ///
   /// Use ``AnyAction`` to receive insert, update, and delete changes in one callback.
   /// Register this callback before calling ``subscribeWithError()``.
+  ///
+  /// ```swift
+  /// let subscription = channel.onPostgresChange(AnyAction.self, schema: "public", table: "messages") { action in
+  ///   switch action {
+  ///   case .insert(let insert): print(insert.record)
+  ///   case .update(let update): print(update.record)
+  ///   case .delete(let delete): print(delete.oldRecord)
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// > Note: Use ``postgresChange(_:schema:table:filter:)`` if you prefer async iteration over closures.
   ///
   /// - Parameters:
   ///   - type: Pass `AnyAction.self` to match all change types.
@@ -797,6 +820,14 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// Registers a closure that is called for every `INSERT` change on the specified table.
   ///
   /// Register this callback before calling ``subscribeWithError()``.
+  ///
+  /// ```swift
+  /// let subscription = channel.onPostgresChange(InsertAction.self, schema: "public", table: "messages") { insert in
+  ///   print(insert.record)
+  /// }
+  /// ```
+  ///
+  /// > Note: Use ``postgresChange(_:schema:table:filter:)`` if you prefer async iteration over closures.
   ///
   /// - Parameters:
   ///   - type: Pass `InsertAction.self`.
@@ -852,6 +883,14 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   ///
   /// Register this callback before calling ``subscribeWithError()``.
   ///
+  /// ```swift
+  /// let subscription = channel.onPostgresChange(UpdateAction.self, schema: "public", table: "messages") { update in
+  ///   print(update.record, update.oldRecord)
+  /// }
+  /// ```
+  ///
+  /// > Note: Use ``postgresChange(_:schema:table:filter:)`` if you prefer async iteration over closures.
+  ///
   /// - Parameters:
   ///   - type: Pass `UpdateAction.self`.
   ///   - schema: The database schema to listen on. Defaults to `"public"`.
@@ -905,6 +944,14 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// Registers a closure that is called for every `DELETE` change on the specified table.
   ///
   /// Register this callback before calling ``subscribeWithError()``.
+  ///
+  /// ```swift
+  /// let subscription = channel.onPostgresChange(DeleteAction.self, schema: "public", table: "messages") { delete in
+  ///   print(delete.oldRecord)
+  /// }
+  /// ```
+  ///
+  /// > Note: Use ``postgresChange(_:schema:table:filter:)`` if you prefer async iteration over closures.
   ///
   /// - Parameters:
   ///   - type: Pass `DeleteAction.self`.
@@ -997,6 +1044,14 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
 
   /// Registers a closure that is called when a JSON broadcast message arrives for the given event.
   ///
+  /// ```swift
+  /// let subscription = channel.onBroadcast(event: "cursor") { payload in
+  ///   print(payload)
+  /// }
+  /// ```
+  ///
+  /// > Note: Use ``broadcastStream(event:)`` if you prefer async iteration over closures.
+  ///
   /// - Parameters:
   ///   - event: The broadcast event name to listen for.
   ///   - callback: A `@Sendable` closure receiving the ``JSONObject`` payload.
@@ -1017,6 +1072,14 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// Use this when you expect binary (non-JSON) broadcast payloads sent via
   /// ``broadcast(event:data:)``. Requires protocol ``RealtimeProtocolVersion/v2``.
   ///
+  /// ```swift
+  /// let subscription = channel.onBroadcastData(event: "frame") { data in
+  ///   process(data)
+  /// }
+  /// ```
+  ///
+  /// > Note: Use ``broadcastDataStream(event:)`` if you prefer async iteration over closures.
+  ///
   /// - Parameters:
   ///   - event: The broadcast event name to listen for.
   ///   - callback: A `@Sendable` closure receiving the raw `Data` payload.
@@ -1035,6 +1098,14 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// Registers a closure that is called when a `system` event is received, providing the full message.
   ///
   /// System events are emitted by the server to convey channel-level status information.
+  ///
+  /// ```swift
+  /// let subscription = channel.onSystem { message in
+  ///   print(message.payload)
+  /// }
+  /// ```
+  ///
+  /// > Note: Use ``system()`` if you prefer async iteration over closures.
   ///
   /// - Parameter callback: A `@Sendable` closure receiving the ``RealtimeMessageV2``.
   /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.

--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -37,6 +37,44 @@ protocol RealtimeClientProtocol: AnyObject, Sendable {
   func _remove(_ channel: any RealtimeChannelProtocol)
 }
 
+/// The entry point for Supabase Realtime subscriptions.
+///
+/// `RealtimeClientV2` manages the underlying WebSocket connection and routes
+/// incoming events to the appropriate ``RealtimeChannelV2`` instances. Create
+/// one client per Supabase project and reuse it across your app.
+///
+/// ```swift
+/// let client = RealtimeClientV2(
+///   url: URL(string: "https://<project>.supabase.co/realtime/v1")!,
+///   options: RealtimeClientOptions(accessToken: { session.accessToken })
+/// )
+///
+/// await client.connect()
+///
+/// let channel = client.channel("room:lobby")
+/// try await channel.subscribe()
+/// ```
+///
+/// ## Topics
+/// ### Channels
+/// - ``channels``
+/// - ``channel(_:options:)``
+/// - ``addChannel(_:)``
+/// - ``removeChannel(_:)``
+/// - ``removeAllChannels()``
+/// ### Connection Status
+/// - ``status``
+/// - ``statusChange``
+/// - ``onStatusChange(_:)``
+/// - ``connect()``
+/// - ``disconnect(code:reason:)``
+/// ### Heartbeat
+/// - ``heartbeat``
+/// - ``onHeartbeat(_:)``
+/// ### Authentication
+/// - ``setAuth(_:)``
+/// ### Sending Messages
+/// - ``push(_:)``
 public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   struct MutableState {
     var accessToken: String?
@@ -87,6 +125,10 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   let connectionManager: ConnectionManager
 
   /// All managed channels indexed by their topics.
+  ///
+  /// The dictionary key is the fully-qualified topic string (e.g. `"realtime:room:lobby"`).
+  /// Channels are added by ``channel(_:options:)`` and removed by ``removeChannel(_:)``
+  /// or ``removeAllChannels()``.
   public var channels: [String: RealtimeChannelV2] {
     mutableState.channels
   }
@@ -94,30 +136,47 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   private let statusSubject = AsyncValueSubject<RealtimeClientStatus>(.disconnected)
   private let heartbeatSubject = AsyncValueSubject<HeartbeatStatus?>(nil)
 
-  /// Listen for connection status changes.
+  /// An async stream that emits connection status changes.
   ///
-  /// You can also use ``onStatusChange(_:)`` for a closure based method.
+  /// The stream emits the current status immediately upon iteration and then each
+  /// subsequent change. Use ``onStatusChange(_:)`` for a closure-based alternative.
+  ///
+  /// ```swift
+  /// for await status in client.statusChange {
+  ///   print("Status changed to \(status)")
+  /// }
+  /// ```
   public var statusChange: AsyncStream<RealtimeClientStatus> {
     statusSubject.values
   }
 
-  /// The current connection status.
+  /// The current WebSocket connection status.
+  ///
+  /// Reflects the last value emitted by ``statusChange``.
   public var status: RealtimeClientStatus {
     statusSubject.value
   }
 
-  /// Listen for heartbeat status.
+  /// An async stream that emits heartbeat status updates.
   ///
-  /// You can also use ``onHeartbeat(_:)`` for a closure based method.
+  /// The client sends a heartbeat at each ``RealtimeClientOptions/defaultHeartbeatInterval``
+  /// interval to keep the connection alive. Use ``onHeartbeat(_:)`` for a closure-based alternative.
+  ///
+  /// ```swift
+  /// for await beat in client.heartbeat {
+  ///   print("Heartbeat: \(beat)")
+  /// }
+  /// ```
   public var heartbeat: AsyncStream<HeartbeatStatus> {
     AsyncStream(heartbeatSubject.values.compactMap { $0 })
   }
 
-  /// Listen for connection status changes.
-  /// - Parameter listener: Closure that will be called when connection status changes.
-  /// - Returns: An observation handle that can be used to stop listening.
+  /// Registers a closure to be called whenever the connection status changes.
   ///
-  /// - Note: Use ``statusChange`` if you prefer to use Async/Await.
+  /// - Parameter listener: A `@Sendable` closure called with the new ``RealtimeClientStatus`` on every change.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
+  ///
+  /// > Note: Use ``statusChange`` if you prefer async iteration over closures.
   public func onStatusChange(
     _ listener: @escaping @Sendable (RealtimeClientStatus) -> Void
   ) -> RealtimeSubscription {
@@ -125,11 +184,12 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     return RealtimeSubscription { task.cancel() }
   }
 
-  /// Listen for heartbeat checks.
-  /// - Parameter listener: Closure that will be called when heartbeat status changes.
-  /// - Returns: An observation handle that can be used to stop listening.
+  /// Registers a closure to be called on every heartbeat cycle.
   ///
-  /// - Note: Use ``heartbeat`` if you prefer to use Async/Await.
+  /// - Parameter listener: A `@Sendable` closure called with the latest ``HeartbeatStatus``.
+  /// - Returns: A ``RealtimeSubscription`` token. Retain it — the subscription is cancelled when the token is deallocated.
+  ///
+  /// > Note: Use ``heartbeat`` if you prefer async iteration over closures.
   public func onHeartbeat(
     _ listener: @escaping @Sendable (HeartbeatStatus) -> Void
   ) -> RealtimeSubscription {
@@ -140,6 +200,11 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     return RealtimeSubscription { task.cancel() }
   }
 
+  /// Creates a new ``RealtimeClientV2`` using the default URLSession WebSocket transport.
+  ///
+  /// - Parameters:
+  ///   - url: The Realtime server URL (e.g. `https://<project>.supabase.co/realtime/v1`).
+  ///   - options: Configuration options for the client.
   public convenience init(url: URL, options: RealtimeClientOptions) {
     var interceptors: [any HTTPClientInterceptor] = []
 
@@ -291,9 +356,14 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
-  /// Connects the socket.
+  /// Opens the WebSocket connection and suspends until it is established.
   ///
-  /// Suspends until connected.
+  /// Calling this method when already connected is a no-op. If ``RealtimeClientOptions/connectOnSubscribe``
+  /// is `true` (the default), this is called automatically when a channel is subscribed to.
+  ///
+  /// ```swift
+  /// await client.connect()
+  /// ```
   public func connect() async {
     options.logger?.debug("Connecting...")
     Self.yieldStatusIfChanged(statusSubject, .connecting)
@@ -313,13 +383,19 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
-  /// Creates a new channel and bind it to this client.
-  /// - Parameters:
-  ///   - topic: Channel's topic.
-  ///   - options: Configuration options for the channel.
-  /// - Returns: Channel instance.
+  /// Returns an existing channel for the given topic or creates a new one.
   ///
-  /// - Note: This method doesn't subscribe to the channel, call ``RealtimeChannelV2/subscribe()`` on the returned channel instance.
+  /// The fully-qualified topic sent to the server is `"realtime:<topic>"`. If a channel
+  /// with the same topic already exists, it is returned without modification.
+  ///
+  /// > Note: This method does not subscribe to the channel. Call ``RealtimeChannelV2/subscribeWithError()``
+  /// > on the returned instance to join the topic.
+  ///
+  /// - Parameters:
+  ///   - topic: The channel topic name (without the `realtime:` prefix).
+  ///   - options: A builder closure to configure ``RealtimeChannelConfig`` options such as
+  ///     broadcast, presence, and privacy settings.
+  /// - Returns: A ``RealtimeChannelV2`` bound to this client.
   public func channel(
     _ topic: String,
     options: @Sendable (inout RealtimeChannelConfig) -> Void = { _ in }
@@ -355,6 +431,10 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
+  /// Registers an externally-created channel with this client.
+  ///
+  /// > Warning: The client now manages channels automatically via ``channel(_:options:)``.
+  /// > This method will be removed in the next major release.
   @available(
     *,
     deprecated,
@@ -367,10 +447,13 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
-  /// Unsubscribe and removes channel.
+  /// Unsubscribes from and removes a channel.
   ///
-  /// If there is no channel left, client is disconnected (or schedules a deferred disconnect when
-  /// ``RealtimeClientOptions/disconnectOnEmptyChannelsAfter`` is positive).
+  /// If the channel is currently subscribed, it is unsubscribed first. After removal,
+  /// if no channels remain, the client disconnects (or schedules a deferred disconnect
+  /// based on ``RealtimeClientOptions/defaultDisconnectOnEmptyChannelsAfter``).
+  ///
+  /// - Parameter channel: The channel to remove.
   public func removeChannel(_ channel: RealtimeChannelV2) async {
     if channel.status == .subscribed {
       await channel.unsubscribe()
@@ -414,8 +497,11 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
-  /// Unsubscribes and removes all channels, then disconnects immediately regardless of
-  /// ``RealtimeClientOptions/disconnectOnEmptyChannelsAfter``.
+  /// Unsubscribes from and removes all channels, then disconnects immediately.
+  ///
+  /// Unlike ``removeChannel(_:)``, this method ignores
+  /// ``RealtimeClientOptions/defaultDisconnectOnEmptyChannelsAfter`` and
+  /// disconnects the WebSocket right away.
   public func removeAllChannels() async {
     await withTaskGroup(of: Void.self) { group in
       for channel in channels.values {
@@ -570,10 +656,15 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
-  /// Disconnects client.
+  /// Closes the WebSocket connection.
+  ///
+  /// Cancels pending tasks, clears the send buffer, and emits a ``RealtimeClientStatus/disconnected``
+  /// status. Any channels that are currently subscribed remain registered and will be re-joined
+  /// automatically if ``connect()`` is called again.
+  ///
   /// - Parameters:
-  ///   - code: A numeric status code to send on disconnect.
-  ///   - reason: A custom reason for the disconnect.
+  ///   - code: An optional numeric close code to send to the server.
+  ///   - reason: An optional human-readable reason string.
   public func disconnect(code: Int? = nil, reason: String? = nil) {
     options.logger?.debug("Closing WebSocket connection")
 
@@ -637,12 +728,13 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
-  /// Sets the JWT access token used for channel subscription authorization and Realtime RLS.
+  /// Updates the JWT access token used for channel authorization and Realtime RLS.
   ///
-  /// If `token` is nil it will use the ``RealtimeClientOptions/accessToken`` callback function or the token set on the client.
+  /// When called, the token is propagated to all currently-subscribed channels. If `token`
+  /// is `nil`, the value is fetched from ``RealtimeClientOptions/accessToken`` if provided,
+  /// or the token already stored on the client is used.
   ///
-  /// On callback used, it will set the value of the token internal to the client.
-  /// - Parameter token: A JWT string to override the token set on the client.
+  /// - Parameter token: A JWT string, or `nil` to refresh from the configured `accessToken` callback.
   public func setAuth(_ token: String? = nil) async {
     var tokenToSend = token
 
@@ -706,9 +798,13 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     }
   }
 
-  /// Push out a message if the socket is connected.
+  /// Sends a message over the WebSocket, buffering it if the socket is not yet connected.
   ///
-  /// If the socket is not connected, the message gets enqueued within a local buffer, and sent out when a connection is next established.
+  /// If the socket is connected, the message is serialized and sent immediately.
+  /// If the socket is not connected, the message is enqueued and flushed once the
+  /// connection is established.
+  ///
+  /// - Parameter message: The ``RealtimeMessageV2`` to send.
   public func push(_ message: RealtimeMessageV2) {
     let callback = { @Sendable (_ client: RealtimeClientV2) in
       do {

--- a/Sources/RealtimeV2/RealtimeJoinConfig.swift
+++ b/Sources/RealtimeV2/RealtimeJoinConfig.swift
@@ -33,28 +33,59 @@ struct RealtimeJoinConfig: Codable, Hashable {
   }
 }
 
-/// Configuration for broadcast replay feature.
-/// Allows replaying broadcast messages from a specific timestamp.
+/// Options for replaying previously broadcast messages when joining a channel.
+///
+/// Pass a `ReplayOption` to ``BroadcastJoinConfig/replay`` to receive messages
+/// that were broadcast before the client subscribed.
+///
+/// ## Topics
+/// ### Properties
+/// - ``since``
+/// - ``limit``
+/// ### Initialization
+/// - ``init(since:limit:)``
 public struct ReplayOption: Codable, Hashable, Sendable {
-  /// Unix timestamp (in milliseconds) from which to start replaying messages
+  /// Unix timestamp in milliseconds. Messages broadcast after this point will be replayed.
   public var since: Int
-  /// Optional limit on the number of messages to replay
+
+  /// Optional maximum number of messages to replay. When `nil`, all matching messages are returned.
   public var limit: Int?
 
+  /// Creates a ``ReplayOption``.
+  ///
+  /// - Parameters:
+  ///   - since: Unix timestamp in milliseconds from which to start replaying messages.
+  ///   - limit: Maximum number of messages to replay, or `nil` for no limit.
   public init(since: Int, limit: Int? = nil) {
     self.since = since
     self.limit = limit
   }
 }
 
+/// Configuration for the broadcast feature of a Realtime channel.
+///
+/// Pass an instance to ``RealtimeChannelConfig/broadcast`` when creating a channel.
+///
+/// ## Topics
+/// ### Properties
+/// - ``acknowledgeBroadcasts``
+/// - ``receiveOwnBroadcasts``
+/// - ``replay``
+/// ### Initialization
+/// - ``init(acknowledgeBroadcasts:receiveOwnBroadcasts:replay:)``
 public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
-  /// Instructs server to acknowledge that broadcast message was received.
+  /// When `true`, the server acknowledges each broadcast message before delivering it.
+  ///
+  /// Useful in combination with ``RealtimeChannelV2/broadcast(event:message:)-2pvzp``
+  /// to ensure delivery before continuing.
   public var acknowledgeBroadcasts: Bool = false
-  /// Broadcast messages back to the sender.
+
+  /// When `true`, broadcast messages are echoed back to the sender in addition to all other subscribers.
   ///
   /// By default, broadcast messages are only sent to other clients.
   public var receiveOwnBroadcasts: Bool = false
-  /// Configures broadcast replay from a specific timestamp
+
+  /// When set, the server replays broadcast messages starting from the given timestamp on join.
   public var replay: ReplayOption?
   /// Instructs the server to emit a `system` event once the Postgres replication
   /// connection backing this channel is established and ready to stream changes.
@@ -65,6 +96,12 @@ public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
   /// `.error` if the connection is not ready in time.
   public var replicationReady: Bool = false
 
+  /// Creates a ``BroadcastJoinConfig``.
+  ///
+  /// - Parameters:
+  ///   - acknowledgeBroadcasts: Whether the server should acknowledge each broadcast. Defaults to `false`.
+  ///   - receiveOwnBroadcasts: Whether to echo broadcasts back to the sender. Defaults to `false`.
+  ///   - replay: Optional replay configuration for receiving past broadcasts on join.
   public init(
     acknowledgeBroadcasts: Bool = false,
     receiveOwnBroadcasts: Bool = false,
@@ -85,16 +122,53 @@ public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
   }
 }
 
+/// Configuration for the presence feature of a Realtime channel.
+///
+/// Pass an instance to ``RealtimeChannelConfig/presence`` when creating a channel.
+///
+/// ## Topics
+/// ### Properties
+/// - ``key``
+/// ### Initialization
+/// - ``init(key:)``
 public struct PresenceJoinConfig: Codable, Hashable, Sendable {
-  /// Track presence payload across clients.
+  /// The client-defined key used to identify this client's presence entry in the presence map.
+  ///
+  /// All clients sharing the same key are grouped together in ``PresenceAction/joins``
+  /// and ``PresenceAction/leaves``. Defaults to an empty string, which lets the server
+  /// assign a random unique key.
   public var key: String = ""
   var enabled: Bool = false
 }
 
+extension PresenceJoinConfig {
+  /// Creates a ``PresenceJoinConfig`` with the specified key.
+  ///
+  /// - Parameter key: The presence key for this client. Defaults to `""`.
+  public init(key: String = "") {
+    self.key = key
+  }
+}
+
+/// The type of Postgres change event to subscribe to.
+///
+/// ## Topics
+/// ### Cases
+/// - ``insert``
+/// - ``update``
+/// - ``delete``
+/// - ``all``
 public enum PostgresChangeEvent: String, Codable, Sendable {
+  /// Subscribe to `INSERT` events only.
   case insert = "INSERT"
+
+  /// Subscribe to `UPDATE` events only.
   case update = "UPDATE"
+
+  /// Subscribe to `DELETE` events only.
   case delete = "DELETE"
+
+  /// Subscribe to all change events (`INSERT`, `UPDATE`, and `DELETE`).
   case all = "*"
 }
 

--- a/Sources/RealtimeV2/RealtimeJoinConfig.swift
+++ b/Sources/RealtimeV2/RealtimeJoinConfig.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// cspell:ignore pvzp
 struct RealtimeJoinPayload: Codable {
   var config: RealtimeJoinConfig
   var accessToken: String?

--- a/Sources/RealtimeV2/RealtimeJoinConfig.swift
+++ b/Sources/RealtimeV2/RealtimeJoinConfig.swift
@@ -48,7 +48,7 @@ public struct ReplayOption: Codable, Hashable, Sendable {
   /// Unix timestamp in milliseconds. Messages broadcast after this point will be replayed.
   public var since: Int
 
-  /// Optional maximum number of messages to replay. When `nil`, all matching messages are returned.
+  /// Optional maximum number of messages to replay. When `nil`, the server default limit applies.
   public var limit: Int?
 
   /// Creates a ``ReplayOption``.

--- a/Sources/RealtimeV2/RealtimeMessageV2.swift
+++ b/Sources/RealtimeV2/RealtimeMessageV2.swift
@@ -1,18 +1,52 @@
 import Foundation
 
-/// A message sent over the Realtime WebSocket connection.
+/// A message exchanged over the Realtime WebSocket connection.
 ///
-/// Both `joinRef` and `ref` are optional because certain messages like heartbeats
-/// don't require a join reference as they don't refer to a specific channel.
+/// Both `joinRef` and `ref` are optional because certain messages (such as heartbeats)
+/// are not scoped to a specific channel and therefore do not require join or message references.
+///
+/// ## Topics
+/// ### Identity
+/// - ``joinRef``
+/// - ``ref``
+/// - ``topic``
+/// - ``event``
+/// ### Payload
+/// - ``payload``
+/// - ``status``
+/// ### Event Classification
+/// - ``eventType``
+/// - ``EventType``
+/// ### Initialization
+/// - ``init(joinRef:ref:topic:event:payload:)``
 public struct RealtimeMessageV2: Hashable, Codable, Sendable {
-  /// Optional join reference. Nil for messages like heartbeats that don't belong to a specific channel.
+  /// The join reference that associates this message with the `phx_join` that opened the channel.
+  ///
+  /// `nil` for messages that are not scoped to a channel (e.g. heartbeats).
   public let joinRef: String?
-  /// Optional message reference. Can be nil for certain message types.
+
+  /// A unique reference string for this individual message, used to correlate replies.
+  ///
+  /// `nil` for server-pushed messages that do not expect a client reply.
   public let ref: String?
+
+  /// The Realtime topic this message is addressed to (e.g. `"realtime:room:lobby"`).
   public let topic: String
+
+  /// The Phoenix event name (e.g. `"phx_join"`, `"broadcast"`, `"postgres_changes"`).
   public let event: String
+
+  /// The JSON payload carried by this message.
   public let payload: JSONObject
 
+  /// Creates a new ``RealtimeMessageV2``.
+  ///
+  /// - Parameters:
+  ///   - joinRef: The join reference, or `nil` for non-channel messages.
+  ///   - ref: The message reference, or `nil` when no reply is expected.
+  ///   - topic: The Realtime topic string.
+  ///   - event: The Phoenix event name.
+  ///   - payload: The JSON payload.
   public init(joinRef: String?, ref: String?, topic: String, event: String, payload: JSONObject) {
     self.joinRef = joinRef
     self.ref = ref
@@ -21,13 +55,18 @@ public struct RealtimeMessageV2: Hashable, Codable, Sendable {
     self.payload = payload
   }
 
-  /// Status for the received message if any.
+  /// The server reply status extracted from the payload, if present.
+  ///
+  /// Parsed from `payload["status"]`. Common values are `.ok` and `.error`.
   public var status: PushStatus? {
     payload["status"]
       .flatMap(\.stringValue)
       .flatMap(PushStatus.init(rawValue:))
   }
 
+  /// The semantic event type parsed from ``event``.
+  ///
+  /// > Warning: Access to the structured event type will be removed in a future release. Inspect the raw ``event`` string directly instead.
   @available(
     *, deprecated,
     message: "Access to event type will be removed, please inspect raw event value instead."
@@ -56,20 +95,53 @@ public struct RealtimeMessageV2: Hashable, Codable, Sendable {
     }
   }
 
+  /// A structured representation of the channel event type.
+  ///
+  /// > Warning: This enum is associated with the deprecated ``eventType`` property.
+  /// > Inspect the raw ``event`` string instead of pattern-matching on this type.
+  ///
+  /// ## Topics
+  /// ### Cases
+  /// - ``system``
+  /// - ``postgresChanges``
+  /// - ``broadcast``
+  /// - ``close``
+  /// - ``error``
+  /// - ``presenceDiff``
+  /// - ``presenceState``
+  /// - ``tokenExpired``
+  /// - ``reply``
   public enum EventType {
+    /// A channel-level system message (e.g. subscribe confirmation).
     case system
+
+    /// A Postgres row change event.
     case postgresChanges
+
+    /// A broadcast message from another client.
     case broadcast
+
+    /// The channel was closed by the server.
     case close
+
+    /// The server reported an error on this channel.
     case error
+
+    /// A presence diff event describing joins and leaves.
     case presenceDiff
+
+    /// A full presence state snapshot.
     case presenceState
+
+    /// Token expiration event — now surfaced as a `system` event; check the payload for details.
     @available(
       *, deprecated,
       message:
         "tokenExpired gets returned as system, check payload for verifying if is a token expiration."
     )
     case tokenExpired
+
+    /// A reply to a client-originated push.
     case reply
   }
 

--- a/Sources/RealtimeV2/RealtimePostgresFilter.swift
+++ b/Sources/RealtimeV2/RealtimePostgresFilter.swift
@@ -50,6 +50,28 @@ public enum RealtimePostgresIsValue: Sendable {
 /// Values containing reserved characters (`,`, `(`, `)`, `"`, `\`) — or
 /// surrounding whitespace — are automatically double-quoted and escaped the way
 /// PostgREST does, so they survive the server's filter parser.
+///
+/// ## Topics
+/// ### Equality Filters
+/// - ``eq(_:value:)``
+/// - ``neq(_:value:)``
+/// - ``is(_:value:)``
+/// - ``isDistinct(_:value:)``
+/// ### Comparison Filters
+/// - ``gt(_:value:)``
+/// - ``gte(_:value:)``
+/// - ``lt(_:value:)``
+/// - ``lte(_:value:)``
+/// ### Pattern Matching Filters
+/// - ``like(_:value:)``
+/// - ``ilike(_:value:)``
+/// - ``match(_:value:)``
+/// - ``imatch(_:value:)``
+/// ### List Filters
+/// - ``in(_:values:)``
+/// ### Logical Operators
+/// - ``not(_:)``
+/// - ``and(_:)``
 public enum RealtimePostgresFilter {
   /// Match rows where `column` equals `value` (`column=eq.value`).
   case eq(_ column: String, value: any RealtimePostgresFilterValue)

--- a/Sources/RealtimeV2/RealtimePostgresFilterValue.swift
+++ b/Sources/RealtimeV2/RealtimePostgresFilterValue.swift
@@ -7,32 +7,46 @@
 
 import Foundation
 
-/// A value that can be used to filter Realtime changes in a channel.
+/// A value that can be used as a comparison operand in a ``RealtimePostgresFilter``.
+///
+/// The protocol requires conforming types to provide a ``rawValue`` string representation
+/// that is embedded directly in the filter query sent to the Realtime server.
+///
+/// `String`, `Int`, `Double`, `Bool`, `UUID`, and `Date` all conform to this protocol out
+/// of the box. Extend your own type if you need custom filter operands.
 public protocol RealtimePostgresFilterValue {
+  /// The string representation of this value as expected by the Realtime filter syntax.
   var rawValue: String { get }
 }
 
 extension String: RealtimePostgresFilterValue {
+  /// The string itself.
   public var rawValue: String { self }
 }
 
 extension Int: RealtimePostgresFilterValue {
+  /// The decimal string representation of this integer.
   public var rawValue: String { "\(self)" }
 }
 
 extension Double: RealtimePostgresFilterValue {
+  /// The string representation of this floating-point value.
   public var rawValue: String { "\(self)" }
 }
 
 extension Bool: RealtimePostgresFilterValue {
+  /// `"true"` or `"false"`.
   public var rawValue: String { "\(self)" }
 }
 
 extension UUID: RealtimePostgresFilterValue {
+  /// The canonical uppercase UUID string (e.g. `"550E8400-E29B-41D4-A716-446655440000"`).
   public var rawValue: String { uuidString }
 }
 
 extension Date: RealtimePostgresFilterValue {
+  /// An ISO 8601 string with fractional seconds and timezone offset
+  /// (e.g. `"2024-01-15T12:00:00.000Z"`), suitable for comparison against `timestamptz` columns.
   public var rawValue: String {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]

--- a/Sources/RealtimeV2/Types.swift
+++ b/Sources/RealtimeV2/Types.swift
@@ -13,6 +13,14 @@ import HTTPTypes
 #endif
 
 /// Phoenix protocol version used for WebSocket communication.
+///
+/// The version controls how messages are serialized on the wire between the client
+/// and the Realtime server.
+///
+/// ## Topics
+/// ### Protocol Versions
+/// - ``v1``
+/// - ``v2``
 public enum RealtimeProtocolVersion: String, Sendable {
   /// Protocol 1.0.0 — JSON object text frames for all messages.
   case v1 = "1.0.0"
@@ -23,6 +31,34 @@ public enum RealtimeProtocolVersion: String, Sendable {
 }
 
 /// Options for initializing ``RealtimeClientV2``.
+///
+/// Use this struct to customize the behavior of the Realtime client, including connection
+/// timing, authentication, protocol version, and app lifecycle handling.
+///
+/// ```swift
+/// let options = RealtimeClientOptions(
+///   heartbeatInterval: 30,
+///   vsn: .v2,
+///   handleAppLifecycle: true
+/// )
+/// let client = RealtimeClientV2(url: realtimeURL, options: options)
+/// ```
+///
+/// ## Topics
+/// ### Protocol and Lifecycle
+/// - ``vsn``
+/// - ``handleAppLifecycle``
+/// ### Default Values
+/// - ``defaultHeartbeatInterval``
+/// - ``defaultReconnectDelay``
+/// - ``defaultTimeoutInterval``
+/// - ``defaultDisconnectOnSessionLoss``
+/// - ``defaultConnectOnSubscribe``
+/// - ``defaultMaxRetryAttempts``
+/// - ``defaultDisconnectOnEmptyChannelsAfter``
+/// - ``defaultHandleAppLifecycle``
+/// ### Initialization
+/// - ``init(headers:heartbeatInterval:reconnectDelay:timeoutInterval:disconnectOnSessionLoss:connectOnSubscribe:maxRetryAttempts:disconnectOnEmptyChannelsAfter:vsn:logLevel:fetch:accessToken:logger:handleAppLifecycle:)``
 public struct RealtimeClientOptions: Sendable {
   package var headers: HTTPFields
   var heartbeatInterval: TimeInterval
@@ -34,6 +70,9 @@ public struct RealtimeClientOptions: Sendable {
   var disconnectOnEmptyChannelsAfter: TimeInterval
 
   /// The Phoenix serializer protocol version.
+  ///
+  /// Defaults to ``RealtimeProtocolVersion/v2``. Use ``RealtimeProtocolVersion/v1`` only
+  /// when connecting to a Realtime server that does not support protocol 2.0.0.
   public var vsn: RealtimeProtocolVersion
 
   /// Whether to automatically handle app lifecycle changes (background/foreground).
@@ -57,12 +96,24 @@ public struct RealtimeClientOptions: Sendable {
   package var accessToken: (@Sendable () async throws -> String?)?
   package var logger: (any SupabaseLogger)?
 
+  /// Default interval, in seconds, between heartbeat messages sent to keep the connection alive.
   public static let defaultHeartbeatInterval: TimeInterval = 25
+
+  /// Default delay, in seconds, before attempting to reconnect after a connection drop.
   public static let defaultReconnectDelay: TimeInterval = 7
+
+  /// Default maximum time, in seconds, to wait for a server reply before treating a request as timed out.
   public static let defaultTimeoutInterval: TimeInterval = 10
+
+  /// Default for whether to disconnect the channel when the session is lost.
   public static let defaultDisconnectOnSessionLoss = true
+
+  /// Default for whether to automatically connect the socket when subscribing to a channel.
   public static let defaultConnectOnSubscribe: Bool = true
+
+  /// Default maximum number of subscribe retry attempts before giving up.
   public static let defaultMaxRetryAttempts: Int = 5
+
   /// Defers the WebSocket disconnect after the last channel is removed, giving a window to reuse
   /// the existing connection when switching channels without a reconnect penalty. Defaults to
   /// `2 × defaultHeartbeatInterval`. Set to 0 for immediate disconnect. If a new channel is
@@ -70,6 +121,9 @@ public struct RealtimeClientOptions: Sendable {
   public static let defaultDisconnectOnEmptyChannelsAfter: TimeInterval =
     2 * defaultHeartbeatInterval
 
+  /// Default value for ``handleAppLifecycle``.
+  ///
+  /// Returns `true` on iOS, macOS, tvOS, and visionOS; `false` on all other platforms.
   public static let defaultHandleAppLifecycle: Bool = {
     #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
       return true
@@ -78,6 +132,23 @@ public struct RealtimeClientOptions: Sendable {
     #endif
   }()
 
+  /// Creates a new ``RealtimeClientOptions`` with the specified configuration.
+  ///
+  /// - Parameters:
+  ///   - headers: Additional HTTP headers sent with each WebSocket upgrade request.
+  ///   - heartbeatInterval: Interval in seconds between heartbeat messages. Defaults to ``defaultHeartbeatInterval``.
+  ///   - reconnectDelay: Delay in seconds before attempting to reconnect after a disconnection. Defaults to ``defaultReconnectDelay``.
+  ///   - timeoutInterval: Maximum time in seconds to wait for a server reply. Defaults to ``defaultTimeoutInterval``.
+  ///   - disconnectOnSessionLoss: Whether to disconnect the channel when the authentication session is lost. Defaults to ``defaultDisconnectOnSessionLoss``.
+  ///   - connectOnSubscribe: Whether to automatically call ``RealtimeClientV2/connect()`` when subscribing to a channel. Defaults to ``defaultConnectOnSubscribe``.
+  ///   - maxRetryAttempts: Maximum number of subscribe retry attempts. Defaults to ``defaultMaxRetryAttempts``.
+  ///   - disconnectOnEmptyChannelsAfter: Seconds to wait before disconnecting when all channels are removed. Defaults to ``defaultDisconnectOnEmptyChannelsAfter``.
+  ///   - vsn: The Phoenix protocol version to use. Defaults to ``RealtimeProtocolVersion/v2``.
+  ///   - logLevel: Optional log level for Realtime log output.
+  ///   - fetch: Optional custom HTTP fetch function used for REST broadcast calls.
+  ///   - accessToken: Optional async closure that returns the current access token.
+  ///   - logger: Optional logger conforming to `SupabaseLogger`.
+  ///   - handleAppLifecycle: Whether to automatically reconnect on app foreground. Defaults to ``defaultHandleAppLifecycle``.
   public init(
     headers: [String: String] = [:],
     heartbeatInterval: TimeInterval = Self.defaultHeartbeatInterval,
@@ -149,18 +220,57 @@ public struct RealtimeClientOptions: Sendable {
   }
 }
 
+/// A token that represents a Realtime subscription and cancels it on deallocation.
+///
+/// Store the returned token from subscription methods (e.g. ``RealtimeChannelV2/onBroadcast(event:callback:)``)
+/// to keep the subscription alive. When the token is deallocated or ``ObservationToken/cancel()``
+/// is called, the underlying callback is removed.
+///
+/// ```swift
+/// let subscription = channel.onBroadcast(event: "message") { payload in
+///   print(payload)
+/// }
+/// defer { subscription.cancel() }
+/// ```
 public typealias RealtimeSubscription = ObservationToken
 
+/// Describes the subscription state of a ``RealtimeChannelV2``.
+///
+/// ## Topics
+/// ### States
+/// - ``unsubscribed``
+/// - ``subscribing``
+/// - ``subscribed``
+/// - ``unsubscribing``
 public enum RealtimeChannelStatus: Sendable {
+  /// The channel has not yet joined or has left the Realtime topic.
   case unsubscribed
+
+  /// The channel is in the process of joining the Realtime topic.
   case subscribing
+
+  /// The channel has successfully joined the Realtime topic and is receiving events.
   case subscribed
+
+  /// The channel is in the process of leaving the Realtime topic.
   case unsubscribing
 }
 
+/// Describes the connection state of a ``RealtimeClientV2``.
+///
+/// ## Topics
+/// ### States
+/// - ``disconnected``
+/// - ``connecting``
+/// - ``connected``
 public enum RealtimeClientStatus: Sendable, CustomStringConvertible {
+  /// The WebSocket is not connected.
   case disconnected
+
+  /// A WebSocket connection attempt is in progress.
   case connecting
+
+  /// The WebSocket is connected and ready to exchange messages.
   case connected
 
   public var description: String {
@@ -172,16 +282,33 @@ public enum RealtimeClientStatus: Sendable, CustomStringConvertible {
   }
 }
 
+/// Describes the result of a heartbeat cycle.
+///
+/// The Realtime client sends periodic heartbeat messages to keep the WebSocket
+/// connection alive. Use ``RealtimeClientV2/heartbeat`` or ``RealtimeClientV2/onHeartbeat(_:)``
+/// to observe heartbeat status changes.
+///
+/// ## Topics
+/// ### States
+/// - ``sent``
+/// - ``ok``
+/// - ``error``
+/// - ``timeout``
+/// - ``disconnected``
 public enum HeartbeatStatus: Sendable {
   /// Heartbeat was sent.
   case sent
-  /// Heartbeat was received.
+
+  /// Heartbeat was received and acknowledged by the server.
   case ok
-  /// Server responded with an error.
+
+  /// Server responded with an error to the heartbeat.
   case error
-  /// Heartbeat wasn't received in time.
+
+  /// Heartbeat was not acknowledged within the configured timeout interval.
   case timeout
-  /// Socket is disconnected.
+
+  /// Socket is disconnected; no heartbeat can be sent.
   case disconnected
 }
 
@@ -189,9 +316,25 @@ extension HTTPField.Name {
   static let apiKey = Self("apiKey")!
 }
 
-/// Log level for Realtime.
+/// Verbosity of log output emitted by the Realtime client.
+///
+/// Pass a value to ``RealtimeClientOptions/init(headers:heartbeatInterval:reconnectDelay:timeoutInterval:disconnectOnSessionLoss:connectOnSubscribe:maxRetryAttempts:disconnectOnEmptyChannelsAfter:vsn:logLevel:fetch:accessToken:logger:handleAppLifecycle:)``
+/// to control how much detail the Realtime server logs.
+///
+/// ## Topics
+/// ### Levels
+/// - ``info``
+/// - ``warn``
+/// - ``error``
 public enum LogLevel: String, Sendable {
-  case info, warn, error
+  /// Informational messages.
+  case info
+
+  /// Warning messages.
+  case warn
+
+  /// Error messages only.
+  case error
 }
 
 struct BroadcastMessagePayload: Encodable {

--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -22,11 +22,11 @@ import HTTPTypes
 /// - ``configuration``
 /// - ``init(configuration:)``
 ///
-/// ### Customising headers
+/// ### Customizing headers
 ///
 /// - ``setHeader(_:forKey:)``
 public class StorageApi: @unchecked Sendable {
-  /// The configuration used to initialise this client instance.
+  /// The configuration used to initialize this client instance.
   public let configuration: StorageClientConfiguration
 
   private struct MutableState {
@@ -38,7 +38,7 @@ public class StorageApi: @unchecked Sendable {
 
   /// Creates a ``StorageApi`` with the given configuration.
   ///
-  /// Subclasses call this initialiser via `super.init(configuration:)`.
+  /// Subclasses call this initializer via `super.init(configuration:)`.
   ///
   /// - Parameter configuration: The configuration that controls the endpoint URL, authentication
   ///   headers, JSON codecs, and HTTP session.
@@ -87,7 +87,7 @@ public class StorageApi: @unchecked Sendable {
 
   /// Sets an HTTP header that will be included in all subsequent requests made by this instance.
   ///
-  /// This method is thread-safe. The header key is normalised to lowercase before being stored.
+  /// This method is thread-safe. The header key is normalized to lowercase before being stored.
   ///
   /// ```swift
   /// storage.from("avatars")

--- a/Sources/Storage/StorageBucketApi.swift
+++ b/Sources/Storage/StorageBucketApi.swift
@@ -32,7 +32,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// Retrieves the details of all Storage buckets within the project.
   ///
   /// - Returns: An array of ``Bucket`` objects, one for each bucket in the project.
-  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   public func listBuckets() async throws -> [Bucket] {
     try await execute(
       HTTPRequest(
@@ -47,7 +47,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   ///
   /// - Parameter id: The unique identifier of the bucket to retrieve.
   /// - Returns: The ``Bucket`` with the given identifier.
-  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func getBucket(_ id: String) async throws -> Bucket {
     try await execute(
       HTTPRequest(
@@ -80,7 +80,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   ///   - options: Options that control visibility, file-size limits, and allowed MIME types.
   ///     Defaults to a private bucket with no size or type restrictions.
   /// - Throws: ``StorageError`` if a bucket with the same identifier already exists, or if the
-  ///   caller is not authorised.
+  ///   caller is not authorized.
   public func createBucket(_ id: String, options: BucketOptions = BucketOptions(isPublic: false))
     async throws
   {
@@ -113,7 +113,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// - Parameters:
   ///   - id: The unique identifier of the bucket to update.
   ///   - options: The new options to apply to the bucket.
-  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func updateBucket(_ id: String, options: BucketOptions) async throws {
     try await execute(
       HTTPRequest(
@@ -138,7 +138,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// > deleted.
   ///
   /// - Parameter id: The unique identifier of the bucket to empty.
-  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func emptyBucket(_ id: String) async throws {
     try await execute(
       HTTPRequest(
@@ -155,7 +155,7 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   ///
   /// - Parameter id: The unique identifier of the bucket to delete.
   /// - Throws: ``StorageError`` if the bucket is not empty, does not exist, or the caller is not
-  ///   authorised.
+  ///   authorized.
   public func deleteBucket(_ id: String) async throws {
     try await execute(
       HTTPRequest(

--- a/Sources/Storage/StorageError.swift
+++ b/Sources/Storage/StorageError.swift
@@ -3,7 +3,7 @@ import Foundation
 /// An error returned by the Supabase Storage API.
 ///
 /// ``StorageError`` is thrown whenever the server responds with a non-2xx status code or when the
-/// response body contains a recognisable error payload. Inspect ``message`` for a human-readable
+/// response body contains a recognizable error payload. Inspect ``message`` for a human-readable
 /// description, and ``statusCode`` for the HTTP status code string returned by the API.
 ///
 /// ```swift

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -188,9 +188,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - path: The relative file path within the bucket, e.g. `"folder/subfolder/filename.png"`.
   ///     The bucket must already exist before attempting to upload.
   ///   - data: The raw bytes to store in the bucket.
-  ///   - options: Upload options such as cache control, content type, and upsert behaviour.
+  ///   - options: Upload options such as cache control, content type, and upsert behavior.
   /// - Returns: A ``FileUploadResponse`` containing the stored object's identifier and path.
-  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorized.
   @discardableResult
   public func upload(
     _ path: String,
@@ -215,9 +215,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - path: The relative file path within the bucket, e.g. `"folder/subfolder/filename.png"`.
   ///     The bucket must already exist before attempting to upload.
   ///   - fileURL: A `file://` URL pointing to the local file to upload.
-  ///   - options: Upload options such as cache control, content type, and upsert behaviour.
+  ///   - options: Upload options such as cache control, content type, and upsert behavior.
   /// - Returns: A ``FileUploadResponse`` containing the stored object's identifier and path.
-  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the upload fails or the caller is not authorized.
   @discardableResult
   public func upload(
     _ path: String,
@@ -243,7 +243,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - data: The raw bytes to overwrite the existing file with.
   ///   - options: Upload options such as cache control and content type.
   /// - Returns: A ``FileUploadResponse`` containing the updated object's identifier and path.
-  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorized.
   @discardableResult
   public func update(
     _ path: String,
@@ -269,7 +269,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - fileURL: A `file://` URL pointing to the local file to use as the replacement.
   ///   - options: Upload options such as cache control and content type.
   /// - Returns: A ``FileUploadResponse`` containing the updated object's identifier and path.
-  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorized.
   @discardableResult
   public func update(
     _ path: String,
@@ -295,7 +295,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - destination: The new file path including the new file name, e.g. `"archive/image.png"`.
   ///   - options: Optional ``DestinationOptions`` specifying a destination bucket. When `nil`,
   ///     the file is moved within the same bucket.
-  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorized.
   public func move(
     from source: String,
     to destination: String,
@@ -329,7 +329,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - options: Optional ``DestinationOptions`` specifying a destination bucket. When `nil`,
   ///     the file is copied within the same bucket.
   /// - Returns: The full storage path of the newly created copy.
-  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the source does not exist or the caller is not authorized.
   @discardableResult
   public func copy(
     from source: String,
@@ -369,7 +369,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: A signed `URL` ready to share.
-  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorized.
   @_disfavoredOverload
   public func createSignedURL(
     path: String,
@@ -423,7 +423,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: A signed `URL` ready to share.
-  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the path does not exist or the caller is not authorized.
   public func createSignedURL(
     path: String,
     expiresIn: Int,
@@ -454,7 +454,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: An array of ``SignedURLResult`` values, one per requested path.
-  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorised). Individual missing
+  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorized). Individual missing
   ///   paths are reported as ``SignedURLResult/failure(path:error:)`` rather than thrown.
   @_disfavoredOverload
   public func createSignedURLs(
@@ -519,7 +519,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: An array of ``SignedURLResult`` values, one per requested path, preserving order.
-  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorised). Individual missing
+  /// - Throws: ``StorageError`` if the request itself fails (e.g. unauthorized). Individual missing
   ///   paths are reported as ``SignedURLResult/failure(path:error:)`` rather than thrown.
   public func createSignedURLs(
     paths: [String],
@@ -585,7 +585,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// - Parameter paths: File paths to delete, including the file name,
   ///   e.g. `["folder/image.png", "other/doc.pdf"]`.
   /// - Returns: An array of ``FileObject`` values representing the files that were removed.
-  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   @discardableResult
   public func remove(paths: [String]) async throws -> [FileObject] {
     try await execute(
@@ -609,7 +609,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - options: Search options for filtering, sorting, and paginating results. Defaults to the
   ///     first 100 files sorted by name ascending.
   /// - Returns: An array of ``FileObject`` values representing the matching files and folders.
-  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   public func list(
     path: String? = nil,
     options: SearchOptions? = nil
@@ -646,7 +646,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   - cacheNonce: An optional nonce appended as a `cacheNonce` query parameter for
   ///     cache-busting purposes.
   /// - Returns: The raw file data.
-  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorized.
   @discardableResult
   public func download(
     path: String,
@@ -681,7 +681,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///
   /// - Parameter path: The file path including the file name, e.g. `"folder/image.png"`.
   /// - Returns: A ``FileObjectV2`` containing size, content type, ETag, and other metadata.
-  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the file does not exist or the caller is not authorized.
   public func info(path: String) async throws -> FileObjectV2 {
     let _path = _getFinalPath(path)
 
@@ -701,7 +701,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// - Parameter path: The file path including the file name, e.g. `"folder/image.png"`.
   /// - Returns: `true` if the file exists and is accessible, `false` if it does not exist.
   /// - Throws: ``StorageError`` for errors other than "not found" (e.g. network failure or
-  ///   authorisation errors).
+  ///   authorization errors).
   public func exists(path: String) async throws -> Bool {
     do {
       try await execute(
@@ -832,9 +832,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///
   /// - Parameters:
   ///   - path: The destination file path including the file name, e.g. `"folder/image.png"`.
-  ///   - options: Optional ``CreateSignedUploadURLOptions`` controlling upsert behaviour.
+  ///   - options: Optional ``CreateSignedUploadURLOptions`` controlling upsert behavior.
   /// - Returns: A ``SignedUploadURL`` containing the signed URL and an upload token.
-  /// - Throws: ``StorageError`` if the request fails or the caller is not authorised.
+  /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   public func createSignedUploadURL(
     path: String,
     options: CreateSignedUploadURLOptions? = nil

--- a/Sources/Storage/StorageHTTPClient.swift
+++ b/Sources/Storage/StorageHTTPClient.swift
@@ -10,7 +10,7 @@ import Foundation
 /// the Storage client can be tested without a real network connection and can be configured to use
 /// a custom session (e.g. with background upload support).
 ///
-/// The default initialiser uses `URLSession.shared`.
+/// The default initializer uses `URLSession.shared`.
 ///
 /// ```swift
 /// // Use a custom URLSession with a specific configuration

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -35,10 +35,10 @@ public struct StorageClientConfiguration: Sendable {
   /// HTTP headers sent with every request, such as the `Authorization` header.
   public var headers: [String: String]
 
-  /// The JSON encoder used to serialise request bodies.
+  /// The JSON encoder used to serialize request bodies.
   public let encoder: JSONEncoder
 
-  /// The JSON decoder used to deserialise response bodies.
+  /// The JSON decoder used to deserialize response bodies.
   public let decoder: JSONDecoder
 
   /// The HTTP session abstraction used to execute requests.

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -901,7 +901,7 @@ extension SortOrder: Codable {
 
 // MARK: - DownloadBehavior
 
-/// Controls the `Content-Disposition` header behaviour for signed and public URLs.
+/// Controls the `Content-Disposition` header behavior for signed and public URLs.
 ///
 /// ```swift
 /// storage.from("docs").getPublicURL(path: "report.pdf", download: .withOriginalName)

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -172,7 +172,7 @@ public struct FileOptions: Sendable {
 
 /// A single signed URL returned as part of a batch sign operation.
 ///
-/// Returned by ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)-5lkmo``
+/// Returned by ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)-5lkmo`` // cspell:ignore lkmo
 /// (the legacy `[SignedURL]` overload). Prefer the ``SignedURLResult`` overload for new code.
 ///
 /// ## Topics

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -4,7 +4,7 @@ import Foundation
   import FoundationNetworking
 #endif
 
-/// Configuration options for customizing ``SupabaseClient`` behaviour.
+/// Configuration options for customizing ``SupabaseClient`` behavior.
 ///
 /// Pass an instance of this struct to ``SupabaseClient/init(supabaseURL:supabaseKey:options:)``
 /// to override defaults for any sub-client.

--- a/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
@@ -5,6 +5,7 @@
 //  Created by Guilherme Souza on 07/05/24.
 //
 
+// cspell:ignore nsupabot nkiwicopple nawailas ndragarcia
 import InlineSnapshotTesting
 import PostgREST
 import XCTest
@@ -280,7 +281,7 @@ final class PostgrestTransformsTests: XCTestCase {
       .csv().execute().string()
     assertInlineSnapshot(of: res, as: .json) {
       #"""
-      "username,data,age_range,status,catchphrase\nsupabot,,\"[1,2)\",ONLINE,\"'cat' 'fat'\"\nkiwicopple,,\"[25,35)\",OFFLINE,\"'bat' 'cat'\"\nawailas,,\"[25,35)\",ONLINE,\"'bat' 'rat'\"\ndragarcia,,\"[20,30)\",ONLINE,\"'fat' 'rat'\""  // cspell:ignore nsupabot nkiwicopple nawailas ndragarcia
+      "username,data,age_range,status,catchphrase\nsupabot,,\"[1,2)\",ONLINE,\"'cat' 'fat'\"\nkiwicopple,,\"[25,35)\",OFFLINE,\"'bat' 'cat'\"\nawailas,,\"[25,35)\",ONLINE,\"'bat' 'rat'\"\ndragarcia,,\"[20,30)\",ONLINE,\"'fat' 'rat'\""
       """#
     }
   }

--- a/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
@@ -280,7 +280,7 @@ final class PostgrestTransformsTests: XCTestCase {
       .csv().execute().string()
     assertInlineSnapshot(of: res, as: .json) {
       #"""
-      "username,data,age_range,status,catchphrase\nsupabot,,\"[1,2)\",ONLINE,\"'cat' 'fat'\"\nkiwicopple,,\"[25,35)\",OFFLINE,\"'bat' 'cat'\"\nawailas,,\"[25,35)\",ONLINE,\"'bat' 'rat'\"\ndragarcia,,\"[20,30)\",ONLINE,\"'fat' 'rat'\""
+      "username,data,age_range,status,catchphrase\nsupabot,,\"[1,2)\",ONLINE,\"'cat' 'fat'\"\nkiwicopple,,\"[25,35)\",OFFLINE,\"'bat' 'cat'\"\nawailas,,\"[25,35)\",ONLINE,\"'bat' 'rat'\"\ndragarcia,,\"[20,30)\",ONLINE,\"'fat' 'rat'\""  // cspell:ignore nsupabot nkiwicopple nawailas ndragarcia
       """#
     }
   }

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -127,7 +127,7 @@ final class RealtimeColdStartTests: XCTestCase {
   /// must re-send `phx_join` on the new socket. Before this fix,
   /// `ChannelStateManager.subscribe()` was a no-op for `.subscribed` channels,
   /// so `rejoinChannels()` silently skipped them — channels went deaf after
-  /// the first reconnect (reported by rpiacent on PR #1003).
+  /// the first reconnect (reported by rpiacent on PR #1003). // cspell:ignore rpiacent
   func testChannelsRejoinAfterReconnect() async throws {
     let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -72,7 +72,6 @@ kiwicopple
 letterboxing
 libro
 libros
-lkmo
 lifecycles
 linkedin
 LinkedIn

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -55,6 +55,7 @@ Guilherme
 Gxlbmdl
 heartbeating
 Heartbeating
+hostnames
 HTTPURL
 Ilike
 ilike
@@ -68,8 +69,10 @@ JWKS
 kakao
 Kakao
 kiwicopple
+letterboxing
 libro
 libros
+lkmo
 lifecycles
 linkedin
 LinkedIn

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -83,11 +83,7 @@ Metas
 newbucket
 niled
 Nlci
-nawailas
-ndragarcia
-nkiwicopple
 nosec
-nsupabot
 NSEC
 NSPOSIX
 NSURL
@@ -123,7 +119,6 @@ refreshable
 refreshtoken
 resends
 Resends
-rpiacent
 Rlbn
 Rvci
 sadcat


### PR DESCRIPTION
## Summary

Adds comprehensive `///` DocC documentation to all public symbols in `Sources/Realtime/` (non-deprecated files only).

### Files documented

- **`Types.swift`** — `RealtimeProtocolVersion`, `RealtimeClientOptions` (init + each public property + all static defaults), `RealtimeSubscription` typealias, `RealtimeChannelStatus`, `RealtimeClientStatus`, `HeartbeatStatus`, `LogLevel`
- **`RealtimeClientV2.swift`** — class-level doc + `## Topics`, `channels`, `statusChange`, `status`, `heartbeat`, `onStatusChange(_:)`, `onHeartbeat(_:)`, `init(url:options:)`, `connect()`, `channel(_:options:)`, `addChannel(_:)` (deprecated), `removeChannel(_:)`, `removeAllChannels()`, `setAuth(_:)`, `disconnect(code:reason:)`, `push(_:)`
- **`RealtimeChannelV2.swift`** — `RealtimeChannelConfig` (all properties), class-level doc + `## Topics`, `topic`, `config`, `status`, `statusChange`, `onStatusChange(_:)`, `subscribeWithError()`, `subscribe()` (deprecated), `unsubscribe()`, both `httpSend` overloads, all `broadcast` overloads, `track(_:)`, `track(state:)`, `untrack()`, `onPresenceChange(_:)`, all 4 `onPostgresChange` overloads, `onBroadcast(event:callback:)`, `onBroadcastData(event:callback:)`, both `onSystem` overloads, `updateAuth(jwt:)` (deprecated)
- **`RealtimeChannel+AsyncAwait.swift`** — `presenceChange()`, all 4 non-deprecated `postgresChange` overloads + their deprecated string-filter counterparts, `broadcastStream(event:)`, `broadcastDataStream(event:)`, `system()`, `broadcast(event:)` (deprecated)
- **`PostgresAction.swift`** — `Column`, `PostgresAction` protocol, `HasRecord` + `decodeRecord(as:decoder:)`, `HasOldRecord` + `decodeOldRecord(as:decoder:)`, `HasRawMessage`, `InsertAction`, `UpdateAction`, `DeleteAction`, `AnyAction`
- **`PresenceAction.swift`** — `PresenceV2` (properties + `decodeState(as:decoder:)`), `PresenceAction` protocol (properties + `decodeJoins` + `decodeLeaves`)
- **`RealtimeMessageV2.swift`** — struct-level doc + `## Topics`, all properties, `eventType` (deprecated), `EventType` enum + all cases, `init`
- **`RealtimeJoinConfig.swift`** — `ReplayOption`, `BroadcastJoinConfig`, `PresenceJoinConfig` (including new `init(key:)` extension), `PostgresChangeEvent`
- **`RealtimePostgresFilter.swift`** — enum-level doc + `## Topics`, all 7 cases
- **`RealtimePostgresFilterValue.swift`** — protocol doc + `rawValue`, conformance docs for `String`, `Int`, `Double`, `Bool`, `UUID`, `Date`

## Test plan

- [x] `make test-docs` passes with no warnings
- [x] `make format` applied and only the 10 `Sources/Realtime/` files are modified