### PR TITLE
fix(storage): preserve limit/offset defaults when list() receives partial options

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -617,6 +617,8 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     let encoder = JSONEncoder.unconfiguredEncoder
 
     var options = options ?? defaultSearchOptions
+    options.limit = options.limit ?? defaultSearchOptions.limit
+    options.offset = options.offset ?? defaultSearchOptions.offset
     options.prefix = path ?? ""
 
     return try await execute(

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -82,6 +82,58 @@ final class StorageFileAPITests: XCTestCase {
     XCTAssertEqual(result[0].name, "test.txt")
   }
 
+  func testListFilesPreservesDefaultLimitWhenOnlyOffsetProvided() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/list/bucket"),
+      statusCode: 200,
+      data: [.post: Data("[]".utf8)]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "Content-Length: 84" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	--data "{\"limit\":100,\"offset\":10,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
+      	"http://localhost:54321/storage/v1/object/list/bucket"
+      """#
+    }
+    .register()
+
+    _ = try await storage.from("bucket").list(
+      path: "folder",
+      options: SearchOptions(offset: 10, sortBy: SortBy(column: "name", order: .ascending))
+    )
+  }
+
+  func testListFilesPreservesDefaultOffsetWhenOnlyLimitProvided() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/list/bucket"),
+      statusCode: 200,
+      data: [.post: Data("[]".utf8)]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "Content-Length: 82" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	--data "{\"limit\":50,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
+      	"http://localhost:54321/storage/v1/object/list/bucket"
+      """#
+    }
+    .register()
+
+    _ = try await storage.from("bucket").list(
+      path: "folder",
+      options: SearchOptions(limit: 50, sortBy: SortBy(column: "name", order: .ascending))
+    )
+  }
+
   func testMove() async throws {
     Mock(
       url: url.appendingPathComponent("object/move"),

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -134,6 +134,33 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
+  func testListFilesWithExplicitZeroLimitIsNotTreatedAsMissing() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/list/bucket"),
+      statusCode: 200,
+      data: [.post: Data("[]".utf8)]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "Content-Length: 81" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	--data "{\"limit\":0,\"offset\":5,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
+      	"http://localhost:54321/storage/v1/object/list/bucket"
+      """#
+    }
+    .register()
+
+    _ = try await storage.from("bucket").list(
+      path: "folder",
+      options: SearchOptions(
+        limit: 0, offset: 5, sortBy: SortBy(column: "name", order: .ascending))
+    )
+  }
+
   func testMove() async throws {
     Mock(
       url: url.appendingPathComponent("object/move"),


### PR DESCRIPTION
## Summary

`StorageFileApi.list()` fell back to the SDK's default `SearchOptions` only when the caller passed no options at all. If a caller passed a `SearchOptions` value that set only one of `limit`/`offset` (or neither, e.g. only `search`), the other field was dropped entirely instead of falling back to the documented defaults (`limit: 100`, `offset: 0`).

This is a sibling fix to #1084 (same root cause, different field — `sortBy`). Scoped separately since the two touch disjoint fields and are independently revertable; combining them into one PR wasn't necessary.

## Changes

- Storage: `list()` now merges `limit`/`offset` against the defaults individually (`options.limit = options.limit ?? defaultSearchOptions.limit`, same for `offset`) before encoding, same pattern as the `sortBy` fix.
- Tests: added `testListFilesPreservesDefaultLimitWhenOnlyOffsetProvided`, `testListFilesPreservesDefaultOffsetWhenOnlyLimitProvided`, and `testListFilesWithExplicitZeroLimitIsNotTreatedAsMissing` (confirms an explicit `limit: 0` isn't mistaken for "absent" by the `??` merge).

## Root cause

[`Sources/Storage/StorageFileApi.swift:619`](Sources/Storage/StorageFileApi.swift#L619) — `var options = options ?? defaultSearchOptions` swaps the entire options struct wholesale, so once a caller supplies any `SearchOptions`, any field they didn't explicitly set (there's no per-field fallback in `SearchOptions.init`) is sent as absent rather than defaulted — contradicting the documented contract in [`Types.swift`](Sources/Storage/Types.swift#L33) ("Defaults to 100" / "Defaults to 0").

## Test plan

- [x] Reproduction tests added: `Tests/StorageTests/StorageFileAPITests.swift`
- [x] Full `StorageTests` suite green: `xcodebuild test -only-testing:StorageTests` — 135/135 passing
- [x] No options / full options cases still covered by existing tests (no regression)