### PR TITLE
feat: raise minimum platform versions to iOS 16 and equivalents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This is the official Supabase SDK for Swift, mirroring the design of supabase-js
 
 - Xcode 16.4+ (supports versions eligible for App Store submission)
 - Swift 6.1+
-- Supported platforms: iOS 13.0+, macOS 10.15+, tvOS 13+, watchOS 6+, visionOS 1+
+- Supported platforms: iOS 16.0+, macOS 13.0+, tvOS 16+, watchOS 9+, visionOS 1+
 - Linux is supported for building but not officially supported for production use
 
 ### Build Commands

--- a/Package.swift
+++ b/Package.swift
@@ -7,11 +7,11 @@ import PackageDescription
 let package = Package(
   name: "Supabase",
   platforms: [
-    .iOS(.v13),
-    .macCatalyst(.v13),
-    .macOS(.v10_15),
-    .watchOS(.v6),
-    .tvOS(.v13),
+    .iOS(.v16),
+    .macCatalyst(.v16),
+    .macOS(.v13),
+    .watchOS(.v9),
+    .tvOS(.v16),
   ],
   products: [
     .library(name: "Auth", targets: ["Auth"]),

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ### Requirements
 
-- iOS 13.0+ / macOS 10.15+ / tvOS 13+ / watchOS 6+ / visionOS 1+
+- iOS 16.0+ / macOS 13.0+ / tvOS 16+ / watchOS 9+ / visionOS 1+
 - Xcode 16.4+
 - Swift 6.1+
 


### PR DESCRIPTION
## Summary

Stacked on #1066 — bumps `Package.swift` platform minimums to the versions that shipped together in the iOS 16 generation:

| Platform | Before | After |
|---|---|---|
| iOS | 13.0 | 16.0 |
| Mac Catalyst | 13 | 16 |
| macOS | 10.15 | 13 (Ventura) |
| watchOS | 6 | 9 |
| tvOS | 13 | 16 |
| visionOS | 1.0 | unchanged (1.0 already postdates iOS 16) |

`README.md`/`AGENTS.md` updated to match.

Per the [Support Policy](README.md#support-policy), dropping older platform versions is not a breaking change and ships in a minor release.

## Test plan

- [x] `swift build --build-tests` succeeds with no errors
- [x] `swift test` passes for `RealtimeTests`, `SupabaseTests`, `AuthTests`, `StorageTests`, `PostgRESTTests`, `FunctionsTests`, `HelpersTests`
- [ ] CI (this PR)