### PR TITLE
feat(realtime): update httpSend() to per-event broadcast URL format with binary support

### DIFF
--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -1,6 +1,7 @@
 import ConcurrencyExtras
 public import Foundation
 import HTTPTypes
+import Helpers
 import IssueReporting
 
 #if canImport(FoundationNetworking)
@@ -90,6 +91,7 @@ protocol RealtimeChannelProtocol: AnyObject, Sendable {
 /// - ``broadcast(event:data:)``
 /// - ``httpSend(event:message:timeout:)-8v03n``
 /// - ``httpSend(event:message:timeout:)-5hhoc``
+/// - ``httpSend(event:data:timeout:)``
 /// ### Presence
 /// - ``track(_:)``
 /// - ``track(state:)``
@@ -314,6 +316,9 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// WebSocket state. Use it when you need guaranteed REST delivery or want to send
   /// a broadcast before subscribing to the channel.
   ///
+  /// > Important: Requires a Realtime server version >= 2.97.0. Older servers don't expose
+  /// > the per-event `/api/broadcast/{topic}/events/{event}` endpoint this method targets.
+  ///
   /// - Parameters:
   ///   - event: The broadcast event name.
   ///   - message: A `Codable` value to send as the message payload.
@@ -333,6 +338,9 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// WebSocket state. Use it when you need guaranteed REST delivery or want to send
   /// a broadcast before subscribing to the channel.
   ///
+  /// > Important: Requires a Realtime server version >= 2.97.0. Older servers don't expose
+  /// > the per-event `/api/broadcast/{topic}/events/{event}` endpoint this method targets.
+  ///
   /// - Parameters:
   ///   - event: The broadcast event name.
   ///   - message: A ``JSONObject`` to send as the message payload.
@@ -347,27 +355,18 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
       throw RealtimeError("Access token is required for httpSend()")
     }
 
+    let isPrivate = await config.isPrivate
+
     var headers: HTTPFields = [.contentType: "application/json"]
     if let apiKey = socket.options.apikey {
       headers[.apiKey] = apiKey
     }
     headers[.authorization] = "Bearer \(accessToken)"
 
-    let body = try await JSONEncoder.supabase().encode(
-      BroadcastMessagePayload(
-        messages: [
-          BroadcastMessagePayload.Message(
-            topic: subTopic,
-            event: event,
-            payload: message,
-            private: config.isPrivate
-          )
-        ]
-      )
-    )
+    let body = try JSONEncoder.supabase().encode(message)
 
     let request = HTTPRequest(
-      url: socket.broadcastURL,
+      url: socket.broadcastURL(topic: subTopic, event: event, isPrivate: isPrivate),
       method: .post,
       headers: headers,
       body: body
@@ -377,6 +376,55 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
       [self] in try await socket.http.send(request)
     }
 
