### PR TITLE
build: adopt explicit import access-level modifiers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -236,6 +236,8 @@ for target in package.targets {
 
   var swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
     .enableExperimentalFeature("StrictConcurrency"),
   ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -238,6 +238,8 @@ for target in package.targets {
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ImmutableWeakCaptures"),
     .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
     .enableExperimentalFeature("StrictConcurrency"),
   ]
 

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 25/01/24.
 //
 
-import Foundation
+public import Foundation
 import HTTPTypes
 
 public struct AuthAdmin: Sendable {

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -197,7 +197,7 @@ public struct AuthAdmin: Sendable {
   /*
    Generate link is commented out temporarily due issues with they Auth's decoding is configured.
    Will revisit it later.
-
+  
   /// Generates email links and OTPs to be sent via a custom email provider.
   ///
   /// - Parameter params: The parameters for the link generation.

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -197,7 +197,7 @@ public struct AuthAdmin: Sendable {
   /*
    Generate link is commented out temporarily due issues with they Auth's decoding is configured.
    Will revisit it later.
-  
+
   /// Generates email links and OTPs to be sent via a custom email provider.
   ///
   /// - Parameter params: The parameters for the link generation.

--- a/Sources/Auth/AuthAdminOAuth.swift
+++ b/Sources/Auth/AuthAdminOAuth.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 02/10/25.
 //
 
-import Foundation
+public import Foundation
 import HTTPTypes
 
 /// Contains all OAuth client administration methods.

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -1,6 +1,7 @@
 import ConcurrencyExtras
 public import Foundation
 import IssueReporting
+
 import struct HTTPTypes.HTTPFields
 
 #if canImport(AuthenticationServices)

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -1,9 +1,10 @@
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 import IssueReporting
+import struct HTTPTypes.HTTPFields
 
 #if canImport(AuthenticationServices)
-  import AuthenticationServices
+  public import AuthenticationServices
 #endif
 
 #if canImport(FoundationNetworking)

--- a/Sources/Auth/AuthClientConfiguration.swift
+++ b/Sources/Auth/AuthClientConfiguration.swift
@@ -5,10 +5,10 @@
 //  Created by Guilherme Souza on 29/04/24.
 //
 
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 extension AuthClient {

--- a/Sources/Auth/AuthError.swift
+++ b/Sources/Auth/AuthError.swift
@@ -1,7 +1,7 @@
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 /// An error code thrown by the server.

--- a/Sources/Auth/AuthMFA.swift
+++ b/Sources/Auth/AuthMFA.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HTTPTypes
 
 /// Contains the full multi-factor authentication API.
 public struct AuthMFA: Sendable {

--- a/Sources/Auth/Defaults.swift
+++ b/Sources/Auth/Defaults.swift
@@ -6,7 +6,7 @@
 //
 
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 
 extension AuthClient.Configuration {
   /// The default JSONEncoder instance used by the ``AuthClient``.

--- a/Sources/Auth/Deprecated.swift
+++ b/Sources/Auth/Deprecated.swift
@@ -5,10 +5,10 @@
 //  Created by Guilherme Souza on 14/12/23.
 //
 
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 @available(*, deprecated, renamed: "AuthClient")

--- a/Sources/Auth/Internal/SessionManager.swift
+++ b/Sources/Auth/Internal/SessionManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HTTPTypes
 
 struct SessionManager: Sendable {
   var session: @Sendable () async throws -> Session

--- a/Sources/Auth/Storage/AuthLocalStorage.swift
+++ b/Sources/Auth/Storage/AuthLocalStorage.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 public protocol AuthLocalStorage: Sendable {
   func store(key: String, value: Data) throws

--- a/Sources/Auth/Storage/KeychainLocalStorage.swift
+++ b/Sources/Auth/Storage/KeychainLocalStorage.swift
@@ -1,5 +1,5 @@
 #if !os(Windows) && !os(Linux) && !os(Android)
-  import Foundation
+  public import Foundation
 
   /// ``AuthLocalStorage`` implementation using Keychain. This is the default local storage used by the library.
   public struct KeychainLocalStorage: AuthLocalStorage {

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 public enum AuthChangeEvent: String, Sendable {
   case initialSession = "INITIAL_SESSION"

--- a/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import HTTPTypes
 
 #if canImport(AuthenticationServices)
-  import AuthenticationServices
+  public import AuthenticationServices
 #endif
 
 extension AuthClient {

--- a/Sources/Auth/WebAuthn/AuthMFA+WebAuthn.swift
+++ b/Sources/Auth/WebAuthn/AuthMFA+WebAuthn.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 #if canImport(AuthenticationServices)
-  import AuthenticationServices
+  public import AuthenticationServices
 #endif
 
 #if canImport(AuthenticationServices) && !os(tvOS) && !os(watchOS)

--- a/Sources/Auth/WebAuthn/WebAuthnTypes.swift
+++ b/Sources/Auth/WebAuthn/WebAuthnTypes.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 11/06/26.
 //
 
-import Foundation
+public import Foundation
 import Helpers
 
 /// Parameters for enrolling a new WebAuthn (passkey) factor as a second factor (MFA).

--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -4,7 +4,7 @@ import HTTPTypes
 public import Helpers
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 let version = Helpers.version

--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -1,7 +1,7 @@
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 import HTTPTypes
-import Helpers
+public import Helpers
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -1,5 +1,6 @@
-import Foundation
+public import Foundation
 import HTTPTypes
+import Helpers
 
 /// An error type representing various errors that can occur while invoking functions.
 public enum FunctionsError: Error, LocalizedError {

--- a/Sources/Helpers/AnyJSON/AnyJSON+Codable.swift
+++ b/Sources/Helpers/AnyJSON/AnyJSON+Codable.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 20/01/24.
 //
 
-import Foundation
+public import Foundation
 
 extension AnyJSON {
   /// The decoder instance used for transforming AnyJSON to some Codable type.

--- a/Sources/Helpers/Base64URL.swift
+++ b/Sources/Helpers/Base64URL.swift
@@ -5,7 +5,7 @@
 //  Created by Claude on 06/10/25.
 //
 
-import Foundation
+package import Foundation
 
 package enum Base64URL {
   /// Decodes a base64url-encoded string to Data

--- a/Sources/Helpers/Codable.swift
+++ b/Sources/Helpers/Codable.swift
@@ -6,7 +6,7 @@
 //
 
 import ConcurrencyExtras
-import Foundation
+package import Foundation
 import XCTestDynamicOverlay
 
 extension JSONDecoder {

--- a/Sources/Helpers/DateFormatter.swift
+++ b/Sources/Helpers/DateFormatter.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 28/12/23.
 //
 
-import Foundation
+package import Foundation
 
 extension DateFormatter {
   fileprivate static func iso8601(includingFractionalSeconds: Bool) -> DateFormatter {

--- a/Sources/Helpers/FoundationExtensions.swift
+++ b/Sources/Helpers/FoundationExtensions.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 23/04/24.
 //
 
-import Foundation
+package import Foundation
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Helpers/HTTP/HTTPClient.swift
+++ b/Sources/Helpers/HTTP/HTTPClient.swift
@@ -8,7 +8,7 @@
 package import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  package import FoundationNetworking
 #endif
 
 package protocol HTTPClientType: Sendable {

--- a/Sources/Helpers/HTTP/HTTPClient.swift
+++ b/Sources/Helpers/HTTP/HTTPClient.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 30/04/24.
 //
 
-import Foundation
+package import Foundation
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Helpers/HTTP/HTTPFields.swift
+++ b/Sources/Helpers/HTTP/HTTPFields.swift
@@ -1,4 +1,5 @@
-import HTTPTypes
+import Foundation
+package import HTTPTypes
 
 extension HTTPFields {
   package init(_ dictionary: [String: String]) {

--- a/Sources/Helpers/HTTP/HTTPRequest.swift
+++ b/Sources/Helpers/HTTP/HTTPRequest.swift
@@ -9,7 +9,7 @@ package import Foundation
 package import HTTPTypes
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  package import FoundationNetworking
 #endif
 
 package struct HTTPRequest: Sendable {

--- a/Sources/Helpers/HTTP/HTTPRequest.swift
+++ b/Sources/Helpers/HTTP/HTTPRequest.swift
@@ -5,8 +5,8 @@
 //  Created by Guilherme Souza on 23/04/24.
 //
 
-import Foundation
-import HTTPTypes
+package import Foundation
+package import HTTPTypes
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Helpers/HTTP/HTTPResponse.swift
+++ b/Sources/Helpers/HTTP/HTTPResponse.swift
@@ -9,7 +9,7 @@ package import Foundation
 package import HTTPTypes
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  package import FoundationNetworking
 #endif
 
 package struct HTTPResponse: Sendable {

--- a/Sources/Helpers/HTTP/HTTPResponse.swift
+++ b/Sources/Helpers/HTTP/HTTPResponse.swift
@@ -5,8 +5,8 @@
 //  Created by Guilherme Souza on 30/04/24.
 //
 
-import Foundation
-import HTTPTypes
+package import Foundation
+package import HTTPTypes
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Helpers/HTTP/LoggerInterceptor.swift
+++ b/Sources/Helpers/HTTP/LoggerInterceptor.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
 package struct LoggerInterceptor: HTTPClientInterceptor {
   let logger: any SupabaseLogger
 

--- a/Sources/Helpers/HTTP/RetryRequestInterceptor.swift
+++ b/Sources/Helpers/HTTP/RetryRequestInterceptor.swift
@@ -5,8 +5,8 @@
 //  Created by Guilherme Souza on 23/04/24.
 //
 
-import Foundation
-import HTTPTypes
+package import Foundation
+package import HTTPTypes
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Helpers/JWT.swift
+++ b/Sources/Helpers/JWT.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 28/11/24.
 //
 
-import Foundation
+package import Foundation
 
 package struct DecodedJWT {
   package let header: [String: Any]

--- a/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
+++ b/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 #if canImport(OSLog)
-  import OSLog
+  public import OSLog
 
   /// A SupabaseLogger implementation that logs to OSLog.
   ///

--- a/Sources/Helpers/Logger/SupabaseLogger.swift
+++ b/Sources/Helpers/Logger/SupabaseLogger.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 public enum SupabaseLogLevel: Int, Codable, CustomStringConvertible, Sendable {
   case verbose

--- a/Sources/Helpers/SharedModels/HTTPError.swift
+++ b/Sources/Helpers/SharedModels/HTTPError.swift
@@ -8,7 +8,7 @@
 public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 /// A generic error from a HTTP request.

--- a/Sources/Helpers/SharedModels/HTTPError.swift
+++ b/Sources/Helpers/SharedModels/HTTPError.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 07/05/24.
 //
 
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Helpers/SharedModels/PostgrestError.swift
+++ b/Sources/Helpers/SharedModels/PostgrestError.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 27/01/24.
 //
 
-import Foundation
+public import Foundation
 
 public struct PostgrestError: Error, Codable, Sendable {
   public let detail: String?

--- a/Sources/Helpers/Task+withTimeout.swift
+++ b/Sources/Helpers/Task+withTimeout.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 19/04/24.
 //
 
-import Foundation
+package import Foundation
 
 @discardableResult
 package func withTimeout<R: Sendable>(

--- a/Sources/Helpers/_Clock.swift
+++ b/Sources/Helpers/_Clock.swift
@@ -7,7 +7,7 @@
 
 import Clocks
 import ConcurrencyExtras
-import Foundation
+package import Foundation
 
 package protocol _Clock: Sendable {
   func sleep(for duration: TimeInterval) async throws

--- a/Sources/PostgREST/Defaults.swift
+++ b/Sources/PostgREST/Defaults.swift
@@ -6,7 +6,7 @@
 //
 
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 
 let version = Helpers.version
 

--- a/Sources/PostgREST/Deprecated.swift
+++ b/Sources/PostgREST/Deprecated.swift
@@ -8,7 +8,7 @@
 public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 extension PostgrestClient.Configuration {

--- a/Sources/PostgREST/Deprecated.swift
+++ b/Sources/PostgREST/Deprecated.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 16/01/24.
 //
 
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -1,6 +1,6 @@
 import ConcurrencyExtras
-import Foundation
-import HTTPTypes
+public import Foundation
+public import HTTPTypes
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -3,7 +3,7 @@ public import Foundation
 public import HTTPTypes
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 /// The main entry point for interacting with a PostgREST server.

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Foundation
 import Helpers
 

--- a/Sources/PostgREST/PostgrestFilterValue.swift
+++ b/Sources/PostgREST/PostgrestFilterValue.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 /// A value that can be used to filter Postgrest queries.
 public protocol PostgrestFilterValue {

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -1,4 +1,6 @@
+import ConcurrencyExtras
 import Foundation
+import HTTPTypes
 
 /// Query builder for SELECT, INSERT, UPDATE, DELETE, and UPSERT operations.
 ///

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -1,4 +1,6 @@
+import ConcurrencyExtras
 import Foundation
+import HTTPTypes
 
 /// Transform builder for applying ORDER BY, LIMIT, and other transformations.
 ///

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -1,7 +1,7 @@
 public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 /// The response returned by a PostgREST query, containing the raw data, HTTP response, row count, and decoded value.

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Realtime/Deprecated/Defaults.swift
+++ b/Sources/Realtime/Deprecated/Defaults.swift
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+public import Foundation
 
 /// A collection of default values and behaviors used across the Client
 public enum Defaults {

--- a/Sources/Realtime/Deprecated/Deprecated.swift
+++ b/Sources/Realtime/Deprecated/Deprecated.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 23/12/23.
 //
 
-import Foundation
+public import Foundation
 
 @available(*, deprecated, renamed: "RealtimeMessage")
 public typealias Message = RealtimeMessage

--- a/Sources/Realtime/Deprecated/PhoenixTransport.swift
+++ b/Sources/Realtime/Deprecated/PhoenixTransport.swift
@@ -42,7 +42,7 @@ public protocol PhoenixTransport {
 
   /**
    Connect to the server
-  
+
    - Parameters:
    - headers: Headers to include in the URLRequests when opening the Websocket connection. Can be empty [:]
    */
@@ -50,7 +50,7 @@ public protocol PhoenixTransport {
 
   /**
    Disconnect from the server.
-  
+
    - Parameters:
    - code: Status code as defined by <ahref="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a>.
    - reason: Reason why the connection is closing. Optional.
@@ -59,7 +59,7 @@ public protocol PhoenixTransport {
 
   /**
    Sends a message to the server.
-  
+
    - Parameter data: Data to send.
    */
   func send(data: Data)
@@ -74,30 +74,30 @@ public protocol PhoenixTransport {
 public protocol PhoenixTransportDelegate {
   /**
    Notified when the `Transport` opens.
-  
+
    - Parameter response: Response from the server indicating that the WebSocket handshake was successful and the connection has been upgraded to webSockets
    */
   func onOpen(response: URLResponse?)
 
   /**
    Notified when the `Transport` receives an error.
-  
+
    - Parameter error: Client-side error from the underlying `Transport` implementation
    - Parameter response: Response from the server, if any, that occurred with the Error
-  
+
    */
   func onError(error: any Error, response: URLResponse?)
 
   /**
    Notified when the `Transport` receives a message from the server.
-  
+
    - Parameter message: Message received from the server
    */
   func onMessage(message: String)
 
   /**
    Notified when the `Transport` closes.
-  
+
    - Parameter code: Code that was sent when the `Transport` closed
    - Parameter reason: A concise human-readable prose explanation for the closure
    */
@@ -151,22 +151,22 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
 
   /**
    Initializes a `Transport` layer built using URLSession's WebSocket
-  
+
    Example:
-  
+
    ```swift
    let url = URL("wss://example.com/socket")
    let transport: Transport = URLSessionTransport(url: url)
    ```
-  
+
    Using a custom `URLSessionConfiguration`
-  
+
    ```swift
    let url = URL("wss://example.com/socket")
    let configuration = URLSessionConfiguration.default
    let transport: Transport = URLSessionTransport(url: url, configuration: configuration)
    ```
-  
+
    - parameter url: URL to connect to
    - parameter configuration: Provide your own URLSessionConfiguration. Uses `.default` if none provided
    */

--- a/Sources/Realtime/Deprecated/PhoenixTransport.swift
+++ b/Sources/Realtime/Deprecated/PhoenixTransport.swift
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 // ----------------------------------------------------------------------

--- a/Sources/Realtime/Deprecated/PhoenixTransport.swift
+++ b/Sources/Realtime/Deprecated/PhoenixTransport.swift
@@ -42,7 +42,7 @@ public protocol PhoenixTransport {
 
   /**
    Connect to the server
-
+  
    - Parameters:
    - headers: Headers to include in the URLRequests when opening the Websocket connection. Can be empty [:]
    */
@@ -50,7 +50,7 @@ public protocol PhoenixTransport {
 
   /**
    Disconnect from the server.
-
+  
    - Parameters:
    - code: Status code as defined by <ahref="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a>.
    - reason: Reason why the connection is closing. Optional.
@@ -59,7 +59,7 @@ public protocol PhoenixTransport {
 
   /**
    Sends a message to the server.
-
+  
    - Parameter data: Data to send.
    */
   func send(data: Data)
@@ -74,30 +74,30 @@ public protocol PhoenixTransport {
 public protocol PhoenixTransportDelegate {
   /**
    Notified when the `Transport` opens.
-
+  
    - Parameter response: Response from the server indicating that the WebSocket handshake was successful and the connection has been upgraded to webSockets
    */
   func onOpen(response: URLResponse?)
 
   /**
    Notified when the `Transport` receives an error.
-
+  
    - Parameter error: Client-side error from the underlying `Transport` implementation
    - Parameter response: Response from the server, if any, that occurred with the Error
-
+  
    */
   func onError(error: any Error, response: URLResponse?)
 
   /**
    Notified when the `Transport` receives a message from the server.
-
+  
    - Parameter message: Message received from the server
    */
   func onMessage(message: String)
 
   /**
    Notified when the `Transport` closes.
-
+  
    - Parameter code: Code that was sent when the `Transport` closed
    - Parameter reason: A concise human-readable prose explanation for the closure
    */
@@ -151,22 +151,22 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
 
   /**
    Initializes a `Transport` layer built using URLSession's WebSocket
-
+  
    Example:
-
+  
    ```swift
    let url = URL("wss://example.com/socket")
    let transport: Transport = URLSessionTransport(url: url)
    ```
-
+  
    Using a custom `URLSessionConfiguration`
-
+  
    ```swift
    let url = URL("wss://example.com/socket")
    let configuration = URLSessionConfiguration.default
    let transport: Transport = URLSessionTransport(url: url, configuration: configuration)
    ```
-
+  
    - parameter url: URL to connect to
    - parameter configuration: Provide your own URLSessionConfiguration. Uses `.default` if none provided
    */

--- a/Sources/Realtime/Deprecated/Push.swift
+++ b/Sources/Realtime/Deprecated/Push.swift
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+public import Foundation
 
 /// Represents pushing data to a `Channel` through the `Socket`
 public class Push {

--- a/Sources/Realtime/Deprecated/RealtimeChannel.swift
+++ b/Sources/Realtime/Deprecated/RealtimeChannel.swift
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 import HTTPTypes
 import Swift
 

--- a/Sources/Realtime/Deprecated/RealtimeClient.swift
+++ b/Sources/Realtime/Deprecated/RealtimeClient.swift
@@ -969,7 +969,7 @@ public class RealtimeClient: PhoenixTransportDelegate {
      We use NORMAL here since the client is the one determining to close the
      connection. However, we set to close status to abnormal so that
      the client knows that it should attempt to reconnect.
-
+    
      If the server subsequently acknowledges with code 1000 (normal close),
      the socket will keep the `.abnormal` close status and trigger a reconnection.
      */

--- a/Sources/Realtime/Deprecated/RealtimeClient.swift
+++ b/Sources/Realtime/Deprecated/RealtimeClient.swift
@@ -969,7 +969,7 @@ public class RealtimeClient: PhoenixTransportDelegate {
      We use NORMAL here since the client is the one determining to close the
      connection. However, we set to close status to abnormal so that
      the client knows that it should attempt to reconnect.
-    
+
      If the server subsequently acknowledges with code 1000 (normal close),
      the socket will keep the `.abnormal` close status and trigger a reconnection.
      */

--- a/Sources/Realtime/Deprecated/RealtimeClient.swift
+++ b/Sources/Realtime/Deprecated/RealtimeClient.swift
@@ -19,10 +19,10 @@
 // THE SOFTWARE.
 
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 public enum SocketError: Error {

--- a/Sources/RealtimeV2/PostgresAction.swift
+++ b/Sources/RealtimeV2/PostgresAction.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 23/12/23.
 //
 
-import Foundation
+public import Foundation
 
 public struct Column: Equatable, Codable, Sendable {
   public let name: String

--- a/Sources/RealtimeV2/PresenceAction.swift
+++ b/Sources/RealtimeV2/PresenceAction.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 24/12/23.
 //
 
-import Foundation
+public import Foundation
 
 public struct PresenceV2: Hashable, Sendable {
   /// The presence reference of the object.

--- a/Sources/RealtimeV2/RealtimeChannel+AsyncAwait.swift
+++ b/Sources/RealtimeV2/RealtimeChannel+AsyncAwait.swift
@@ -5,7 +5,8 @@
 //  Created by Guilherme Souza on 17/04/24.
 //
 
-import Foundation
+import ConcurrencyExtras
+public import Foundation
 
 extension RealtimeChannelV2 {
   /// Listen for clients joining / leaving the channel using presences.

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -1,5 +1,5 @@
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 import HTTPTypes
 import IssueReporting
 

--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -7,8 +7,8 @@
 
 import ConcurrencyExtras
 public import Foundation
-import Helpers
 import HTTPTypes
+import Helpers
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -6,8 +6,9 @@
 //
 
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 import Helpers
+import HTTPTypes
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/RealtimeV2/RealtimePostgresFilterValue.swift
+++ b/Sources/RealtimeV2/RealtimePostgresFilterValue.swift
@@ -5,7 +5,7 @@
 //  Created by Lucas Abijmil on 19/02/2025.
 //
 
-import Foundation
+public import Foundation
 
 /// A value that can be used to filter Realtime changes in a channel.
 public protocol RealtimePostgresFilterValue {

--- a/Sources/RealtimeV2/Types.swift
+++ b/Sources/RealtimeV2/Types.swift
@@ -9,7 +9,7 @@ public import Foundation
 package import HTTPTypes
 
 #if canImport(FoundationNetworking)
-  package import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 /// Phoenix protocol version used for WebSocket communication.

--- a/Sources/RealtimeV2/Types.swift
+++ b/Sources/RealtimeV2/Types.swift
@@ -9,7 +9,7 @@ public import Foundation
 package import HTTPTypes
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  package import FoundationNetworking
 #endif
 
 /// Phoenix protocol version used for WebSocket communication.

--- a/Sources/RealtimeV2/Types.swift
+++ b/Sources/RealtimeV2/Types.swift
@@ -5,8 +5,8 @@
 //  Created by Guilherme Souza on 13/05/24.
 //
 
-import Foundation
-import HTTPTypes
+public import Foundation
+package import HTTPTypes
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Storage/Codable.swift
+++ b/Sources/Storage/Codable.swift
@@ -6,7 +6,7 @@
 //
 
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 
 extension JSONEncoder {
   @available(*, deprecated, message: "Access to storage encoder is going to be removed.")

--- a/Sources/Storage/Deprecated.swift
+++ b/Sources/Storage/Deprecated.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 16/01/24.
 //
 
-import Foundation
+public import Foundation
 
 extension StorageClientConfiguration {
   @available(

--- a/Sources/Storage/StorageBucketApi.swift
+++ b/Sources/Storage/StorageBucketApi.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HTTPTypes
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Storage/StorageError.swift
+++ b/Sources/Storage/StorageError.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 public struct StorageError: Error, Decodable, Sendable {
   public var statusCode: String?

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 import HTTPTypes
 
 #if canImport(FoundationNetworking)

--- a/Sources/Storage/StorageHTTPClient.swift
+++ b/Sources/Storage/StorageHTTPClient.swift
@@ -1,7 +1,7 @@
 public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 /// An HTTP session abstraction used by the Storage client to perform network requests.

--- a/Sources/Storage/StorageHTTPClient.swift
+++ b/Sources/Storage/StorageHTTPClient.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 public struct StorageClientConfiguration: Sendable {
   public var url: URL

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 public struct SearchOptions: Encodable, Sendable {
   var prefix: String

--- a/Sources/Supabase/Deprecated.swift
+++ b/Sources/Supabase/Deprecated.swift
@@ -5,7 +5,8 @@
 //  Created by Guilherme Souza on 15/05/24.
 //
 
-import Foundation
+import ConcurrencyExtras
+public import Foundation
 
 extension SupabaseClient {
   /// Database client for Supabase.

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -1,10 +1,10 @@
 import ConcurrencyExtras
-import Foundation
+public import Foundation
 import HTTPTypes
 import IssueReporting
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 /// Supabase Client.

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -1,7 +1,7 @@
-import Foundation
+public import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+  public import FoundationNetworking
 #endif
 
 public struct SupabaseClientOptions: Sendable {

--- a/Sources/TestHelpers/HTTPClientMock.swift
+++ b/Sources/TestHelpers/HTTPClientMock.swift
@@ -7,7 +7,7 @@
 
 import ConcurrencyExtras
 import Foundation
-import Helpers
+package import Helpers
 import XCTestDynamicOverlay
 
 package actor HTTPClientMock: HTTPClientType {

--- a/Sources/TestHelpers/InMemoryLocalStorage.swift
+++ b/Sources/TestHelpers/InMemoryLocalStorage.swift
@@ -1,6 +1,6 @@
-import Auth
+package import Auth
 import ConcurrencyExtras
-import Foundation
+package import Foundation
 
 package final class InMemoryLocalStorage: AuthLocalStorage, @unchecked Sendable {
   let _storage = LockIsolated([String: Data]())

--- a/Sources/TestHelpers/MockExtensions.swift
+++ b/Sources/TestHelpers/MockExtensions.swift
@@ -5,9 +5,9 @@
 //  Created by Guilherme Souza on 21/01/25.
 //
 
-import Foundation
-import InlineSnapshotTesting
-import Mocker
+package import Foundation
+package import InlineSnapshotTesting
+package import Mocker
 
 extension Mock {
   package func snapshotRequest(

--- a/Sources/TestHelpers/URLRequestSnapshot.swift
+++ b/Sources/TestHelpers/URLRequestSnapshot.swift
@@ -11,7 +11,7 @@
   package import Foundation
 
   #if canImport(FoundationNetworking)
-    import FoundationNetworking
+    package import FoundationNetworking
   #endif
 
   extension Snapshotting where Value == URLRequest, Format == String {

--- a/Sources/TestHelpers/URLRequestSnapshot.swift
+++ b/Sources/TestHelpers/URLRequestSnapshot.swift
@@ -5,10 +5,10 @@
 //  Created by Guilherme Souza on 22/01/25.
 //
 
-@preconcurrency import InlineSnapshotTesting
+@preconcurrency package import InlineSnapshotTesting
 
 #if !os(WASI)
-  import Foundation
+  package import Foundation
 
   #if canImport(FoundationNetworking)
     import FoundationNetworking

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -5,13 +5,14 @@
 //  Created by Guilherme Souza on 23/10/23.
 //
 
-@_spi(Experimental) @testable import Auth
 import ConcurrencyExtras
 import CustomDump
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
 import XCTest
+
+@_spi(Experimental) @testable import Auth
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -5,14 +5,13 @@
 //  Created by Guilherme Souza on 23/10/23.
 //
 
+@_spi(Experimental) @testable import Auth
 import ConcurrencyExtras
 import CustomDump
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
 import XCTest
-
-@_spi(Experimental) @testable import Auth
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking


### PR DESCRIPTION
## Summary

- `MemberImportVisibility` in the per-target `swiftSettings` loop in `Package.swift`.
- Updates every non-test source file across all targets (`Helpers`, `Auth`, `Functions`, `PostgREST`, `RealtimeV2`, `Realtime`, `Storage`, `Supabase`, and `TestHelpers`, which is a regular `.target` despite the name) to declare `public import` / `package import` wherever a type crosses that file's public or package API surface, or add a plain `import` where a module's members were used without being directly imported (relying on a transitive import, which `MemberImportVisibility` no longer allows).
- **Only import statements were changed — no declaration's access level was modified anywhere.**
- Stacked on #1071.

## Test plan
- [x] `swift build` succeeds with zero errors
- [x] `swift build --build-tests` succeeds with zero errors
- [x] `swift test` — the failures present (26) are pre-existing and reproduce identically on the unmodified base commit when run as the same full parallel suite:
  - `IntegrationTests.RealtimeIntegrationTests` failures require a live local Supabase instance (`supabase start`), not present in this environment.
  - Two `StorageTests` snapshot tests are order-dependent under full-suite parallel execution and fail/pass depending on run order, independent of this change.
- [x] `swift-format lint -r` on all touched files shows no new warnings versus the base commit (one pre-existing-style `OrderedImports` issue that this change itself introduced in `AuthClient.swift` was caught and fixed before committing)