### PR TITLE
fix: support new realtime features

### DIFF
--- a/Sources/Realtime/RealtimeChannel+AsyncAwait.swift
+++ b/Sources/Realtime/RealtimeChannel+AsyncAwait.swift
@@ -28,10 +28,13 @@ extension RealtimeChannelV2 {
     _: InsertAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: RealtimePostgresFilter? = nil
+    filter: RealtimePostgresFilter? = nil,
+    select: [String]? = nil
   ) -> AsyncStream<InsertAction> {
-    postgresChange(event: .insert, schema: schema, table: table, filter: filter?.value)
-      .compactErase()
+    postgresChange(
+      event: .insert, schema: schema, table: table, filter: filter?.value, select: select
+    )
+    .compactErase()
   }
 
   /// Listen for postgres changes in a channel.
@@ -45,9 +48,10 @@ extension RealtimeChannelV2 {
     _: InsertAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil
+    filter: String? = nil,
+    select: [String]? = nil
   ) -> AsyncStream<InsertAction> {
-    postgresChange(event: .insert, schema: schema, table: table, filter: filter)
+    postgresChange(event: .insert, schema: schema, table: table, filter: filter, select: select)
       .compactErase()
   }
 
@@ -56,10 +60,13 @@ extension RealtimeChannelV2 {
     _: UpdateAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: RealtimePostgresFilter? = nil
+    filter: RealtimePostgresFilter? = nil,
+    select: [String]? = nil
   ) -> AsyncStream<UpdateAction> {
-    postgresChange(event: .update, schema: schema, table: table, filter: filter?.value)
-      .compactErase()
+    postgresChange(
+      event: .update, schema: schema, table: table, filter: filter?.value, select: select
+    )
+    .compactErase()
   }
 
   /// Listen for postgres changes in a channel.
@@ -73,9 +80,10 @@ extension RealtimeChannelV2 {
     _: UpdateAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil
+    filter: String? = nil,
+    select: [String]? = nil
   ) -> AsyncStream<UpdateAction> {
-    postgresChange(event: .update, schema: schema, table: table, filter: filter)
+    postgresChange(event: .update, schema: schema, table: table, filter: filter, select: select)
       .compactErase()
   }
 
@@ -84,10 +92,13 @@ extension RealtimeChannelV2 {
     _: DeleteAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: RealtimePostgresFilter? = nil
+    filter: RealtimePostgresFilter? = nil,
+    select: [String]? = nil
   ) -> AsyncStream<DeleteAction> {
-    postgresChange(event: .delete, schema: schema, table: table, filter: filter?.value)
-      .compactErase()
+    postgresChange(
+      event: .delete, schema: schema, table: table, filter: filter?.value, select: select
+    )
+    .compactErase()
   }
 
   /// Listen for postgres changes in a channel.
@@ -101,9 +112,10 @@ extension RealtimeChannelV2 {
     _: DeleteAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil
+    filter: String? = nil,
+    select: [String]? = nil
   ) -> AsyncStream<DeleteAction> {
-    postgresChange(event: .delete, schema: schema, table: table, filter: filter)
+    postgresChange(event: .delete, schema: schema, table: table, filter: filter, select: select)
       .compactErase()
   }
 
@@ -112,9 +124,12 @@ extension RealtimeChannelV2 {
     _: AnyAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: RealtimePostgresFilter? = nil
+    filter: RealtimePostgresFilter? = nil,
+    select: [String]? = nil
   ) -> AsyncStream<AnyAction> {
-    postgresChange(event: .all, schema: schema, table: table, filter: filter?.value)
+    postgresChange(
+      event: .all, schema: schema, table: table, filter: filter?.value, select: select
+    )
   }
 
   /// Listen for postgres changes in a channel.
@@ -128,23 +143,26 @@ extension RealtimeChannelV2 {
     _: AnyAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil
+    filter: String? = nil,
+    select: [String]? = nil
   ) -> AsyncStream<AnyAction> {
-    postgresChange(event: .all, schema: schema, table: table, filter: filter)
+    postgresChange(event: .all, schema: schema, table: table, filter: filter, select: select)
   }
 
   private func postgresChange(
     event: PostgresChangeEvent,
     schema: String,
     table: String?,
-    filter: String?
+    filter: String?,
+    select: [String]? = nil
   ) -> AsyncStream<AnyAction> {
     let (stream, continuation) = AsyncStream<AnyAction>.makeStream()
     let subscription = _onPostgresChange(
       event: event,
       schema: schema,
       table: table,
-      filter: filter
+      filter: filter,
+      select: select
     ) {
       continuation.yield($0)
     }

--- a/Sources/Realtime/RealtimeChannelV2.swift
+++ b/Sources/Realtime/RealtimeChannelV2.swift
@@ -618,36 +618,75 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   }
 
   /// Listen for postgres changes in a channel.
