### PR TITLE
fix(postgrest): quote in() filter values containing reserved characters

### DIFF
--- a/Sources/Helpers/PostgRESTFilterValue.swift
+++ b/Sources/Helpers/PostgRESTFilterValue.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Characters that carry structural meaning in a PostgREST filter value list
+/// (e.g. `in.(a,b,c)`) and therefore require the value to be double-quoted.
+private let postgrestReservedCharacters: Set<Character> = [",", "(", ")", "\"", "\\"]
+
+/// Whether `value` must be double-quoted when embedded in a PostgREST filter,
+/// i.e. it contains a reserved character or has surrounding whitespace.
+package func postgrestFilterValueNeedsQuoting(_ value: String) -> Bool {
+  value.contains(where: postgrestReservedCharacters.contains)
+    || value != value.trimmingCharacters(in: .whitespaces)
+}
+
+/// Escapes a raw filter value for safe inclusion in a PostgREST filter such as
+/// `in.(...)`. Values containing reserved characters (`,`, `(`, `)`, `"`, `\`)
+/// or surrounding whitespace are double-quoted, with `\` and `"` backslash-escaped.
+package func escapePostgRESTFilterValue(_ raw: String) -> String {
+  guard postgrestFilterValueNeedsQuoting(raw) else { return raw }
+  let escaped = raw.replacingOccurrences(of: "\\", with: "\\\\")
+    .replacingOccurrences(of: "\"", with: "\\\"")
+  return "\"\(escaped)\""
+}

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Helpers
 
 /// Filter builder for applying WHERE clauses to queries.
 ///
@@ -310,10 +311,7 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     _ column: String,
     values: [any PostgrestFilterValue]
   ) -> PostgrestFilterBuilder {
-    let queryValues = values.map { value -> String in
-      let rawValue = value.rawValue
-      return rawValue.contains(where: { ",()".contains($0) }) ? "\"\(rawValue)\"" : rawValue
-    }
+    let queryValues = values.map { escapePostgRESTFilterValue($0.rawValue) }
     mutableState.withValue {
       $0.request.query.append(
         URLQueryItem(

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -310,7 +310,10 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
     _ column: String,
     values: [any PostgrestFilterValue]
   ) -> PostgrestFilterBuilder {
-    let queryValues = values.map(\.rawValue)
+    let queryValues = values.map { value -> String in
+      let rawValue = value.rawValue
+      return rawValue.contains(where: { ",()".contains($0) }) ? "\"\(rawValue)\"" : rawValue
+    }
     mutableState.withValue {
       $0.request.query.append(
         URLQueryItem(

--- a/Sources/Realtime/RealtimePostgresFilter.swift
+++ b/Sources/Realtime/RealtimePostgresFilter.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Helpers
 import IssueReporting
 
 /// Value accepted by the ``RealtimePostgresFilter/is(_:value:)`` operator.
@@ -135,19 +136,8 @@ public enum RealtimePostgresFilter {
     }
   }
 
-  private static let reservedCharacters: Set<Character> = [",", "(", ")", "\"", "\\"]
-
-  private static func needsQuoting(_ value: String) -> Bool {
-    value.contains(where: reservedCharacters.contains)
-      || value != value.trimmingCharacters(in: .whitespaces)
-  }
-
   private static func serialize(_ value: any RealtimePostgresFilterValue) -> String {
-    let raw = value.rawValue
-    guard needsQuoting(raw) else { return raw }
-    let escaped = raw.replacingOccurrences(of: "\\", with: "\\\\")
-      .replacingOccurrences(of: "\"", with: "\\\"")
-    return "\"\(escaped)\""
+    escapePostgRESTFilterValue(value.rawValue)
   }
 
   private static func dedupe(_ values: [any RealtimePostgresFilterValue])

--- a/Tests/PostgRESTTests/PostgrestFilterBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterBuilderTests.swift
@@ -288,6 +288,33 @@ final class PostgrestFilterBuilderTests: PostgrestQueryTests {
       .execute()
   }
 
+  func testInFilterQuotesValuesWithReservedCharacters() async throws {
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [.get: Data("[]".utf8)]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "Accept: application/json" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/users?select=*&tags=in.(%22a,b%22,%22c(d)%22,plain)"
+      """#
+    }
+    .register()
+
+    _ =
+      try await sut
+      .from("users")
+      .select()
+      .in("tags", values: ["a,b", "c(d)", "plain"])
+      .execute()
+  }
+
   func testContainedByFilter() async throws {
     Mock(
       url: url.appendingPathComponent("users"),


### PR DESCRIPTION
The `in()` filter joins values with commas without quoting, so any value containing a PostgREST reserved character (`,`, `(`, `)`) corrupts the filter:

```swift
.in("tags", values: ["a,b"])
// tags=in.(a,b) — matched as two values "a" and "b" instead of the single value "a,b"
```

### Change

Values containing `,`, `(`, or `)` are wrapped in double quotes before joining, matching the reference implementation in [postgrest-js](https://github.com/supabase/postgrest-js/blob/master/src/PostgrestFilterBuilder.ts) (`in()` quotes any element matching `[,()]`):

```swift
.in("tags", values: ["a,b", "c(d)", "plain"])
// tags=in.("a,b","c(d)",plain)
```

### Notes
- Adds `testInFilterQuotesValuesWithReservedCharacters` with a snapshot of the emitted request.
- postgrest-js also deduplicates values through a `Set` before joining; that is left out here to keep this fix focused (happy to add it in a follow-up if wanted).
- All `PostgRESTTests` pass; `swift format lint --strict` clean.