### PR TITLE
build: enable ImmutableWeakCaptures and InferIsolatedConformances

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -236,6 +236,8 @@ for target in package.targets {
 
   var swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
     .enableExperimentalFeature("StrictConcurrency"),
   ]
 


### PR DESCRIPTION
## Summary
- Adopts two narrow upcoming-feature flags `ImmutableWeakCaptures` and `InferIsolatedConformances`.
- First of a stack of 3 PRs adopting that package's Swift 6 modernization. This one is deliberately narrow and low-risk (no behavior change expected); the invasive import-visibility migration is split into a later PR in the stack.

## Test plan
- [x] `swift build` succeeds
- [x] `swift build --build-tests` succeeds