+  ///
+  /// - Parameters:
+  ///   - schema: The database schema to listen to. Defaults to `"public"`.
+  ///   - table: The table to listen to. Listens to all tables when `nil`.
+  ///   - filter: A ``RealtimePostgresFilter`` restricting which changes are received.
+  ///   - select: Restricts the change payload to a subset of columns instead of
+  ///     the full row. Requires an explicit `schema` and `table`.
   public func onPostgresChange(
     _: AnyAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil,
+    filter: RealtimePostgresFilter? = nil,
+    select: [String]? = nil,
     callback: @escaping @Sendable (AnyAction) -> Void
   ) -> RealtimeSubscription {
     _onPostgresChange(
       event: .all,
       schema: schema,
       table: table,
-      filter: filter
+      filter: filter?.value,
+      select: select
     ) {
       callback($0)
     }
   }
 
   /// Listen for postgres changes in a channel.
+  @_disfavoredOverload
+  public func onPostgresChange(
+    _: AnyAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil,
+    select: [String]? = nil,
+    callback: @escaping @Sendable (AnyAction) -> Void
+  ) -> RealtimeSubscription {
+    _onPostgresChange(
+      event: .all,
+      schema: schema,
+      table: table,
+      filter: filter,
+      select: select
+    ) {
+      callback($0)
+    }
+  }
+
+  /// Listen for postgres changes in a channel.
+  ///
+  /// - Parameters:
+  ///   - schema: The database schema to listen to. Defaults to `"public"`.
+  ///   - table: The table to listen to. Listens to all tables when `nil`.
+  ///   - filter: A ``RealtimePostgresFilter`` restricting which changes are received.
+  ///   - select: Restricts the change payload to a subset of columns instead of
+  ///     the full row. Requires an explicit `schema` and `table`.
   public func onPostgresChange(
     _: InsertAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil,
+    filter: RealtimePostgresFilter? = nil,
+    select: [String]? = nil,
     callback: @escaping @Sendable (InsertAction) -> Void
   ) -> RealtimeSubscription {
     _onPostgresChange(
       event: .insert,
       schema: schema,
       table: table,
-      filter: filter
+      filter: filter?.value,
+      select: select
     ) {
       guard case .insert(let action) = $0 else { return }
       callback(action)
@@ -655,18 +694,49 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   }
 
   /// Listen for postgres changes in a channel.
+  @_disfavoredOverload
+  public func onPostgresChange(
+    _: InsertAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil,
+    select: [String]? = nil,
+    callback: @escaping @Sendable (InsertAction) -> Void
+  ) -> RealtimeSubscription {
+    _onPostgresChange(
+      event: .insert,
+      schema: schema,
+      table: table,
+      filter: filter,
+      select: select
+    ) {
+      guard case .insert(let action) = $0 else { return }
+      callback(action)
+    }
+  }
+
+  /// Listen for postgres changes in a channel.
+  ///
+  /// - Parameters:
+  ///   - schema: The database schema to listen to. Defaults to `"public"`.
+  ///   - table: The table to listen to. Listens to all tables when `nil`.
+  ///   - filter: A ``RealtimePostgresFilter`` restricting which changes are received.
+  ///   - select: Restricts the change payload to a subset of columns instead of
+  ///     the full row. Requires an explicit `schema` and `table`.
   public func onPostgresChange(
     _: UpdateAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil,
+    filter: RealtimePostgresFilter? = nil,
+    select: [String]? = nil,
     callback: @escaping @Sendable (UpdateAction) -> Void
   ) -> RealtimeSubscription {
     _onPostgresChange(
       event: .update,
       schema: schema,
       table: table,
-      filter: filter
+      filter: filter?.value,
+      select: select
     ) {
       guard case .update(let action) = $0 else { return }
       callback(action)
@@ -674,18 +744,71 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   }
 
   /// Listen for postgres changes in a channel.
+  @_disfavoredOverload
+  public func onPostgresChange(
+    _: UpdateAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil,
+    select: [String]? = nil,
+    callback: @escaping @Sendable (UpdateAction) -> Void
+  ) -> RealtimeSubscription {
+    _onPostgresChange(
+      event: .update,
+      schema: schema,
+      table: table,
+      filter: filter,
+      select: select
+    ) {
+      guard case .update(let action) = $0 else { return }
+      callback(action)
+    }
+  }
+
+  /// Listen for postgres changes in a channel.
+  ///
+  /// - Parameters:
+  ///   - schema: The database schema to listen to. Defaults to `"public"`.
+  ///   - table: The table to listen to. Listens to all tables when `nil`.
+  ///   - filter: A ``RealtimePostgresFilter`` restricting which changes are received.
+  ///   - select: Restricts the change payload to a subset of columns instead of
+  ///     the full row. Requires an explicit `schema` and `table`.
   public func onPostgresChange(
     _: DeleteAction.Type,
     schema: String = "public",
     table: String? = nil,
-    filter: String? = nil,
+    filter: RealtimePostgresFilter? = nil,
+    select: [String]? = nil,
     callback: @escaping @Sendable (DeleteAction) -> Void
   ) -> RealtimeSubscription {
     _onPostgresChange(
       event: .delete,
       schema: schema,
       table: table,
-      filter: filter
+      filter: filter?.value,
+      select: select
+    ) {
+      guard case .delete(let action) = $0 else { return }
+      callback(action)
+    }
+  }
+
+  /// Listen for postgres changes in a channel.
+  @_disfavoredOverload
+  public func onPostgresChange(
+    _: DeleteAction.Type,
+    schema: String = "public",
+    table: String? = nil,
+    filter: String? = nil,
+    select: [String]? = nil,
+    callback: @escaping @Sendable (DeleteAction) -> Void
+  ) -> RealtimeSubscription {
+    _onPostgresChange(
+      event: .delete,
+      schema: schema,
+      table: table,
+      filter: filter,
+      select: select
     ) {
       guard case .delete(let action) = $0 else { return }
       callback(action)
@@ -697,6 +820,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     schema: String,
     table: String?,
     filter: String?,
+    select: [String]? = nil,
     callback: @escaping @Sendable (AnyAction) -> Void
   ) -> RealtimeSubscription {
     guard status != .subscribed && status != .subscribing else {
@@ -713,7 +837,8 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
       event: event,
       schema: schema,
       table: table,
-      filter: filter
+      filter: filter,
+      select: select
     )
 
     // Synchronous append — the buffer lives on the channel, not the actor,

--- a/Sources/Realtime/RealtimeJoinConfig.swift
+++ b/Sources/Realtime/RealtimeJoinConfig.swift
@@ -56,21 +56,32 @@ public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
   public var receiveOwnBroadcasts: Bool = false
   /// Configures broadcast replay from a specific timestamp
   public var replay: ReplayOption?
+  /// Instructs the server to emit a `system` event once the Postgres replication
+  /// connection backing this channel is established and ready to stream changes.
+  ///
+  /// Listen for it with ``RealtimeChannelV2/onSystem(callback:)-(_)`` (or the
+  /// ``RealtimeChannelV2/system()`` async stream): the message's `status` is
+  /// `.ok` (message `"Replication connection established"`) on success, or
+  /// `.error` if the connection is not ready in time.
+  public var replicationReady: Bool = false
 
   public init(
     acknowledgeBroadcasts: Bool = false,
     receiveOwnBroadcasts: Bool = false,
-    replay: ReplayOption? = nil
+    replay: ReplayOption? = nil,
+    replicationReady: Bool = false
   ) {
     self.acknowledgeBroadcasts = acknowledgeBroadcasts
     self.receiveOwnBroadcasts = receiveOwnBroadcasts
     self.replay = replay
+    self.replicationReady = replicationReady
   }
 
   enum CodingKeys: String, CodingKey {
     case acknowledgeBroadcasts = "ack"
     case receiveOwnBroadcasts = "self"
     case replay
+    case replicationReady = "replication_ready"
   }
 }
 
@@ -92,8 +103,12 @@ struct PostgresJoinConfig: Codable, Hashable, Sendable {
   var schema: String
   var table: String?
   var filter: String?
+  /// Restricts the change payload to a subset of columns instead of the full row.
+  var select: [String]?
   var id: Int = 0
 
+  // `select` is excluded from `==`/`hash`: the server-echoed config used for
+  // callback-id matching does not carry it.
   static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.schema == rhs.schema
       && lhs.table == rhs.table
@@ -114,6 +129,7 @@ struct PostgresJoinConfig: Codable, Hashable, Sendable {
     try container.encode(schema, forKey: .schema)
     try container.encodeIfPresent(table, forKey: .table)
     try container.encodeIfPresent(filter, forKey: .filter)
+    try container.encodeIfPresent(select, forKey: .select)
 
     if id != 0 {
       try container.encode(id, forKey: .id)

--- a/Sources/Realtime/RealtimePostgresFilter.swift
+++ b/Sources/Realtime/RealtimePostgresFilter.swift
@@ -5,32 +5,155 @@
 //  Created by Lucas Abijmil on 19/02/2025.
 //
 
-/// A filter that can be used in Realtime.
+import Foundation
+import IssueReporting
+
+/// Value accepted by the ``RealtimePostgresFilter/is(_:value:)`` operator.
+///
+/// Mirrors the SQL `IS` check: `column IS null / true / false / unknown`.
+public enum RealtimePostgresIsValue: Sendable {
+  case null
+  case `true`
+  case `false`
+  case unknown
+
+  var rawValue: String {
+    switch self {
+    case .null: return "null"
+    case .true: return "true"
+    case .false: return "false"
+    case .unknown: return "unknown"
+    }
+  }
+}
+
+/// A filter that can be used in Realtime `postgres_changes` subscriptions.
+///
+/// A filter is a `column=operator.value` expression evaluated server-side (for
+/// example `id=eq.1` or `title=like.%foo%`). Operators mirror the PostgREST
+/// surface that Realtime supports.
+///
+/// Use ``not(_:)`` to negate a single condition (`column=not.operator.value`)
+/// and ``and(_:)`` to combine multiple conditions with a logical `AND`
+/// (comma-separated).
+///
+/// ```swift
+/// // amount=gt.100,status=not.in.(draft),title=like.%foo%
+/// let filter: RealtimePostgresFilter = .and([
+///   .gt("amount", value: 100),
+///   .not(.in("status", values: ["draft"])),
+///   .like("title", value: "%foo%"),
+/// ])
+/// ```
+///
+/// Values containing reserved characters (`,`, `(`, `)`, `"`, `\`) — or
+/// surrounding whitespace — are automatically double-quoted and escaped the way
+/// PostgREST does, so they survive the server's filter parser.
 public enum RealtimePostgresFilter {
+  /// Match rows where `column` equals `value` (`column=eq.value`).
   case eq(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` does not equal `value` (`column=neq.value`).
   case neq(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` is greater than `value` (`column=gt.value`).
   case gt(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` is greater than or equal to `value` (`column=gte.value`).
   case gte(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` is less than `value` (`column=lt.value`).
   case lt(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` is less than or equal to `value` (`column=lte.value`).
   case lte(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` is one of `values` (`column=in.(a,b,c)`). Duplicates are removed.
   case `in`(_ column: String, values: [any RealtimePostgresFilterValue])
+  /// Match rows where `column` matches the case-sensitive `value` pattern (`column=like.value`).
+  case like(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` matches the case-insensitive `value` pattern (`column=ilike.value`).
+  case ilike(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` matches the POSIX regex `value` (`column=match.value`).
+  case match(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` matches the case-insensitive POSIX regex `value` (`column=imatch.value`).
+  case imatch(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Match rows where `column` `IS` the given value (`column=is.null`).
+  case `is`(_ column: String, value: RealtimePostgresIsValue)
+  /// Match rows where `column` is distinct from `value` (`column=isdistinct.value`). NULL-safe inequality.
+  case isDistinct(_ column: String, value: any RealtimePostgresFilterValue)
+  /// Negate any single-condition filter with the `not.` prefix (`column=not.operator.value`).
+  indirect case not(RealtimePostgresFilter)
+  /// Combine multiple conditions with a logical `AND` (comma-separated).
+  case and([RealtimePostgresFilter])
+
+  private var parts: (column: String, expr: String)? {
+    switch self {
+    case .eq(let column, let value):
+      return (column, "eq.\(Self.serialize(value))")
+    case .neq(let column, let value):
+      return (column, "neq.\(Self.serialize(value))")
+    case .gt(let column, let value):
+      return (column, "gt.\(Self.serialize(value))")
+    case .gte(let column, let value):
+      return (column, "gte.\(Self.serialize(value))")
+    case .lt(let column, let value):
+      return (column, "lt.\(Self.serialize(value))")
+    case .lte(let column, let value):
+      return (column, "lte.\(Self.serialize(value))")
+    case .in(let column, let values):
+      let items = Self.dedupe(values)
+        .map { Self.serialize($0) }
+        .joined(separator: ",")
+      return (column, "in.(\(items))")
+    case .like(let column, let value):
+      return (column, "like.\(Self.serialize(value))")
+    case .ilike(let column, let value):
+      return (column, "ilike.\(Self.serialize(value))")
+    case .match(let column, let value):
+      return (column, "match.\(Self.serialize(value))")
+    case .imatch(let column, let value):
+      return (column, "imatch.\(Self.serialize(value))")
+    case .is(let column, let value):
+      return (column, "is.\(value.rawValue)")
+    case .isDistinct(let column, let value):
+      return (column, "isdistinct.\(Self.serialize(value))")
+    case .not, .and:
+      return nil
+    }
+  }
 
   var value: String {
     switch self {
-    case .eq(let column, let value):
-      return "\(column)=eq.\(value.rawValue)"
-    case .neq(let column, let value):
-      return "\(column)=neq.\(value.rawValue)"
-    case .gt(let column, let value):
-      return "\(column)=gt.\(value.rawValue)"
-    case .gte(let column, let value):
-      return "\(column)=gte.\(value.rawValue)"
-    case .lt(let column, let value):
-      return "\(column)=lt.\(value.rawValue)"
-    case .lte(let column, let value):
-      return "\(column)=lte.\(value.rawValue)"
-    case .in(let column, let values):
-      return "\(column)=in.(\(values.map(\.rawValue).joined(separator: ",")))"
+    case .and(let filters):
+      return filters.map(\.value).joined(separator: ",")
+    case .not(let inner):
+      guard let parts = inner.parts else {
+        reportIssue(
+          "RealtimePostgresFilter.not can only negate a single condition, not `.not`/`.and`."
+        )
+        return inner.value
+      }
+      return "\(parts.column)=not.\(parts.expr)"
+    default:
+      let parts = parts!
+      return "\(parts.column)=\(parts.expr)"
     }
+  }
+
+  private static let reservedCharacters: Set<Character> = [",", "(", ")", "\"", "\\"]
+
+  private static func needsQuoting(_ value: String) -> Bool {
+    value.contains(where: reservedCharacters.contains)
+      || value != value.trimmingCharacters(in: .whitespaces)
+  }
+
+  private static func serialize(_ value: any RealtimePostgresFilterValue) -> String {
+    let raw = value.rawValue
+    guard needsQuoting(raw) else { return raw }
+    let escaped = raw.replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "\"", with: "\\\"")
+    return "\"\(escaped)\""
+  }
+
+  private static func dedupe(_ values: [any RealtimePostgresFilterValue])
+    -> [any RealtimePostgresFilterValue]
+  {
+    var seen = Set<String>()
+    return values.filter { seen.insert($0.rawValue).inserted }
   }
 }

--- a/Tests/RealtimeTests/PostgresJoinConfigTests.swift
+++ b/Tests/RealtimeTests/PostgresJoinConfigTests.swift
@@ -123,4 +123,58 @@ final class PostgresJoinConfigTests: XCTestCase {
 
     XCTAssertNotEqual(config1.hashValue, config2.hashValue)
   }
+
+  func testConfigDifferingOnlyBySelectAreEqual() {
+    let config1 = PostgresJoinConfig(
+      event: .insert,
+      schema: "public",
+      table: "users",
+      filter: "id=1",
+      select: ["id", "name"],
+      id: 1
+    )
+    let config2 = PostgresJoinConfig(
+      event: .insert,
+      schema: "public",
+      table: "users",
+      filter: "id=1",
+      select: nil,
+      id: 1
+    )
+
+    XCTAssertEqual(config1, config2)
+    XCTAssertEqual(config1.hashValue, config2.hashValue)
+  }
+
+  func testSelectEncodesAsArray() throws {
+    let config = PostgresJoinConfig(
+      event: .insert,
+      schema: "public",
+      table: "users",
+      filter: nil,
+      select: ["id", "first_name"],
+      id: 1
+    )
+
+    let data = try JSONEncoder().encode(config)
+    let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+    XCTAssertEqual(jsonObject?["select"] as? [String], ["id", "first_name"])
+  }
+
+  func testSelectOmittedWhenNil() throws {
+    let config = PostgresJoinConfig(
+      event: .insert,
+      schema: "public",
+      table: "users",
+      filter: nil,
+      select: nil,
+      id: 1
+    )
+
+    let data = try JSONEncoder().encode(config)
+    let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+    XCTAssertNil(jsonObject?["select"])
+  }
 }

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -32,6 +32,26 @@ final class RealtimeChannelTests: XCTestCase {
     logger: nil
   )
 
+  func testTypedFilterAndSelectAreBufferedIntoPostgresJoinConfig() {
+    let subscription = sut.onPostgresChange(
+      UpdateAction.self,
+      table: "orders",
+      filter: .and([
+        .gt("amount", value: 100),
+        .not(.in("status", values: ["draft"])),
+      ]),
+      select: ["id", "name"]
+    ) { _ in }
+    defer { subscription.cancel() }
+
+    let changes = sut.clientChanges.value
+    XCTAssertEqual(changes.count, 1)
+    XCTAssertEqual(changes.first?.event, .update)
+    XCTAssertEqual(changes.first?.table, "orders")
+    XCTAssertEqual(changes.first?.filter, "amount=gt.100,status=not.in.(draft)")
+    XCTAssertEqual(changes.first?.select, ["id", "name"])
+  }
+
   // MARK: - Callback rejection tests
 
   #if canImport(Darwin)
@@ -293,6 +313,7 @@ final class RealtimeChannelTests: XCTestCase {
                 - some: "id=eq.1"
               - id: 0
               - schema: "public"
+              - select: Optional<Array<String>>.none
               ▿ table: Optional<String>
                 - some: "users"
             - id: 1
@@ -305,6 +326,7 @@ final class RealtimeChannelTests: XCTestCase {
               - filter: Optional<String>.none
               - id: 0
               - schema: "private"
+              - select: Optional<Array<String>>.none
               - table: Optional<String>.none
             - id: 2
         ▿ RealtimeCallback
@@ -316,6 +338,7 @@ final class RealtimeChannelTests: XCTestCase {
               - filter: Optional<String>.none
               - id: 0
               - schema: "public"
+              - select: Optional<Array<String>>.none
               ▿ table: Optional<String>
                 - some: "messages"
             - id: 3
@@ -328,6 +351,7 @@ final class RealtimeChannelTests: XCTestCase {
               - filter: Optional<String>.none
               - id: 0
               - schema: "public"
+              - select: Optional<Array<String>>.none
               - table: Optional<String>.none
             - id: 4
         ▿ RealtimeCallback

--- a/Tests/RealtimeTests/RealtimeJoinConfigTests.swift
+++ b/Tests/RealtimeTests/RealtimeJoinConfigTests.swift
@@ -47,7 +47,7 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let jsonData = """
       {
         "config": {
-          "broadcast": {"ack": false, "self": false},
+          "broadcast": {"ack": false, "self": false, "replication_ready": false},
           "presence": {"key": "", "enabled": false},
           "postgres_changes": [],
           "private": false
@@ -173,7 +173,8 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let jsonData = """
       {
         "ack": true,
-        "self": false
+        "self": false,
+        "replication_ready": false
       }
       """.data(using: .utf8)!
 
@@ -182,6 +183,44 @@ final class RealtimeJoinConfigTests: XCTestCase {
 
     XCTAssertTrue(config.acknowledgeBroadcasts)
     XCTAssertFalse(config.receiveOwnBroadcasts)
+  }
+
+  func testBroadcastJoinConfigReplicationReadyDefaultsFalse() {
+    let config = BroadcastJoinConfig()
+
+    XCTAssertFalse(config.replicationReady)
+  }
+
+  func testBroadcastJoinConfigEncodesReplicationReadyWhenFalse() throws {
+    let config = BroadcastJoinConfig()
+
+    let data = try JSONEncoder().encode(config)
+    let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+    XCTAssertEqual(jsonObject?["replication_ready"] as? Bool, false)
+  }
+
+  func testBroadcastJoinConfigEncodesReplicationReadyWhenTrue() throws {
+    let config = BroadcastJoinConfig(replicationReady: true)
+
+    let data = try JSONEncoder().encode(config)
+    let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+    XCTAssertEqual(jsonObject?["replication_ready"] as? Bool, true)
+  }
+
+  func testBroadcastJoinConfigDecodesReplicationReady() throws {
+    let jsonData = """
+      {
+        "ack": false,
+        "self": false,
+        "replication_ready": true
+      }
+      """.data(using: .utf8)!
+
+    let config = try JSONDecoder().decode(BroadcastJoinConfig.self, from: jsonData)
+
+    XCTAssertTrue(config.replicationReady)
   }
 
   // MARK: - PresenceJoinConfig Tests

--- a/Tests/RealtimeTests/RealtimePostgresFilterTests.swift
+++ b/Tests/RealtimeTests/RealtimePostgresFilterTests.swift
@@ -66,4 +66,103 @@ final class RealtimePostgresFilterTests: XCTestCase {
 
     XCTAssertEqual(filter.value, "column=in.(value1,value2)")
   }
+
+  func testInDeduplicatesValues() {
+    let filter: RealtimePostgresFilter = .in("status", values: ["a", "b", "a"])
+
+    XCTAssertEqual(filter.value, "status=in.(a,b)")
+  }
+
+  func testLike() {
+    let filter: RealtimePostgresFilter = .like("title", value: "%foo%")
+
+    XCTAssertEqual(filter.value, "title=like.%foo%")
+  }
+
+  func testILike() {
+    let filter: RealtimePostgresFilter = .ilike("title", value: "%foo%")
+
+    XCTAssertEqual(filter.value, "title=ilike.%foo%")
+  }
+
+  func testMatch() {
+    let filter: RealtimePostgresFilter = .match("title", value: "^foo")
+
+    XCTAssertEqual(filter.value, "title=match.^foo")
+  }
+
+  func testIMatch() {
+    let filter: RealtimePostgresFilter = .imatch("title", value: "^foo")
+
+    XCTAssertEqual(filter.value, "title=imatch.^foo")
+  }
+
+  func testIs() {
+    XCTAssertEqual(
+      (.is("deleted_at", value: .null) as RealtimePostgresFilter).value, "deleted_at=is.null")
+    XCTAssertEqual((.is("active", value: .true) as RealtimePostgresFilter).value, "active=is.true")
+    XCTAssertEqual(
+      (.is("active", value: .false) as RealtimePostgresFilter).value, "active=is.false")
+    XCTAssertEqual(
+      (.is("state", value: .unknown) as RealtimePostgresFilter).value, "state=is.unknown")
+  }
+
+  func testIsDistinct() {
+    let filter: RealtimePostgresFilter = .isDistinct("value", value: 1)
+
+    XCTAssertEqual(filter.value, "value=isdistinct.1")
+  }
+
+  func testNot() {
+    let filter: RealtimePostgresFilter = .not(.eq("id", value: 1))
+
+    XCTAssertEqual(filter.value, "id=not.eq.1")
+  }
+
+  func testNotIn() {
+    let filter: RealtimePostgresFilter = .not(.in("status", values: ["draft", "archived"]))
+
+    XCTAssertEqual(filter.value, "status=not.in.(draft,archived)")
+  }
+
+  func testAnd() {
+    let filter: RealtimePostgresFilter = .and([
+      .gt("amount", value: 100),
+      .in("status", values: ["open", "pending"]),
+    ])
+
+    XCTAssertEqual(filter.value, "amount=gt.100,status=in.(open,pending)")
+  }
+
+  func testAndWithNot() {
+    let filter: RealtimePostgresFilter = .and([
+      .gt("amount", value: 100),
+      .not(.in("status", values: ["draft", "archived"])),
+      .like("title", value: "%foo%"),
+    ])
+
+    XCTAssertEqual(
+      filter.value,
+      "amount=gt.100,status=not.in.(draft,archived),title=like.%foo%"
+    )
+  }
+
+  func testReservedCharacterQuoting() {
+    XCTAssertEqual((.eq("name", value: "a,b") as RealtimePostgresFilter).value, #"name=eq."a,b""#)
+    XCTAssertEqual((.eq("name", value: "a(b)") as RealtimePostgresFilter).value, #"name=eq."a(b)""#)
+    XCTAssertEqual((.eq("name", value: " a") as RealtimePostgresFilter).value, #"name=eq." a""#)
+  }
+
+  func testReservedCharacterQuotingEscapesQuotesAndBackslashes() {
+    XCTAssertEqual(
+      (.eq("name", value: #"a"b\c"#) as RealtimePostgresFilter).value,
+      #"name=eq."a\"b\\c""#
+    )
+  }
+
+  func testReservedCharacterQuotingInList() {
+    let filter: RealtimePostgresFilter = .in("tag", values: ["a,b", "c"])
+
+    XCTAssertEqual(filter.value, #"tag=in.("a,b",c)"#)
+  }
 }

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -175,6 +175,7 @@ import XCTest
                 "config" : {
                   "broadcast" : {
                     "ack" : false,
+                    "replication_ready" : false,
                     "self" : false
                   },
                   "postgres_changes" : [
@@ -267,6 +268,7 @@ import XCTest
               "config" : {
                 "broadcast" : {
                   "ack" : false,
+                  "replication_ready" : false,
                   "self" : false
                 },
                 "postgres_changes" : [
@@ -291,6 +293,7 @@ import XCTest
               "config" : {
                 "broadcast" : {
                   "ack" : false,
+                  "replication_ready" : false,
                   "self" : false
                 },
                 "postgres_changes" : [

--- a/docs/migrations/RealtimeV2 Migration Guide.md
+++ b/docs/migrations/RealtimeV2 Migration Guide.md
@@ -70,6 +70,50 @@ for change in channel.postgresChange(AnyAction.self, table: "messages") {
 }
 ```
 
+#### Filtering changes
+
+Pass a `RealtimePostgresFilter` to receive only the changes matching a
+`column=operator.value` expression. In addition to `eq`/`neq`/`gt`/`gte`/`lt`/`lte`/`in`,
+the following operators are supported: `like`, `ilike`, `match`, `imatch`, `is`
+and `isDistinct`. Any single condition can be negated with `.not(_:)`, and
+multiple conditions can be combined with `.and(_:)` (applied server-side as a
+logical `AND`).
+
+```swift
+// amount=gt.100,status=not.in.(draft),title=like.%foo%
+for await update in channel.postgresChange(
+    UpdateAction.self,
+    table: "orders",
+    filter: .and([
+        .gt("amount", value: 100),
+        .not(.in("status", values: ["draft"])),
+        .like("title", value: "%foo%"),
+    ])
+) {
+    // ...
+}
+```
+
+Values containing reserved characters (`,`, `(`, `)`, `"`, `\`) or surrounding
+whitespace are automatically double-quoted and escaped PostgREST-style.
+
+#### Selecting columns
+
+Use `select` to receive only a subset of columns instead of the full row. This
+reduces payload size (helpful for large `bytea`/`jsonb` columns). The listed
+columns must be selectable by the subscribing role, and an explicit `schema` and
+`table` are required.
+
+```swift
+for await change in channel.postgresChange(
+    AnyAction.self,
+    table: "users",
+    select: ["id", "first_name"]
+) {
+    // change payloads only contain { id, first_name }
+}
+```
+
 ### Tracking Presence
 
 Use `track(state:)` method for tracking Presence.
@@ -134,4 +178,28 @@ Use `broadcastStream()` method for observing broadcast events.
 for await event in channel.broadcastStream(event: "PING") {
     let message = try event.decode(as: PingEventMessage.self)
 }
+```
+
+### Knowing when the replication connection is ready
+
+Opt in with `broadcast.replicationReady` when creating the channel to have the
+server emit a `system` event once the Postgres replication connection backing
+the channel is established and ready to stream changes. The notification arrives
+through the existing `onSystem`/`system()` API — `status == .ok` means the
+connection is ready (message `"Replication connection established"`).
+
+```swift
+let channel = supabase.channel("room") {
+    $0.broadcast.replicationReady = true
+}
+
+Task {
+    for await message in channel.system() {
+        if message.status == .ok {
+            // Replication connection is ready.
+        }
+    }
+}
+
+await channel.subscribe()
 ```

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -339,10 +339,29 @@ features:
   realtime.channel.send: implemented
   realtime.channel.broadcast_http: implemented
 
-  realtime.subscriptions.broadcast: implemented
+  realtime.subscriptions.broadcast:
+    status: implemented
+    symbols:
+      - BroadcastJoinConfig.replicationReady
+      - BroadcastJoinConfig.encode
   realtime.subscriptions.postgres_changes: implemented
   realtime.subscriptions.subscribe_presence: implemented
-  realtime.subscriptions.postgres_changes_filter: implemented
+  realtime.subscriptions.postgres_changes_filter:
+    status: implemented
+    symbols:
+      - RealtimePostgresFilter.like
+      - RealtimePostgresFilter.ilike
+      - RealtimePostgresFilter.match
+      - RealtimePostgresFilter.imatch
+      - RealtimePostgresFilter.is
+      - RealtimePostgresFilter.isDistinct
+      - RealtimePostgresFilter.not
+      - RealtimePostgresFilter.and
+      - RealtimePostgresIsValue
+      - RealtimePostgresIsValue.null
+      - RealtimePostgresIsValue.true
+      - RealtimePostgresIsValue.false
+      - RealtimePostgresIsValue.unknown
   realtime.subscriptions.private_channel: implemented
   realtime.subscriptions.broadcast_self: implemented
   realtime.subscriptions.broadcast_ack: implemented


### PR DESCRIPTION
## What kind of change does this PR introduce?

* support new system message to information replication connection is ready
* support new filters
* support select

https://linear.app/supabase/issue/SDK-1172/parityrealtime-add-postgres-changes-filter-builder-new-operators-and
https://linear.app/supabase/issue/SDK-1181/parityrealtime-add-replication-ready-broadcast-option-and-system-event