### PR TITLE
ci: don't cancel main/release CI runs on concurrency conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel in-progress runs for PRs (fast feedback on new pushes).
+  # Never cancel pushes to main/release branches: the Release workflow only
+  # fires when this CI run's conclusion is "success", so a cancelled run on
+  # a release-please release commit silently skips publishing the release.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- The CI concurrency group `ci-${{ github.ref }}` with `cancel-in-progress: true` scoped to the branch ref meant every push to `main` shared one group — a follow-up push landing while a previous main CI run was still in flight would cancel it.
- `release.yml` only invokes release-please when the triggering CI `workflow_run` concludes with `success`, so a cancelled run silently skips publishing any pending release.
- This exact sequence happened on commit 102a146b1a7066602d0d9d03bfa65936d123ed6a (the release-please "chore(main): release 2.50.0" merge commit): PR #1074 merged 4 minutes later, cancelling that CI run ([run 28808362154](https://github.com/supabase/supabase-swift/actions/runs/28808362154)), so the Release workflow was skipped and v2.50.0 was never tagged/published.
- Fix: only cancel in-progress runs for `pull_request` events (fast feedback on new commits to an open PR); pushes to `main`/`release/*` always run to completion so the release gate isn't broken by unrelated concurrent merges.

## Recovery
Manually dispatched `release.yml` via `workflow_dispatch` to unblock the pending release — v2.50.0 is now tagged and published on commit 102a146b1a7066602d0d9d03bfa65936d123ed6a.

## Test plan
- [x] Verified root cause via `gh api .../check-runs` and `gh run list` history (cancelled CI run → skipped Release workflow_run)
- [x] Validated new YAML parses correctly
- [ ] Confirm on the next PR that pushing a new commit to that PR still cancels the stale run (cancel-in-progress still active for `pull_request`)
- [ ] Confirm on the next rapid back-to-back merge to `main` that both CI runs complete instead of the first being cancelled