### PR TITLE
fix(realtime): send bare topic in broadcast REST body

### DIFF
--- a/Sources/Realtime/RealtimeChannelV2.swift
+++ b/Sources/Realtime/RealtimeChannelV2.swift
@@ -37,9 +37,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
 
   /// The channel's topic without the `realtime:` prefix, as expected by the
   /// broadcast REST endpoint (WebSocket frames use the full ``topic``).
-  var subTopic: String {
-    topic.hasPrefix("realtime:") ? String(topic.dropFirst("realtime:".count)) : topic
-  }
+  let subTopic: String
 
   @MainActor public private(set) var config: RealtimeChannelConfig
 
@@ -86,6 +84,8 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     logger: (any SupabaseLogger)?
   ) {
     self.topic = topic
+    self.subTopic =
+      topic.hasPrefix("realtime:") ? String(topic.dropFirst("realtime:".count)) : topic
     self.config = config
     self.logger = logger
     self.socket = socket

--- a/Sources/Realtime/RealtimeChannelV2.swift
+++ b/Sources/Realtime/RealtimeChannelV2.swift
@@ -35,6 +35,12 @@ protocol RealtimeChannelProtocol: AnyObject, Sendable {
 public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   public let topic: String
 
+  /// The channel's topic without the `realtime:` prefix, as expected by the
+  /// broadcast REST endpoint (WebSocket frames use the full ``topic``).
+  var subTopic: String {
+    topic.hasPrefix("realtime:") ? String(topic.dropFirst("realtime:".count)) : topic
+  }
+
   @MainActor public private(set) var config: RealtimeChannelConfig
 
   let logger: (any SupabaseLogger)?
@@ -253,7 +259,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
       BroadcastMessagePayload(
         messages: [
           BroadcastMessagePayload.Message(
-            topic: topic,
+            topic: subTopic,
             event: event,
             payload: message,
             private: config.isPrivate
@@ -328,7 +334,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
               BroadcastMessagePayload(
                 messages: [
                   BroadcastMessagePayload.Message(
-                    topic: topic,
+                    topic: subTopic,
                     event: event,
                     payload: message,
                     private: config.isPrivate

--- a/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
@@ -246,6 +246,35 @@ import XCTest
       XCTAssertEqual(payload?["payload"]?.objectValue?["key"]?.stringValue, "value")
     }
 
+    // MARK: - REST broadcast body uses the sub-topic (without `realtime:` prefix)
+
+    func testHttpSend_bodyTopicHasNoRealtimePrefix() async throws {
+      await http.any { _ in
+        HTTPResponse(
+          data: Data(),
+          response: HTTPURLResponse(
+            url: self.sut.broadcastURL,
+            statusCode: 202,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      }
+
+      let channel = sut.channel("test")
+      XCTAssertEqual(channel.topic, "realtime:test")
+
+      try await channel.httpSend(
+        event: "my_event", message: ["hello": .string("world")] as JSONObject
+      )
+
+      let request = await http.receivedRequests.last
+      let body = try XCTUnwrap(request?.body)
+      let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+      let messages = json?["messages"] as? [[String: Any]]
+      XCTAssertEqual(messages?.first?["topic"] as? String, "test")
+    }
+
     // MARK: - End-to-end binary frame via WebSocket
 
     func testEndToEnd_binaryFrameViaWebSocket() async throws {

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -506,7 +506,7 @@ final class RealtimeChannelTests: XCTestCase {
 
     let body = try JSONDecoder().decode(BroadcastPayload.self, from: request.body ?? Data())
     XCTAssertEqual(body.messages.count, 1)
-    XCTAssertEqual(body.messages[0].topic, "realtime:test-topic")
+    XCTAssertEqual(body.messages[0].topic, "test-topic")
     XCTAssertEqual(body.messages[0].event, "test-event")
     XCTAssertEqual(body.messages[0].private, true)
   }

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -677,7 +677,7 @@ import XCTest
         	--header "Authorization: Bearer custom.access.token" \
         	--header "Content-Type: application/json" \
         	--header "apiKey: publishable.api.key" \
-        	--data "{\"messages\":[{\"event\":\"test\",\"payload\":{\"value\":42},\"private\":false,\"topic\":\"realtime:public:messages\"}]}" \
+        	--data "{\"messages\":[{\"event\":\"test\",\"payload\":{\"value\":42},\"private\":false,\"topic\":\"public:messages\"}]}" \
         	"http://localhost:54321/realtime/v1/api/broadcast"
         """#
       }


### PR DESCRIPTION
### Problem

`RealtimeChannelV2`'s REST broadcast path sends the channel's **full Phoenix topic** (`realtime:foo`) in the `/api/broadcast` request body, but the broadcast endpoint routes on the **bare sub-topic** (`foo`). As a result, REST-delivered broadcasts are routed to a topic namespace no WebSocket subscriber is listening on and are **silently dropped**.

This affects both REST entry points:
- `httpSend(event:message:)` — explicit REST delivery
- `broadcast(event:message:)` — the automatic REST fallback when the channel isn't subscribed

```swift
let channel = client.channel("room1")   // channel.topic == "realtime:room1"
try await channel.httpSend(event: "msg", message: ["x": 1])
// body → {"messages":[{"topic":"realtime:room1", ...}]}   ❌ misrouted
// expected                    {"topic":"room1", ...}       ✅
```

### Cause

`channel.topic` is set to `"realtime:\(topic)"`, and both REST payloads used it directly. This is a V2 regression — the deprecated V1 client strips the prefix (`subTopic`) for the REST body, and only the WebSocket frames use the full topic.

### Fix

Add an internal `subTopic` accessor that strips the leading `realtime:` prefix, and use it in the two REST body sites. WebSocket push frames continue to use the full `topic`.

### Tests

- Added `testHttpSend_bodyTopicHasNoRealtimePrefix` asserting the REST body carries the bare topic (verified to fail before the fix).
- Updated two existing tests (`testHttpSendSucceedsOn202Status`, `testBroadcastWithHTTP`) that asserted the prefixed topic.
- Full `RealtimeTests` suite passes (233 tests). No public API change.
