### PR TITLE
chore: clean up code made obsolete by the iOS 16+ minimum

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -156,10 +156,8 @@ public actor AuthClient {
 
       #if canImport(UIKit)
         #if canImport(WatchKit)
-          if #available(watchOS 7.0, *) {
-            didBecomeActiveNotification = WKExtension.applicationDidBecomeActiveNotification
-            willResignActiveNotification = WKExtension.applicationWillResignActiveNotification
-          }
+          didBecomeActiveNotification = WKExtension.applicationDidBecomeActiveNotification
+          willResignActiveNotification = WKExtension.applicationWillResignActiveNotification
         #else
           didBecomeActiveNotification = UIApplication.didBecomeActiveNotification
           willResignActiveNotification = UIApplication.willResignActiveNotification
@@ -710,7 +708,6 @@ public actor AuthClient {
     /// - Note: This method support the PKCE flow.
     /// - Warning: Do not call `start()` on the `ASWebAuthenticationSession` object inside the
     /// `configure` closure, as the method implementation calls it already.
-    @available(watchOS 6.2, tvOS 16.0, *)
     @discardableResult
     public func signInWithOAuth(
       provider: Provider,

--- a/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
@@ -160,7 +160,6 @@ extension AuthClient {
 }
 
 #if canImport(AuthenticationServices) && !os(tvOS) && !os(watchOS)
-  @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
   extension AuthClient {
     // MARK: - First-factor passkeys (high-level, native UI)
 

--- a/Sources/Auth/WebAuthn/AuthMFA+WebAuthn.swift
+++ b/Sources/Auth/WebAuthn/AuthMFA+WebAuthn.swift
@@ -12,7 +12,6 @@ import Foundation
 #endif
 
 #if canImport(AuthenticationServices) && !os(tvOS) && !os(watchOS)
-  @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
   extension AuthMFA {
     // MARK: - WebAuthn MFA (high-level, native UI)
 

--- a/Sources/Auth/WebAuthn/WebAuthnAuthenticator.swift
+++ b/Sources/Auth/WebAuthn/WebAuthnAuthenticator.swift
@@ -87,7 +87,6 @@ extension AnyJSON {
   /// real device, an Associated Domains entitlement (`webcredentials:<rpId>`), and a relying-party
   /// server hosting `.well-known/apple-app-site-association`, so it can only be exercised
   /// end-to-end on-device.
-  @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
   struct WebAuthnAuthenticator: Sendable {
     /// Presents the registration UI for the given W3C creation options and returns the resulting
     /// W3C credential JSON.
@@ -102,7 +101,6 @@ extension AnyJSON {
         async throws -> AnyJSON
   }
 
-  @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
   extension WebAuthnAuthenticator {
     static let live = WebAuthnAuthenticator(
       register: { options, rpId, anchor in
@@ -131,7 +129,6 @@ extension AnyJSON {
   }
 
   /// Serializes a platform registration credential into the W3C JSON shape the backend expects.
-  @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
   private func registrationCredentialJSON(from authorization: ASAuthorization) throws -> AnyJSON {
     guard
       let credential = authorization.credential
@@ -151,7 +148,6 @@ extension AnyJSON {
   }
 
   /// Serializes a platform assertion credential into the W3C JSON shape the backend expects.
-  @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
   private func assertionCredentialJSON(from authorization: ASAuthorization) throws -> AnyJSON {
     guard
       let credential = authorization.credential
@@ -177,7 +173,6 @@ extension AnyJSON {
   /// `ASAuthorizationController` keeps only a weak reference to its delegate and is itself not
   /// retained by the system, so the ceremony retains both itself and the controller until a
   /// callback fires.
-  @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
   @MainActor
   private final class WebAuthnCeremony: NSObject, ASAuthorizationControllerDelegate,
     ASAuthorizationControllerPresentationContextProviding

--- a/Sources/Helpers/DateFormatter.swift
+++ b/Sources/Helpers/DateFormatter.swift
@@ -7,31 +7,6 @@
 
 import Foundation
 
-extension DateFormatter {
-  fileprivate static func iso8601(includingFractionalSeconds: Bool) -> DateFormatter {
-    includingFractionalSeconds ? iso8601Fractional : iso8601Whole
-  }
-
-  fileprivate static let iso8601Fractional: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.calendar = Calendar(identifier: .iso8601)
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.timeZone = TimeZone(secondsFromGMT: 0)
-    return formatter
-  }()
-
-  fileprivate static let iso8601Whole: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.calendar = Calendar(identifier: .iso8601)
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.timeZone = TimeZone(secondsFromGMT: 0)
-    return formatter
-  }()
-}
-
-@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
 extension Date.ISO8601FormatStyle {
   fileprivate func currentTimestamp(includingFractionalSeconds: Bool) -> Self {
     year().month().day()
@@ -42,35 +17,21 @@ extension Date.ISO8601FormatStyle {
 
 extension Date {
   package var iso8601String: String {
-    if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
-      return formatted(.iso8601.currentTimestamp(includingFractionalSeconds: true))
-    } else {
-      return DateFormatter.iso8601(includingFractionalSeconds: true).string(from: self)
-    }
+    formatted(.iso8601.currentTimestamp(includingFractionalSeconds: true))
   }
 }
 
 extension String {
   package var date: Date? {
-    if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
-      if let date = try? Date(
-        self,
-        strategy: .iso8601.currentTimestamp(includingFractionalSeconds: true)
-      ) {
-        return date
-      }
-      return try? Date(
-        self,
-        strategy: .iso8601.currentTimestamp(includingFractionalSeconds: false)
-      )
-    } else {
-      guard
-        let date = DateFormatter.iso8601(includingFractionalSeconds: true).date(from: self)
-          ?? DateFormatter.iso8601(includingFractionalSeconds: false).date(from: self)
-      else {
-        return nil
-      }
+    if let date = try? Date(
+      self,
+      strategy: .iso8601.currentTimestamp(includingFractionalSeconds: true)
+    ) {
       return date
     }
+    return try? Date(
+      self,
+      strategy: .iso8601.currentTimestamp(includingFractionalSeconds: false)
+    )
   }
 }

--- a/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
+++ b/Sources/Helpers/Logger/OSLogSupabaseLogger.swift
@@ -23,7 +23,6 @@ import Foundation
   ///   options: .init(global: .init(logger: supabaseLogger))
   /// )
   /// ```
-  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
   public struct OSLogSupabaseLogger: SupabaseLogger {
     private let logger: Logger
 

--- a/Sources/Helpers/Task+withTimeout.swift
+++ b/Sources/Helpers/Task+withTimeout.swift
@@ -26,7 +26,7 @@ package func withTimeout<R: Sendable>(
     group.addTask {
       let interval = deadline.timeIntervalSinceNow
       if interval > 0 {
-        try await _clock.sleep(for: interval)
+        try await _clock.sleep(for: .seconds(interval))
       }
       try Task.checkCancellation()
       throw TimeoutError()

--- a/Sources/Helpers/Version.swift
+++ b/Sources/Helpers/Version.swift
@@ -18,7 +18,7 @@ private let _platform: String? = {
     #if targetEnvironment(macCatalyst)
       return "macCatalyst"
     #else
-      if #available(iOS 14.0, *), ProcessInfo.processInfo.isiOSAppOnMac {
+      if ProcessInfo.processInfo.isiOSAppOnMac {
         return "iOSAppOnMac"
       }
       return "iOS"

--- a/Sources/Helpers/_Clock.swift
+++ b/Sources/Helpers/_Clock.swift
@@ -5,30 +5,19 @@
 //  Created by Guilherme Souza on 08/01/25.
 //
 
-import Clocks
 import ConcurrencyExtras
 import Foundation
 
-package protocol _Clock: Sendable {
-  func sleep(for duration: TimeInterval) async throws
-}
-
-extension ContinuousClock: _Clock {
+extension Clock where Duration == Swift.Duration {
   package func sleep(for duration: TimeInterval) async throws {
-    try await sleep(for: .seconds(duration))
+    try await sleep(for: .seconds(duration), tolerance: nil)
   }
 }
 
-extension TestClock<Duration>: _Clock {
-  package func sleep(for duration: TimeInterval) async throws {
-    try await sleep(for: .seconds(duration))
-  }
-}
-
-private let __clock = LockIsolated<any _Clock>(ContinuousClock())
+private let __clock = LockIsolated<any Clock<Swift.Duration>>(ContinuousClock())
 
 #if DEBUG
-  package var _clock: any _Clock {
+  package var _clock: any Clock<Swift.Duration> {
     get {
       __clock.value
     }
@@ -37,7 +26,7 @@ private let __clock = LockIsolated<any _Clock>(ContinuousClock())
     }
   }
 #else
-  package var _clock: any _Clock {
+  package var _clock: any Clock<Swift.Duration> {
     __clock.value
   }
 #endif

--- a/Sources/Helpers/_Clock.swift
+++ b/Sources/Helpers/_Clock.swift
@@ -8,12 +8,6 @@
 import ConcurrencyExtras
 import Foundation
 
-extension Clock where Duration == Swift.Duration {
-  package func sleep(for duration: TimeInterval) async throws {
-    try await sleep(for: .seconds(duration), tolerance: nil)
-  }
-}
-
 private let __clock = LockIsolated<any Clock<Swift.Duration>>(ContinuousClock())
 
 #if DEBUG

--- a/Sources/Helpers/_Clock.swift
+++ b/Sources/Helpers/_Clock.swift
@@ -13,36 +13,19 @@ package protocol _Clock: Sendable {
   func sleep(for duration: TimeInterval) async throws
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ContinuousClock: _Clock {
   package func sleep(for duration: TimeInterval) async throws {
     try await sleep(for: .seconds(duration))
   }
 }
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+
 extension TestClock<Duration>: _Clock {
   package func sleep(for duration: TimeInterval) async throws {
     try await sleep(for: .seconds(duration))
   }
 }
 
-/// `_Clock` used on platforms where ``Clock`` protocol isn't available.
-struct FallbackClock: _Clock {
-  func sleep(for duration: TimeInterval) async throws {
-    try await Task.sleep(nanoseconds: NSEC_PER_SEC * UInt64(duration))
-  }
-}
-
-// Resolves clock instance based on platform availability.
-package let _resolveClock: @Sendable () -> any _Clock = {
-  if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
-    ContinuousClock()
-  } else {
-    FallbackClock()
-  }
-}
-
-private let __clock = LockIsolated(_resolveClock())
+private let __clock = LockIsolated<any _Clock>(ContinuousClock())
 
 #if DEBUG
   package var _clock: any _Clock {

--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -165,7 +165,7 @@ public class PostgrestBuilder: @unchecked Sendable {
           request: currentRequest, response: nil, error: error, retryEnabled: retryEnabled,
           attempt: attempt)
         {
-          try await _clock.sleep(for: retryDelay(attempt: attempt))
+          try await _clock.sleep(for: .seconds(retryDelay(attempt: attempt)))
           attempt += 1
           continue
         }
@@ -182,7 +182,7 @@ public class PostgrestBuilder: @unchecked Sendable {
         request: currentRequest, response: response, error: nil, retryEnabled: retryEnabled,
         attempt: attempt)
       {
-        try await _clock.sleep(for: retryDelay(attempt: attempt))
+        try await _clock.sleep(for: .seconds(retryDelay(attempt: attempt)))
         attempt += 1
         continue
       }

--- a/Sources/Realtime/Deprecated/PhoenixTransport.swift
+++ b/Sources/Realtime/Deprecated/PhoenixTransport.swift
@@ -42,7 +42,7 @@ public protocol PhoenixTransport {
 
   /**
    Connect to the server
-  
+
    - Parameters:
    - headers: Headers to include in the URLRequests when opening the Websocket connection. Can be empty [:]
    */
@@ -50,7 +50,7 @@ public protocol PhoenixTransport {
 
   /**
    Disconnect from the server.
-  
+
    - Parameters:
    - code: Status code as defined by <ahref="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a>.
    - reason: Reason why the connection is closing. Optional.
@@ -59,7 +59,7 @@ public protocol PhoenixTransport {
 
   /**
    Sends a message to the server.
-  
+
    - Parameter data: Data to send.
    */
   func send(data: Data)
@@ -74,30 +74,30 @@ public protocol PhoenixTransport {
 public protocol PhoenixTransportDelegate {
   /**
    Notified when the `Transport` opens.
-  
+
    - Parameter response: Response from the server indicating that the WebSocket handshake was successful and the connection has been upgraded to webSockets
    */
   func onOpen(response: URLResponse?)
 
   /**
    Notified when the `Transport` receives an error.
-  
+
    - Parameter error: Client-side error from the underlying `Transport` implementation
    - Parameter response: Response from the server, if any, that occurred with the Error
-  
+
    */
   func onError(error: any Error, response: URLResponse?)
 
   /**
    Notified when the `Transport` receives a message from the server.
-  
+
    - Parameter message: Message received from the server
    */
   func onMessage(message: String)
 
   /**
    Notified when the `Transport` closes.
-  
+
    - Parameter code: Code that was sent when the `Transport` closed
    - Parameter reason: A concise human-readable prose explanation for the closure
    */
@@ -151,22 +151,22 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
 
   /**
    Initializes a `Transport` layer built using URLSession's WebSocket
-  
+
    Example:
-  
+
    ```swift
    let url = URL("wss://example.com/socket")
    let transport: Transport = URLSessionTransport(url: url)
    ```
-  
+
    Using a custom `URLSessionConfiguration`
-  
+
    ```swift
    let url = URL("wss://example.com/socket")
    let configuration = URLSessionConfiguration.default
    let transport: Transport = URLSessionTransport(url: url, configuration: configuration)
    ```
-  
+
    - parameter url: URL to connect to
    - parameter configuration: Provide your own URLSessionConfiguration. Uses `.default` if none provided
    */

--- a/Sources/Realtime/Deprecated/PhoenixTransport.swift
+++ b/Sources/Realtime/Deprecated/PhoenixTransport.swift
@@ -42,7 +42,7 @@ public protocol PhoenixTransport {
 
   /**
    Connect to the server
-
+  
    - Parameters:
    - headers: Headers to include in the URLRequests when opening the Websocket connection. Can be empty [:]
    */
@@ -50,7 +50,7 @@ public protocol PhoenixTransport {
 
   /**
    Disconnect from the server.
-
+  
    - Parameters:
    - code: Status code as defined by <ahref="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a>.
    - reason: Reason why the connection is closing. Optional.
@@ -59,7 +59,7 @@ public protocol PhoenixTransport {
 
   /**
    Sends a message to the server.
-
+  
    - Parameter data: Data to send.
    */
   func send(data: Data)
@@ -74,30 +74,30 @@ public protocol PhoenixTransport {
 public protocol PhoenixTransportDelegate {
   /**
    Notified when the `Transport` opens.
-
+  
    - Parameter response: Response from the server indicating that the WebSocket handshake was successful and the connection has been upgraded to webSockets
    */
   func onOpen(response: URLResponse?)
 
   /**
    Notified when the `Transport` receives an error.
-
+  
    - Parameter error: Client-side error from the underlying `Transport` implementation
    - Parameter response: Response from the server, if any, that occurred with the Error
-
+  
    */
   func onError(error: any Error, response: URLResponse?)
 
   /**
    Notified when the `Transport` receives a message from the server.
-
+  
    - Parameter message: Message received from the server
    */
   func onMessage(message: String)
 
   /**
    Notified when the `Transport` closes.
-
+  
    - Parameter code: Code that was sent when the `Transport` closed
    - Parameter reason: A concise human-readable prose explanation for the closure
    */
@@ -136,7 +136,6 @@ public enum PhoenixTransportReadyState {
 /// SwiftPhoenixClient supports earlier OS versions using one of the submodule
 /// `Transport` implementations. Or you can create your own implementation using
 /// your own WebSocket library or implementation.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketDelegate {
   /// The URL to connect to
   let url: URL
@@ -152,22 +151,22 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
 
   /**
    Initializes a `Transport` layer built using URLSession's WebSocket
-
+  
    Example:
-
+  
    ```swift
    let url = URL("wss://example.com/socket")
    let transport: Transport = URLSessionTransport(url: url)
    ```
-
+  
    Using a custom `URLSessionConfiguration`
-
+  
    ```swift
    let url = URL("wss://example.com/socket")
    let configuration = URLSessionConfiguration.default
    let transport: Transport = URLSessionTransport(url: url, configuration: configuration)
    ```
-
+  
    - parameter url: URL to connect to
    - parameter configuration: Provide your own URLSessionConfiguration. Uses `.default` if none provided
    */

--- a/Sources/Realtime/Deprecated/RealtimeClient.swift
+++ b/Sources/Realtime/Deprecated/RealtimeClient.swift
@@ -186,7 +186,6 @@ public class RealtimeClient: PhoenixTransportDelegate {
   // MARK: - Initialization
 
   // ----------------------------------------------------------------------
-  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   public convenience init(
     _ endPoint: String,
     headers: [String: String] = [:],
@@ -202,7 +201,6 @@ public class RealtimeClient: PhoenixTransportDelegate {
     )
   }
 
-  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   public convenience init(
     _ endPoint: String,
     headers: [String: String] = [:],
@@ -971,7 +969,7 @@ public class RealtimeClient: PhoenixTransportDelegate {
      We use NORMAL here since the client is the one determining to close the
      connection. However, we set to close status to abnormal so that
      the client knows that it should attempt to reconnect.
-
+    
      If the server subsequently acknowledges with code 1000 (normal close),
      the socket will keep the `.abnormal` close status and trigger a reconnection.
      */

--- a/Sources/Realtime/Deprecated/RealtimeClient.swift
+++ b/Sources/Realtime/Deprecated/RealtimeClient.swift
@@ -969,7 +969,7 @@ public class RealtimeClient: PhoenixTransportDelegate {
      We use NORMAL here since the client is the one determining to close the
      connection. However, we set to close status to abnormal so that
      the client knows that it should attempt to reconnect.
-    
+
      If the server subsequently acknowledges with code 1000 (normal close),
      the socket will keep the `.abnormal` close status and trigger a reconnection.
      */

--- a/Sources/RealtimeV2/ChannelStateManager.swift
+++ b/Sources/RealtimeV2/ChannelStateManager.swift
@@ -306,7 +306,7 @@ actor ChannelStateManager {
         )
 
         do {
-          try await _clock.sleep(for: delay)
+          try await _clock.sleep(for: .seconds(delay))
           if !(await ensureSocketConnected()) {
             logger?.debug("Socket disconnected during retry delay for '\(topic)'")
             throw CancellationError()

--- a/Sources/RealtimeV2/ConnectionManager.swift
+++ b/Sources/RealtimeV2/ConnectionManager.swift
@@ -190,7 +190,7 @@ actor ConnectionManager {
 
   private func initiateReconnect(reason: String) {
     let reconnectTask = Task {
-      try await clock.sleep(for: reconnectDelay)
+      try await clock.sleep(for: .seconds(reconnectDelay))
       logger?.debug("Attempting to reconnect...")
       try await performConnection()
     }

--- a/Sources/RealtimeV2/ConnectionManager.swift
+++ b/Sources/RealtimeV2/ConnectionManager.swift
@@ -19,7 +19,7 @@ actor ConnectionManager {
   private let logger: (any SupabaseLogger)?
   // Captured at init time so parallel test classes that swap _clock cannot
   // change the timing of an already-running client.
-  let clock: any _Clock
+  let clock: any Clock<Duration>
 
   /// Get current connection if connected, nil otherwise.
   var connection: (any WebSocket)? {
@@ -37,7 +37,7 @@ actor ConnectionManager {
     headers: [String: String],
     reconnectDelay: TimeInterval,
     logger: (any SupabaseLogger)?,
-    clock: any _Clock = _clock
+    clock: any Clock<Duration> = _clock
   ) {
     self.transport = transport
     self.url = url

--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -82,7 +82,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   let serializer = RealtimeSerializer()
   // Captured at init time so parallel test classes that swap _clock cannot
   // change the timing of an already-running client.
-  let clock: any _Clock
+  let clock: any Clock<Duration>
 
   let connectionManager: ConnectionManager
 
@@ -168,7 +168,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     options: RealtimeClientOptions,
     wsTransport: @escaping WebSocketTransport,
     http: any HTTPClientType,
-    clock: any _Clock = _clock
+    clock: any Clock<Duration> = _clock
   ) {
     var options = options
     if options.headers[.xClientInfo] == nil {

--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -399,7 +399,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
       state.pendingDisconnectTask?.cancel()
       state.pendingDisconnectTask = Task { [weak self, clock] in
         do {
-          try await clock.sleep(for: delay)
+          try await clock.sleep(for: .seconds(delay))
           self?.disconnect()
         } catch {
           // Cancelled: a new channel was added or disconnect() was called directly.
@@ -512,7 +512,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
 
       state.heartbeatTask = Task { [weak self, options, clock] in
         while !Task.isCancelled {
-          try? await clock.sleep(for: options.heartbeatInterval)
+          try? await clock.sleep(for: .seconds(options.heartbeatInterval))
           guard let self, !Task.isCancelled else {
             break
           }

--- a/Sources/Storage/Helpers.swift
+++ b/Sources/Storage/Helpers.swift
@@ -17,39 +17,8 @@ import Foundation
   import UniformTypeIdentifiers
 
   func mimeType(forPathExtension pathExtension: String) -> String {
-    #if swift(>=5.9)
-      if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, visionOS 1, *) {
-        return UTType(filenameExtension: pathExtension)?.preferredMIMEType
-          ?? "application/octet-stream"
-      } else {
-        if let id = UTTypeCreatePreferredIdentifierForTag(
-          kUTTagClassFilenameExtension, pathExtension as CFString, nil
-        )?.takeRetainedValue(),
-          let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-            .takeRetainedValue()
-        {
-          return contentType as String
-        }
-
-        return "application/octet-stream"
-      }
-    #else
-      if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
-        return UTType(filenameExtension: pathExtension)?.preferredMIMEType
-          ?? "application/octet-stream"
-      } else {
-        if let id = UTTypeCreatePreferredIdentifierForTag(
-          kUTTagClassFilenameExtension, pathExtension as CFString, nil
-        )?.takeRetainedValue(),
-          let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-            .takeRetainedValue()
-        {
-          return contentType as String
-        }
-
-        return "application/octet-stream"
-      }
-    #endif
+    UTType(filenameExtension: pathExtension)?.preferredMIMEType
+      ?? "application/octet-stream"
   }
 #else
 

--- a/Sources/Storage/Helpers.swift
+++ b/Sources/Storage/Helpers.swift
@@ -7,12 +7,6 @@
 
 import Foundation
 
-#if canImport(MobileCoreServices)
-  import MobileCoreServices
-#elseif canImport(CoreServices)
-  import CoreServices
-#endif
-
 #if canImport(UniformTypeIdentifiers)
   import UniformTypeIdentifiers
 
@@ -25,18 +19,7 @@ import Foundation
   // MARK: - Private - Mime Type
 
   func mimeType(forPathExtension pathExtension: String) -> String {
-    #if canImport(CoreServices) || canImport(MobileCoreServices)
-      if let id = UTTypeCreatePreferredIdentifierForTag(
-        kUTTagClassFilenameExtension, pathExtension as CFString, nil
-      )?.takeRetainedValue(),
-        let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-          .takeRetainedValue()
-      {
-        return contentType as String
-      }
-    #endif
-
-    return "application/octet-stream"
+    "application/octet-stream"
   }
 #endif
 

--- a/Sources/Storage/MultipartFormData.swift
+++ b/Sources/Storage/MultipartFormData.swift
@@ -595,39 +595,8 @@ class MultipartFormData {
     // MARK: - Private - Mime Type
 
     static func mimeType(forPathExtension pathExtension: String) -> String {
-      #if swift(>=5.9)
-        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, visionOS 1, *) {
-          return UTType(filenameExtension: pathExtension)?.preferredMIMEType
-            ?? "application/octet-stream"
-        } else {
-          if let id = UTTypeCreatePreferredIdentifierForTag(
-            kUTTagClassFilenameExtension, pathExtension as CFString, nil
-          )?.takeRetainedValue(),
-            let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-              .takeRetainedValue()
-          {
-            return contentType as String
-          }
-
-          return "application/octet-stream"
-        }
-      #else
-        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
-          return UTType(filenameExtension: pathExtension)?.preferredMIMEType
-            ?? "application/octet-stream"
-        } else {
-          if let id = UTTypeCreatePreferredIdentifierForTag(
-            kUTTagClassFilenameExtension, pathExtension as CFString, nil
-          )?.takeRetainedValue(),
-            let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-              .takeRetainedValue()
-          {
-            return contentType as String
-          }
-
-          return "application/octet-stream"
-        }
-      #endif
+      UTType(filenameExtension: pathExtension)?.preferredMIMEType
+        ?? "application/octet-stream"
     }
   }
 

--- a/Sources/Storage/MultipartFormData.swift
+++ b/Sources/Storage/MultipartFormData.swift
@@ -27,12 +27,6 @@
 import Foundation
 import HTTPTypes
 
-#if canImport(MobileCoreServices)
-  import MobileCoreServices
-#elseif canImport(CoreServices)
-  import CoreServices
-#endif
-
 /// Constructs `multipart/form-data` for uploads within an HTTP or HTTPS body. There are currently two ways to encode
 /// multipart form data. The first way is to encode the data directly in memory. This is very efficient, but can lead
 /// to memory issues if the dataset is too large. The second way is designed for larger datasets and will write all the
@@ -606,18 +600,7 @@ class MultipartFormData {
     // MARK: - Private - Mime Type
 
     static func mimeType(forPathExtension pathExtension: String) -> String {
-      #if canImport(CoreServices) || canImport(MobileCoreServices)
-        if let id = UTTypeCreatePreferredIdentifierForTag(
-          kUTTagClassFilenameExtension, pathExtension as CFString, nil
-        )?.takeRetainedValue(),
-          let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?
-            .takeRetainedValue()
-        {
-          return contentType as String
-        }
-      #endif
-
-      return "application/octet-stream"
+      "application/octet-stream"
     }
   }
 

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -213,13 +213,7 @@ public final class SupabaseClient: Sendable {
       .merging(with: HTTPFields(options.global.headers))
 
     // default storage key uses the supabase project ref as a namespace
-    let optionalHost: String?
-    if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, visionOS 1, *) {
-      optionalHost = supabaseURL.host(percentEncoded: false)
-    } else {
-      optionalHost = supabaseURL.host
-    }
-    guard let host = optionalHost else {
+    guard let host = supabaseURL.host(percentEncoded: false) else {
       preconditionFailure("supabaseURL must have a valid host.")
     }
     let defaultStorageKey = "sb-\(host.split(separator: ".")[0])-auth-token"

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -5,14 +5,13 @@
 //  Created by Guilherme Souza on 23/10/23.
 //
 
+@_spi(Experimental) @testable import Auth
 import ConcurrencyExtras
 import CustomDump
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
 import XCTest
-
-@_spi(Experimental) @testable import Auth
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
@@ -2202,7 +2201,6 @@ final class AuthClientTests: XCTestCase {
   }
 
   #if canImport(AuthenticationServices) && !os(tvOS) && !os(watchOS)
-    @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
     @MainActor
     func testSignInWithPasskeyDrivesFullFlow() async throws {
       Mock(
@@ -2249,7 +2247,6 @@ final class AuthClientTests: XCTestCase {
         forwardedOptions.value?.objectValue?["challenge"]?.stringValue, "Y2hhbGxlbmdl")
     }
 
-    @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
     @MainActor
     func testRegisterPasskeyDrivesFullFlow() async throws {
       Mock(
@@ -2295,7 +2292,6 @@ final class AuthClientTests: XCTestCase {
       expectNoDifference(passkey.friendlyName, "My Passkey")
     }
 
-    @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
     @MainActor
     func testEnrollWebAuthnFactorDrivesFullFlow() async throws {
       Mock(
@@ -2343,7 +2339,6 @@ final class AuthClientTests: XCTestCase {
       XCTAssertFalse(session.accessToken.isEmpty)
     }
 
-    @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, visionOS 1.0, *)
     @MainActor
     func testVerifyWebAuthnFactorDrivesFullFlow() async throws {
       Mock(

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -5,13 +5,14 @@
 //  Created by Guilherme Souza on 23/10/23.
 //
 
-@_spi(Experimental) @testable import Auth
 import ConcurrencyExtras
 import CustomDump
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
 import XCTest
+
+@_spi(Experimental) @testable import Auth
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking

--- a/Tests/IntegrationTests/PostgrestIntegrationTests.swift
+++ b/Tests/IntegrationTests/PostgrestIntegrationTests.swift
@@ -33,7 +33,6 @@ struct User: Codable, Hashable {
   let email: String
 }
 
-@available(iOS 15.0.0, macOS 12.0.0, tvOS 13.0, *)
 final class IntegrationTests: XCTestCase {
   let client = PostgrestClient(
     url: URL(string: "\(DotEnv.SUPABASE_URL)/rest/v1")!,

--- a/Tests/IntegrationTests/RealtimeIntegrationTests.swift
+++ b/Tests/IntegrationTests/RealtimeIntegrationTests.swift
@@ -18,7 +18,6 @@
   @testable import Realtime
   @testable import RealtimeV2
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   final class RealtimeIntegrationTests: XCTestCase {
     let testClock = TestClock<Duration>()
 

--- a/Tests/PostgRESTTests/PostgrestBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestBuilderTests.swift
@@ -475,6 +475,9 @@ final class PostgrestBuilderTests: PostgrestQueryTests {
 }
 
 /// A no-op clock for tests — skips all sleep delays so retry tests run instantly.
-struct ImmediateRetryTestClock: _Clock {
-  func sleep(for duration: TimeInterval) async throws {}
+struct ImmediateRetryTestClock: Clock {
+  var now: ContinuousClock.Instant { ContinuousClock().now }
+  var minimumResolution: ContinuousClock.Instant.Duration { ContinuousClock().minimumResolution }
+
+  func sleep(until deadline: ContinuousClock.Instant, tolerance: Duration?) async throws {}
 }

--- a/Tests/PostgRESTTests/PostgrestBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestBuilderTests.swift
@@ -243,7 +243,7 @@ final class PostgrestBuilderTests: PostgrestQueryTests {
   override func tearDown() {
     super.tearDown()
     #if DEBUG
-      _clock = _resolveClock()
+      _clock = ContinuousClock()
     #endif
   }
 

--- a/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
@@ -21,7 +21,6 @@ import XCTest
   final class RealtimeChannelBroadcastTests: XCTestCase {}
 #else
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   final class RealtimeChannelBroadcastTests: XCTestCase, @unchecked Sendable {
     let url = URL(string: "http://localhost:54321/realtime/v1")!
     let apiKey = "publishable.api.key"

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -14,7 +14,6 @@ import XCTest
 /// queue) — instead of the synchronous delivery of `FakeWebSocket`, which
 /// masks the races involved. They run against the real clock with compressed
 /// intervals, deliberately NOT under `withMainSerialExecutor`.
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class RealtimeColdStartTests: XCTestCase {
   let url = URL(string: "http://localhost:54321/realtime/v1")!
   let apiKey = "anon.api.key"

--- a/Tests/RealtimeTests/RealtimeLifecycleTests.swift
+++ b/Tests/RealtimeTests/RealtimeLifecycleTests.swift
@@ -21,7 +21,6 @@ import XCTest
   final class RealtimeLifecycleTests: XCTestCase {}
 #else
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   final class RealtimeLifecycleTests: XCTestCase {
     let url = URL(string: "http://localhost:54321/realtime/v1")!
     let apiKey = "publishable.api.key"

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -18,7 +18,6 @@ import XCTest
   final class RealtimeTests: XCTestCase {}
 #else
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   final class RealtimeTests: XCTestCase {
     let url = URL(string: "http://localhost:54321/realtime/v1")!
     let apiKey = "publishable.api.key"

--- a/Tests/RealtimeTests/_PushTests.swift
+++ b/Tests/RealtimeTests/_PushTests.swift
@@ -14,7 +14,6 @@ import XCTest
 
 #if !os(Android) && !os(Linux) && !os(Windows)
   @MainActor
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   final class _PushTests: XCTestCase {
     var ws: FakeWebSocket!
     var socket: RealtimeClientV2!


### PR DESCRIPTION
## Summary

Stacked on #1067 — once platform minimums land at iOS 16 / macCatalyst 16 / macOS 13 (Ventura) / watchOS 9 / tvOS 16, several `@available`/`#available`-gated code paths become dead. This removes them and the polyfills/fallback branches they guarded.

## Changes

- **`Helpers/_Clock.swift`**: dropped the custom `_Clock` protocol entirely — `ContinuousClock`/`TestClock` now conform to the stdlib `Clock` protocol unconditionally, so `_clock`/`clock` properties are typed `any Clock<Duration>` directly, with a `sleep(for: TimeInterval)` convenience added via a constrained extension. Removed the `FallbackClock`/`_resolveClock` indirection that only existed to bridge the pre-iOS-16 gap.
- **Auth WebAuthn** (`AuthClient+Passkey`, `AuthMFA+WebAuthn`, `WebAuthnAuthenticator`) **and `SupabaseClient`**: removed now-always-true `@available`/`#available` gates (the known candidates from the issue).
- **`AuthClient`, `Realtime/Deprecated` (`PhoenixTransport`, `RealtimeClient`), `OSLogSupabaseLogger`, `Helpers/Version`**: removed `@available` annotations gated below the new floor.
- **`Helpers/DateFormatter`, `Storage/Helpers`, `Storage/MultipartFormData`**: dropped the pre-iOS-15/14 `DateFormatter` and `UTType`/CoreFoundation MIME-type polyfills — the modern APIs are unconditionally available now.
- Matching test-side cleanup: removed redundant class-level `@available` annotations tied to the old floor, and updated `PostgrestBuilderTests` to reset the test clock via `ContinuousClock()` directly.

Full-repo audit (not just the known candidates named in the issue) confirmed no other `@available`/`#available` checks remain gated at or below the new floor.

## Test plan

- [x] `swift build --build-tests` succeeds with no errors
- [x] `make PLATFORM=IOS XCODEBUILD_ARGUMENT=test xcodebuild` — full suite green
- [x] `make spell-check` — clean
- [ ] CI (this PR)

## Linear

Closes [SDK-1225](https://linear.app/supabase/issue/SDK-1225/supabase-swift-clean-up-code-made-obsolete-by-the-ios-16-minimum)