### PR TITLE
fix(storage): restore source compatibility for deprecated overloads

### DIFF
--- a/Sources/Storage/Deprecated.swift
+++ b/Sources/Storage/Deprecated.swift
@@ -284,7 +284,7 @@ extension BucketOptions {
     message: "Use `init(isPublic:fileSizeLimit:allowedMimeTypes:)` with StorageByteCount instead."
   )
   public init(
-    isPublic: Bool = false,
+    isPublic: Bool,
     fileSizeLimit: String? = nil,
     allowedMimeTypes: [String]? = nil
   ) {
@@ -296,6 +296,7 @@ extension BucketOptions {
 }
 
 extension SortBy {
+  @_disfavoredOverload
   @available(*, deprecated, message: "Use `init` with `SortOrder` instead.")
   public init(column: String? = nil, order: String? = nil) {
     self.column = column

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -316,7 +316,9 @@ public struct StorageByteCount: Sendable, Hashable {
   }
 
   private static func formatValue(_ value: Double) -> String {
-    value.truncatingRemainder(dividingBy: 1) == 0 ? String(Int64(value)) : String(value)
+    value.truncatingRemainder(dividingBy: 1) == 0
+      ? Int64(exactly: value).map(String.init) ?? String(value)
+      : String(value)
   }
 
   /// Creates a ``StorageByteCount`` from a number of kilobytes.

--- a/Tests/StorageTests/BucketOptionsTests.swift
+++ b/Tests/StorageTests/BucketOptionsTests.swift
@@ -74,4 +74,24 @@ final class BucketOptionsTests: XCTestCase {
     let options = BucketOptions(public: false, fileSizeLimit: "1mb")
     XCTAssertEqual(options.fileSizeLimit, "1mb")
   }
+
+  func testDeprecatedStringFileSizeLimitVariable() {
+    let limit: String? = "1mb"
+    let options = BucketOptions(fileSizeLimit: limit)
+    XCTAssertEqual(options.fileSizeLimit, "1mb")
+  }
+
+  func testDeprecatedIsPublicStringFileSizeLimitVariable() {
+    let limit: String? = "1mb"
+    let options = BucketOptions(isPublic: true, fileSizeLimit: limit)
+    XCTAssertTrue(options.isPublic)
+    XCTAssertEqual(options.fileSizeLimit, "1mb")
+  }
+
+  func testAllowedMimeTypesOnly() {
+    let options = BucketOptions(allowedMimeTypes: ["image/png"])
+    XCTAssertFalse(options.isPublic)
+    XCTAssertNil(options.fileSizeLimit)
+    XCTAssertEqual(options.allowedMimeTypes, ["image/png"])
+  }
 }

--- a/Tests/StorageTests/ValueTypesTests.swift
+++ b/Tests/StorageTests/ValueTypesTests.swift
@@ -60,6 +60,39 @@ final class StorageByteCountTests: XCTestCase {
     let json = String(decoding: encoded, as: UTF8.self)
     XCTAssertEqual(json, "\"1mb\"")
   }
+
+  func testGigabytesWholeValueOutsideInt64Range() {
+    let count = StorageByteCount.gigabytes(1e19)
+    XCTAssertEqual(count.stringValue, "1e+19gb")
+  }
+}
+
+// MARK: - SortBy
+
+final class SortByTests: XCTestCase {
+  func testInitWithDefaultedOrder() {
+    let sortBy = SortBy(column: "name")
+    XCTAssertEqual(sortBy.column, "name")
+    XCTAssertNil(sortBy.order)
+  }
+
+  func testInitWithSortOrder() {
+    let sortBy = SortBy(column: "name", order: .ascending)
+    XCTAssertEqual(sortBy.order, "asc")
+  }
+
+  func testDeprecatedInitWithStringVariable() {
+    let order: String? = "desc"
+    let sortBy = SortBy(column: "name", order: order)
+    XCTAssertEqual(sortBy.order, "desc")
+  }
+
+  func testDeprecatedInitWithOrderVariableOnly() {
+    let order: String? = "asc"
+    let sortBy = SortBy(order: order)
+    XCTAssertNil(sortBy.column)
+    XCTAssertEqual(sortBy.order, "asc")
+  }
 }
 
 // MARK: - ResizeMode


### PR DESCRIPTION
The v3 backport in #1049 introduced two source-compatibility regressions for existing callers, both verified by compilation:

**1. `SortBy` with a defaulted `order` no longer compiles.** The deprecated `SortBy(column:order:)` bridge is the only bridge in `Deprecated.swift` without `@_disfavoredOverload`, so any call omitting `order` is ambiguous against the new `SortOrder?`-typed initializer:

```swift
SortBy(column: "name")   // error: ambiguous use of 'init(column:order:)'
SortBy()                 // error: ambiguous use of 'init(column:order:)'
```

Adding the missing `@_disfavoredOverload` restores resolution. As a side effect, `defaultSearchOptions` in `StorageFileApi.swift` now resolves its string literals to the primary initializer (via `SortOrder`'s `ExpressibleByStringLiteral`), removing the deprecation warning from the SDK's own build.

**2. `BucketOptions(fileSizeLimit:)` with a `String?` variable no longer compiles.** `BucketOptions` has two all-defaults deprecated bridges (`public:`-labeled and `isPublic:`-labeled, both taking `String?`), and `@_disfavoredOverload` does not rank two disfavored candidates against each other:

```swift
let limit: String? = "1mb"
BucketOptions(fileSizeLimit: limit)   // error: ambiguous use of 'init'
```

Requiring an explicit `isPublic` label on the new-name bridge makes label-omitted legacy calls resolve uniquely to the `public:` bridge, while keeping the rename migration path (`BucketOptions(isPublic: true, fileSizeLimit: stringVariable)`) working. String literals were and remain unaffected (they resolve to the primary initializer through `StorageByteCount`'s string-literal conformance).

**3. (Minor) `StorageByteCount.formatValue` trapped on whole doubles outside `Int64` range** (`String(Int64(1e19))` is a trapping conversion). Switched to `Int64(exactly:)` with a `String(value)` fallback.

### Note on the API-stability check

I ran `swift package diagnose-api-breaking-changes` against `main` locally: it reports one item, `BucketOptions.init(isPublic:fileSizeLimit:allowedMimeTypes:) has removed default argument from parameter 0` — that is the deprecated `String?`-typed bridge (it shares its selector with the primary initializer), which was introduced in #1049 after v2.48.0. Since it has never been released, no released API changes; the title intentionally has no `!` so release-please doesn't treat this as a major. Since the pending 2.49.0 release (#1024) would otherwise ship these regressions, it would be good to land this before it.

### Notes
- Regression tests added for each affected call shape (`SortByTests`, `BucketOptionsTests`, `StorageByteCountTests`); all 132 `StorageTests` pass.
- `swift format lint --strict` clean.
