### PR TITLE
fix(realtime): break retain cycle in heartbeat task

### DIFF
--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -510,10 +510,10 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     mutableState.withValue { state in
       state.heartbeatTask?.cancel()
 
-      state.heartbeatTask = Task { [options, clock] in
+      state.heartbeatTask = Task { [weak self, options, clock] in
         while !Task.isCancelled {
           try? await clock.sleep(for: options.heartbeatInterval)
-          if Task.isCancelled {
+          guard let self, !Task.isCancelled else {
             break
           }
           await self.sendHeartbeat()

--- a/Tests/RealtimeTests/RealtimeLifecycleTests.swift
+++ b/Tests/RealtimeTests/RealtimeLifecycleTests.swift
@@ -195,6 +195,33 @@ import XCTest
       XCTAssertEqual(sut.status, .disconnected)
     }
 
+    func testHeartbeatTaskDoesNotRetainClient() async throws {
+      weak var weakClient: RealtimeClientV2?
+
+      func scope() async {
+        let sut = makeClient()
+        weakClient = sut
+        await sut.connect()
+        XCTAssertEqual(sut.status, .connected)
+
+        await testClock.advance(by: .seconds(30))
+
+        servers.value.last?.close(code: 4001, reason: "test teardown")
+      }
+      await scope()
+
+      let deadline = Date().addingTimeInterval(5)
+      while weakClient != nil, Date() < deadline {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+      }
+
+      XCTAssertNil(
+        weakClient,
+        "RealtimeClientV2 leaked: the heartbeat task retained self, preventing deinit."
+      )
+    }
+
     func testHandleAppLifecycleFalseDoesNotInstallLifecycleManager() {
       let sut = makeClient(handleAppLifecycle: false)
       XCTAssertNil(sut.mutableState.lifecycleManager)


### PR DESCRIPTION
### Problem

`RealtimeClientV2.startHeartbeating()` stores a `Task` in the client owned `mutableState`, and the task body calls `self.sendHeartbeat()` with `self` captured strongly. That forms a reference cycle: the client retains `mutableState`, which retains `heartbeatTask`, whose closure retains `self`.

```swift
state.heartbeatTask = Task { [options, clock] in
  while !Task.isCancelled {
    try? await clock.sleep(for: options.heartbeatInterval)
    if Task.isCancelled { break }
    await self.sendHeartbeat()   // strong self
  }
}
```

The loop only exits on `Task.isCancelled`, which is set in `disconnect()` / `deinit`, but `deinit` can never run while the task keeps the client alive. So if a caller connects and then releases every reference to the client without calling `disconnect()`, the client, its WebSocket, and its channels are never freed, and the heartbeat keeps firing every `heartbeatInterval` against the server. The sibling `listenForMessages` task already captures `self` weakly; the heartbeat task was the one place that did not.

### Fix

Capture `self` weakly and stop the loop once it has been released.

```swift
state.heartbeatTask = Task { [weak self, options, clock] in
  while !Task.isCancelled {
    try? await clock.sleep(for: options.heartbeatInterval)
    guard let self, !Task.isCancelled else { break }
    await self.sendHeartbeat()
  }
}
```

### Tests

Added `testHeartbeatTaskDoesNotRetainClient` to `RealtimeLifecycleTests`. It connects a client, advances the test clock past the heartbeat interval so the task loops at least once, closes the transport with an application close code (4000+) so the message task ends without a reconnect, then drops the strong reference and asserts the weak reference becomes nil. The test fails before this change (the client leaks) and passes after. Full `RealtimeTests` suite passes (234 tests).

No public API change.
