### PR TITLE
fix(postgrest): quote column names in insert()/upsert() columns list

### DIFF
--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -81,7 +81,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
         $0.request.query.appendOrUpdate(
           URLQueryItem(
             name: "columns",
-            value: uniqueKeys.joined(separator: ",")
+            value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
           )
         )
       }
@@ -138,7 +138,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
         $0.request.query.appendOrUpdate(
           URLQueryItem(
             name: "columns",
-            value: uniqueKeys.joined(separator: ",")
+            value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
           )
         )
       }

--- a/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
@@ -177,7 +177,7 @@ final class PostgrestQueryBuilderTests: PostgrestQueryTests {
       	--header "X-Client-Info: postgrest-swift/0.0.0" \
       	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
       	--data "[{\"id\":1,\"username\":\"supabase\"},{\"id\":1,\"username\":\"supa\"}]" \
-      	"http://localhost:54321/rest/v1/users?columns=id,username"
+      	"http://localhost:54321/rest/v1/users?columns=%22id%22,%22username%22"
       """#
     }
     .register()
@@ -192,6 +192,37 @@ final class PostgrestQueryBuilderTests: PostgrestQueryTests {
         returning: .minimal,
         count: .estimated
       )
+      .execute()
+  }
+
+  func testInsertQuotesColumnNameContainingReservedCharacter() async throws {
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 201,
+      data: [
+        .post: Data()
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "Accept: application/json" \
+      	--header "Content-Length: 11" \
+      	--header "Content-Type: application/json" \
+      	--header "Prefer: return=minimal" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	--data "[{\"a,b\":1}]" \
+      	"http://localhost:54321/rest/v1/users?columns=%22a,b%22"
+      """#
+    }
+    .register()
+
+    try await sut
+      .from("users")
+      .insert([["a,b": 1]], returning: .minimal)
       .execute()
   }
 
@@ -279,7 +310,7 @@ final class PostgrestQueryBuilderTests: PostgrestQueryTests {
       	--header "X-Client-Info: postgrest-swift/0.0.0" \
       	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
       	--data "[{\"id\":1,\"username\":\"admin\"},{\"id\":2,\"username\":\"supabase\"}]" \
-      	"http://localhost:54321/rest/v1/users?columns=id,username&on_conflict=username"
+      	"http://localhost:54321/rest/v1/users?columns=%22id%22,%22username%22&on_conflict=username"
       """#
     }
     .register()

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.bulk-insert-users.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.bulk-insert-users.txt
@@ -4,4 +4,4 @@ curl \
 	--header "Content-Type: application/json" \
 	--header "X-Client-Info: postgrest-swift/x.y.z" \
 	--data "[{\"email\":\"johndoe@supabase.io\"},{\"email\":\"johndoe2@supabase.io\",\"username\":\"johndoe2\"}]" \
-	"https://example.supabase.co/users?columns=email,username"
+	"https://example.supabase.co/users?columns=%22email%22,%22username%22"

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.bulk-upsert.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.bulk-upsert.txt
@@ -5,4 +5,4 @@ curl \
 	--header "Prefer: resolution=merge-duplicates,return=representation" \
 	--header "X-Client-Info: postgrest-swift/x.y.z" \
 	--data "[{\"email\":\"johndoe@supabase.io\"},{\"email\":\"johndoe2@supabase.io\",\"username\":\"johndoe2\"}]" \
-	"https://example.supabase.co/users?columns=email,username"
+	"https://example.supabase.co/users?columns=%22email%22,%22username%22"

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.select-after-bulk-upsert.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.select-after-bulk-upsert.txt
@@ -5,4 +5,4 @@ curl \
 	--header "Prefer: resolution=merge-duplicates,return=representation" \
 	--header "X-Client-Info: postgrest-swift/x.y.z" \
 	--data "[{\"email\":\"johndoe@supabase.io\"},{\"email\":\"johndoe2@supabase.io\"}]" \
-	"https://example.supabase.co/users?columns=email&on_conflict=username&select=*"
+	"https://example.supabase.co/users?columns=%22email%22&on_conflict=username&select=*"


### PR DESCRIPTION
### Problem

`insert()` and `upsert()` build the `columns` query parameter by joining raw column names with commas:

```swift
value: uniqueKeys.joined(separator: ",")
```

So a column name that contains a PostgREST list delimiter (`,`, `(`, `)`) is mis-split into multiple columns:

```swift
try client.from("events").insert([["user,id": 1, "name": "a"]])
// columns=name,user,id  → PostgREST sees THREE columns; the "user,id" column is lost
```

### Fix

Wrap each column name in double quotes before joining, matching [postgrest-js](https://github.com/supabase/postgrest-js) (`insert()` maps every column to `` `"${column}"` ``):

```swift
value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
// columns=%22name%22,%22user,id%22  → PostgREST sees TWO columns, correct
```

For ordinary column names both forms are accepted by PostgREST, so most callers are unaffected; the quoting only matters for names containing a delimiter. This is the same class of fix as #1061 (`in()` value quoting).

### Tests

- Added `testInsertQuotesColumnNameContainingReservedCharacter` (a column named `a,b` → `columns=%22a,b%22`, one identifier).
- Updated `testInsert`, `testUpsert`, and the `bulk-insert-users` / `bulk-upsert` / `select-after-bulk-upsert` snapshots to the quoted form.
- Full `PostgRESTTests` pass (96 tests). No public API change.
