### PR TITLE
test(helpers): fix flaky Storage snapshot tests caused by AnyJSON.encoder leak

### DIFF
--- a/Tests/HelpersTests/AnyJSONTests.swift
+++ b/Tests/HelpersTests/AnyJSONTests.swift
@@ -72,7 +72,9 @@ final class AnyJSONTests: XCTestCase {
 
   func testEncode() throws {
     let encoder = AnyJSON.encoder
+    let originalFormatting = encoder.outputFormatting
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    defer { encoder.outputFormatting = originalFormatting }
 
     let data = try encoder.encode(jsonObject)
     let decodedJSONString = try XCTUnwrap(String(data: data, encoding: .utf8))


### PR DESCRIPTION
## Summary
- `AnyJSONTests.testEncode` mutated the shared `AnyJSON.encoder` singleton's `outputFormatting` to `[.prettyPrinted, .sortedKeys]` and never restored it.
- Since `swift test` runs all `XCTestCase` classes across every module serially in one process (alphabetically), that leaked formatting persisted past `AnyJSONTests` into later-running `StorageFileAPITests`/`SupabaseStorageTests`, which also encode through `AnyJSON.encoder` via `encodeMetadata(_:)`. This corrupted the multipart `metadata` field's JSON and broke fixed-string snapshot assertions (`testUpdateFromData`, `testUpdateFromURL`, `testUploadData`) — but only when running the full suite, never in isolation.
- Fix: save and restore `encoder.outputFormatting` via `defer` in the test.

This is the safe, minimal fix. A follow-up refactor to stop caching `AnyJSON.encoder`/`.decoder` as mutable singletons (so this class of bug can't recur) is tracked in [SDK-1245](https://linear.app/supabase/issue/SDK-1245/refactor-anyjsonencoderdecoder-away-from-shared-mutable-singletons).

## Test plan
- [x] `swift test --skip IntegrationTests` — 788/788 passing (previously 3 failures)
- [x] Re-ran full suite twice to confirm no order-dependent flakiness
- [x] `swift test --filter HelpersTests.AnyJSONTests` passes in isolation