### PR TITLE
build: remove redundant StrictConcurrency experimental feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -226,17 +226,16 @@ let package = Package(
 )
 
 for target in package.targets {
-  // Test targets never opted into `StrictConcurrency`/`ExistentialAny` below, so bumping
-  // swift-tools-version to 6.1 must not silently switch their *default* language mode to
-  // Swift 6 either — pin them to v5 to preserve their pre-6.1 compilation behavior exactly.
+  // Test targets never opted into `ExistentialAny` below, so bumping swift-tools-version
+  // to 6.1 must not silently switch their *default* language mode to Swift 6 either —
+  // pin them to v5 to preserve their pre-6.1 compilation behavior exactly.
   if target.isTest {
     target.swiftSettings = [.swiftLanguageMode(.v5)]
     continue
   }
 
   var swiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
-    .enableExperimentalFeature("StrictConcurrency"),
+    .enableUpcomingFeature("ExistentialAny")
   ]
 
   // The `Realtime` target hosts the legacy pre-async/await Phoenix client under


### PR DESCRIPTION
## Summary
- Removes `.enableExperimentalFeature("StrictConcurrency")` from the per-target `swiftSettings` loop in `Package.swift`.
- Non-test targets don't set an explicit `swiftLanguageMode`, so under `swift-tools-version 6.1` they already default to the Swift 6 language mode, where strict concurrency checking is inherent rather than an opt-in experimental feature. This flag has been a no-op since the Swift 5.10 drop (#1066).

## Test plan
- [x] `swift build` succeeds
- [x] `swift build --build-tests` succeeds