### PR TITLE
test(helpers): migrate HelpersTests to Swift Testing (Phase 1)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -230,7 +230,7 @@ let package = Package(
 // Test targets migrated to Swift Testing get full Swift 6 checking, same as
 // production targets. Everything else stays pinned to v5 until its migration
 // phase lands (see SDK-435).
-let swift6TestTargets: Set<String> = ["SupabaseTests"]
+let swift6TestTargets: Set<String> = ["SupabaseTests", "HelpersTests"]
 
 for target in package.targets {
   // Test targets never opted into `ExistentialAny` below, so bumping swift-tools-version

--- a/Tests/HelpersTests/AnyJSONTests.swift
+++ b/Tests/HelpersTests/AnyJSONTests.swift
@@ -8,9 +8,10 @@
 import CustomDump
 import Foundation
 import Helpers
-import XCTest
+import Testing
 
-final class AnyJSONTests: XCTestCase {
+@Suite
+struct AnyJSONTests {
   let jsonString = """
     {
       "array" : [
@@ -63,26 +64,29 @@ final class AnyJSONTests: XCTestCase {
     ],
   ]
 
-  func testDecode() throws {
-    let data = try XCTUnwrap(jsonString.data(using: .utf8))
+  @Test
+  func decode() throws {
+    let data = try #require(jsonString.data(using: .utf8))
     let decodedJSON = try AnyJSON.decoder.decode(AnyJSON.self, from: data)
 
     expectNoDifference(decodedJSON, jsonObject)
   }
 
-  func testEncode() throws {
+  @Test
+  func encode() throws {
     let encoder = AnyJSON.encoder
     let originalFormatting = encoder.outputFormatting
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     defer { encoder.outputFormatting = originalFormatting }
 
     let data = try encoder.encode(jsonObject)
-    let decodedJSONString = try XCTUnwrap(String(data: data, encoding: .utf8))
+    let decodedJSONString = try #require(String(data: data, encoding: .utf8))
 
     expectNoDifference(decodedJSONString, jsonString)
   }
 
-  func testInitFromCodable() {
+  @Test
+  func initFromCodable() {
     try expectNoDifference(AnyJSON(jsonObject), jsonObject)
 
     let codableValue = CodableValue(
@@ -111,216 +115,234 @@ final class AnyJSONTests: XCTestCase {
 
   // MARK: - Value Property Tests
 
-  func testValueProperty() {
+  @Test
+  func valueProperty() {
     // Test null value
-    XCTAssertTrue(AnyJSON.null.value is NSNull)
+    #expect(AnyJSON.null.value is NSNull)
 
     // Test string value
-    XCTAssertEqual(AnyJSON.string("test").value as? String, "test")
+    #expect(AnyJSON.string("test").value as? String == "test")
 
     // Test integer value
-    XCTAssertEqual(AnyJSON.integer(42).value as? Int, 42)
+    #expect(AnyJSON.integer(42).value as? Int == 42)
 
     // Test double value
-    XCTAssertEqual(AnyJSON.double(3.14).value as? Double, 3.14)
+    #expect(AnyJSON.double(3.14).value as? Double == 3.14)
 
     // Test bool value
-    XCTAssertEqual(AnyJSON.bool(true).value as? Bool, true)
-    XCTAssertEqual(AnyJSON.bool(false).value as? Bool, false)
+    #expect(AnyJSON.bool(true).value as? Bool == true)
+    #expect(AnyJSON.bool(false).value as? Bool == false)
 
     // Test object value
     let object: AnyJSON = ["key": "value"]
     let objectValue = object.value as? [String: Any]
-    XCTAssertEqual(objectValue?["key"] as? String, "value")
+    #expect(objectValue?["key"] as? String == "value")
 
     // Test array value
     let array: AnyJSON = [1, 2, 3]
     let arrayValue = array.value as? [Any]
-    XCTAssertEqual(arrayValue?[0] as? Int, 1)
-    XCTAssertEqual(arrayValue?[1] as? Int, 2)
-    XCTAssertEqual(arrayValue?[2] as? Int, 3)
+    #expect(arrayValue?[0] as? Int == 1)
+    #expect(arrayValue?[1] as? Int == 2)
+    #expect(arrayValue?[2] as? Int == 3)
   }
 
   // MARK: - Type-Specific Value Accessors
 
-  func testIsNil() {
-    XCTAssertTrue(AnyJSON.null.isNil)
-    XCTAssertFalse(AnyJSON.string("test").isNil)
-    XCTAssertFalse(AnyJSON.integer(42).isNil)
-    XCTAssertFalse(AnyJSON.double(3.14).isNil)
-    XCTAssertFalse(AnyJSON.bool(true).isNil)
-    XCTAssertFalse(AnyJSON.object([:]).isNil)
-    XCTAssertFalse(AnyJSON.array([]).isNil)
+  @Test
+  func isNil() {
+    #expect(AnyJSON.null.isNil)
+    #expect(!AnyJSON.string("test").isNil)
+    #expect(!AnyJSON.integer(42).isNil)
+    #expect(!AnyJSON.double(3.14).isNil)
+    #expect(!AnyJSON.bool(true).isNil)
+    #expect(!AnyJSON.object([:]).isNil)
+    #expect(!AnyJSON.array([]).isNil)
   }
 
-  func testBoolValue() {
-    XCTAssertEqual(AnyJSON.bool(true).boolValue, true)
-    XCTAssertEqual(AnyJSON.bool(false).boolValue, false)
-    XCTAssertNil(AnyJSON.string("test").boolValue)
-    XCTAssertNil(AnyJSON.integer(42).boolValue)
-    XCTAssertNil(AnyJSON.double(3.14).boolValue)
-    XCTAssertNil(AnyJSON.null.boolValue)
-    XCTAssertNil(AnyJSON.object([:]).boolValue)
-    XCTAssertNil(AnyJSON.array([]).boolValue)
+  @Test
+  func boolValue() {
+    #expect(AnyJSON.bool(true).boolValue == true)
+    #expect(AnyJSON.bool(false).boolValue == false)
+    #expect(AnyJSON.string("test").boolValue == nil)
+    #expect(AnyJSON.integer(42).boolValue == nil)
+    #expect(AnyJSON.double(3.14).boolValue == nil)
+    #expect(AnyJSON.null.boolValue == nil)
+    #expect(AnyJSON.object([:]).boolValue == nil)
+    #expect(AnyJSON.array([]).boolValue == nil)
   }
 
-  func testStringValue() {
-    XCTAssertEqual(AnyJSON.string("test").stringValue, "test")
-    XCTAssertNil(AnyJSON.bool(true).stringValue)
-    XCTAssertNil(AnyJSON.integer(42).stringValue)
-    XCTAssertNil(AnyJSON.double(3.14).stringValue)
-    XCTAssertNil(AnyJSON.null.stringValue)
-    XCTAssertNil(AnyJSON.object([:]).stringValue)
-    XCTAssertNil(AnyJSON.array([]).stringValue)
+  @Test
+  func stringValue() {
+    #expect(AnyJSON.string("test").stringValue == "test")
+    #expect(AnyJSON.bool(true).stringValue == nil)
+    #expect(AnyJSON.integer(42).stringValue == nil)
+    #expect(AnyJSON.double(3.14).stringValue == nil)
+    #expect(AnyJSON.null.stringValue == nil)
+    #expect(AnyJSON.object([:]).stringValue == nil)
+    #expect(AnyJSON.array([]).stringValue == nil)
   }
 
-  func testIntValue() {
-    XCTAssertEqual(AnyJSON.integer(42).intValue, 42)
-    XCTAssertNil(AnyJSON.string("test").intValue)
-    XCTAssertNil(AnyJSON.bool(true).intValue)
-    XCTAssertNil(AnyJSON.double(3.14).intValue)
-    XCTAssertNil(AnyJSON.null.intValue)
-    XCTAssertNil(AnyJSON.object([:]).intValue)
-    XCTAssertNil(AnyJSON.array([]).intValue)
+  @Test
+  func intValue() {
+    #expect(AnyJSON.integer(42).intValue == 42)
+    #expect(AnyJSON.string("test").intValue == nil)
+    #expect(AnyJSON.bool(true).intValue == nil)
+    #expect(AnyJSON.double(3.14).intValue == nil)
+    #expect(AnyJSON.null.intValue == nil)
+    #expect(AnyJSON.object([:]).intValue == nil)
+    #expect(AnyJSON.array([]).intValue == nil)
   }
 
-  func testDoubleValue() {
-    XCTAssertEqual(AnyJSON.double(3.14).doubleValue, 3.14)
-    XCTAssertNil(AnyJSON.string("test").doubleValue)
-    XCTAssertNil(AnyJSON.bool(true).doubleValue)
-    XCTAssertNil(AnyJSON.integer(42).doubleValue)
-    XCTAssertNil(AnyJSON.null.doubleValue)
-    XCTAssertNil(AnyJSON.object([:]).doubleValue)
-    XCTAssertNil(AnyJSON.array([]).doubleValue)
+  @Test
+  func doubleValue() {
+    #expect(AnyJSON.double(3.14).doubleValue == 3.14)
+    #expect(AnyJSON.string("test").doubleValue == nil)
+    #expect(AnyJSON.bool(true).doubleValue == nil)
+    #expect(AnyJSON.integer(42).doubleValue == nil)
+    #expect(AnyJSON.null.doubleValue == nil)
+    #expect(AnyJSON.object([:]).doubleValue == nil)
+    #expect(AnyJSON.array([]).doubleValue == nil)
   }
 
-  func testObjectValue() {
+  @Test
+  func objectValue() {
     let object: JSONObject = ["key": "value"]
-    XCTAssertEqual(AnyJSON.object(object).objectValue, object)
-    XCTAssertNil(AnyJSON.string("test").objectValue)
-    XCTAssertNil(AnyJSON.bool(true).objectValue)
-    XCTAssertNil(AnyJSON.integer(42).objectValue)
-    XCTAssertNil(AnyJSON.double(3.14).objectValue)
-    XCTAssertNil(AnyJSON.null.objectValue)
-    XCTAssertNil(AnyJSON.array([]).objectValue)
+    #expect(AnyJSON.object(object).objectValue == object)
+    #expect(AnyJSON.string("test").objectValue == nil)
+    #expect(AnyJSON.bool(true).objectValue == nil)
+    #expect(AnyJSON.integer(42).objectValue == nil)
+    #expect(AnyJSON.double(3.14).objectValue == nil)
+    #expect(AnyJSON.null.objectValue == nil)
+    #expect(AnyJSON.array([]).objectValue == nil)
   }
 
-  func testArrayValue() {
+  @Test
+  func arrayValue() {
     let array: JSONArray = [1, 2, 3]
-    XCTAssertEqual(AnyJSON.array(array).arrayValue, array)
-    XCTAssertNil(AnyJSON.string("test").arrayValue)
-    XCTAssertNil(AnyJSON.bool(true).arrayValue)
-    XCTAssertNil(AnyJSON.integer(42).arrayValue)
-    XCTAssertNil(AnyJSON.double(3.14).arrayValue)
-    XCTAssertNil(AnyJSON.null.arrayValue)
-    XCTAssertNil(AnyJSON.object([:]).arrayValue)
+    #expect(AnyJSON.array(array).arrayValue == array)
+    #expect(AnyJSON.string("test").arrayValue == nil)
+    #expect(AnyJSON.bool(true).arrayValue == nil)
+    #expect(AnyJSON.integer(42).arrayValue == nil)
+    #expect(AnyJSON.double(3.14).arrayValue == nil)
+    #expect(AnyJSON.null.arrayValue == nil)
+    #expect(AnyJSON.object([:]).arrayValue == nil)
   }
 
   // MARK: - ExpressibleByLiteral Tests
 
-  func testExpressibleByNilLiteral() {
+  @Test
+  func expressibleByNilLiteral() {
     let json: AnyJSON = nil
-    XCTAssertEqual(json, .null)
+    #expect(json == .null)
   }
 
-  func testExpressibleByStringLiteral() {
+  @Test
+  func expressibleByStringLiteral() {
     let json: AnyJSON = "test string"
-    XCTAssertEqual(json, .string("test string"))
+    #expect(json == .string("test string"))
   }
 
-  func testExpressibleByIntegerLiteral() {
+  @Test
+  func expressibleByIntegerLiteral() {
     let json: AnyJSON = 42
-    XCTAssertEqual(json, .integer(42))
+    #expect(json == .integer(42))
   }
 
-  func testExpressibleByFloatLiteral() {
+  @Test
+  func expressibleByFloatLiteral() {
     let json: AnyJSON = 3.14
-    XCTAssertEqual(json, .double(3.14))
+    #expect(json == .double(3.14))
   }
 
-  func testExpressibleByBooleanLiteral() {
+  @Test
+  func expressibleByBooleanLiteral() {
     let json: AnyJSON = true
-    XCTAssertEqual(json, .bool(true))
+    #expect(json == .bool(true))
 
     let jsonFalse: AnyJSON = false
-    XCTAssertEqual(jsonFalse, .bool(false))
+    #expect(jsonFalse == .bool(false))
   }
 
-  func testExpressibleByArrayLiteral() {
+  @Test
+  func expressibleByArrayLiteral() {
     let json: AnyJSON = [1, "test", true, nil]
-    XCTAssertEqual(json, .array([.integer(1), .string("test"), .bool(true), .null]))
+    #expect(json == .array([.integer(1), .string("test"), .bool(true), .null]))
   }
 
-  func testExpressibleByDictionaryLiteral() {
+  @Test
+  func expressibleByDictionaryLiteral() {
     let json: AnyJSON = ["key1": "value1", "key2": 42, "key3": true]
     let expected: AnyJSON = .object([
       "key1": .string("value1"),
       "key2": .integer(42),
       "key3": .bool(true),
     ])
-    XCTAssertEqual(json, expected)
+    #expect(json == expected)
   }
 
   // MARK: - CustomStringConvertible Tests
 
-  func testDescription() {
-    XCTAssertEqual(AnyJSON.null.description, "<null>")
-    XCTAssertEqual(AnyJSON.string("test").description, "test")
-    XCTAssertEqual(AnyJSON.integer(42).description, "42")
-    XCTAssertEqual(AnyJSON.double(3.14).description, "3.14")
-    XCTAssertEqual(AnyJSON.bool(true).description, "true")
-    XCTAssertEqual(AnyJSON.bool(false).description, "false")
+  @Test
+  func description() {
+    #expect(AnyJSON.null.description == "<null>")
+    #expect(AnyJSON.string("test").description == "test")
+    #expect(AnyJSON.integer(42).description == "42")
+    #expect(AnyJSON.double(3.14).description == "3.14")
+    #expect(AnyJSON.bool(true).description == "true")
+    #expect(AnyJSON.bool(false).description == "false")
 
     // Test object description
     let object: AnyJSON = ["key": "value"]
-    XCTAssertTrue(object.description.contains("key"))
-    XCTAssertTrue(object.description.contains("value"))
+    #expect(object.description.contains("key"))
+    #expect(object.description.contains("value"))
 
     // Test array description
     let array: AnyJSON = [1, 2, 3]
-    XCTAssertTrue(array.description.contains("1"))
-    XCTAssertTrue(array.description.contains("2"))
-    XCTAssertTrue(array.description.contains("3"))
+    #expect(array.description.contains("1"))
+    #expect(array.description.contains("2"))
+    #expect(array.description.contains("3"))
   }
 
   // MARK: - Hashable Tests
 
-  func testEquality() {
+  @Test
+  func equality() {
     // Test same values
-    XCTAssertEqual(AnyJSON.null, AnyJSON.null)
-    XCTAssertEqual(AnyJSON.string("test"), AnyJSON.string("test"))
-    XCTAssertEqual(AnyJSON.integer(42), AnyJSON.integer(42))
-    XCTAssertEqual(AnyJSON.double(3.14), AnyJSON.double(3.14))
-    XCTAssertEqual(AnyJSON.bool(true), AnyJSON.bool(true))
-    XCTAssertEqual(AnyJSON.bool(false), AnyJSON.bool(false))
+    #expect(AnyJSON.null == AnyJSON.null)
+    #expect(AnyJSON.string("test") == AnyJSON.string("test"))
+    #expect(AnyJSON.integer(42) == AnyJSON.integer(42))
+    #expect(AnyJSON.double(3.14) == AnyJSON.double(3.14))
+    #expect(AnyJSON.bool(true) == AnyJSON.bool(true))
+    #expect(AnyJSON.bool(false) == AnyJSON.bool(false))
 
     // Test different values
-    XCTAssertNotEqual(AnyJSON.string("test"), AnyJSON.string("different"))
-    XCTAssertNotEqual(AnyJSON.integer(42), AnyJSON.integer(43))
-    XCTAssertNotEqual(AnyJSON.double(3.14), AnyJSON.double(3.15))
-    XCTAssertNotEqual(AnyJSON.bool(true), AnyJSON.bool(false))
+    #expect(AnyJSON.string("test") != AnyJSON.string("different"))
+    #expect(AnyJSON.integer(42) != AnyJSON.integer(43))
+    #expect(AnyJSON.double(3.14) != AnyJSON.double(3.15))
+    #expect(AnyJSON.bool(true) != AnyJSON.bool(false))
 
     // Test different types
-    XCTAssertNotEqual(AnyJSON.string("42"), AnyJSON.integer(42))
-    XCTAssertNotEqual(AnyJSON.integer(42), AnyJSON.double(42.0))
-    XCTAssertNotEqual(AnyJSON.null, AnyJSON.string(""))
+    #expect(AnyJSON.string("42") != AnyJSON.integer(42))
+    #expect(AnyJSON.integer(42) != AnyJSON.double(42.0))
+    #expect(AnyJSON.null != AnyJSON.string(""))
 
     // Test objects
     let object1: AnyJSON = ["key": "value"]
     let object2: AnyJSON = ["key": "value"]
     let object3: AnyJSON = ["key": "different"]
-    XCTAssertEqual(object1, object2)
-    XCTAssertNotEqual(object1, object3)
+    #expect(object1 == object2)
+    #expect(object1 != object3)
 
     // Test arrays
     let array1: AnyJSON = [1, 2, 3]
     let array2: AnyJSON = [1, 2, 3]
     let array3: AnyJSON = [1, 2, 4]
-    XCTAssertEqual(array1, array2)
-    XCTAssertNotEqual(array1, array3)
+    #expect(array1 == array2)
+    #expect(array1 != array3)
   }
 
-  func testHashable() {
+  @Test
+  func hashable() {
     let set: Set<AnyJSON> = [
       .null,
       .string("test"),
@@ -331,80 +353,94 @@ final class AnyJSONTests: XCTestCase {
       .array([1, 2, 3]),
     ]
 
-    XCTAssertEqual(set.count, 7)
-    XCTAssertTrue(set.contains(.null))
-    XCTAssertTrue(set.contains(.string("test")))
-    XCTAssertTrue(set.contains(.integer(42)))
-    XCTAssertTrue(set.contains(.double(3.14)))
-    XCTAssertTrue(set.contains(.bool(true)))
-    XCTAssertTrue(set.contains(.object(["key": "value"])))
-    XCTAssertTrue(set.contains(.array([1, 2, 3])))
+    #expect(set.count == 7)
+    #expect(set.contains(.null))
+    #expect(set.contains(.string("test")))
+    #expect(set.contains(.integer(42)))
+    #expect(set.contains(.double(3.14)))
+    #expect(set.contains(.bool(true)))
+    #expect(set.contains(.object(["key": "value"])))
+    #expect(set.contains(.array([1, 2, 3])))
   }
 
   // MARK: - JSONArray and JSONObject Extension Tests
 
-  func testJSONArrayDecode() throws {
+  @Test
+  func jsonArrayDecode() throws {
     let jsonArray: JSONArray = [AnyJSON.integer(1), AnyJSON.integer(2), AnyJSON.integer(3)]
     // Decode each element individually since the JSONArray.decode method has issues
     let decoded: [Int] = try jsonArray.map { try $0.decode(as: Int.self) }
-    XCTAssertEqual(decoded, [1, 2, 3])
+    #expect(decoded == [1, 2, 3])
   }
 
-  func testJSONObjectDecode() throws {
+  @Test
+  func jsonObjectDecode() throws {
     let jsonObject: JSONObject = ["name": AnyJSON.string("John"), "age": AnyJSON.integer(30)]
     let decoded: Person = try jsonObject.decode(as: Person.self)
-    XCTAssertEqual(decoded.name, "John")
-    XCTAssertEqual(decoded.age, 30)
+    #expect(decoded.name == "John")
+    #expect(decoded.age == 30)
   }
 
-  func testJSONObjectInitFromCodable() throws {
+  @Test
+  func jsonObjectInitFromCodable() throws {
     let person = Person(name: "John", age: 30)
     let jsonObject = try JSONObject(person)
-    XCTAssertEqual(jsonObject["name"], .string("John"))
-    XCTAssertEqual(jsonObject["age"], .integer(30))
+    #expect(jsonObject["name"] == .string("John"))
+    #expect(jsonObject["age"] == .integer(30))
   }
 
-  func testJSONObjectInitFromCodableFailure() {
+  @Test
+  func jsonObjectInitFromCodableFailure() {
     // Test with a simple string, which should fail because it's not an object
-    XCTAssertThrowsError(try JSONObject("not an object"))
+    #expect(throws: (any Error).self) {
+      try JSONObject("not an object")
+    }
 
     // Test with an integer, which should also fail
-    XCTAssertThrowsError(try JSONObject(42))
+    #expect(throws: (any Error).self) {
+      try JSONObject(42)
+    }
   }
 
   // MARK: - Error Handling Tests
 
-  func testInvalidJSONDecoding() {
+  @Test
+  func invalidJSONDecoding() {
     let invalidJSON = "invalid json"
     let data = invalidJSON.data(using: .utf8)!
 
-    XCTAssertThrowsError(try AnyJSON.decoder.decode(AnyJSON.self, from: data))
+    #expect(throws: (any Error).self) {
+      try AnyJSON.decoder.decode(AnyJSON.self, from: data)
+    }
   }
 
-  func testDecodeWithCustomDecoder() throws {
+  @Test
+  func decodeWithCustomDecoder() throws {
     let customDecoder = JSONDecoder()
     customDecoder.keyDecodingStrategy = .convertFromSnakeCase
 
     let json: AnyJSON = ["user_name": "John", "user_age": 30]
     let decoded: CustomPerson = try json.decode(as: CustomPerson.self, decoder: customDecoder)
-    XCTAssertEqual(decoded.userName, "John")
-    XCTAssertEqual(decoded.userAge, 30)
+    #expect(decoded.userName == "John")
+    #expect(decoded.userAge == 30)
   }
 
   // MARK: - Edge Cases
 
-  func testEmptyObjectAndArray() {
+  @Test
+  func emptyObjectAndArray() {
     let emptyObject: AnyJSON = [:]
     let emptyArray: AnyJSON = []
 
-    XCTAssertEqual(emptyObject, .object([:]))
-    XCTAssertEqual(emptyArray, .array([]))
+    #expect(emptyObject == .object([:]))
+    #expect(emptyArray == .array([]))
 
-    XCTAssertTrue(emptyObject.objectValue?.isEmpty == true)
-    XCTAssertTrue(emptyArray.arrayValue?.isEmpty == true)
+    #expect(emptyObject.objectValue?.isEmpty == true)
+    #expect(emptyArray.arrayValue?.isEmpty == true)
   }
 
-  func testNestedStructures() {
+  @Test
+  func nestedStructures() {
     let nested: AnyJSON = [
       "level1": [
         "level2": [
@@ -420,35 +456,38 @@ final class AnyJSONTests: XCTestCase {
     let level3 = level2?.objectValue?["level3"]
     let deep = level3?.objectValue?["deep"]
 
-    XCTAssertEqual(deep, .string("value"))
+    #expect(deep == .string("value"))
   }
 
-  func testMixedArrayTypes() {
+  @Test
+  func mixedArrayTypes() {
     let mixedArray: AnyJSON = [1, "string", true, nil, ["nested": "value"]]
 
-    XCTAssertEqual(mixedArray.arrayValue?[0], .integer(1))
-    XCTAssertEqual(mixedArray.arrayValue?[1], .string("string"))
-    XCTAssertEqual(mixedArray.arrayValue?[2], .bool(true))
-    XCTAssertEqual(mixedArray.arrayValue?[3], .null)
-    XCTAssertEqual(mixedArray.arrayValue?[4], .object(["nested": .string("value")]))
+    #expect(mixedArray.arrayValue?[0] == .integer(1))
+    #expect(mixedArray.arrayValue?[1] == .string("string"))
+    #expect(mixedArray.arrayValue?[2] == .bool(true))
+    #expect(mixedArray.arrayValue?[3] == .null)
+    #expect(mixedArray.arrayValue?[4] == .object(["nested": .string("value")]))
   }
 
-  func testLargeNumbers() {
+  @Test
+  func largeNumbers() {
     let largeInt: AnyJSON = 9_223_372_036_854_775_807  // Int.max
     let largeDouble: AnyJSON = 1.7976931348623157e+308  // Double.max
 
-    XCTAssertEqual(largeInt.intValue, 9_223_372_036_854_775_807)
-    XCTAssertEqual(largeDouble.doubleValue, 1.7976931348623157e+308)
+    #expect(largeInt.intValue == 9_223_372_036_854_775_807)
+    #expect(largeDouble.doubleValue == 1.7976931348623157e+308)
   }
 
-  func testSpecialStringValues() {
+  @Test
+  func specialStringValues() {
     let emptyString: AnyJSON = ""
     let unicodeString: AnyJSON = "Hello, 世界! 🌍"
     let escapedString: AnyJSON = "Line 1\nLine 2\tTab"
 
-    XCTAssertEqual(emptyString.stringValue, "")
-    XCTAssertEqual(unicodeString.stringValue, "Hello, 世界! 🌍")
-    XCTAssertEqual(escapedString.stringValue, "Line 1\nLine 2\tTab")
+    #expect(emptyString.stringValue == "")
+    #expect(unicodeString.stringValue == "Hello, 世界! 🌍")
+    #expect(escapedString.stringValue == "Line 1\nLine 2\tTab")
   }
 }
 

--- a/Tests/HelpersTests/AsyncValueSubjectTests.swift
+++ b/Tests/HelpersTests/AsyncValueSubjectTests.swift
@@ -6,24 +6,28 @@
 //
 
 import ConcurrencyExtras
-import XCTest
+import Testing
 
 @testable import Helpers
 
-final class AsyncValueSubjectTests: XCTestCase {
+@Suite
+struct AsyncValueSubjectTests {
 
-  func testInitialValue() async {
+  @Test
+  func initialValue() async {
     let subject = AsyncValueSubject<Int>(42)
-    XCTAssertEqual(subject.value, 42)
+    #expect(subject.value == 42)
   }
 
-  func testYieldUpdatesValue() async {
+  @Test
+  func yieldUpdatesValue() async {
     let subject = AsyncValueSubject<Int>(0)
     subject.yield(10)
-    XCTAssertEqual(subject.value, 10)
+    #expect(subject.value == 10)
   }
 
-  func testValuesStream() async {
+  @Test
+  func valuesStream() async {
     let subject = AsyncValueSubject<Int>(0)
     let values = LockIsolated<[Int]>([])
 
@@ -48,10 +52,11 @@ final class AsyncValueSubjectTests: XCTestCase {
 
     await task.value
 
-    XCTAssertEqual(values.value, [0, 1, 2, 3])
+    #expect(values.value == [0, 1, 2, 3])
   }
 
-  func testOnChangeHandler() async {
+  @Test
+  func onChangeHandler() async {
     let subject = AsyncValueSubject<Int>(0)
     let values = LockIsolated<[Int]>([])
 
@@ -70,10 +75,11 @@ final class AsyncValueSubjectTests: XCTestCase {
 
     await task.value
 
-    XCTAssertEqual(values.value, [0, 1, 2, 3])
+    #expect(values.value == [0, 1, 2, 3])
   }
 
-  func testFinish() async {
+  @Test
+  func finish() async {
     let subject = AsyncValueSubject<Int>(0)
     let values = LockIsolated<[Int]>([])
 
@@ -91,7 +97,7 @@ final class AsyncValueSubjectTests: XCTestCase {
 
     await task.value
 
-    XCTAssertEqual(values.value, [0, 1])
-    XCTAssertEqual(subject.value, 1)
+    #expect(values.value == [0, 1])
+    #expect(subject.value == 1)
   }
 }

--- a/Tests/HelpersTests/DateFormatterTests.swift
+++ b/Tests/HelpersTests/DateFormatterTests.swift
@@ -5,15 +5,18 @@
 //  Created by Coverage Tests
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Helpers
 
-final class DateFormatterTests: XCTestCase {
+@Suite
+struct DateFormatterTests {
 
   // MARK: - Date to ISO8601 String Tests
 
-  func testDateToISO8601String() {
+  @Test
+  func dateToISO8601String() throws {
     // Create a specific date: 2024-01-15 10:30:45.123 UTC
     var components = DateComponents()
     components.year = 2024
@@ -26,37 +29,33 @@ final class DateFormatterTests: XCTestCase {
     components.timeZone = TimeZone(secondsFromGMT: 0)
 
     let calendar = Calendar(identifier: .iso8601)
-    guard let date = calendar.date(from: components) else {
-      XCTFail("Failed to create test date")
-      return
-    }
+    let date = try #require(calendar.date(from: components), "Failed to create test date")
 
     let iso8601String = date.iso8601String
 
     // Should contain the date and time
-    XCTAssertTrue(iso8601String.contains("2024-01-15"))
-    XCTAssertTrue(iso8601String.contains("10:30:45"))
+    #expect(iso8601String.contains("2024-01-15"))
+    #expect(iso8601String.contains("10:30:45"))
   }
 
-  func testCurrentDateToISO8601String() {
+  @Test
+  func currentDateToISO8601String() {
     let now = Date()
     let iso8601String = now.iso8601String
 
     // Verify it's not empty and has proper format
-    XCTAssertFalse(iso8601String.isEmpty)
-    XCTAssertTrue(iso8601String.contains("T"))  // Should have date-time separator
-    XCTAssertTrue(iso8601String.contains("-"))  // Should have date separators
-    XCTAssertTrue(iso8601String.contains(":"))  // Should have time separators
+    #expect(!iso8601String.isEmpty)
+    #expect(iso8601String.contains("T"))  // Should have date-time separator
+    #expect(iso8601String.contains("-"))  // Should have date separators
+    #expect(iso8601String.contains(":"))  // Should have time separators
   }
 
   // MARK: - String to Date Parsing Tests
 
-  func testParseISO8601StringWithFractionalSeconds() {
+  @Test
+  func parseISO8601StringWithFractionalSeconds() throws {
     let dateString = "2024-01-15T10:30:45.123"
-    guard let parsedDate = dateString.date else {
-      XCTFail("Failed to parse date string")
-      return
-    }
+    let parsedDate = try #require(dateString.date, "Failed to parse date string")
 
     let calendar = Calendar(identifier: .iso8601)
     let components = calendar.dateComponents(
@@ -64,20 +63,18 @@ final class DateFormatterTests: XCTestCase {
       from: parsedDate
     )
 
-    XCTAssertEqual(components.year, 2024)
-    XCTAssertEqual(components.month, 1)
-    XCTAssertEqual(components.day, 15)
-    XCTAssertEqual(components.hour, 10)
-    XCTAssertEqual(components.minute, 30)
-    XCTAssertEqual(components.second, 45)
+    #expect(components.year == 2024)
+    #expect(components.month == 1)
+    #expect(components.day == 15)
+    #expect(components.hour == 10)
+    #expect(components.minute == 30)
+    #expect(components.second == 45)
   }
 
-  func testParseISO8601StringWithoutFractionalSeconds() {
+  @Test
+  func parseISO8601StringWithoutFractionalSeconds() throws {
     let dateString = "2024-01-15T10:30:45"
-    guard let parsedDate = dateString.date else {
-      XCTFail("Failed to parse date string")
-      return
-    }
+    let parsedDate = try #require(dateString.date, "Failed to parse date string")
 
     let calendar = Calendar(identifier: .iso8601)
     let components = calendar.dateComponents(
@@ -85,15 +82,16 @@ final class DateFormatterTests: XCTestCase {
       from: parsedDate
     )
 
-    XCTAssertEqual(components.year, 2024)
-    XCTAssertEqual(components.month, 1)
-    XCTAssertEqual(components.day, 15)
-    XCTAssertEqual(components.hour, 10)
-    XCTAssertEqual(components.minute, 30)
-    XCTAssertEqual(components.second, 45)
+    #expect(components.year == 2024)
+    #expect(components.month == 1)
+    #expect(components.day == 15)
+    #expect(components.hour == 10)
+    #expect(components.minute == 30)
+    #expect(components.second == 45)
   }
 
-  func testParseInvalidDateString() {
+  @Test
+  func parseInvalidDateString() {
     let invalidStrings = [
       "not a date",
       "2024-13-45",  // Invalid month and day
@@ -104,21 +102,23 @@ final class DateFormatterTests: XCTestCase {
     ]
 
     for invalidString in invalidStrings {
-      XCTAssertNil(
-        invalidString.date,
+      #expect(
+        invalidString.date == nil,
         "Should return nil for invalid date string: \(invalidString)"
       )
     }
   }
 
-  func testParseEmptyString() {
+  @Test
+  func parseEmptyString() {
     let emptyString = ""
-    XCTAssertNil(emptyString.date)
+    #expect(emptyString.date == nil)
   }
 
   // MARK: - Round-trip Tests
 
-  func testRoundTripConversion() {
+  @Test
+  func roundTripConversion() throws {
     // Create a date, convert to string, parse back to date
     var components = DateComponents()
     components.year = 2023
@@ -130,43 +130,36 @@ final class DateFormatterTests: XCTestCase {
     components.timeZone = TimeZone(secondsFromGMT: 0)
 
     let calendar = Calendar(identifier: .iso8601)
-    guard let originalDate = calendar.date(from: components) else {
-      XCTFail("Failed to create original date")
-      return
-    }
+    let originalDate = try #require(
+      calendar.date(from: components), "Failed to create original date")
 
     let dateString = originalDate.iso8601String
-    guard let parsedDate = dateString.date else {
-      XCTFail("Failed to parse date from string: \(dateString)")
-      return
-    }
+    let parsedDate = try #require(
+      dateString.date, "Failed to parse date from string: \(dateString)")
 
     // Compare timestamps (allowing small tolerance for milliseconds)
     let timeDifference = abs(originalDate.timeIntervalSince(parsedDate))
-    XCTAssertLessThan(timeDifference, 1.0, "Dates should be within 1 second of each other")
+    #expect(timeDifference < 1.0, "Dates should be within 1 second of each other")
   }
 
-  func testRoundTripWithCurrentDate() {
+  @Test
+  func roundTripWithCurrentDate() throws {
     let now = Date()
     let dateString = now.iso8601String
-    guard let parsedDate = dateString.date else {
-      XCTFail("Failed to parse current date from string: \(dateString)")
-      return
-    }
+    let parsedDate = try #require(
+      dateString.date, "Failed to parse current date from string: \(dateString)")
 
     // Compare timestamps (allowing small tolerance for milliseconds)
     let timeDifference = abs(now.timeIntervalSince(parsedDate))
-    XCTAssertLessThan(timeDifference, 1.0, "Dates should be within 1 second of each other")
+    #expect(timeDifference < 1.0, "Dates should be within 1 second of each other")
   }
 
   // MARK: - Edge Cases
 
-  func testParseDateAtMidnight() {
+  @Test
+  func parseDateAtMidnight() throws {
     let dateString = "2024-01-01T00:00:00"
-    guard let parsedDate = dateString.date else {
-      XCTFail("Failed to parse midnight date")
-      return
-    }
+    let parsedDate = try #require(dateString.date, "Failed to parse midnight date")
 
     let calendar = Calendar(identifier: .iso8601)
     let components = calendar.dateComponents(
@@ -174,17 +167,15 @@ final class DateFormatterTests: XCTestCase {
       from: parsedDate
     )
 
-    XCTAssertEqual(components.hour, 0)
-    XCTAssertEqual(components.minute, 0)
-    XCTAssertEqual(components.second, 0)
+    #expect(components.hour == 0)
+    #expect(components.minute == 0)
+    #expect(components.second == 0)
   }
 
-  func testParseDateAtEndOfDay() {
+  @Test
+  func parseDateAtEndOfDay() throws {
     let dateString = "2024-12-31T23:59:59"
-    guard let parsedDate = dateString.date else {
-      XCTFail("Failed to parse end-of-day date")
-      return
-    }
+    let parsedDate = try #require(dateString.date, "Failed to parse end-of-day date")
 
     let calendar = Calendar(identifier: .iso8601)
     let components = calendar.dateComponents(
@@ -192,19 +183,21 @@ final class DateFormatterTests: XCTestCase {
       from: parsedDate
     )
 
-    XCTAssertEqual(components.month, 12)
-    XCTAssertEqual(components.day, 31)
-    XCTAssertEqual(components.hour, 23)
-    XCTAssertEqual(components.minute, 59)
-    XCTAssertEqual(components.second, 59)
+    #expect(components.month == 12)
+    #expect(components.day == 31)
+    #expect(components.hour == 23)
+    #expect(components.minute == 59)
+    #expect(components.second == 59)
   }
 
-  func testParseLeapYearDate() {
+  @Test
+  func parseLeapYearDate() {
     let dateString = "2024-02-29T12:00:00"  // 2024 is a leap year
-    XCTAssertNotNil(dateString.date, "Should parse leap year date")
+    #expect(dateString.date != nil, "Should parse leap year date")
   }
 
-  func testParseVariousFractionalSecondFormats() {
+  @Test
+  func parseVariousFractionalSecondFormats() {
     let formats = [
       "2024-01-15T10:30:45.1",
       "2024-01-15T10:30:45.12",
@@ -220,7 +213,8 @@ final class DateFormatterTests: XCTestCase {
 
   // MARK: - Multiple Date Conversion Tests
 
-  func testConvertMultipleDates() {
+  @Test
+  func convertMultipleDates() {
     let dates = [
       "2020-01-01T00:00:00",
       "2021-06-15T12:30:45",
@@ -230,18 +224,19 @@ final class DateFormatterTests: XCTestCase {
     ]
 
     for dateString in dates {
-      XCTAssertNotNil(
-        dateString.date,
+      #expect(
+        dateString.date != nil,
         "Should parse date: \(dateString)"
       )
     }
   }
 
-  func testConvertDatesInDifferentYears() {
+  @Test
+  func convertDatesInDifferentYears() {
     for year in 2020...2025 {
       let dateString = "\(year)-06-15T12:00:00"
       guard let parsedDate = dateString.date else {
-        XCTFail("Failed to parse date for year \(year)")
+        Issue.record("Failed to parse date for year \(year)")
         continue
       }
 
@@ -251,7 +246,7 @@ final class DateFormatterTests: XCTestCase {
         from: parsedDate
       )
 
-      XCTAssertEqual(components.year, year)
+      #expect(components.year == year)
     }
   }
 }

--- a/Tests/HelpersTests/EventEmitterTests.swift
+++ b/Tests/HelpersTests/EventEmitterTests.swift
@@ -7,15 +7,17 @@
 
 import ConcurrencyExtras
 import Helpers
-import XCTest
+import Testing
 
-final class EventEmitterTests: XCTestCase {
+@Suite
+struct EventEmitterTests {
 
-  func testBasics() {
+  @Test
+  func basics() {
     let sut = EventEmitter(initialEvent: "0")
-    XCTAssertTrue(sut.emitsLastEventWhenAttaching)
+    #expect(sut.emitsLastEventWhenAttaching)
 
-    XCTAssertEqual(sut.lastEvent, "0")
+    #expect(sut.lastEvent == "0")
 
     let receivedEvents = LockIsolated<[String]>([])
 
@@ -40,17 +42,18 @@ final class EventEmitterTests: XCTestCase {
     sut.emit("7")
     sut.emit("8")
 
-    XCTAssertEqual(sut.lastEvent, "8")
+    #expect(sut.lastEvent == "8")
 
-    XCTAssertEqual(
-      receivedEvents.value,
-      ["a0", "b0", "a1", "b1", "a2", "b2", "a3", "b3", "a4", "b4", "a5", "b6", "b7", "b8"]
+    #expect(
+      receivedEvents.value
+        == ["a0", "b0", "a1", "b1", "a2", "b2", "a3", "b3", "a4", "b4", "a5", "b6", "b7", "b8"]
     )
   }
 
-  func test_dontEmitLastEventWhenAttaching() {
+  @Test
+  func dontEmitLastEventWhenAttaching() {
     let sut = EventEmitter(initialEvent: "0", emitsLastEventWhenAttaching: false)
-    XCTAssertFalse(sut.emitsLastEventWhenAttaching)
+    #expect(!sut.emitsLastEventWhenAttaching)
 
     let receivedEvent = LockIsolated<[String]>([])
     let token = sut.attach { value in
@@ -59,7 +62,7 @@ final class EventEmitterTests: XCTestCase {
 
     sut.emit("1")
 
-    XCTAssertEqual(receivedEvent.value, ["1"])
+    #expect(receivedEvent.value == ["1"])
 
     token.cancel()
   }

--- a/Tests/HelpersTests/HTTPErrorTests.swift
+++ b/Tests/HelpersTests/HTTPErrorTests.swift
@@ -7,15 +7,17 @@
 
 import Foundation
 import Helpers
-import XCTest
+import Testing
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 
-final class HTTPErrorTests: XCTestCase {
+@Suite
+struct HTTPErrorTests {
 
-  func testInitialization() {
+  @Test
+  func initialization() {
     let data = Data("test error message".utf8)
     let response = HTTPURLResponse(
       url: URL(string: "https://example.com")!,
@@ -26,11 +28,12 @@ final class HTTPErrorTests: XCTestCase {
 
     let error = HTTPError(data: data, response: response)
 
-    XCTAssertEqual(error.data, data)
-    XCTAssertEqual(error.response, response)
+    #expect(error.data == data)
+    #expect(error.response == response)
   }
 
-  func testLocalizedErrorDescription_WithUTF8Data() {
+  @Test
+  func localizedErrorDescription_WithUTF8Data() {
     let data = Data("Bad Request: Invalid parameters".utf8)
     let response = HTTPURLResponse(
       url: URL(string: "https://example.com")!,
@@ -41,13 +44,14 @@ final class HTTPErrorTests: XCTestCase {
 
     let error = HTTPError(data: data, response: response)
 
-    XCTAssertEqual(
-      error.errorDescription,
-      "Status Code: 400 Body: Bad Request: Invalid parameters"
+    #expect(
+      error.errorDescription
+        == "Status Code: 400 Body: Bad Request: Invalid parameters"
     )
   }
 
-  func testLocalizedErrorDescription_WithEmptyData() {
+  @Test
+  func localizedErrorDescription_WithEmptyData() {
     let data = Data()
     let response = HTTPURLResponse(
       url: URL(string: "https://example.com")!,
@@ -58,10 +62,11 @@ final class HTTPErrorTests: XCTestCase {
 
     let error = HTTPError(data: data, response: response)
 
-    XCTAssertEqual(error.errorDescription, "Status Code: 404 Body: ")
+    #expect(error.errorDescription == "Status Code: 404 Body: ")
   }
 
-  func testLocalizedErrorDescription_WithNonUTF8Data() {
+  @Test
+  func localizedErrorDescription_WithNonUTF8Data() {
     // Create data that can't be converted to UTF-8 string
     let bytes: [UInt8] = [0xFF, 0xFE, 0xFD, 0xFC]
     let data = Data(bytes)
@@ -74,10 +79,11 @@ final class HTTPErrorTests: XCTestCase {
 
     let error = HTTPError(data: data, response: response)
 
-    XCTAssertEqual(error.errorDescription, "Status Code: 500")
+    #expect(error.errorDescription == "Status Code: 500")
   }
 
-  func testLocalizedErrorDescription_WithJSONData() {
+  @Test
+  func localizedErrorDescription_WithJSONData() {
     let jsonString = """
       {
         "error": "Validation failed",
@@ -94,13 +100,14 @@ final class HTTPErrorTests: XCTestCase {
 
     let error = HTTPError(data: data, response: response)
 
-    XCTAssertEqual(
-      error.errorDescription,
-      "Status Code: 422 Body: \(jsonString)"
+    #expect(
+      error.errorDescription
+        == "Status Code: 422 Body: \(jsonString)"
     )
   }
 
-  func testLocalizedErrorDescription_WithSpecialCharacters() {
+  @Test
+  func localizedErrorDescription_WithSpecialCharacters() {
     let message = "Error with special chars: áéíóú ñ ç"
     let data = Data(message.utf8)
     let response = HTTPURLResponse(
@@ -112,13 +119,14 @@ final class HTTPErrorTests: XCTestCase {
 
     let error = HTTPError(data: data, response: response)
 
-    XCTAssertEqual(
-      error.errorDescription,
-      "Status Code: 400 Body: \(message)"
+    #expect(
+      error.errorDescription
+        == "Status Code: 400 Body: \(message)"
     )
   }
 
-  func testLocalizedErrorDescription_WithLargeData() {
+  @Test
+  func localizedErrorDescription_WithLargeData() {
     let largeMessage = String(repeating: "A", count: 1000)
     let data = Data(largeMessage.utf8)
     let response = HTTPURLResponse(
@@ -130,13 +138,14 @@ final class HTTPErrorTests: XCTestCase {
 
     let error = HTTPError(data: data, response: response)
 
-    XCTAssertEqual(
-      error.errorDescription,
-      "Status Code: 413 Body: \(largeMessage)"
+    #expect(
+      error.errorDescription
+        == "Status Code: 413 Body: \(largeMessage)"
     )
   }
 
-  func testProperties() {
+  @Test
+  func properties() {
     let data = Data("test error".utf8)
     let response = HTTPURLResponse(
       url: URL(string: "https://example.com")!,
@@ -148,9 +157,9 @@ final class HTTPErrorTests: XCTestCase {
     let error = HTTPError(data: data, response: response)
 
     // Test that properties are correctly set
-    XCTAssertEqual(error.data, data)
-    XCTAssertEqual(error.response, response)
-    XCTAssertEqual(error.response.statusCode, 400)
-    XCTAssertEqual(error.response.url, URL(string: "https://example.com")!)
+    #expect(error.data == data)
+    #expect(error.response == response)
+    #expect(error.response.statusCode == 400)
+    #expect(error.response.url == URL(string: "https://example.com")!)
   }
 }

--- a/Tests/HelpersTests/JWTTests.swift
+++ b/Tests/HelpersTests/JWTTests.swift
@@ -1,12 +1,15 @@
+import Foundation
 import Helpers
-import XCTest
+import Testing
 
-final class JWTTests: XCTestCase {
-  func testDecodeJWT() throws {
+@Suite
+struct JWTTests {
+  @Test
+  func decodeJWT() throws {
     let token =
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoxNjQ4NjQwMDIxLCJzdWIiOiJmMzNkM2VjOS1hMmVlLTQ3YzQtODBlMS01YmQ5MTlmM2Q4YjgiLCJlbWFpbCI6ImhpQGJpbmFyeXNjcmFwaW5nLmNvIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6e30sInJvbGUiOiJhdXRoZW50aWNhdGVkIn0.CGr5zNE5Yltlbn_3Ms2cjSLs_AW9RKM3lxh7cTQrg0w"
     let jwt = JWT.decodePayload(token)
-    let exp = try XCTUnwrap(jwt?["exp"] as? TimeInterval)
-    XCTAssertEqual(exp, 1_648_640_021)
+    let exp = try #require(jwt?["exp"] as? TimeInterval)
+    #expect(exp == 1_648_640_021)
   }
 }

--- a/Tests/HelpersTests/LoggerInterceptorTests.swift
+++ b/Tests/HelpersTests/LoggerInterceptorTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import HTTPTypes
-import XCTest
+import Testing
 
 @testable import Helpers
 
@@ -15,7 +15,8 @@ import XCTest
   import FoundationNetworking
 #endif
 
-final class LoggerInterceptorTests: XCTestCase {
+@Suite
+struct LoggerInterceptorTests {
 
   typealias Method = HTTPTypes.HTTPRequest.Method
 
@@ -63,7 +64,8 @@ final class LoggerInterceptorTests: XCTestCase {
 
   // MARK: - Interceptor Tests
 
-  func testInterceptorLogsRequest() async throws {
+  @Test
+  func interceptorLogsRequest() async throws {
     let logger = MockLogger()
     let interceptor = LoggerInterceptor(logger: logger)
 
@@ -75,12 +77,13 @@ final class LoggerInterceptorTests: XCTestCase {
     }
 
     // Verify request was logged
-    XCTAssertEqual(logger.verboseLogs.count, 2)  // Request and response
-    XCTAssertTrue(logger.verboseLogs[0].contains("Request:"))
-    XCTAssertTrue(logger.verboseLogs[0].contains("/users"))
+    #expect(logger.verboseLogs.count == 2)  // Request and response
+    #expect(logger.verboseLogs[0].contains("Request:"))
+    #expect(logger.verboseLogs[0].contains("/users"))
   }
 
-  func testInterceptorLogsResponse() async throws {
+  @Test
+  func interceptorLogsResponse() async throws {
     let logger = MockLogger()
     let interceptor = LoggerInterceptor(logger: logger)
 
@@ -93,11 +96,12 @@ final class LoggerInterceptorTests: XCTestCase {
     }
 
     // Verify response was logged
-    XCTAssertEqual(logger.verboseLogs.count, 2)
-    XCTAssertTrue(logger.verboseLogs[1].contains("Response: Status code: 200"))
+    #expect(logger.verboseLogs.count == 2)
+    #expect(logger.verboseLogs[1].contains("Response: Status code: 200"))
   }
 
-  func testInterceptorLogsError() async throws {
+  @Test
+  func interceptorLogsError() async throws {
     let logger = MockLogger()
     let interceptor = LoggerInterceptor(logger: logger)
 
@@ -109,17 +113,18 @@ final class LoggerInterceptorTests: XCTestCase {
       let _ = try await interceptor.intercept(request) { _ in
         throw TestError()
       }
-      XCTFail("Should have thrown error")
+      Issue.record("Should have thrown error")
     } catch {
       // Expected error
     }
 
     // Verify error was logged
-    XCTAssertEqual(logger.errorLogs.count, 1)
-    XCTAssertTrue(logger.errorLogs[0].contains("Response: Failure"))
+    #expect(logger.errorLogs.count == 1)
+    #expect(logger.errorLogs[0].contains("Response: Failure"))
   }
 
-  func testInterceptorWithJSONBody() async throws {
+  @Test
+  func interceptorWithJSONBody() async throws {
     let logger = MockLogger()
     let interceptor = LoggerInterceptor(logger: logger)
 
@@ -132,11 +137,12 @@ final class LoggerInterceptorTests: XCTestCase {
     }
 
     // Verify JSON body was logged
-    XCTAssertTrue(logger.verboseLogs[0].contains("Body:"))
-    XCTAssertTrue(logger.verboseLogs[0].contains("name"))
+    #expect(logger.verboseLogs[0].contains("Body:"))
+    #expect(logger.verboseLogs[0].contains("name"))
   }
 
-  func testInterceptorWithEmptyBody() async throws {
+  @Test
+  func interceptorWithEmptyBody() async throws {
     let logger = MockLogger()
     let interceptor = LoggerInterceptor(logger: logger)
 
@@ -148,10 +154,11 @@ final class LoggerInterceptorTests: XCTestCase {
     }
 
     // Verify empty body handling
-    XCTAssertTrue(logger.verboseLogs[0].contains("<none>"))
+    #expect(logger.verboseLogs[0].contains("<none>"))
   }
 
-  func testInterceptorWithDifferentMethods() async throws {
+  @Test
+  func interceptorWithDifferentMethods() async throws {
     let methods: [(Method, String)] = [
       (.get, "GET"),
       (.post, "POST"),
@@ -171,14 +178,15 @@ final class LoggerInterceptorTests: XCTestCase {
         return expectedResponse
       }
 
-      XCTAssertTrue(
+      #expect(
         logger.verboseLogs[0].contains("Request:"),
         "Should log \(methodString) request"
       )
     }
   }
 
-  func testInterceptorWithDifferentStatusCodes() async throws {
+  @Test
+  func interceptorWithDifferentStatusCodes() async throws {
     let statusCodes = [200, 201, 400, 401, 404, 500]
 
     for statusCode in statusCodes {
@@ -192,7 +200,7 @@ final class LoggerInterceptorTests: XCTestCase {
         return expectedResponse
       }
 
-      XCTAssertTrue(
+      #expect(
         logger.verboseLogs[1].contains("Status code: \(statusCode)"),
         "Should log status code \(statusCode)"
       )
@@ -201,44 +209,50 @@ final class LoggerInterceptorTests: XCTestCase {
 
   // MARK: - Stringify Function Tests
 
-  func testStringifyWithNilData() {
+  @Test
+  func stringifyWithNilData() {
     let result = stringify(nil)
-    XCTAssertEqual(result, "<none>")
+    #expect(result == "<none>")
   }
 
-  func testStringifyWithJSONData() {
+  @Test
+  func stringifyWithJSONData() {
     let jsonData = #"{"key": "value", "number": 42}"#.data(using: .utf8)!
     let result = stringify(jsonData)
 
-    XCTAssertTrue(result.contains("key"))
-    XCTAssertTrue(result.contains("value"))
-    XCTAssertTrue(result.contains("number"))
+    #expect(result.contains("key"))
+    #expect(result.contains("value"))
+    #expect(result.contains("number"))
   }
 
-  func testStringifyWithNonJSONData() {
+  @Test
+  func stringifyWithNonJSONData() {
     let textData = "Plain text content".data(using: .utf8)!
     let result = stringify(textData)
 
-    XCTAssertEqual(result, "Plain text content")
+    #expect(result == "Plain text content")
   }
 
-  func testStringifyWithInvalidUTF8Data() {
+  @Test
+  func stringifyWithInvalidUTF8Data() {
     // Invalid UTF-8 sequence
     let invalidData = Data([0xFF, 0xFE, 0xFD])
     let result = stringify(invalidData)
 
-    XCTAssertEqual(result, "<failed>")
+    #expect(result == "<failed>")
   }
 
-  func testStringifyWithEmptyData() {
+  @Test
+  func stringifyWithEmptyData() {
     let emptyData = Data()
     let result = stringify(emptyData)
 
     // Empty JSON object or empty string
-    XCTAssertTrue(result.isEmpty)
+    #expect(result.isEmpty)
   }
 
-  func testStringifyWithComplexJSON() {
+  @Test
+  func stringifyWithComplexJSON() {
     let complexJSON = """
       {
         "users": [
@@ -254,37 +268,41 @@ final class LoggerInterceptorTests: XCTestCase {
 
     let result = stringify(complexJSON)
 
-    XCTAssertTrue(result.contains("users"))
-    XCTAssertTrue(result.contains("Alice"))
-    XCTAssertTrue(result.contains("nested"))
+    #expect(result.contains("users"))
+    #expect(result.contains("Alice"))
+    #expect(result.contains("nested"))
   }
 
-  func testStringifyWithArrayJSON() {
+  @Test
+  func stringifyWithArrayJSON() {
     let arrayJSON = #"[1, 2, 3, 4, 5]"#.data(using: .utf8)!
     let result = stringify(arrayJSON)
 
-    XCTAssertTrue(result.contains("1"))
-    XCTAssertTrue(result.contains("5"))
+    #expect(result.contains("1"))
+    #expect(result.contains("5"))
   }
 
-  func testStringifyWithBooleanJSON() {
+  @Test
+  func stringifyWithBooleanJSON() {
     let boolJSON = #"{"active": true, "deleted": false}"#.data(using: .utf8)!
     let result = stringify(boolJSON)
 
-    XCTAssertTrue(result.contains("active"))
-    XCTAssertTrue(result.contains("true") || result.contains("1"))
+    #expect(result.contains("active"))
+    #expect(result.contains("true") || result.contains("1"))
   }
 
-  func testStringifyWithNullJSON() {
+  @Test
+  func stringifyWithNullJSON() {
     let nullJSON = #"{"value": null}"#.data(using: .utf8)!
     let result = stringify(nullJSON)
 
-    XCTAssertTrue(result.contains("value"))
+    #expect(result.contains("value"))
   }
 
   // MARK: - Integration Tests
 
-  func testInterceptorPassesThroughResponse() async throws {
+  @Test
+  func interceptorPassesThroughResponse() async throws {
     let logger = MockLogger()
     let interceptor = LoggerInterceptor(logger: logger)
 
@@ -297,11 +315,12 @@ final class LoggerInterceptorTests: XCTestCase {
     }
 
     // Verify response is passed through unchanged
-    XCTAssertEqual(actualResponse.statusCode, 201)
-    XCTAssertEqual(actualResponse.data, testData)
+    #expect(actualResponse.statusCode == 201)
+    #expect(actualResponse.data == testData)
   }
 
-  func testInterceptorPassesThroughError() async throws {
+  @Test
+  func interceptorPassesThroughError() async throws {
     let logger = MockLogger()
     let interceptor = LoggerInterceptor(logger: logger)
 
@@ -317,11 +336,11 @@ final class LoggerInterceptorTests: XCTestCase {
       let _ = try await interceptor.intercept(request) { _ in
         throw expectedError
       }
-      XCTFail("Should have thrown error")
+      Issue.record("Should have thrown error")
     } catch let error as CustomError {
-      XCTAssertEqual(error, expectedError)
+      #expect(error == expectedError)
     } catch {
-      XCTFail("Wrong error type thrown")
+      Issue.record("Wrong error type thrown")
     }
   }
 }

--- a/Tests/HelpersTests/ObservationTokenTests.swift
+++ b/Tests/HelpersTests/ObservationTokenTests.swift
@@ -8,10 +8,12 @@
 import ConcurrencyExtras
 import Foundation
 import Helpers
-import XCTest
+import Testing
 
-final class ObservationTokenTests: XCTestCase {
-  func testRemove() {
+@Suite
+struct ObservationTokenTests {
+  @Test
+  func remove() {
     let onRemoveCallCount = LockIsolated(0)
     let handle = ObservationToken {
       onRemoveCallCount.withValue {
@@ -22,10 +24,11 @@ final class ObservationTokenTests: XCTestCase {
     handle.cancel()
     handle.cancel()
 
-    XCTAssertEqual(onRemoveCallCount.value, 1)
+    #expect(onRemoveCallCount.value == 1)
   }
 
-  func testDeinit() {
+  @Test
+  func deinitCancelsToken() {
     let onRemoveCallCount = LockIsolated(0)
     var handle: ObservationToken? = ObservationToken {
       onRemoveCallCount.withValue {
@@ -36,6 +39,6 @@ final class ObservationTokenTests: XCTestCase {
     _ = handle  // Silence unused variable warning
     handle = nil
 
-    XCTAssertEqual(onRemoveCallCount.value, 1)
+    #expect(onRemoveCallCount.value == 1)
   }
 }

--- a/Tests/HelpersTests/PostgrestErrorTests.swift
+++ b/Tests/HelpersTests/PostgrestErrorTests.swift
@@ -7,13 +7,15 @@
 
 import Foundation
 import Helpers
-import XCTest
+import Testing
 
-final class PostgrestErrorTests: XCTestCase {
+@Suite
+struct PostgrestErrorTests {
 
-  func testLocalizedErrorConformance() {
+  @Test
+  func localizedErrorConformance() {
     let error = PostgrestError(message: "test error message")
-    XCTAssertEqual(error.errorDescription, "test error message")
+    #expect(error.errorDescription == "test error message")
   }
 
 }

--- a/Tests/HelpersTests/RetryRequestInterceptorTests.swift
+++ b/Tests/HelpersTests/RetryRequestInterceptorTests.swift
@@ -8,7 +8,7 @@
 import ConcurrencyExtras
 import Foundation
 import HTTPTypes
-import XCTest
+import Testing
 
 @testable import Helpers
 
@@ -16,7 +16,8 @@ import XCTest
   import FoundationNetworking
 #endif
 
-final class RetryRequestInterceptorTests: XCTestCase {
+@Suite
+struct RetryRequestInterceptorTests {
 
   // MARK: - Helpers
 
@@ -44,28 +45,31 @@ final class RetryRequestInterceptorTests: XCTestCase {
 
   // MARK: - defaultRetryableHTTPStatusCodes
 
-  func testDefaultRetryableHTTPStatusCodesContainsStandardCodes() {
+  @Test
+  func defaultRetryableHTTPStatusCodesContainsStandardCodes() {
     let codes = RetryRequestInterceptor.defaultRetryableHTTPStatusCodes
-    XCTAssertTrue(codes.contains(408))
-    XCTAssertTrue(codes.contains(500))
-    XCTAssertTrue(codes.contains(502))
-    XCTAssertTrue(codes.contains(503))
-    XCTAssertTrue(codes.contains(504))
+    #expect(codes.contains(408))
+    #expect(codes.contains(500))
+    #expect(codes.contains(502))
+    #expect(codes.contains(503))
+    #expect(codes.contains(504))
   }
 
-  func testDefaultRetryableHTTPStatusCodesContainsCloudflareCodes() {
+  @Test
+  func defaultRetryableHTTPStatusCodesContainsCloudflareCodes() {
     let codes = RetryRequestInterceptor.defaultRetryableHTTPStatusCodes
-    XCTAssertTrue(codes.contains(520), "520 (Cloudflare Unknown Error) should be retryable")
-    XCTAssertTrue(codes.contains(521), "521 (Web Server Down) should be retryable")
-    XCTAssertTrue(codes.contains(522), "522 (Connection Timed Out) should be retryable")
-    XCTAssertTrue(codes.contains(523), "523 (Origin Is Unreachable) should be retryable")
-    XCTAssertTrue(codes.contains(524), "524 (A Timeout Occurred) should be retryable")
-    XCTAssertTrue(codes.contains(530), "530 (Site Frozen) should be retryable")
+    #expect(codes.contains(520), "520 (Cloudflare Unknown Error) should be retryable")
+    #expect(codes.contains(521), "521 (Web Server Down) should be retryable")
+    #expect(codes.contains(522), "522 (Connection Timed Out) should be retryable")
+    #expect(codes.contains(523), "523 (Origin Is Unreachable) should be retryable")
+    #expect(codes.contains(524), "524 (A Timeout Occurred) should be retryable")
+    #expect(codes.contains(530), "530 (Site Frozen) should be retryable")
   }
 
   // MARK: - Retry behavior for Cloudflare codes
 
-  func testRetriesOnCloudflareErrorCodes() async throws {
+  @Test
+  func retriesOnCloudflareErrorCodes() async throws {
     let interceptor = makeInterceptor(retryLimit: 2)
     let request = makeRequest()
     let cloudflareCodes = [520, 521, 522, 523, 524, 530]
@@ -79,12 +83,13 @@ final class RetryRequestInterceptorTests: XCTestCase {
         }
         return self.makeResponse(statusCode: 200)
       }
-      XCTAssertEqual(finalResponse.statusCode, 200, "Should retry on \(code) and succeed")
-      XCTAssertEqual(callCount.value, 2, "Should have called next twice for \(code)")
+      #expect(finalResponse.statusCode == 200, "Should retry on \(code) and succeed")
+      #expect(callCount.value == 2, "Should have called next twice for \(code)")
     }
   }
 
-  func testDoesNotRetryOnNonRetryableStatusCodes() async throws {
+  @Test
+  func doesNotRetryOnNonRetryableStatusCodes() async throws {
     let interceptor = makeInterceptor(retryLimit: 2)
     let request = makeRequest()
     let nonRetryableCodes = [400, 401, 403, 404, 422]
@@ -95,12 +100,13 @@ final class RetryRequestInterceptorTests: XCTestCase {
         callCount.withValue { $0 += 1 }
         return self.makeResponse(statusCode: code)
       }
-      XCTAssertEqual(response.statusCode, code)
-      XCTAssertEqual(callCount.value, 1, "Should not retry on \(code)")
+      #expect(response.statusCode == code)
+      #expect(callCount.value == 1, "Should not retry on \(code)")
     }
   }
 
-  func testRetriesOnStandardRetryableStatusCodes() async throws {
+  @Test
+  func retriesOnStandardRetryableStatusCodes() async throws {
     let interceptor = makeInterceptor(retryLimit: 2)
     let request = makeRequest()
     let retryableCodes = [408, 500, 502, 503, 504]
@@ -114,12 +120,13 @@ final class RetryRequestInterceptorTests: XCTestCase {
         }
         return self.makeResponse(statusCode: 200)
       }
-      XCTAssertEqual(finalResponse.statusCode, 200, "Should retry on \(code) and succeed")
-      XCTAssertEqual(callCount.value, 2, "Should have called next twice for \(code)")
+      #expect(finalResponse.statusCode == 200, "Should retry on \(code) and succeed")
+      #expect(callCount.value == 2, "Should have called next twice for \(code)")
     }
   }
 
-  func testDoesNotRetryOnNonRetryableMethod() async throws {
+  @Test
+  func doesNotRetryOnNonRetryableMethod() async throws {
     let interceptor = makeInterceptor(retryLimit: 2)
     let request = makeRequest(method: .post)
 
@@ -128,11 +135,12 @@ final class RetryRequestInterceptorTests: XCTestCase {
       callCount.withValue { $0 += 1 }
       return self.makeResponse(statusCode: 500)
     }
-    XCTAssertEqual(response.statusCode, 500)
-    XCTAssertEqual(callCount.value, 1, "POST should not be retried")
+    #expect(response.statusCode == 500)
+    #expect(callCount.value == 1, "POST should not be retried")
   }
 
-  func testRespectsRetryLimit() async throws {
+  @Test
+  func respectsRetryLimit() async throws {
     let interceptor = makeInterceptor(retryLimit: 2)
     let request = makeRequest()
 
@@ -141,7 +149,7 @@ final class RetryRequestInterceptorTests: XCTestCase {
       callCount.withValue { $0 += 1 }
       return self.makeResponse(statusCode: 520)
     }
-    XCTAssertEqual(response.statusCode, 520)
-    XCTAssertEqual(callCount.value, 2, "Should not exceed retryLimit")
+    #expect(response.statusCode == 520)
+    #expect(callCount.value == 2, "Should not exceed retryLimit")
   }
 }

--- a/Tests/HelpersTests/WithTimeoutTests.swift
+++ b/Tests/HelpersTests/WithTimeoutTests.swift
@@ -5,11 +5,9 @@
 //  Created by Guilherme Souza on 19/04/24.
 //
 
-import Foundation
 import Helpers
-import XCTest
 
-final class WithTimeoutTests: XCTestCase {
+struct WithTimeoutTests {
   //  func testWithTimeout() async {
   //    do {
   //      try await withTimeout(interval: 0.25) {


### PR DESCRIPTION
## Summary

Phase 1 of the repo-wide XCTest → Swift Testing migration tracked in [SDK-435](https://linear.app/supabase/issue/SDK-435), stacked on Phase 0 (#1090). Converts the lowest-risk target — `Tests/HelpersTests` has no `setUp`/`tearDown`, no Mocker, no snapshot assertions — validating the base mechanical conversion pattern before the Mocker-heavy phases.

**Stacked PR**: base is `test/sdk-1247-swift-testing-phase0-pilot`, not `main`. Diff will shrink once #1090 merges.

## Changes

- All 11 files in `Tests/HelpersTests` converted from `XCTestCase`/`XCTAssert*` to Swift Testing (`@Suite`/`@Test`/`#expect`/`#require`). `test` prefix dropped from test method names per the Phase 0 convention (e.g. `testDecode` → `decode`); `testDeinit` → `deinitCancelsToken` specifically because `deinit` is a reserved keyword.
- `Package.swift`: added `"HelpersTests"` to the `swift6TestTargets` set, so the target compiles under full Swift 6 strict-concurrency checking (matching production targets) instead of the legacy Swift 5 pin.
- `XCTFail` → `Issue.record`, `XCTUnwrap` → `try #require`, `XCTAssertThrowsError` → `#expect(throws:)`.

## Test plan

- [x] `grep -rn "import XCTest" Tests/HelpersTests/` → no matches
- [x] `swift build --target HelpersTests` under full Swift 6 mode → clean
- [x] `swift test --filter HelpersTests` → 90/90 pass, 10 suites
- [x] `xcodebuild test -only-testing:HelpersTests` (macOS) → 90/90 pass — verified on both hosts after Phase 0 surfaced a case where `swift test` alone didn't reproduce an xcodebuild-hosted issue
- [x] `swift-format lint` → clean
- [ ] Full CI matrix (macOS, macOS-legacy @ Xcode 16.4, SPM, Linux) — pending this PR's CI run

## Linear

Closes [SDK-1248](https://linear.app/supabase/issue/SDK-1248)