+    try Self.validateHTTPSendResponse(response)
+  }
+
+  /// Sends a binary broadcast message via the REST API.
+  ///
+  /// This method always targets the REST broadcast endpoint regardless of the current
+  /// WebSocket state. The payload is sent as-is with an `application/octet-stream`
+  /// content type — use this for raw binary payloads (e.g. images, custom binary formats)
+  /// that shouldn't be JSON-encoded.
+  ///
+  /// > Important: Requires a Realtime server version >= 2.97.0.
+  ///
+  /// - Parameters:
+  ///   - event: The broadcast event name.
+  ///   - data: Raw binary data to send as the request body.
+  ///   - timeout: An optional timeout in seconds. Defaults to the socket's configured timeout.
+  /// - Throws: A ``RealtimeError`` if the access token is missing or the request fails.
+  public func httpSend(
+    event: String,
+    data: Data,
+    timeout: TimeInterval? = nil
+  ) async throws {
+    guard let accessToken = await socket._getAccessToken() else {
+      throw RealtimeError("Access token is required for httpSend()")
+    }
+
+    let isPrivate = await config.isPrivate
+
+    var headers: HTTPFields = [.contentType: "application/octet-stream"]
+    if let apiKey = socket.options.apikey {
+      headers[.apiKey] = apiKey
+    }
+    headers[.authorization] = "Bearer \(accessToken)"
+
+    let request = HTTPRequest(
+      url: socket.broadcastURL(topic: subTopic, event: event, isPrivate: isPrivate),
+      method: .post,
+      headers: headers,
+      body: data
+    )
+
+    let response = try await withTimeout(interval: timeout ?? socket.options.timeoutInterval) {
+      [self] in try await socket.http.send(request)
+    }
+
+    try Self.validateHTTPSendResponse(response)
+  }
+
+  private static func validateHTTPSendResponse(_ response: Helpers.HTTPResponse) throws {
     guard response.statusCode == 202 else {
       // Try to parse error message from response body
       var errorMessage = HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
@@ -435,21 +483,10 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
       let task = Task { [headers] in
         _ = try? await socket.http.send(
           HTTPRequest(
-            url: socket.broadcastURL,
+            url: socket.broadcastURL(topic: subTopic, event: event, isPrivate: config.isPrivate),
             method: .post,
             headers: headers,
-            body: JSONEncoder.supabase().encode(
-              BroadcastMessagePayload(
-                messages: [
-                  BroadcastMessagePayload.Message(
-                    topic: subTopic,
-                    event: event,
-                    payload: message,
-                    private: config.isPrivate
-                  )
-                ]
-              )
-            )
+            body: JSONEncoder.supabase().encode(message)
           )
         )
       }

--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -23,7 +23,7 @@ protocol RealtimeClientProtocol: AnyObject, Sendable {
   var status: RealtimeClientStatus { get }
   var options: RealtimeClientOptions { get }
   var http: any HTTPClientType { get }
-  var broadcastURL: URL { get }
+  func broadcastURL(topic: String, event: String, isPrivate: Bool) -> URL
 
   func connect() async
   func push(_ message: RealtimeMessageV2)
@@ -988,7 +988,47 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     return url
   }
 
-  var broadcastURL: URL {
-    url.appendingPathComponent("api/broadcast")
+  /// Builds the REST broadcast URL for a single event: `.../api/broadcast/{topic}/events/{event}`.
+  ///
+  /// Topic and event are percent-encoded as individual path segments (so values containing
+  /// `/` don't introduce extra path components), and a private channel adds `?private=true`.
+  func broadcastURL(topic: String, event: String, isPrivate: Bool) -> URL {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      return url
+    }
+
+    let encodedTopic =
+      topic.addingPercentEncoding(withAllowedCharacters: .sbURLPathComponentAllowed) ?? topic
+    let encodedEvent =
+      event.addingPercentEncoding(withAllowedCharacters: .sbURLPathComponentAllowed) ?? event
+
+    var path = components.percentEncodedPath
+    if path.hasSuffix("/") { path.removeLast() }
+    path += "/api/broadcast/\(encodedTopic)/events/\(encodedEvent)"
+    components.percentEncodedPath = path
+
+    if isPrivate {
+      components.queryItems = [URLQueryItem(name: "private", value: "true")]
+    }
+
+    guard let url = components.url else {
+      return url
+    }
+
+    return url
   }
+}
+
+extension CharacterSet {
+  /// Characters allowed in a single percent-encoded URL path segment (e.g. a broadcast
+  /// topic or event name).
+  ///
+  /// Restricted to RFC 3986 "unreserved" characters so values containing `/`, `:`, or other
+  /// reserved characters are always escaped rather than being interpreted as additional
+  /// path structure.
+  static let sbURLPathComponentAllowed: CharacterSet = {
+    var allowed = CharacterSet.alphanumerics
+    allowed.insert(charactersIn: "-._~")
+    return allowed
+  }()
 }

--- a/Sources/RealtimeV2/Types.swift
+++ b/Sources/RealtimeV2/Types.swift
@@ -336,14 +336,3 @@ public enum LogLevel: String, Sendable {
   /// Error messages only.
   case error
 }
-
-struct BroadcastMessagePayload: Encodable {
-  let messages: [Message]
-
-  struct Message: Encodable {
-    let topic: String
-    let event: String
-    let payload: JSONObject
-    let `private`: Bool
-  }
-}

--- a/Tests/RealtimeTests/PushV2Tests.swift
+++ b/Tests/RealtimeTests/PushV2Tests.swift
@@ -299,7 +299,10 @@ private final class MockRealtimeClient: RealtimeClientProtocol, @unchecked Senda
   private let _status = LockIsolated<RealtimeClientStatus>(.connected)
   let options: RealtimeClientOptions
   let http: any HTTPClientType = MockHTTPClient()
-  let broadcastURL = URL(string: "https://test.supabase.co/api/broadcast")!
+
+  func broadcastURL(topic: String, event: String, isPrivate: Bool) -> URL {
+    URL(string: "https://test.supabase.co/api/broadcast")!
+  }
 
   var status: RealtimeClientStatus {
     _status.value

--- a/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
@@ -246,14 +246,14 @@ import XCTest
       XCTAssertEqual(payload?["payload"]?.objectValue?["key"]?.stringValue, "value")
     }
 
-    // MARK: - REST broadcast body uses the sub-topic (without `realtime:` prefix)
+    // MARK: - REST broadcast URL uses the sub-topic (without `realtime:` prefix)
 
-    func testHttpSend_bodyTopicHasNoRealtimePrefix() async throws {
+    func testHttpSend_urlUsesSubTopicWithoutRealtimePrefix() async throws {
       await http.any { _ in
         HTTPResponse(
           data: Data(),
           response: HTTPURLResponse(
-            url: self.sut.broadcastURL,
+            url: self.url,
             statusCode: 202,
             httpVersion: nil,
             headerFields: nil
@@ -269,10 +269,12 @@ import XCTest
       )
 
       let request = await http.receivedRequests.last
+      let url = try XCTUnwrap(request?.url)
+      XCTAssertEqual(url.path, "/realtime/v1/api/broadcast/test/events/my_event")
+
       let body = try XCTUnwrap(request?.body)
       let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
-      let messages = json?["messages"] as? [[String: Any]]
-      XCTAssertEqual(messages?.first?["topic"] as? String, "test")
+      XCTAssertEqual(json?["hello"] as? String, "world")
     }
 
     // MARK: - End-to-end binary frame via WebSocket

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -499,17 +499,116 @@ final class RealtimeChannelTests: XCTestCase {
     XCTAssertEqual(requests.count, 1)
 
     let request = requests[0]
-    XCTAssertEqual(request.url.absoluteString, "https://localhost:54321/realtime/v1/api/broadcast")
+    XCTAssertEqual(
+      request.url.absoluteString,
+      "https://localhost:54321/realtime/v1/api/broadcast/test-topic/events/test-event?private=true"
+    )
     XCTAssertEqual(request.method, .post)
     XCTAssertEqual(request.headers[.authorization], "Bearer test-token")
     XCTAssertEqual(request.headers[.apiKey], "test-key")
     XCTAssertEqual(request.headers[.contentType], "application/json")
 
-    let body = try JSONDecoder().decode(BroadcastPayload.self, from: request.body ?? Data())
-    XCTAssertEqual(body.messages.count, 1)
-    XCTAssertEqual(body.messages[0].topic, "test-topic")
-    XCTAssertEqual(body.messages[0].event, "test-event")
-    XCTAssertEqual(body.messages[0].private, true)
+    let body = try JSONDecoder().decode([String: String].self, from: request.body ?? Data())
+    XCTAssertEqual(body, ["data": "explicit"])
+  }
+
+  func testHttpSendPercentEncodesTopicAndEventInURL() async throws {
+    let httpClient = HTTPClientMock()
+    await httpClient.when({ _ in true }) { _ in
+      HTTPResponse(
+        data: Data(),
+        response: HTTPURLResponse(
+          url: URL(string: "https://localhost:54321/api/broadcast")!,
+          statusCode: 202,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    }
+    let (client, _) = FakeWebSocket.fakes()
+
+    let socket = RealtimeClientV2(
+      url: URL(string: "https://localhost:54321/realtime/v1")!,
+      options: RealtimeClientOptions(
+        headers: ["apikey": "test-key"],
+        accessToken: { "test-token" }
+      ),
+      wsTransport: { _, _ in client },
+      http: httpClient
+    )
+
+    let channel = socket.channel("room/one")
+
+    try await channel.httpSend(event: "cursor move", message: ["x": 1])
+
+    let requests = await httpClient.receivedRequests
+    XCTAssertEqual(
+      requests[0].url.absoluteString,
+      "https://localhost:54321/realtime/v1/api/broadcast/room%2Fone/events/cursor%20move"
+    )
+  }
+
+  func testHttpSendWithBinaryDataSendsOctetStream() async throws {
+    let httpClient = HTTPClientMock()
+    await httpClient.when({ _ in true }) { _ in
+      HTTPResponse(
+        data: Data(),
+        response: HTTPURLResponse(
+          url: URL(string: "https://localhost:54321/api/broadcast")!,
+          statusCode: 202,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+      )
+    }
+    let (client, _) = FakeWebSocket.fakes()
+
+    let socket = RealtimeClientV2(
+      url: URL(string: "https://localhost:54321/realtime/v1")!,
+      options: RealtimeClientOptions(
+        headers: ["apikey": "test-key"],
+        accessToken: { "test-token" }
+      ),
+      wsTransport: { _, _ in client },
+      http: httpClient
+    )
+
+    let channel = socket.channel("test-topic")
+
+    let payload = Data([0x01, 0x02, 0x03])
+    try await channel.httpSend(event: "binary-event", data: payload)
+
+    let requests = await httpClient.receivedRequests
+    XCTAssertEqual(requests.count, 1)
+
+    let request = requests[0]
+    XCTAssertEqual(
+      request.url.absoluteString,
+      "https://localhost:54321/realtime/v1/api/broadcast/test-topic/events/binary-event"
+    )
+    XCTAssertEqual(request.headers[.contentType], "application/octet-stream")
+    XCTAssertEqual(request.body, payload)
+  }
+
+  func testHttpSendWithBinaryDataThrowsWhenAccessTokenIsMissing() async {
+    let httpClient = HTTPClientMock()
+    let (client, _) = FakeWebSocket.fakes()
+
+    let socket = RealtimeClientV2(
+      url: URL(string: "https://localhost:54321/realtime/v1")!,
+      options: RealtimeClientOptions(headers: ["apikey": "test-key"]),
+      wsTransport: { _, _ in client },
+      http: httpClient
+    )
+
+    let channel = socket.channel("test-topic")
+
+    do {
+      try await channel.httpSend(event: "test", data: Data([0x01]))
+      XCTFail("Expected httpSend to throw an error when access token is missing")
+    } catch {
+      XCTAssertEqual(error.localizedDescription, "Access token is required for httpSend()")
+    }
   }
 
   func testHttpSendThrowsOnNon202Status() async {
@@ -692,18 +791,6 @@ final class RealtimeChannelTests: XCTestCase {
         "Expected status text fallback, got '\(error.localizedDescription)'"
       )
     }
-  }
-}
-
-// Helper struct for decoding broadcast payload in tests
-private struct BroadcastPayload: Decodable {
-  let messages: [Message]
-
-  struct Message: Decodable {
-    let topic: String
-    let event: String
-    let payload: [String: String]
-    let `private`: Bool
   }
 }
 

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -650,12 +650,12 @@ import XCTest
 
     func testBroadcastWithHTTP() async throws {
       await http.when {
-        $0.url.path.hasSuffix("broadcast")
+        $0.url.path.contains("/api/broadcast/")
       } return: { _ in
         HTTPResponse(
           data: "{}".data(using: .utf8)!,
           response: HTTPURLResponse(
-            url: self.sut.broadcastURL,
+            url: self.url,
             statusCode: 200,
             httpVersion: nil,
             headerFields: nil
@@ -677,8 +677,8 @@ import XCTest
         	--header "Authorization: Bearer custom.access.token" \
         	--header "Content-Type: application/json" \
         	--header "apiKey: publishable.api.key" \
-        	--data "{\"messages\":[{\"event\":\"test\",\"payload\":{\"value\":42},\"private\":false,\"topic\":\"public:messages\"}]}" \
-        	"http://localhost:54321/realtime/v1/api/broadcast"
+        	--data "{\"value\":42}" \
+        	"http://localhost:54321/realtime/v1/api/broadcast/public%3Amessages/events/test"
         """#
       }
     }


### PR DESCRIPTION
## Summary

Updates the Realtime `httpSend()` REST broadcast to match a breaking change in supabase-js (SDK parity): the endpoint moves from a single `POST /api/broadcast` with a `messages` array wrapper to a per-event URL, and adds binary payload support.

## Changes

- `httpSend(event:message:timeout:)`: now targets `POST /api/broadcast/{topic}/events/{event}` and sends the payload directly (no `messages` wrapper).
- Adds `?private=true` query param when the channel is private.
- Topic and event names are percent-encoded as individual URL path segments (so `/`, `:`, spaces, etc. don't corrupt the path).
- New `httpSend(event:data:timeout:)` overload for raw binary `Data` payloads, sent with `Content-Type: application/octet-stream`.
- The `broadcast(event:message:)` REST fallback (used when broadcasting before a channel subscribes) was updated to the same URL/body format for consistency.
- Removed the now-unused `BroadcastMessagePayload` wrapper type.
- `RealtimeClientProtocol.broadcastURL` changed from a stored property to `func broadcastURL(topic:event:isPrivate:) -> URL`.
- Doc comments on `httpSend` now note the `>= 2.97.0` Realtime server version requirement.

Deliberately out of scope: the deprecated V1 `Realtime` module (`Sources/Realtime/Deprecated/`) still uses the old `/api/broadcast` format. It's legacy and not the primary maintained surface; supabase-js parity only concerns the V2 client.

## Test plan

- [x] New tests: percent-encoding of `/` and space in topic/event, private-channel `?private=true` query param, binary payload + `application/octet-stream` header, missing-access-token error for both JSON and binary variants (`Tests/RealtimeTests/RealtimeChannelTests.swift`, `Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift`)
- [x] Updated existing snapshot/body-shape tests to the new URL/body format (`Tests/RealtimeTests/RealtimeTests.swift`, `Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift`)
- [x] Full suite green: `make PLATFORM=MACOS XCODEBUILD_ARGUMENT=test xcodebuild`
- [x] `make format`, `make spell-check`

## Linear

Closes SDK-1019