### PR TITLE
build: treat warnings as errors on compiler(>=6.4)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -249,5 +249,9 @@ for target in package.targets {
     swiftSettings.append(.swiftLanguageMode(.v5))
   }
 
+  #if compiler(>=6.4)
+    swiftSettings.append(.treatAllWarnings(as: .error))
+  #endif
+
   target.swiftSettings = swiftSettings
 }


### PR DESCRIPTION
## Summary
- Adopts the `treatAllWarnings(as: .error)` gate from [pointfreeco/sqlite-data#467](https://github.com/pointfreeco/sqlite-data/pull/467), active only when `#if compiler(>=6.4)`.
- Stacked on #1071.

## ⚠️ Known risk — please read before merging
This repo currently has pre-existing deprecation warnings that this setting will turn into build failures once the CI toolchain moves to Swift 6.4+ (e.g. `defaultStorageEncoder`/`defaultStorageDecoder` in `Storage`, deprecated APIs under `Sources/Realtime/Deprecated/`). I could not test the gate actually engaging locally — this environment's toolchain is Swift 6.3.3, so the `#if compiler(>=6.4)` branch never activates and this PR is a no-op today.

Before or alongside bumping CI to a 6.4+ toolchain, those pre-existing warnings should be resolved (or the affected targets excluded from this setting), otherwise the build will start failing with no code change once the compiler updates.

## Test plan
- [x] `swift build` succeeds (gate inactive on this toolchain, so unchanged from PR1)
- [ ] Re-verify once CI/local toolchain reaches Swift 6.4, since the gate can't be exercised here