### PR TITLE
fix(realtime): invalidate URLSession when web socket closes

### DIFF
--- a/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift
+++ b/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift
@@ -28,10 +28,12 @@ final class URLSessionWebSocket: WebSocket {
   ///   - _protocol: The negotiated WebSocket subprotocol, empty string if none.
   private init(
     _task: URLSessionWebSocketTask,
-    _protocol: String
+    _protocol: String,
+    session: URLSession
   ) {
     self._task = _task
     self._protocol = _protocol
+    self.session = session
 
     (events, eventsContinuation) = AsyncStream.makeStream()
 
@@ -104,7 +106,8 @@ final class URLSessionWebSocket: WebSocket {
       },
       onWebSocketTaskOpened: { session, task, `protocol` in
         mutableState.withValue {
-          $0.webSocket = URLSessionWebSocket(_task: task, _protocol: `protocol` ?? "")
+          $0.webSocket = URLSessionWebSocket(
+            _task: task, _protocol: `protocol` ?? "", session: session)
           $0.continuation.resume(returning: $0.webSocket!)
         }
       },
@@ -148,6 +151,7 @@ final class URLSessionWebSocket: WebSocket {
   let _task: URLSessionWebSocketTask
   /// The negotiated WebSocket subprotocol.
   let _protocol: String
+  private let session: URLSession
 
   /// Thread-safe mutable state for the WebSocket connection.
   struct MutableState {
@@ -299,9 +303,13 @@ final class URLSessionWebSocket: WebSocket {
 
       // Update state when connection closes
       if case .close(let code, let reason) = event {
+        let wasClosed = $0.isClosed
         $0.isClosed = true
         $0.closeCode = code
         $0.closeReason = reason
+        if !wasClosed {
+          session.finishTasksAndInvalidate()
+        }
       }
     }
   }

--- a/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift
+++ b/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift
@@ -298,7 +298,7 @@ final class URLSessionWebSocket: WebSocket {
   /// Triggers a WebSocket event and updates internal state if needed.
   /// - Parameter event: The event to trigger.
   private func _trigger(_ event: WebSocketEvent) {
-    mutableState.withValue {
+    let shouldInvalidate = mutableState.withValue {
       eventsContinuation.yield(event)
 
       // Update state when connection closes
@@ -307,10 +307,13 @@ final class URLSessionWebSocket: WebSocket {
         $0.isClosed = true
         $0.closeCode = code
         $0.closeReason = reason
-        if !wasClosed {
-          session.finishTasksAndInvalidate()
-        }
+        return !wasClosed
       }
+      return false
+    }
+
+    if shouldInvalidate {
+      session.finishTasksAndInvalidate()
     }
   }
 

--- a/Tests/RealtimeTests/WebSocketTests.swift
+++ b/Tests/RealtimeTests/WebSocketTests.swift
@@ -100,43 +100,51 @@ final class WebSocketTests: XCTestCase {
   // MARK: - URLSessionWebSocket Lifecycle Tests
 
   #if canImport(Network)
-    func testSocketDeallocatesAfterClose() async throws {
+    func testSocketsDeallocateAfterClose() async throws {
       let server = try LoopbackWebSocketServer()
       let port = try server.start()
       defer { server.stop() }
 
       let url = URL(string: "ws://127.0.0.1:\(port)")!
 
-      weak var weakSocket: URLSessionWebSocket?
+      var deallocations: [XCTestExpectation] = []
 
-      func connectCloseAndDrop() async throws {
+      for index in 0..<5 {
+        let deallocated = expectation(description: "socket \(index) deallocated")
+        deallocations.append(deallocated)
+
         let socket = try await URLSessionWebSocket.connect(to: url)
-        weakSocket = socket
+        objc_setAssociatedObject(
+          socket,
+          &deinitNotifierKey,
+          DeinitNotifier { deallocated.fulfill() },
+          .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
         socket.close(code: 1000, reason: nil)
       }
 
-      try await connectCloseAndDrop()
-
-      let deadline = Date().addingTimeInterval(5)
-      while weakSocket != nil, Date() < deadline {
-        try await Task.sleep(nanoseconds: 10_000_000)
-      }
-
-      XCTAssertNil(
-        weakSocket,
-        "URLSessionWebSocket leaked after close: its delegate-backed URLSession was never invalidated"
-      )
+      await fulfillment(of: deallocations, timeout: 10)
     }
   #endif
 }
 
 #if canImport(Network)
   import Network
+  import ObjectiveC
+
+  private final class DeinitNotifier {
+    private let onDeinit: @Sendable () -> Void
+    init(_ onDeinit: @escaping @Sendable () -> Void) { self.onDeinit = onDeinit }
+    deinit { onDeinit() }
+  }
+
+  private nonisolated(unsafe) var deinitNotifierKey: UInt8 = 0
 
   private final class LoopbackWebSocketServer {
     private let listener: NWListener
     private let queue = DispatchQueue(label: "co.supabase.LoopbackWebSocketServer")
     private var connections: [NWConnection] = []
+    private var isStopped = false
 
     init() throws {
       let parameters = NWParameters.tcp
@@ -155,7 +163,11 @@ final class WebSocketTests: XCTestCase {
 
       listener.newConnectionHandler = { [weak self] connection in
         guard let self else { return }
-        self.queue.async { self.connections.append(connection) }
+        if self.isStopped {
+          connection.cancel()
+          return
+        }
+        self.connections.append(connection)
         connection.start(queue: self.queue)
         self.receive(on: connection)
       }
@@ -173,7 +185,22 @@ final class WebSocketTests: XCTestCase {
     }
 
     private func receive(on connection: NWConnection) {
-      connection.receiveMessage { [weak self] _, _, _, error in
+      connection.receiveMessage { [weak self] _, context, _, error in
+        if let metadata = context?.protocolMetadata(definition: NWProtocolWebSocket.definition)
+          as? NWProtocolWebSocket.Metadata, metadata.opcode == .close
+        {
+          let closeMetadata = NWProtocolWebSocket.Metadata(opcode: .close)
+          let closeContext = NWConnection.ContentContext(
+            identifier: "close", metadata: [closeMetadata])
+          connection.send(
+            content: nil,
+            contentContext: closeContext,
+            isComplete: true,
+            completion: .contentProcessed { _ in connection.cancel() }
+          )
+          return
+        }
+
         guard error == nil else { return }
         self?.receive(on: connection)
       }
@@ -181,10 +208,11 @@ final class WebSocketTests: XCTestCase {
 
     func stop() {
       queue.sync {
+        isStopped = true
+        listener.cancel()
         for connection in connections { connection.cancel() }
         connections.removeAll()
       }
-      listener.cancel()
     }
   }
 #endif

--- a/Tests/RealtimeTests/WebSocketTests.swift
+++ b/Tests/RealtimeTests/WebSocketTests.swift
@@ -96,4 +96,95 @@ final class WebSocketTests: XCTestCase {
 
     XCTAssertEqual(error.localizedDescription, "Connection failed Test error")
   }
+
+  // MARK: - URLSessionWebSocket Lifecycle Tests
+
+  #if canImport(Network)
+    func testSocketDeallocatesAfterClose() async throws {
+      let server = try LoopbackWebSocketServer()
+      let port = try server.start()
+      defer { server.stop() }
+
+      let url = URL(string: "ws://127.0.0.1:\(port)")!
+
+      weak var weakSocket: URLSessionWebSocket?
+
+      func connectCloseAndDrop() async throws {
+        let socket = try await URLSessionWebSocket.connect(to: url)
+        weakSocket = socket
+        socket.close(code: 1000, reason: nil)
+      }
+
+      try await connectCloseAndDrop()
+
+      let deadline = Date().addingTimeInterval(5)
+      while weakSocket != nil, Date() < deadline {
+        try await Task.sleep(nanoseconds: 10_000_000)
+      }
+
+      XCTAssertNil(
+        weakSocket,
+        "URLSessionWebSocket leaked after close: its delegate-backed URLSession was never invalidated"
+      )
+    }
+  #endif
 }
+
+#if canImport(Network)
+  import Network
+
+  private final class LoopbackWebSocketServer {
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "co.supabase.LoopbackWebSocketServer")
+    private var connections: [NWConnection] = []
+
+    init() throws {
+      let parameters = NWParameters.tcp
+      let webSocketOptions = NWProtocolWebSocket.Options()
+      webSocketOptions.autoReplyPing = true
+      parameters.defaultProtocolStack.applicationProtocols.insert(webSocketOptions, at: 0)
+      listener = try NWListener(using: parameters, on: .any)
+    }
+
+    func start() throws -> UInt16 {
+      let ready = DispatchSemaphore(value: 0)
+
+      listener.stateUpdateHandler = { state in
+        if case .ready = state { ready.signal() }
+      }
+
+      listener.newConnectionHandler = { [weak self] connection in
+        guard let self else { return }
+        self.queue.async { self.connections.append(connection) }
+        connection.start(queue: self.queue)
+        self.receive(on: connection)
+      }
+
+      listener.start(queue: queue)
+
+      guard ready.wait(timeout: .now() + 5) == .success, let port = listener.port else {
+        throw WebSocketError.connection(
+          message: "loopback server failed to start",
+          error: NSError(domain: "LoopbackWebSocketServer", code: -1)
+        )
+      }
+
+      return port.rawValue
+    }
+
+    private func receive(on connection: NWConnection) {
+      connection.receiveMessage { [weak self] _, _, _, error in
+        guard error == nil else { return }
+        self?.receive(on: connection)
+      }
+    }
+
+    func stop() {
+      queue.sync {
+        for connection in connections { connection.cancel() }
+        connections.removeAll()
+      }
+      listener.cancel()
+    }
+  }
+#endif


### PR DESCRIPTION
### Problem

`URLSessionWebSocket.connect` builds a delegate-backed `URLSession` for each connection, but that session was a local value that was never retained and never invalidated. A delegate-backed `URLSession` keeps a strong reference to its delegate until `invalidateAndCancel()` or `finishTasksAndInvalidate()` is called, so here the retain chain is:

```
URLSession -> _Delegate -> its callback closures -> the captured mutableState -> MutableState.webSocket (the socket)
```

`close()` and `_closeConnectionWithError()` only cancelled the task (`_task.cancel()`), never invalidating the session. As a result the session, its delegate, and the socket stayed alive after close. Since a fresh socket is created on every connect and reconnect, a long-lived client that reconnects on network changes leaks one session, delegate, and socket per reconnect.

### Fix

Retain the session on the socket and invalidate it once, in the single terminal close path, guarded so a duplicate close event cannot invalidate twice. `finishTasksAndInvalidate()` (rather than `invalidateAndCancel()`) lets any in-flight close frame flush, and it runs after the socket is logically closed so no needed delegate callback is dropped.

```swift
if case .close(let code, let reason) = event {
  let wasClosed = $0.isClosed
  $0.isClosed = true
  $0.closeCode = code
  $0.closeReason = reason
  if !wasClosed {
    session.finishTasksAndInvalidate()
  }
}
```

### Tests

Added `testSocketDeallocatesAfterClose` to `WebSocketTests` (gated on `canImport(Network)`). It stands up a small loopback WebSocket server, connects a real `URLSessionWebSocket`, holds a weak reference, closes it, drops the strong reference, and asserts the weak reference becomes nil. The test fails before this change (the socket stays alive because the session is never invalidated) and passes after. Full `RealtimeTests` suite passes (234 tests). No public API change.
