### PR TITLE
fix(auth): include code_challenge in resend() when using PKCE flow

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -1185,6 +1185,8 @@ public actor AuthClient {
     emailRedirectTo: URL? = nil,
     captchaToken: String? = nil
   ) async throws {
+    let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+
     _ = try await api.execute(
       HTTPRequest(
         url: configuration.url.appendingPathComponent("resend"),
@@ -1201,7 +1203,9 @@ public actor AuthClient {
           ResendEmailParams(
             type: type,
             email: email,
-            gotrueMetaSecurity: captchaToken.map(AuthMetaSecurity.init(captchaToken:))
+            gotrueMetaSecurity: captchaToken.map(AuthMetaSecurity.init(captchaToken:)),
+            codeChallenge: codeChallenge,
+            codeChallengeMethod: codeChallengeMethod
           )
         )
       )

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1161,6 +1161,8 @@ struct ResendEmailParams: Encodable {
   let type: ResendEmailType
   let email: String
   let gotrueMetaSecurity: AuthMetaSecurity?
+  let codeChallenge: String?
+  let codeChallengeMethod: String?
 }
 
 /// The type of mobile OTP to resend when calling ``AuthClient/resend(phone:type:captchaToken:)``.

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -1360,6 +1360,38 @@ final class AuthClientTests: XCTestCase {
       #"""
       curl \
       	--request POST \
+      	--header "Content-Length: 201" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: auth-swift/0.0.0" \
+      	--header "X-Supabase-Api-Version: 2024-01-01" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	--data "{\"code_challenge\":\"hgJeigklONUI1pKSS98MIAbtJGaNu0zJU1iSiFOn2lY\",\"code_challenge_method\":\"s256\",\"email\":\"example@mail.com\",\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"type\":\"email_change\"}" \
+      	"http://localhost:54321/auth/v1/resend?redirect_to=https://supabase.com"
+      """#
+    }
+    .register()
+
+    let sut = makeSUT()
+
+    try await sut.resend(
+      email: "example@mail.com",
+      type: .emailChange,
+      emailRedirectTo: URL(string: "https://supabase.com"),
+      captchaToken: "captcha-token"
+    )
+  }
+
+  func testResendEmailImplicitFlow() async throws {
+    Mock(
+      url: clientURL.appendingPathComponent("resend"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [.post: Data()]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
       	--header "Content-Length: 107" \
       	--header "Content-Type: application/json" \
       	--header "X-Client-Info: auth-swift/0.0.0" \
@@ -1371,7 +1403,7 @@ final class AuthClientTests: XCTestCase {
     }
     .register()
 
-    let sut = makeSUT()
+    let sut = makeSUT(flowType: .implicit)
 
     try await sut.resend(
       email: "example@mail.com",


### PR DESCRIPTION
## Summary

`resend()` for email confirmations (`signup` / `email_change`) always produced an implicit-flow-style request, even when the client is configured with PKCE `flowType`. This meant a resent confirmation link couldn't complete the PKCE exchange. `resend(email:...)` now generates a fresh `code_challenge`/`code_challenge_method` pair (via the same `prepareForPKCE()` helper already used by `signUp`/`signInWithOTP`) and includes it in the `POST /resend` body when PKCE is configured.

This mirrors [supabase-js#2144](https://github.com/supabase/supabase-js/pull/2144) for SDK parity (Linear SDK-1025).

## Changes

- `Sources/Auth/AuthClient.swift`: `resend(email:type:emailRedirectTo:captchaToken:)` now calls `prepareForPKCE()` and passes the resulting challenge/method through.
- `Sources/Auth/Types.swift`: `ResendEmailParams` gains optional `codeChallenge`/`codeChallengeMethod` fields (encoded as `null`/omitted under implicit flow, same as `SignUpRequest`).
- `resend(phone:...)` (SMS/phone-change) and implicit flow are unchanged.

## Root cause

`Sources/Auth/AuthClient.swift` — the email `resend()` request body never included PKCE parameters, unlike `signUp`/`signInWithOTP`/`signInWithSSO`, which all call `prepareForPKCE()`. Adding the same call and threading the result into `ResendEmailParams` closes the gap.

## Test plan

- [x] Reproduction test added/updated: `Tests/AuthTests/AuthClientTests.swift` — `testResendEmail` (PKCE flow, asserts `code_challenge`/`code_challenge_method` in the request body) and new `testResendEmailImplicitFlow` (implicit flow, asserts they're absent).
- [x] Full `AuthTests` suite green (`xcodebuild test -only-testing:AuthTests`, 203 tests, 0 failures).
- [x] Self code review completed, no issues found.

## Linear

Closes SDK-1025