### PR TITLE
fix(postgrest): encode rpc GET/HEAD scalar params by JSON type

### DIFF
--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -293,8 +293,7 @@ public final class PostgrestClient: Sendable {
       }
 
       for (key, value) in json {
-        let formattedValue = (value as? [Any]).map(cleanFilterArray) ?? String(describing: value)
-        url.appendQueryItems([URLQueryItem(name: key, value: formattedValue)])
+        url.appendQueryItems([URLQueryItem(name: key, value: queryValue(for: value))])
       }
 
     } else {
@@ -362,6 +361,33 @@ public final class PostgrestClient: Sendable {
     var configuration = configuration
     configuration.schema = schema
     return PostgrestClient(configuration: configuration)
+  }
+
+  private func queryValue(for value: Any) -> String {
+    switch value {
+    case let array as [Any]:
+      return cleanFilterArray(array)
+    case is NSNull:
+      return "null"
+    case let number as NSNumber:
+      if number === kCFBooleanTrue {
+        return "true"
+      }
+      if number === kCFBooleanFalse {
+        return "false"
+      }
+      return number.stringValue
+    case let string as String:
+      return string
+    default:
+      if let data = try? JSONSerialization.data(
+        withJSONObject: value, options: [.sortedKeys, .withoutEscapingSlashes]),
+        let json = String(data: data, encoding: .utf8)
+      {
+        return json
+      }
+      return String(describing: value)
+    }
   }
 
   private func cleanFilterArray(_ filter: [Any]) -> String {

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -286,7 +286,7 @@ public final class PostgrestClient: Sendable {
     if head || get {
       method = head ? .head : .get
 
-      guard let json = try JSONSerialization.jsonObject(with: bodyData) as? [String: Any] else {
+      guard case .object(let json) = try AnyJSON.decoder.decode(AnyJSON.self, from: bodyData) else {
         throw PostgrestError(
           message: "Params should be a key-value type when using `GET` or `HEAD` options."
         )
@@ -363,35 +363,30 @@ public final class PostgrestClient: Sendable {
     return PostgrestClient(configuration: configuration)
   }
 
-  private func queryValue(for value: Any) -> String {
+  private func queryValue(for value: AnyJSON) -> String {
     switch value {
-    case let array as [Any]:
-      return cleanFilterArray(array)
-    case is NSNull:
+    case .null:
       return "null"
-    case let number as NSNumber:
-      if number === kCFBooleanTrue {
-        return "true"
-      }
-      if number === kCFBooleanFalse {
-        return "false"
-      }
-      return number.stringValue
-    case let string as String:
+    case .bool(let bool):
+      return bool ? "true" : "false"
+    case .integer(let integer):
+      return String(integer)
+    case .double(let double):
+      return String(double)
+    case .string(let string):
       return string
-    default:
-      if let data = try? JSONSerialization.data(
-        withJSONObject: value, options: [.sortedKeys, .withoutEscapingSlashes]),
+    case .array(let array):
+      return "{\(array.map(queryValue(for:)).joined(separator: ","))}"
+    case .object:
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+      if let data = try? encoder.encode(value),
         let json = String(data: data, encoding: .utf8)
       {
         return json
       }
-      return String(describing: value)
+      return ""
     }
-  }
-
-  private func cleanFilterArray(_ filter: [Any]) -> String {
-    "{\(filter.map { String(describing: $0) }.joined(separator: ","))}"
   }
 }
 

--- a/Tests/PostgRESTTests/PostgrestRpcBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestRpcBuilderTests.swift
@@ -145,6 +145,42 @@ final class PostgrestRpcBuilderTests: PostgrestQueryTests {
     XCTAssertEqual(response.sum, 6)
   }
 
+  func testRpcWithGetMethodEncodesScalarParamsByJSONType() async throws {
+    Mock(
+      url: url.appendingPathComponent("rpc/scalar"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .get: Data("{}".utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "Accept: application/json" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/rpc/scalar?disabled=false&enabled=true&maybe=null&nested=%7B%22a%22:1%7D&number=42"
+      """#
+    }
+    .register()
+
+    try await sut
+      .rpc(
+        "scalar",
+        params: [
+          "enabled": true,
+          "disabled": false,
+          "number": 42,
+          "maybe": .null,
+          "nested": ["a": 1],
+        ] as JSONObject,
+        get: true
+      )
+      .execute()
+  }
+
   func testRpcWithCount() async throws {
     Mock(
       url: url.appendingPathComponent("rpc/hello"),

--- a/Tests/PostgRESTTests/PostgrestRpcBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestRpcBuilderTests.swift
@@ -161,7 +161,7 @@ final class PostgrestRpcBuilderTests: PostgrestQueryTests {
       	--header "Content-Type: application/json" \
       	--header "X-Client-Info: postgrest-swift/0.0.0" \
       	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/rest/v1/rpc/scalar?disabled=false&enabled=true&maybe=null&nested=%7B%22a%22:1%7D&number=42"
+      	"http://localhost:54321/rest/v1/rpc/scalar?disabled=false&enabled=true&flags=%7Btrue,false,null%7D&maybe=null&nested=%7B%22a%22:1%7D&number=42"
       """#
     }
     .register()
@@ -175,6 +175,7 @@ final class PostgrestRpcBuilderTests: PostgrestQueryTests {
           "number": 42,
           "maybe": .null,
           "nested": ["a": 1],
+          "flags": [true, false, .null],
         ] as JSONObject,
         get: true
       )


### PR DESCRIPTION
### Problem

`rpc(_:params:head:get:count:)` builds the GET/HEAD query string from the `JSONSerialization` output with `String(describing:)`, which mis-encodes every non-string scalar:

```swift
for (key, value) in json {
  let formattedValue = (value as? [Any]).map(cleanFilterArray) ?? String(describing: value)
  url.appendQueryItems([URLQueryItem(name: key, value: formattedValue)])
}
```

- `Bool` becomes `1` / `0` (postgrest-js sends `true` / `false`)
- JSON `null` becomes `<null>`
- a nested object becomes the Objective-C `NSDictionary` debug string, e.g. `{\n    a = 1;\n}`

So `rpc("fn", params: ["enabled": true, "nested": ["a": 1]], get: true)` builds `?enabled=1&nested=%7B%0A%20%20%20%20a%20%3D%201;%0A%7D` instead of a usable query.

### Fix

Format each value by its actual JSON type:

- bool -> `true` / `false`
- null -> `null`
- number -> its numeric string
- array -> `{a,b,c}` (unchanged, via the existing `cleanFilterArray`)
- object -> JSON with sorted keys

Scalars and arrays now match postgrest-js. postgrest-js can't represent an object in a GET query at all (it stringifies to `[object Object]`); instead of sending garbage this encodes it as JSON, which PostgREST can cast for a `json`/`jsonb` argument. If you would rather object args fall back to POST (as supabase-js does), I am happy to change that.

### Tests

Added `testRpcWithGetMethodEncodesScalarParamsByJSONType`, which asserts a single `rpc(get: true)` call encodes `true`, `false`, `null`, an integer, and a nested object correctly. It fails before this change (bool -> `1`/`0`, null -> `<null>`, object -> the NSDictionary string) and passes after. Full `PostgRESTTests` suite passes (97 tests). No public API change.
