### PR TITLE
test(storage): migrate StorageTests to Swift Testing, keep Mocker (Phase 3)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -180,15 +180,11 @@ let package = Package(
     .testTarget(
       name: "StorageTests",
       dependencies: [
-        .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "Mocker",
         "TestHelpers",
         "Storage",
-      ],
-      exclude: [
-        "__Snapshots__"
       ],
       resources: [
         .copy("sadcat.jpg"),
@@ -247,7 +243,7 @@ let package = Package(
 // Test targets migrated to Swift Testing get full Swift 6 checking, same as
 // production targets. Everything else stays pinned to v5 until its migration
 // phase lands (see SDK-435).
-let swift6TestTargets: Set<String> = ["SupabaseTests", "HelpersTests"]
+let swift6TestTargets: Set<String> = ["SupabaseTests", "HelpersTests", "StorageTests"]
 
 for target in package.targets {
   // Test targets never opted into `ExistentialAny` below, so bumping swift-tools-version

--- a/Tests/StorageTests/BucketOptionsTests.swift
+++ b/Tests/StorageTests/BucketOptionsTests.swift
@@ -1,97 +1,113 @@
-import XCTest
+import Testing
 
 @testable import Storage
 
-final class BucketOptionsTests: XCTestCase {
-  func testDefaultInitialization() {
+@Suite
+struct BucketOptionsTests {
+  @Test
+  func defaultInitialization() {
     let options = BucketOptions(isPublic: false)
 
-    XCTAssertFalse(options.public)
-    XCTAssertNil(options.fileSizeLimit)
-    XCTAssertNil(options.allowedMimeTypes)
+    #expect(!options.public)
+    #expect(options.fileSizeLimit == nil)
+    #expect(options.allowedMimeTypes == nil)
   }
 
-  func testCustomInitialization() {
+  @Test
+  func customInitialization() {
     let options = BucketOptions(
       public: true,
       fileSizeLimit: "5000000",
       allowedMimeTypes: ["image/jpeg", "image/png"]
     )
 
-    XCTAssertTrue(options.public)
-    XCTAssertEqual(options.fileSizeLimit, "5000000")
-    XCTAssertEqual(options.allowedMimeTypes, ["image/jpeg", "image/png"])
+    #expect(options.public)
+    #expect(options.fileSizeLimit == "5000000")
+    #expect(options.allowedMimeTypes == ["image/jpeg", "image/png"])
   }
 
-  func testIsPublicRename() {
+  @Test
+  func isPublicRename() {
     let options = BucketOptions(isPublic: true)
-    XCTAssertTrue(options.isPublic)
+    #expect(options.isPublic)
   }
 
-  func testFileSizeLimitInteger() {
+  @Test
+  func fileSizeLimitInteger() {
     let options = BucketOptions(isPublic: false, fileSizeLimit: StorageByteCount(5_000_000))
-    XCTAssertEqual(options.fileSizeLimit, "5000000")
+    #expect(options.fileSizeLimit == "5000000")
   }
 
-  func testFileSizeLimitMegabytes() {
+  @Test
+  func fileSizeLimitMegabytes() {
     let options = BucketOptions(isPublic: false, fileSizeLimit: .megabytes(1.5))
-    XCTAssertEqual(options.fileSizeLimit, "1.5mb")
+    #expect(options.fileSizeLimit == "1.5mb")
   }
 
-  func testFileSizeLimitIntegerLiteral() {
+  @Test
+  func fileSizeLimitIntegerLiteral() {
     let options = BucketOptions(fileSizeLimit: 5_000_000)
-    XCTAssertEqual(options.fileSizeLimit, "5000000")
+    #expect(options.fileSizeLimit == "5000000")
   }
 
-  func testDeprecatedPublicBridge() {
+  @Test
+  func deprecatedPublicBridge() {
     var options = BucketOptions(isPublic: false)
     options.public = true  // deprecated setter
-    XCTAssertTrue(options.isPublic)
-    XCTAssertTrue(options.public)  // deprecated getter
+    #expect(options.isPublic)
+    #expect(options.public)  // deprecated getter
   }
 
-  func testDeprecatedStringFileSizeLimitBridge() {
+  @Test
+  func deprecatedStringFileSizeLimitBridge() {
     let options = BucketOptions(public: false, fileSizeLimit: "5242880")
-    XCTAssertEqual(options.fileSizeLimit, "5242880")
+    #expect(options.fileSizeLimit == "5242880")
   }
 
-  func testDeprecatedStringFileSizeLimitNil() {
+  @Test
+  func deprecatedStringFileSizeLimitNil() {
     let options = BucketOptions(public: false, fileSizeLimit: nil)
-    XCTAssertNil(options.fileSizeLimit)
+    #expect(options.fileSizeLimit == nil)
   }
 
-  func testStringLiteralHumanReadable() {
+  @Test
+  func stringLiteralHumanReadable() {
     let options = BucketOptions(isPublic: false, fileSizeLimit: "1mb")
-    XCTAssertEqual(options.fileSizeLimit, "1mb")
+    #expect(options.fileSizeLimit == "1mb")
   }
 
-  func testStringLiteralNumeric() {
+  @Test
+  func stringLiteralNumeric() {
     let options = BucketOptions(isPublic: false, fileSizeLimit: "5242880")
-    XCTAssertEqual(options.fileSizeLimit, "5242880")
+    #expect(options.fileSizeLimit == "5242880")
   }
 
-  func testDeprecatedStringBridgeHumanReadable() {
+  @Test
+  func deprecatedStringBridgeHumanReadable() {
     let options = BucketOptions(public: false, fileSizeLimit: "1mb")
-    XCTAssertEqual(options.fileSizeLimit, "1mb")
+    #expect(options.fileSizeLimit == "1mb")
   }
 
-  func testDeprecatedStringFileSizeLimitVariable() {
+  @Test
+  func deprecatedStringFileSizeLimitVariable() {
     let limit: String? = "1mb"
     let options = BucketOptions(fileSizeLimit: limit)
-    XCTAssertEqual(options.fileSizeLimit, "1mb")
+    #expect(options.fileSizeLimit == "1mb")
   }
 
-  func testDeprecatedIsPublicStringFileSizeLimitVariable() {
+  @Test
+  func deprecatedIsPublicStringFileSizeLimitVariable() {
     let limit: String? = "1mb"
     let options = BucketOptions(isPublic: true, fileSizeLimit: limit)
-    XCTAssertTrue(options.isPublic)
-    XCTAssertEqual(options.fileSizeLimit, "1mb")
+    #expect(options.isPublic)
+    #expect(options.fileSizeLimit == "1mb")
   }
 
-  func testAllowedMimeTypesOnly() {
+  @Test
+  func allowedMimeTypesOnly() {
     let options = BucketOptions(allowedMimeTypes: ["image/png"])
-    XCTAssertFalse(options.isPublic)
-    XCTAssertNil(options.fileSizeLimit)
-    XCTAssertEqual(options.allowedMimeTypes, ["image/png"])
+    #expect(!options.isPublic)
+    #expect(options.fileSizeLimit == nil)
+    #expect(options.allowedMimeTypes == ["image/png"])
   }
 }

--- a/Tests/StorageTests/DownloadBehaviorTests.swift
+++ b/Tests/StorageTests/DownloadBehaviorTests.swift
@@ -5,44 +5,48 @@
 
 import Foundation
 import Storage
-import XCTest
+import Testing
 
-final class DownloadBehaviorURLTests: XCTestCase {
-  var bucket: StorageFileApi!
+@Suite
+struct DownloadBehaviorURLTests {
+  let bucket: StorageFileApi
 
-  override func setUp() {
-    super.setUp()
+  init() {
     bucket = SupabaseStorageClient.test(
       supabaseURL: "http://localhost:54321/storage/v1",
       apiKey: "test-api-key"
     ).from("test-bucket")
   }
 
-  func testGetPublicURL_noDownload() throws {
+  @Test
+  func getPublicURL_noDownload() throws {
     let url = try bucket.getPublicURL(path: "image.png")
     let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
     let downloadItem = components?.queryItems?.first { $0.name == "download" }
-    XCTAssertNil(downloadItem)
+    #expect(downloadItem == nil)
   }
 
-  func testGetPublicURL_withOriginalName() throws {
+  @Test
+  func getPublicURL_withOriginalName() throws {
     let url = try bucket.getPublicURL(path: "image.png", download: .withOriginalName)
     let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
     let downloadItem = components?.queryItems?.first { $0.name == "download" }
-    XCTAssertEqual(downloadItem?.value, "")
+    #expect(downloadItem?.value == "")
   }
 
-  func testGetPublicURL_namedDownload() throws {
+  @Test
+  func getPublicURL_namedDownload() throws {
     let url = try bucket.getPublicURL(path: "image.png", download: .named("photo.jpg"))
     let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
     let downloadItem = components?.queryItems?.first { $0.name == "download" }
-    XCTAssertEqual(downloadItem?.value, "photo.jpg")
+    #expect(downloadItem?.value == "photo.jpg")
   }
 
-  func testGetPublicURL_nilDownload() throws {
+  @Test
+  func getPublicURL_nilDownload() throws {
     let url = try bucket.getPublicURL(path: "image.png", download: Optional<DownloadBehavior>.none)
     let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
     let downloadItem = components?.queryItems?.first { $0.name == "download" }
-    XCTAssertNil(downloadItem)
+    #expect(downloadItem == nil)
   }
 }

--- a/Tests/StorageTests/FileOptionsTests.swift
+++ b/Tests/StorageTests/FileOptionsTests.swift
@@ -1,18 +1,21 @@
-import XCTest
+import Testing
 
 @testable import Storage
 
-final class FileOptionsTests: XCTestCase {
-  func testDefaultInitialization() {
+@Suite
+struct FileOptionsTests {
+  @Test
+  func defaultInitialization() {
     let options = FileOptions()
 
-    XCTAssertEqual(options.cacheControl, "3600")
-    XCTAssertNil(options.contentType)
-    XCTAssertFalse(options.upsert)
-    XCTAssertNil(options.metadata)
+    #expect(options.cacheControl == "3600")
+    #expect(options.contentType == nil)
+    #expect(!options.upsert)
+    #expect(options.metadata == nil)
   }
 
-  func testCustomInitialization() {
+  @Test
+  func customInitialization() {
     let metadata: [String: AnyJSON] = ["key": .string("value")]
     let options = FileOptions(
       cacheControl: "7200",
@@ -21,9 +24,9 @@ final class FileOptionsTests: XCTestCase {
       metadata: metadata
     )
 
-    XCTAssertEqual(options.cacheControl, "7200")
-    XCTAssertEqual(options.contentType, "image/jpeg")
-    XCTAssertTrue(options.upsert)
-    XCTAssertEqual(options.metadata?["key"], .string("value"))
+    #expect(options.cacheControl == "7200")
+    #expect(options.contentType == "image/jpeg")
+    #expect(options.upsert)
+    #expect(options.metadata?["key"] == .string("value"))
   }
 }

--- a/Tests/StorageTests/MultipartFormDataTests.swift
+++ b/Tests/StorageTests/MultipartFormDataTests.swift
@@ -1,24 +1,29 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import Storage
 
-final class MultipartFormDataTests: XCTestCase {
-  func testBoundaryGeneration() {
+@Suite
+struct MultipartFormDataTests {
+  @Test
+  func boundaryGeneration() {
     let formData = MultipartFormData()
-    XCTAssertFalse(formData.boundary.isEmpty)
-    XCTAssertTrue(formData.contentType.contains("multipart/form-data; boundary="))
+    #expect(!formData.boundary.isEmpty)
+    #expect(formData.contentType.contains("multipart/form-data; boundary="))
   }
 
-  func testAppendingData() {
+  @Test
+  func appendingData() {
     let formData = MultipartFormData()
     let testData = "Hello World".data(using: .utf8)!
 
     formData.append(testData, withName: "test", fileName: "test.txt", mimeType: "text/plain")
 
-    XCTAssertGreaterThan(formData.contentLength, 0)
+    #expect(formData.contentLength > 0)
   }
 
-  func testContentHeaders() {
+  @Test
+  func contentHeaders() {
     let formData = MultipartFormData()
     let testData = "Test".data(using: .utf8)!
 
@@ -29,27 +34,30 @@ final class MultipartFormDataTests: XCTestCase {
       mimeType: "text/plain"
     )
 
-    XCTAssertTrue(formData.contentType.hasPrefix("multipart/form-data"))
+    #expect(formData.contentType.hasPrefix("multipart/form-data"))
   }
 
-  func testCustomBoundary() {
+  @Test
+  func customBoundary() {
     let customBoundary = "test-boundary-12345"
     let formData = MultipartFormData(boundary: customBoundary)
 
-    XCTAssertEqual(formData.boundary, customBoundary)
-    XCTAssertTrue(formData.contentType.contains(customBoundary))
+    #expect(formData.boundary == customBoundary)
+    #expect(formData.contentType.contains(customBoundary))
   }
 
-  func testAppendDataWithoutFileName() {
+  @Test
+  func appendDataWithoutFileName() {
     let formData = MultipartFormData()
     let testData = "Test data".data(using: .utf8)!
 
     formData.append(testData, withName: "field")
 
-    XCTAssertGreaterThan(formData.contentLength, 0)
+    #expect(formData.contentLength > 0)
   }
 
-  func testMultipleAppends() {
+  @Test
+  func multipleAppends() {
     let formData = MultipartFormData()
     let data1 = "First".data(using: .utf8)!
     let data2 = "Second".data(using: .utf8)!
@@ -57,25 +65,27 @@ final class MultipartFormDataTests: XCTestCase {
     formData.append(data1, withName: "field1", fileName: "file1.txt", mimeType: "text/plain")
     formData.append(data2, withName: "field2", fileName: "file2.txt", mimeType: "text/plain")
 
-    XCTAssertEqual(formData.contentLength, UInt64(data1.count + data2.count))
+    #expect(formData.contentLength == UInt64(data1.count + data2.count))
   }
 
-  func testEncodeFormData() throws {
+  @Test
+  func encodeFormData() throws {
     let formData = MultipartFormData()
     let testData = "Test content".data(using: .utf8)!
 
     formData.append(testData, withName: "file", fileName: "test.txt", mimeType: "text/plain")
 
     let encoded = try formData.encode()
-    XCTAssertGreaterThan(encoded.count, 0)
+    #expect(encoded.count > 0)
 
     // Verify encoded data contains boundary
     let encodedString = String(data: encoded, encoding: .utf8)
-    XCTAssertNotNil(encodedString)
-    XCTAssertTrue(encodedString!.contains(formData.boundary))
+    #expect(encodedString != nil)
+    #expect(encodedString!.contains(formData.boundary))
   }
 
-  func testAppendFileURL() throws {
+  @Test
+  func appendFileURL() throws {
     let formData = MultipartFormData()
 
     // Create a temporary file
@@ -88,10 +98,11 @@ final class MultipartFormDataTests: XCTestCase {
 
     formData.append(fileURL, withName: "upload")
 
-    XCTAssertGreaterThan(formData.contentLength, 0)
+    #expect(formData.contentLength > 0)
   }
 
-  func testAppendFileURLWithCustomMetadata() throws {
+  @Test
+  func appendFileURLWithCustomMetadata() throws {
     let formData = MultipartFormData()
 
     // Create a temporary file
@@ -105,31 +116,38 @@ final class MultipartFormDataTests: XCTestCase {
     formData.append(
       fileURL, withName: "data", fileName: "custom.json", mimeType: "application/json")
 
-    XCTAssertGreaterThan(formData.contentLength, 0)
+    #expect(formData.contentLength > 0)
   }
 
   #if !os(Linux) && !os(Windows) && !os(Android)
-    func testAppendInvalidFileURL() {
+    @Test
+    func appendInvalidFileURL() {
       let formData = MultipartFormData()
       let invalidURL = URL(fileURLWithPath: "/nonexistent/path/file.txt")
 
       formData.append(invalidURL, withName: "file")
 
       // Should fail during encoding
-      XCTAssertThrowsError(try formData.encode())
+      #expect(throws: (any Error).self) {
+        try formData.encode()
+      }
     }
 
-    func testAppendNonFileURL() {
+    @Test
+    func appendNonFileURL() {
       let formData = MultipartFormData()
       let httpURL = URL(string: "https://example.com/file.txt")!
 
       formData.append(httpURL, withName: "file", fileName: "file.txt", mimeType: "text/plain")
 
       // Should fail during encoding
-      XCTAssertThrowsError(try formData.encode())
+      #expect(throws: (any Error).self) {
+        try formData.encode()
+      }
     }
 
-    func testAppendDirectory() throws {
+    @Test
+    func appendDirectory() throws {
       let formData = MultipartFormData()
 
       // Use a known directory
@@ -138,11 +156,14 @@ final class MultipartFormDataTests: XCTestCase {
       formData.append(dirURL, withName: "dir")
 
       // Should fail during encoding
-      XCTAssertThrowsError(try formData.encode())
+      #expect(throws: (any Error).self) {
+        try formData.encode()
+      }
     }
   #endif
 
-  func testAppendInputStream() {
+  @Test
+  func appendInputStream() {
     let formData = MultipartFormData()
     let testData = "Stream data".data(using: .utf8)!
     let stream = InputStream(data: testData)
@@ -155,18 +176,20 @@ final class MultipartFormDataTests: XCTestCase {
       mimeType: "text/plain"
     )
 
-    XCTAssertEqual(formData.contentLength, UInt64(testData.count))
+    #expect(formData.contentLength == UInt64(testData.count))
   }
 
-  func testEmptyFormData() throws {
+  @Test
+  func emptyFormData() throws {
     let formData = MultipartFormData()
 
     // Encoding empty form data should succeed
     let encoded = try formData.encode()
-    XCTAssertEqual(encoded.count, 0)
+    #expect(encoded.count == 0)
   }
 
-  func testLargeData() throws {
+  @Test
+  func largeData() throws {
     let formData = MultipartFormData()
 
     // Create 1MB of data
@@ -175,10 +198,11 @@ final class MultipartFormDataTests: XCTestCase {
       largeData, withName: "large", fileName: "large.bin", mimeType: "application/octet-stream")
 
     let encoded = try formData.encode()
-    XCTAssertGreaterThan(encoded.count, largeData.count)
+    #expect(encoded.count > largeData.count)
   }
 
-  func testWriteEncodedDataToFile() throws {
+  @Test
+  func writeEncodedDataToFile() throws {
     let formData = MultipartFormData()
     let testData = "Test file write".data(using: .utf8)!
 
@@ -190,13 +214,14 @@ final class MultipartFormDataTests: XCTestCase {
 
     try formData.writeEncodedData(to: outputURL)
 
-    XCTAssertTrue(FileManager.default.fileExists(atPath: outputURL.path))
+    #expect(FileManager.default.fileExists(atPath: outputURL.path))
 
     let written = try Data(contentsOf: outputURL)
-    XCTAssertGreaterThan(written.count, 0)
+    #expect(written.count > 0)
   }
 
-  func testWriteToExistingFile() throws {
+  @Test
+  func writeToExistingFile() throws {
     let formData = MultipartFormData()
     let testData = "Test".data(using: .utf8)!
 
@@ -210,10 +235,13 @@ final class MultipartFormDataTests: XCTestCase {
     defer { try? FileManager.default.removeItem(at: outputURL) }
 
     // Should throw because file already exists
-    XCTAssertThrowsError(try formData.writeEncodedData(to: outputURL))
+    #expect(throws: (any Error).self) {
+      try formData.writeEncodedData(to: outputURL)
+    }
   }
 
-  func testWriteToNonFileURL() throws {
+  @Test
+  func writeToNonFileURL() throws {
     let formData = MultipartFormData()
     let testData = "Test".data(using: .utf8)!
 
@@ -222,26 +250,31 @@ final class MultipartFormDataTests: XCTestCase {
     let httpURL = URL(string: "https://example.com/output.txt")!
 
     // Should throw because URL is not a file URL
-    XCTAssertThrowsError(try formData.writeEncodedData(to: httpURL))
+    #expect(throws: (any Error).self) {
+      try formData.writeEncodedData(to: httpURL)
+    }
   }
 
-  func testMultipartFormDataErrorUnderlyingError() {
+  @Test
+  func multipartFormDataErrorUnderlyingError() {
     let nsError = NSError(domain: "test", code: 1, userInfo: nil)
     let error = MultipartFormDataError.inputStreamReadFailed(error: nsError)
 
-    XCTAssertNotNil(error.underlyingError)
-    XCTAssertNil(error.url)
+    #expect(error.underlyingError != nil)
+    #expect(error.url == nil)
   }
 
-  func testMultipartFormDataErrorURL() {
+  @Test
+  func multipartFormDataErrorURL() {
     let url = URL(fileURLWithPath: "/test/file.txt")
     let error = MultipartFormDataError.bodyPartFileNotReachable(at: url)
 
-    XCTAssertNotNil(error.url)
-    XCTAssertNil(error.underlyingError)
+    #expect(error.url != nil)
+    #expect(error.underlyingError == nil)
   }
 
-  func testContentLengthCalculation() {
+  @Test
+  func contentLengthCalculation() {
     let formData = MultipartFormData()
     let data1 = "Part 1".data(using: .utf8)!
     let data2 = "Part 2".data(using: .utf8)!
@@ -250,6 +283,6 @@ final class MultipartFormDataTests: XCTestCase {
     formData.append(data2, withName: "part2")
 
     let expectedLength = UInt64(data1.count + data2.count)
-    XCTAssertEqual(formData.contentLength, expectedLength)
+    #expect(formData.contentLength == expectedLength)
   }
 }

--- a/Tests/StorageTests/StorageBucketAPITests.swift
+++ b/Tests/StorageTests/StorageBucketAPITests.swift
@@ -1,7 +1,7 @@
-import InlineSnapshotTesting
+import Foundation
 import Mocker
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import Storage
 
@@ -9,23 +9,25 @@ import XCTest
   import FoundationNetworking
 #endif
 
-final class StorageBucketAPITests: XCTestCase {
+/// `.serialized`: Mocker registers stubs in a process-global table with no per-test isolation, so
+/// tests that stub overlapping URLs (e.g. `bucket`) would otherwise race against each other under
+/// Swift Testing's default parallel execution.
+@Suite(.serialized)
+struct StorageBucketAPITests {
   let url = URL(string: "http://localhost:54321/storage/v1")!
-  var storage: SupabaseStorageClient!
 
-  override func setUp() {
-    super.setUp()
-
-    let configuration = URLSessionConfiguration.default
-    configuration.protocolClasses = [MockingURLProtocol.self]
-
-    let session = URLSession(configuration: configuration)
-
+  init() {
     JSONEncoder.defaultStorageEncoder.outputFormatting = [
       .sortedKeys
     ]
+  }
 
-    storage = SupabaseStorageClient(
+  private func makeSUT() -> SupabaseStorageClient {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MockingURLProtocol.self]
+    let session = URLSession(configuration: configuration)
+
+    return SupabaseStorageClient(
       configuration: StorageClientConfiguration(
         url: url,
         headers: [
@@ -41,14 +43,8 @@ final class StorageBucketAPITests: XCTestCase {
     )
   }
 
-  override func tearDown() {
-    super.tearDown()
-
-    Mocker.removeAll()
-  }
-
-  func testURLConstruction() {
-    let urlTestCases = [
+  @Test(
+    arguments: [
       (
         "https://blah.supabase.co/storage/v1",
         "https://blah.storage.supabase.co/storage/v1",
@@ -75,43 +71,45 @@ final class StorageBucketAPITests: XCTestCase {
         "support local host with port without modification"
       ),
     ]
-
-    for (input, expect, description) in urlTestCases {
-      runActivity(named: "should \(description) if useNewHostname is true") {
-        let storage = SupabaseStorageClient(
-          configuration: StorageClientConfiguration(
-            url: URL(string: input)!,
-            headers: [:],
-            useNewHostname: true
-          )
-        )
-        XCTAssertEqual(storage.configuration.url.absoluteString, expect)
-      }
-
-      runActivity(named: "should not modify host if useNewHostname is false") {
-        let storage = SupabaseStorageClient(
-          configuration: StorageClientConfiguration(
-            url: URL(string: input)!,
-            headers: [:],
-            useNewHostname: false
-          )
-        )
-        XCTAssertEqual(storage.configuration.url.absoluteString, input)
-      }
-    }
+  )
+  func urlConstructionWithNewHostname(input: String, expected: String, description: String) {
+    let storage = SupabaseStorageClient(
+      configuration: StorageClientConfiguration(
+        url: URL(string: input)!,
+        headers: [:],
+        useNewHostname: true
+      )
+    )
+    #expect(
+      storage.configuration.url.absoluteString == expected,
+      "should \(description) if useNewHostname is true"
+    )
   }
 
-  private func runActivity(named name: String, body: () -> Void) {
-    #if os(Linux)
-      body()
-    #else
-      XCTContext.runActivity(named: name) { _ in
-        body()
-      }
-    #endif
+  @Test(
+    arguments: [
+      "https://blah.supabase.co/storage/v1",
+      "https://blah.supabase.red/storage/v1",
+      "https://blah.storage.supabase.co/storage/v1",
+      "https://blah.supabase.co.example.com/storage/v1",
+      "http://localhost:1234/storage/v1",
+    ]
+  )
+  func urlConstructionWithoutNewHostname(input: String) {
+    let storage = SupabaseStorageClient(
+      configuration: StorageClientConfiguration(
+        url: URL(string: input)!,
+        headers: [:],
+        useNewHostname: false
+      )
+    )
+    #expect(storage.configuration.url.absoluteString == input)
   }
 
-  func testGetBucket() async throws {
+  @Test
+  func getBucket() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("bucket/bucket123"),
       statusCode: 200,
@@ -141,11 +139,14 @@ final class StorageBucketAPITests: XCTestCase {
     .register()
 
     let bucket = try await storage.getBucket("bucket123")
-    XCTAssertEqual(bucket.id, "bucket123")
-    XCTAssertEqual(bucket.name, "test-bucket")
+    #expect(bucket.id == "bucket123")
+    #expect(bucket.name == "test-bucket")
   }
 
-  func testListBuckets() async throws {
+  @Test
+  func listBuckets() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("bucket"),
       statusCode: 200,
@@ -177,11 +178,14 @@ final class StorageBucketAPITests: XCTestCase {
     .register()
 
     let buckets = try await storage.listBuckets()
-    XCTAssertEqual(buckets.count, 1)
-    XCTAssertEqual(buckets[0].name, "test-bucket")
+    #expect(buckets.count == 1)
+    #expect(buckets[0].name == "test-bucket")
   }
 
-  func testCreateBucket() async throws {
+  @Test
+  func createBucket() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("bucket"),
       statusCode: 200,
@@ -221,7 +225,10 @@ final class StorageBucketAPITests: XCTestCase {
     )
   }
 
-  func testUpdateBucket() async throws {
+  @Test
+  func updateBucket() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("bucket/bucket123"),
       statusCode: 200,
@@ -261,7 +268,10 @@ final class StorageBucketAPITests: XCTestCase {
     )
   }
 
-  func testDeleteBucket() async throws {
+  @Test
+  func deleteBucket() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("bucket/bucket123"),
       statusCode: 200,
@@ -283,7 +293,10 @@ final class StorageBucketAPITests: XCTestCase {
     try await storage.deleteBucket("bucket123")
   }
 
-  func testEmptyBucket() async throws {
+  @Test
+  func emptyBucket() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("bucket/bucket123/empty"),
       statusCode: 200,
@@ -305,7 +318,10 @@ final class StorageBucketAPITests: XCTestCase {
     try await storage.emptyBucket("bucket123")
   }
 
-  func testCreateBucketWithFileSizeLimit() async throws {
+  @Test
+  func createBucketWithFileSizeLimit() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("bucket"),
       statusCode: 200,
@@ -344,7 +360,10 @@ final class StorageBucketAPITests: XCTestCase {
     )
   }
 
-  func testCreateBucketWithHumanReadableFileSizeLimit() async throws {
+  @Test
+  func createBucketWithHumanReadableFileSizeLimit() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("bucket"),
       statusCode: 200,

--- a/Tests/StorageTests/StorageBucketAPITests.swift
+++ b/Tests/StorageTests/StorageBucketAPITests.swift
@@ -9,396 +9,405 @@ import Testing
   import FoundationNetworking
 #endif
 
-/// `.serialized`: Mocker registers stubs in a process-global table with no per-test isolation, so
-/// tests that stub overlapping URLs (e.g. `bucket`) would otherwise race against each other under
-/// Swift Testing's default parallel execution.
+/// Shared serialization boundary for the Mocker-backed Storage test suites (this one and
+/// ``StorageFileAPITests``): Mocker's mock registry is process-global, so these suites can't just
+/// serialize their own tests internally, they must never run concurrently *with each other* either
+/// -- otherwise one suite's `Mocker.removeAll()` (see `makeSUT()`) can wipe out mocks the other
+/// suite just registered. `.serialized` on a suite applies recursively to its nested suites, so
+/// nesting both under this empty namespace enforces that.
 @Suite(.serialized)
-struct StorageBucketAPITests {
-  let url = URL(string: "http://localhost:54321/storage/v1")!
+enum StorageMockerTests {}
 
-  init() {
-    JSONEncoder.defaultStorageEncoder.outputFormatting = [
-      .sortedKeys
-    ]
-  }
+extension StorageMockerTests {
+  struct StorageBucketAPITests {
+    let url = URL(string: "http://localhost:54321/storage/v1")!
 
-  private func makeSUT() -> SupabaseStorageClient {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [MockingURLProtocol.self]
-    let session = URLSession(configuration: configuration)
+    init() {
+      JSONEncoder.defaultStorageEncoder.outputFormatting = [
+        .sortedKeys
+      ]
+    }
 
-    return SupabaseStorageClient(
-      configuration: StorageClientConfiguration(
-        url: url,
-        headers: [
-          "apikey":
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
-        ],
-        session: StorageHTTPSession(
-          fetch: { try await session.data(for: $0) },
-          upload: { try await session.upload(for: $0, from: $1) }
-        ),
-        logger: nil
-      )
-    )
-  }
+    private func makeSUT() -> SupabaseStorageClient {
+      Mocker.removeAll()
 
-  @Test(
-    arguments: [
-      (
-        "https://blah.supabase.co/storage/v1",
-        "https://blah.storage.supabase.co/storage/v1",
-        "update legacy prod host to new host"
-      ),
-      (
-        "https://blah.supabase.red/storage/v1",
-        "https://blah.storage.supabase.red/storage/v1",
-        "update legacy staging host to new host"
-      ),
-      (
-        "https://blah.storage.supabase.co/storage/v1",
-        "https://blah.storage.supabase.co/storage/v1",
-        "accept new host without modification"
-      ),
-      (
-        "https://blah.supabase.co.example.com/storage/v1",
-        "https://blah.supabase.co.example.com/storage/v1",
-        "not modify non-platform hosts"
-      ),
-      (
-        "http://localhost:1234/storage/v1",
-        "http://localhost:1234/storage/v1",
-        "support local host with port without modification"
-      ),
-    ]
-  )
-  func urlConstructionWithNewHostname(input: String, expected: String, description: String) {
-    let storage = SupabaseStorageClient(
-      configuration: StorageClientConfiguration(
-        url: URL(string: input)!,
-        headers: [:],
-        useNewHostname: true
-      )
-    )
-    #expect(
-      storage.configuration.url.absoluteString == expected,
-      "should \(description) if useNewHostname is true"
-    )
-  }
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.protocolClasses = [MockingURLProtocol.self]
+      let session = URLSession(configuration: configuration)
 
-  @Test(
-    arguments: [
-      "https://blah.supabase.co/storage/v1",
-      "https://blah.supabase.red/storage/v1",
-      "https://blah.storage.supabase.co/storage/v1",
-      "https://blah.supabase.co.example.com/storage/v1",
-      "http://localhost:1234/storage/v1",
-    ]
-  )
-  func urlConstructionWithoutNewHostname(input: String) {
-    let storage = SupabaseStorageClient(
-      configuration: StorageClientConfiguration(
-        url: URL(string: input)!,
-        headers: [:],
-        useNewHostname: false
-      )
-    )
-    #expect(storage.configuration.url.absoluteString == input)
-  }
-
-  @Test
-  func getBucket() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("bucket/bucket123"),
-      statusCode: 200,
-      data: [
-        .get: Data(
-          """
-          {
-              "id": "bucket123",
-              "name": "test-bucket",
-              "owner": "owner123",
-              "public": false,
-              "created_at": "2024-01-01T00:00:00.000Z",
-              "updated_at": "2024-01-01T00:00:00.000Z"
-          }
-          """.utf8
+      return SupabaseStorageClient(
+        configuration: StorageClientConfiguration(
+          url: url,
+          headers: [
+            "apikey":
+              "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
+          ],
+          session: StorageHTTPSession(
+            fetch: { try await session.data(for: $0) },
+            upload: { try await session.upload(for: $0, from: $1) }
+          ),
+          logger: nil
         )
+      )
+    }
+
+    @Test(
+      arguments: [
+        (
+          "https://blah.supabase.co/storage/v1",
+          "https://blah.storage.supabase.co/storage/v1",
+          "update legacy prod host to new host"
+        ),
+        (
+          "https://blah.supabase.red/storage/v1",
+          "https://blah.storage.supabase.red/storage/v1",
+          "update legacy staging host to new host"
+        ),
+        (
+          "https://blah.storage.supabase.co/storage/v1",
+          "https://blah.storage.supabase.co/storage/v1",
+          "accept new host without modification"
+        ),
+        (
+          "https://blah.supabase.co.example.com/storage/v1",
+          "https://blah.supabase.co.example.com/storage/v1",
+          "not modify non-platform hosts"
+        ),
+        (
+          "http://localhost:1234/storage/v1",
+          "http://localhost:1234/storage/v1",
+          "support local host with port without modification"
+        ),
       ]
     )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/bucket/bucket123"
-      """#
+    func urlConstructionWithNewHostname(input: String, expected: String, description: String) {
+      let storage = SupabaseStorageClient(
+        configuration: StorageClientConfiguration(
+          url: URL(string: input)!,
+          headers: [:],
+          useNewHostname: true
+        )
+      )
+      #expect(
+        storage.configuration.url.absoluteString == expected,
+        "should \(description) if useNewHostname is true"
+      )
     }
-    .register()
 
-    let bucket = try await storage.getBucket("bucket123")
-    #expect(bucket.id == "bucket123")
-    #expect(bucket.name == "test-bucket")
-  }
+    @Test(
+      arguments: [
+        "https://blah.supabase.co/storage/v1",
+        "https://blah.supabase.red/storage/v1",
+        "https://blah.storage.supabase.co/storage/v1",
+        "https://blah.supabase.co.example.com/storage/v1",
+        "http://localhost:1234/storage/v1",
+      ]
+    )
+    func urlConstructionWithoutNewHostname(input: String) {
+      let storage = SupabaseStorageClient(
+        configuration: StorageClientConfiguration(
+          url: URL(string: input)!,
+          headers: [:],
+          useNewHostname: false
+        )
+      )
+      #expect(storage.configuration.url.absoluteString == input)
+    }
 
-  @Test
-  func listBuckets() async throws {
-    let storage = makeSUT()
+    @Test
+    func getBucket() async throws {
+      let storage = makeSUT()
 
-    Mock(
-      url: url.appendingPathComponent("bucket"),
-      statusCode: 200,
-      data: [
-        .get: Data(
-          """
-          [
+      Mock(
+        url: url.appendingPathComponent("bucket/bucket123"),
+        statusCode: 200,
+        data: [
+          .get: Data(
+            """
+            {
+                "id": "bucket123",
+                "name": "test-bucket",
+                "owner": "owner123",
+                "public": false,
+                "created_at": "2024-01-01T00:00:00.000Z",
+                "updated_at": "2024-01-01T00:00:00.000Z"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/bucket/bucket123"
+        """#
+      }
+      .register()
+
+      let bucket = try await storage.getBucket("bucket123")
+      #expect(bucket.id == "bucket123")
+      #expect(bucket.name == "test-bucket")
+    }
+
+    @Test
+    func listBuckets() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("bucket"),
+        statusCode: 200,
+        data: [
+          .get: Data(
+            """
+            [
+              {
+                "id": "bucket123",
+                "name": "test-bucket",
+                "owner": "owner123",
+                "public": false,
+                "created_at": "2024-01-01T00:00:00.000Z",
+                "updated_at": "2024-01-01T00:00:00.000Z"
+              }
+            ]
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/bucket"
+        """#
+      }
+      .register()
+
+      let buckets = try await storage.listBuckets()
+      #expect(buckets.count == 1)
+      #expect(buckets[0].name == "test-bucket")
+    }
+
+    @Test
+    func createBucket() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("bucket"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "id": "newbucket",
+              "name": "new-bucket",
+              "owner": "owner123",
+              "public": true,
+              "created_at": "2024-01-01T00:00:00.000Z",
+              "updated_at": "2024-01-01T00:00:00.000Z"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 51" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"id\":\"newbucket\",\"name\":\"newbucket\",\"public\":true}" \
+        	"http://localhost:54321/storage/v1/bucket"
+        """#
+      }
+      .register()
+
+      let options = BucketOptions(public: true)
+      try await storage.createBucket(
+        "newbucket",
+        options: options
+      )
+    }
+
+    @Test
+    func updateBucket() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("bucket/bucket123"),
+        statusCode: 200,
+        data: [
+          .put: Data(
+            """
             {
               "id": "bucket123",
-              "name": "test-bucket",
+              "name": "updated-bucket",
+              "owner": "owner123",
+              "public": true,
+              "created_at": "2024-01-01T00:00:00.000Z",
+              "updated_at": "2024-01-01T00:00:00.000Z"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request PUT \
+        	--header "Content-Length: 51" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"id\":\"bucket123\",\"name\":\"bucket123\",\"public\":true}" \
+        	"http://localhost:54321/storage/v1/bucket/bucket123"
+        """#
+      }
+      .register()
+
+      let options = BucketOptions(public: true)
+      try await storage.updateBucket(
+        "bucket123",
+        options: options
+      )
+    }
+
+    @Test
+    func deleteBucket() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("bucket/bucket123"),
+        statusCode: 200,
+        data: [
+          .delete: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request DELETE \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/bucket/bucket123"
+        """#
+      }
+      .register()
+
+      try await storage.deleteBucket("bucket123")
+    }
+
+    @Test
+    func emptyBucket() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("bucket/bucket123/empty"),
+        statusCode: 200,
+        data: [
+          .post: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/bucket/bucket123/empty"
+        """#
+      }
+      .register()
+
+      try await storage.emptyBucket("bucket123")
+    }
+
+    @Test
+    func createBucketWithFileSizeLimit() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("bucket"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "id": "newbucket",
+              "name": "newbucket",
               "owner": "owner123",
               "public": false,
               "created_at": "2024-01-01T00:00:00.000Z",
               "updated_at": "2024-01-01T00:00:00.000Z"
             }
-          ]
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/bucket"
-      """#
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 79" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"file_size_limit\":10485760,\"id\":\"newbucket\",\"name\":\"newbucket\",\"public\":false}" \
+        	"http://localhost:54321/storage/v1/bucket"
+        """#
+      }
+      .register()
+
+      try await storage.createBucket(
+        "newbucket",
+        options: BucketOptions(isPublic: false, fileSizeLimit: 10_485_760)
+      )
     }
-    .register()
 
-    let buckets = try await storage.listBuckets()
-    #expect(buckets.count == 1)
-    #expect(buckets[0].name == "test-bucket")
-  }
+    @Test
+    func createBucketWithHumanReadableFileSizeLimit() async throws {
+      let storage = makeSUT()
 
-  @Test
-  func createBucket() async throws {
-    let storage = makeSUT()
+      Mock(
+        url: url.appendingPathComponent("bucket"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "id": "newbucket",
+              "name": "newbucket",
+              "owner": "owner123",
+              "public": false,
+              "created_at": "2024-01-01T00:00:00.000Z",
+              "updated_at": "2024-01-01T00:00:00.000Z"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 76" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"file_size_limit\":\"1mb\",\"id\":\"newbucket\",\"name\":\"newbucket\",\"public\":false}" \
+        	"http://localhost:54321/storage/v1/bucket"
+        """#
+      }
+      .register()
 
-    Mock(
-      url: url.appendingPathComponent("bucket"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "id": "newbucket",
-            "name": "new-bucket",
-            "owner": "owner123",
-            "public": true,
-            "created_at": "2024-01-01T00:00:00.000Z",
-            "updated_at": "2024-01-01T00:00:00.000Z"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 51" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"id\":\"newbucket\",\"name\":\"newbucket\",\"public\":true}" \
-      	"http://localhost:54321/storage/v1/bucket"
-      """#
+      try await storage.createBucket(
+        "newbucket",
+        options: BucketOptions(isPublic: false, fileSizeLimit: "1mb")
+      )
     }
-    .register()
-
-    let options = BucketOptions(public: true)
-    try await storage.createBucket(
-      "newbucket",
-      options: options
-    )
-  }
-
-  @Test
-  func updateBucket() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("bucket/bucket123"),
-      statusCode: 200,
-      data: [
-        .put: Data(
-          """
-          {
-            "id": "bucket123",
-            "name": "updated-bucket",
-            "owner": "owner123",
-            "public": true,
-            "created_at": "2024-01-01T00:00:00.000Z",
-            "updated_at": "2024-01-01T00:00:00.000Z"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request PUT \
-      	--header "Content-Length: 51" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"id\":\"bucket123\",\"name\":\"bucket123\",\"public\":true}" \
-      	"http://localhost:54321/storage/v1/bucket/bucket123"
-      """#
-    }
-    .register()
-
-    let options = BucketOptions(public: true)
-    try await storage.updateBucket(
-      "bucket123",
-      options: options
-    )
-  }
-
-  @Test
-  func deleteBucket() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("bucket/bucket123"),
-      statusCode: 200,
-      data: [
-        .delete: Data()
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request DELETE \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/bucket/bucket123"
-      """#
-    }
-    .register()
-
-    try await storage.deleteBucket("bucket123")
-  }
-
-  @Test
-  func emptyBucket() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("bucket/bucket123/empty"),
-      statusCode: 200,
-      data: [
-        .post: Data()
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/bucket/bucket123/empty"
-      """#
-    }
-    .register()
-
-    try await storage.emptyBucket("bucket123")
-  }
-
-  @Test
-  func createBucketWithFileSizeLimit() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("bucket"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "id": "newbucket",
-            "name": "newbucket",
-            "owner": "owner123",
-            "public": false,
-            "created_at": "2024-01-01T00:00:00.000Z",
-            "updated_at": "2024-01-01T00:00:00.000Z"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 79" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"file_size_limit\":10485760,\"id\":\"newbucket\",\"name\":\"newbucket\",\"public\":false}" \
-      	"http://localhost:54321/storage/v1/bucket"
-      """#
-    }
-    .register()
-
-    try await storage.createBucket(
-      "newbucket",
-      options: BucketOptions(isPublic: false, fileSizeLimit: 10_485_760)
-    )
-  }
-
-  @Test
-  func createBucketWithHumanReadableFileSizeLimit() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("bucket"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "id": "newbucket",
-            "name": "newbucket",
-            "owner": "owner123",
-            "public": false,
-            "created_at": "2024-01-01T00:00:00.000Z",
-            "updated_at": "2024-01-01T00:00:00.000Z"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 76" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"file_size_limit\":\"1mb\",\"id\":\"newbucket\",\"name\":\"newbucket\",\"public\":false}" \
-      	"http://localhost:54321/storage/v1/bucket"
-      """#
-    }
-    .register()
-
-    try await storage.createBucket(
-      "newbucket",
-      options: BucketOptions(isPublic: false, fileSizeLimit: "1mb")
-    )
   }
 }

--- a/Tests/StorageTests/StorageErrorTests.swift
+++ b/Tests/StorageTests/StorageErrorTests.swift
@@ -1,31 +1,36 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import Storage
 
-final class StorageErrorTests: XCTestCase {
-  func testErrorInitialization() {
+@Suite
+struct StorageErrorTests {
+  @Test
+  func errorInitialization() {
     let error = StorageError(
       statusCode: "404",
       message: "File not found",
       error: "NotFound"
     )
 
-    XCTAssertEqual(error.statusCode, "404")
-    XCTAssertEqual(error.message, "File not found")
-    XCTAssertEqual(error.error, "NotFound")
+    #expect(error.statusCode == "404")
+    #expect(error.message == "File not found")
+    #expect(error.error == "NotFound")
   }
 
-  func testLocalizedError() {
+  @Test
+  func localizedError() {
     let error = StorageError(
       statusCode: "500",
       message: "Internal server error",
       error: nil
     )
 
-    XCTAssertEqual(error.errorDescription, "Internal server error")
+    #expect(error.errorDescription == "Internal server error")
   }
 
-  func testDecoding() throws {
+  @Test
+  func decoding() throws {
     let json = """
       {
           "statusCode": "403",
@@ -36,8 +41,8 @@ final class StorageErrorTests: XCTestCase {
 
     let error = try JSONDecoder().decode(StorageError.self, from: json)
 
-    XCTAssertEqual(error.statusCode, "403")
-    XCTAssertEqual(error.message, "Unauthorized access")
-    XCTAssertEqual(error.error, "Forbidden")
+    #expect(error.statusCode == "403")
+    #expect(error.message == "Unauthorized access")
+    #expect(error.error == "Forbidden")
   }
 }

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -1,7 +1,8 @@
-import InlineSnapshotTesting
+import ConcurrencyExtras
+import Foundation
 import Mocker
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import Storage
 
@@ -9,24 +10,26 @@ import XCTest
   import FoundationNetworking
 #endif
 
-final class StorageFileAPITests: XCTestCase {
+/// `.serialized`: Mocker registers stubs in a process-global table with no per-test isolation, so
+/// tests that stub overlapping URLs (e.g. `object/move`) would otherwise race against each other
+/// under Swift Testing's default parallel execution.
+@Suite(.serialized)
+struct StorageFileAPITests {
   let url = URL(string: "http://localhost:54321/storage/v1")!
-  var storage: SupabaseStorageClient!
 
-  override func setUp() {
-    super.setUp()
-
+  init() {
     testingBoundary.setValue("alamofire.boundary.e56f43407f772505")
 
     JSONEncoder.defaultStorageEncoder.outputFormatting = [.sortedKeys]
     JSONEncoder.unconfiguredEncoder.outputFormatting = [.sortedKeys]
+  }
 
-    let configuration = URLSessionConfiguration.default
+  private func makeSUT() -> SupabaseStorageClient {
+    let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [MockingURLProtocol.self]
-
     let session = URLSession(configuration: configuration)
 
-    storage = SupabaseStorageClient(
+    return SupabaseStorageClient(
       configuration: StorageClientConfiguration(
         url: url,
         headers: [
@@ -42,7 +45,10 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
-  func testListFiles() async throws {
+  @Test
+  func listFiles() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/list/bucket"),
       statusCode: 200,
@@ -78,11 +84,14 @@ final class StorageFileAPITests: XCTestCase {
     .register()
 
     let result = try await storage.from("bucket").list(path: "folder")
-    XCTAssertEqual(result.count, 1)
-    XCTAssertEqual(result[0].name, "test.txt")
+    #expect(result.count == 1)
+    #expect(result[0].name == "test.txt")
   }
 
-  func testListFilesWithPartialSortByColumn() async throws {
+  @Test
+  func listFilesWithPartialSortByColumn() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/list/bucket"),
       statusCode: 200,
@@ -108,7 +117,10 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
-  func testListFilesWithPartialSortByOrder() async throws {
+  @Test
+  func listFilesWithPartialSortByOrder() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/list/bucket"),
       statusCode: 200,
@@ -134,7 +146,10 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
-  func testListFilesWithFullSortByOverride() async throws {
+  @Test
+  func listFilesWithFullSortByOverride() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/list/bucket"),
       statusCode: 200,
@@ -160,7 +175,10 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
-  func testListFilesPreservesDefaultLimitWhenOnlyOffsetProvided() async throws {
+  @Test
+  func listFilesPreservesDefaultLimitWhenOnlyOffsetProvided() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/list/bucket"),
       statusCode: 200,
@@ -186,7 +204,10 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
-  func testListFilesPreservesDefaultOffsetWhenOnlyLimitProvided() async throws {
+  @Test
+  func listFilesPreservesDefaultOffsetWhenOnlyLimitProvided() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/list/bucket"),
       statusCode: 200,
@@ -212,7 +233,10 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
-  func testListFilesWithExplicitZeroLimitIsNotTreatedAsMissing() async throws {
+  @Test
+  func listFilesWithExplicitZeroLimitIsNotTreatedAsMissing() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/list/bucket"),
       statusCode: 200,
@@ -239,7 +263,10 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
-  func testMove() async throws {
+  @Test
+  func move() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/move"),
       statusCode: 200,
@@ -267,7 +294,10 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
-  func testCopy() async throws {
+  @Test
+  func copy() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/copy"),
       statusCode: 200,
@@ -300,10 +330,13 @@ final class StorageFileAPITests: XCTestCase {
       to: "dest/file.txt"
     )
 
-    XCTAssertEqual(key, "object/dest/file.txt")
+    #expect(key == "object/dest/file.txt")
   }
 
-  func testCreateSignedURL() async throws {
+  @Test
+  func createSignedURL() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/sign/bucket/file.txt"),
       statusCode: 200,
@@ -335,11 +368,14 @@ final class StorageFileAPITests: XCTestCase {
       path: "file.txt",
       expiresIn: 3600
     )
-    XCTAssertEqual(
-      url.absoluteString, "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+    #expect(
+      url.absoluteString == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
   }
 
-  func testCreateSignedURL_download() async throws {
+  @Test
+  func createSignedURL_download() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/sign/bucket/file.txt"),
       statusCode: 200,
@@ -372,12 +408,15 @@ final class StorageFileAPITests: XCTestCase {
       expiresIn: 3600,
       download: true
     )
-    XCTAssertEqual(
-      url.absoluteString,
-      "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
+    #expect(
+      url.absoluteString
+        == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
   }
 
-  func testCreateSignedURLs() async throws {
+  @Test
+  func createSignedURLs() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/sign/bucket"),
       statusCode: 200,
@@ -417,24 +456,27 @@ final class StorageFileAPITests: XCTestCase {
       paths: paths,
       expiresIn: 3600
     )
-    XCTAssertEqual(results.count, 2)
+    #expect(results.count == 2)
     guard case .success(let path0, let url0) = results[0] else {
-      return XCTFail("Expected success for file.txt")
+      Issue.record("Expected success for file.txt")
+      return
     }
-    XCTAssertEqual(path0, "file.txt")
-    XCTAssertEqual(
-      url0.absoluteString,
-      "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+    #expect(path0 == "file.txt")
+    #expect(
+      url0.absoluteString == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
     guard case .success(let path1, let url1) = results[1] else {
-      return XCTFail("Expected success for file2.txt")
+      Issue.record("Expected success for file2.txt")
+      return
     }
-    XCTAssertEqual(path1, "file2.txt")
-    XCTAssertEqual(
-      url1.absoluteString,
-      "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi")
+    #expect(path1 == "file2.txt")
+    #expect(
+      url1.absoluteString == "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi")
   }
 
-  func testCreateSignedURLs_download() async throws {
+  @Test
+  func createSignedURLs_download() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/sign/bucket"),
       statusCode: 200,
@@ -475,22 +517,27 @@ final class StorageFileAPITests: XCTestCase {
       expiresIn: 3600,
       download: true
     )
-    XCTAssertEqual(results.count, 2)
+    #expect(results.count == 2)
     guard case .success(_, let url0) = results[0] else {
-      return XCTFail("Expected success for file.txt")
+      Issue.record("Expected success for file.txt")
+      return
     }
-    XCTAssertEqual(
-      url0.absoluteString,
-      "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
+    #expect(
+      url0.absoluteString
+        == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
     guard case .success(_, let url1) = results[1] else {
-      return XCTFail("Expected success for file2.txt")
+      Issue.record("Expected success for file2.txt")
+      return
     }
-    XCTAssertEqual(
-      url1.absoluteString,
-      "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi&download=")
+    #expect(
+      url1.absoluteString
+        == "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi&download=")
   }
 
-  func testCreateSignedURLs_withNullSignedURL() async throws {
+  @Test
+  func createSignedURLs_withNullSignedURL() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/sign/bucket"),
       statusCode: 200,
@@ -518,19 +565,24 @@ final class StorageFileAPITests: XCTestCase {
       paths: ["file.txt", "missing.txt"],
       expiresIn: 3600
     )
-    XCTAssertEqual(results.count, 2)
+    #expect(results.count == 2)
     guard case .success(let path0, _) = results[0] else {
-      return XCTFail("Expected success for file.txt")
+      Issue.record("Expected success for file.txt")
+      return
     }
-    XCTAssertEqual(path0, "file.txt")
+    #expect(path0 == "file.txt")
     guard case .failure(let path1, let error1) = results[1] else {
-      return XCTFail("Expected failure for missing.txt")
+      Issue.record("Expected failure for missing.txt")
+      return
     }
-    XCTAssertEqual(path1, "missing.txt")
-    XCTAssertEqual(error1, "Either the object does not exist or you do not have access to it")
+    #expect(path1 == "missing.txt")
+    #expect(error1 == "Either the object does not exist or you do not have access to it")
   }
 
-  func testRemove() async throws {
+  @Test
+  func remove() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket"),
       statusCode: 204,
@@ -576,11 +628,14 @@ final class StorageFileAPITests: XCTestCase {
       paths: ["file1.txt", "file2.txt"]
     )
 
-    XCTAssertEqual(objects[0].name, "file1.txt")
-    XCTAssertEqual(objects[1].name, "file2.txt")
+    #expect(objects[0].name == "file1.txt")
+    #expect(objects[1].name == "file2.txt")
   }
 
-  func testNonSuccessStatusCode() async throws {
+  @Test
+  func nonSuccessStatusCode() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/move"),
       statusCode: 400,
@@ -611,13 +666,16 @@ final class StorageFileAPITests: XCTestCase {
     do {
       try await storage.from("bucket")
         .move(from: "source", to: "destination")
-      XCTFail()
+      Issue.record()
     } catch let error as StorageError {
-      XCTAssertEqual(error.message, "Error")
+      #expect(error.message == "Error")
     }
   }
 
-  func testNonSuccessStatusCodeWithNonJSONResponse() async throws {
+  @Test
+  func nonSuccessStatusCodeWithNonJSONResponse() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/move"),
       statusCode: 412,
@@ -642,14 +700,17 @@ final class StorageFileAPITests: XCTestCase {
     do {
       try await storage.from("bucket")
         .move(from: "source", to: "destination")
-      XCTFail()
+      Issue.record()
     } catch let error as HTTPError {
-      XCTAssertEqual(error.data, Data("error".utf8))
-      XCTAssertEqual(error.response.statusCode, 412)
+      #expect(error.data == Data("error".utf8))
+      #expect(error.response.statusCode == 412)
     }
   }
 
-  func testUpdateFromData() async throws {
+  @Test
+  func updateFromData() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 200,
@@ -704,12 +765,15 @@ final class StorageFileAPITests: XCTestCase {
         )
       )
 
-    XCTAssertEqual(response.id, "123")
-    XCTAssertEqual(response.path, "file.txt")
-    XCTAssertEqual(response.fullPath, "bucket/file.txt")
+    #expect(response.id == "123")
+    #expect(response.path == "file.txt")
+    #expect(response.fullPath == "bucket/file.txt")
   }
 
-  func testUploadReturnsCleanedPath() async throws {
+  @Test
+  func uploadReturnsCleanedPath() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/folder/file.txt"),
       statusCode: 200,
@@ -733,11 +797,14 @@ final class StorageFileAPITests: XCTestCase {
         options: FileOptions(contentType: "text/plain")
       )
 
-    XCTAssertEqual(response.path, "folder/file.txt")
-    XCTAssertEqual(response.fullPath, "bucket/folder/file.txt")
+    #expect(response.path == "folder/file.txt")
+    #expect(response.fullPath == "bucket/folder/file.txt")
   }
 
-  func testUploadFromURL_honorsContentType() async throws {
+  @Test
+  func uploadFromURL_honorsContentType() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 200,
@@ -786,12 +853,15 @@ final class StorageFileAPITests: XCTestCase {
         options: FileOptions(contentType: "image/png")
       )
 
-    XCTAssertEqual(response.id, "123")
-    XCTAssertEqual(response.path, "file.txt")
-    XCTAssertEqual(response.fullPath, "bucket/file.txt")
+    #expect(response.id == "123")
+    #expect(response.path == "file.txt")
+    #expect(response.fullPath == "bucket/file.txt")
   }
 
-  func testUpdateFromURL() async throws {
+  @Test
+  func updateFromURL() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 200,
@@ -847,12 +917,15 @@ final class StorageFileAPITests: XCTestCase {
         )
       )
 
-    XCTAssertEqual(response.id, "123")
-    XCTAssertEqual(response.path, "file.txt")
-    XCTAssertEqual(response.fullPath, "bucket/file.txt")
+    #expect(response.id == "123")
+    #expect(response.path == "file.txt")
+    #expect(response.fullPath == "bucket/file.txt")
   }
 
-  func testDownload() async throws {
+  @Test
+  func download() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 200,
@@ -873,10 +946,13 @@ final class StorageFileAPITests: XCTestCase {
     let data = try await storage.from("bucket")
       .download(path: "file.txt")
 
-    XCTAssertEqual(data, Data("hello world".utf8))
+    #expect(data == Data("hello world".utf8))
   }
 
-  func testDownloadWithAdditionalQuery() async throws {
+  @Test
+  func downloadWithAdditionalQuery() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       ignoreQuery: true,
@@ -901,10 +977,13 @@ final class StorageFileAPITests: XCTestCase {
         query: [URLQueryItem(name: "version", value: "1")]
       )
 
-    XCTAssertEqual(data, Data("hello world".utf8))
+    #expect(data == Data("hello world".utf8))
   }
 
-  func testDownload_withEmptyTransformOptions() async throws {
+  @Test
+  func download_withEmptyTransformOptions() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 200,
@@ -917,44 +996,56 @@ final class StorageFileAPITests: XCTestCase {
     let data = try await storage.from("bucket")
       .download(path: "file.txt", options: TransformOptions())
 
-    XCTAssertEqual(data, Data("hello world".utf8))
+    #expect(data == Data("hello world".utf8))
   }
 
-  func testGetPublicURL_withEmptyTransformOptions() throws {
+  @Test
+  func getPublicURL_withEmptyTransformOptions() throws {
+    let storage = makeSUT()
+
     let publicURL = try storage.from("bucket")
       .getPublicURL(path: "image.png", options: TransformOptions())
 
-    XCTAssertTrue(
+    #expect(
       publicURL.absoluteString.contains("/object/public/"),
       "Empty transform should use /object/public/ path, got: \(publicURL.absoluteString)"
     )
-    XCTAssertFalse(
-      publicURL.absoluteString.contains("/render/image/"),
+    #expect(
+      !publicURL.absoluteString.contains("/render/image/"),
       "Empty transform should not use /render/image/ path, got: \(publicURL.absoluteString)"
     )
   }
 
-  func testGetPublicURL_withActualTransformOptions() throws {
+  @Test
+  func getPublicURL_withActualTransformOptions() throws {
+    let storage = makeSUT()
+
     let publicURL = try storage.from("bucket")
       .getPublicURL(path: "image.png", options: TransformOptions(width: 200))
 
-    XCTAssertTrue(
+    #expect(
       publicURL.absoluteString.contains("/render/image/"),
       "Non-empty transform should use /render/image/ path, got: \(publicURL.absoluteString)"
     )
   }
 
-  func testGetPublicURLStripsLeadingSlash() throws {
+  @Test
+  func getPublicURLStripsLeadingSlash() throws {
+    let storage = makeSUT()
+
     let publicURL = try storage.from("bucket")
       .getPublicURL(path: "/folder/image.png")
 
-    XCTAssertEqual(
-      publicURL.absoluteString,
-      "http://localhost:54321/storage/v1/object/public/bucket/folder/image.png"
+    #expect(
+      publicURL.absoluteString
+        == "http://localhost:54321/storage/v1/object/public/bucket/folder/image.png"
     )
   }
 
-  func testDownloadStripsLeadingSlash() async throws {
+  @Test
+  func downloadStripsLeadingSlash() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 200,
@@ -975,10 +1066,13 @@ final class StorageFileAPITests: XCTestCase {
     let data = try await storage.from("bucket")
       .download(path: "/file.txt")
 
-    XCTAssertEqual(data, Data("hello world".utf8))
+    #expect(data == Data("hello world".utf8))
   }
 
-  func testDownload_withOptions() async throws {
+  @Test
+  func download_withOptions() async throws {
+    let storage = makeSUT()
+
     let imageData = try! Data(
       contentsOf: Bundle.module.url(forResource: "sadcat", withExtension: "jpg")!)
 
@@ -1006,10 +1100,13 @@ final class StorageFileAPITests: XCTestCase {
         options: TransformOptions(format: "cover")
       )
 
-    XCTAssertEqual(data, imageData)
+    #expect(data == imageData)
   }
 
-  func testInfo() async throws {
+  @Test
+  func info() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/info/bucket/file.txt"),
       statusCode: 200,
@@ -1037,10 +1134,13 @@ final class StorageFileAPITests: XCTestCase {
 
     let info = try await storage.from("bucket").info(path: "file.txt")
 
-    XCTAssertEqual(info.name, "file.txt")
+    #expect(info.name == "file.txt")
   }
 
-  func testExists() async throws {
+  @Test
+  func exists() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 200,
@@ -1061,10 +1161,13 @@ final class StorageFileAPITests: XCTestCase {
 
     let exists = try await storage.from("bucket").exists(path: "file.txt")
 
-    XCTAssertTrue(exists)
+    #expect(exists)
   }
 
-  func testExists_400_error() async throws {
+  @Test
+  func exists_400_error() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 400,
@@ -1085,10 +1188,13 @@ final class StorageFileAPITests: XCTestCase {
 
     let exists = try await storage.from("bucket").exists(path: "file.txt")
 
-    XCTAssertFalse(exists)
+    #expect(!exists)
   }
 
-  func testExists_404_error() async throws {
+  @Test
+  func exists_404_error() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       statusCode: 404,
@@ -1109,10 +1215,13 @@ final class StorageFileAPITests: XCTestCase {
 
     let exists = try await storage.from("bucket").exists(path: "file.txt")
 
-    XCTAssertFalse(exists)
+    #expect(!exists)
   }
 
-  func testCreateSignedUploadURL() async throws {
+  @Test
+  func createSignedUploadURL() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
       statusCode: 200,
@@ -1140,14 +1249,17 @@ final class StorageFileAPITests: XCTestCase {
     let response = try await storage.from("bucket")
       .createSignedUploadURL(path: "file.txt")
 
-    XCTAssertEqual(response.path, "file.txt")
-    XCTAssertEqual(response.token, "abc.def.ghi")
-    XCTAssertEqual(
-      response.signedURL.absoluteString,
-      "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+    #expect(response.path == "file.txt")
+    #expect(response.token == "abc.def.ghi")
+    #expect(
+      response.signedURL.absoluteString
+        == "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
   }
 
-  func testCreateSignedUploadURL_withUpsert() async throws {
+  @Test
+  func createSignedUploadURL_withUpsert() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
       statusCode: 200,
@@ -1181,14 +1293,17 @@ final class StorageFileAPITests: XCTestCase {
         )
       )
 
-    XCTAssertEqual(response.path, "file.txt")
-    XCTAssertEqual(response.token, "abc.def.ghi")
-    XCTAssertEqual(
-      response.signedURL.absoluteString,
-      "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+    #expect(response.path == "file.txt")
+    #expect(response.token == "abc.def.ghi")
+    #expect(
+      response.signedURL.absoluteString
+        == "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
   }
 
-  func testCreateSignedUploadURLCleansPath() async throws {
+  @Test
+  func createSignedUploadURLCleansPath() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/upload/sign/bucket/folder/file.txt"),
       statusCode: 200,
@@ -1216,11 +1331,14 @@ final class StorageFileAPITests: XCTestCase {
     let response = try await storage.from("bucket")
       .createSignedUploadURL(path: "/folder//file.txt")
 
-    XCTAssertEqual(response.path, "folder/file.txt")
-    XCTAssertEqual(response.token, "abc.def.ghi")
+    #expect(response.path == "folder/file.txt")
+    #expect(response.token == "abc.def.ghi")
   }
 
-  func testUploadToSignedURLCleansPath() async throws {
+  @Test
+  func uploadToSignedURLCleansPath() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/upload/sign/bucket/folder/file.txt"),
       ignoreQuery: true,
@@ -1263,11 +1381,14 @@ final class StorageFileAPITests: XCTestCase {
     let response = try await storage.from("bucket")
       .uploadToSignedURL("/folder//file.txt", token: "abc.def.ghi", data: Data("hello world".utf8))
 
-    XCTAssertEqual(response.path, "folder/file.txt")
-    XCTAssertEqual(response.fullPath, "bucket/folder/file.txt")
+    #expect(response.path == "folder/file.txt")
+    #expect(response.fullPath == "bucket/folder/file.txt")
   }
 
-  func testUploadToSignedURL() async throws {
+  @Test
+  func uploadToSignedURL() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
       ignoreQuery: true,
@@ -1310,11 +1431,14 @@ final class StorageFileAPITests: XCTestCase {
     let response = try await storage.from("bucket")
       .uploadToSignedURL("file.txt", token: "abc.def.ghi", data: Data("hello world".utf8))
 
-    XCTAssertEqual(response.path, "file.txt")
-    XCTAssertEqual(response.fullPath, "bucket/file.txt")
+    #expect(response.path == "file.txt")
+    #expect(response.fullPath == "bucket/file.txt")
   }
 
-  func testUploadToSignedURL_fromFileURL() async throws {
+  @Test
+  func uploadToSignedURL_fromFileURL() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
       ignoreQuery: true,
@@ -1366,11 +1490,14 @@ final class StorageFileAPITests: XCTestCase {
         )
       )
 
-    XCTAssertEqual(response.path, "file.txt")
-    XCTAssertEqual(response.fullPath, "bucket/file.txt")
+    #expect(response.path == "file.txt")
+    #expect(response.fullPath == "bucket/file.txt")
   }
 
-  func testCreateSignedURL_cacheNonce() async throws {
+  @Test
+  func createSignedURL_cacheNonce() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/sign/bucket/file.txt"),
       statusCode: 200,
@@ -1391,12 +1518,15 @@ final class StorageFileAPITests: XCTestCase {
       expiresIn: 3600,
       cacheNonce: "abc123"
     )
-    XCTAssertEqual(
-      url.absoluteString,
-      "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&cacheNonce=abc123")
+    #expect(
+      url.absoluteString
+        == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&cacheNonce=abc123")
   }
 
-  func testCreateSignedURLs_cacheNonce() async throws {
+  @Test
+  func createSignedURLs_cacheNonce() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/sign/bucket"),
       statusCode: 200,
@@ -1421,24 +1551,30 @@ final class StorageFileAPITests: XCTestCase {
       cacheNonce: "abc123"
     )
     guard case .success(_, let url) = results[0] else {
-      return XCTFail("Expected success for file.txt")
+      Issue.record("Expected success for file.txt")
+      return
     }
-    XCTAssertEqual(
-      url.absoluteString,
-      "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&cacheNonce=abc123")
+    #expect(
+      url.absoluteString
+        == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&cacheNonce=abc123")
   }
 
-  func testGetPublicURL_cacheNonce() throws {
+  @Test
+  func getPublicURL_cacheNonce() throws {
+    let storage = makeSUT()
+
     let url = try storage.from("bucket").getPublicURL(
       path: "file.txt",
       cacheNonce: "abc123"
     )
-    XCTAssertEqual(
-      url.absoluteString,
-      "\(self.url)/object/public/bucket/file.txt?cacheNonce=abc123")
+    #expect(
+      url.absoluteString == "\(self.url)/object/public/bucket/file.txt?cacheNonce=abc123")
   }
 
-  func testDownload_cacheNonce() async throws {
+  @Test
+  func download_cacheNonce() async throws {
+    let storage = makeSUT()
+
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),
       ignoreQuery: true,
@@ -1460,6 +1596,6 @@ final class StorageFileAPITests: XCTestCase {
     let data = try await storage.from("bucket")
       .download(path: "file.txt", cacheNonce: "abc123")
 
-    XCTAssertEqual(data, Data("hello world".utf8))
+    #expect(data == Data("hello world".utf8))
   }
 }

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -10,1592 +10,1595 @@ import Testing
   import FoundationNetworking
 #endif
 
-/// `.serialized`: Mocker registers stubs in a process-global table with no per-test isolation, so
-/// tests that stub overlapping URLs (e.g. `object/move`) would otherwise race against each other
-/// under Swift Testing's default parallel execution.
-@Suite(.serialized)
-struct StorageFileAPITests {
-  let url = URL(string: "http://localhost:54321/storage/v1")!
+extension StorageMockerTests {
+  struct StorageFileAPITests {
+    let url = URL(string: "http://localhost:54321/storage/v1")!
 
-  init() {
-    testingBoundary.setValue("alamofire.boundary.e56f43407f772505")
+    init() {
+      testingBoundary.setValue("alamofire.boundary.e56f43407f772505")
 
-    JSONEncoder.defaultStorageEncoder.outputFormatting = [.sortedKeys]
-    JSONEncoder.unconfiguredEncoder.outputFormatting = [.sortedKeys]
-  }
+      JSONEncoder.defaultStorageEncoder.outputFormatting = [.sortedKeys]
+      JSONEncoder.unconfiguredEncoder.outputFormatting = [.sortedKeys]
+    }
 
-  private func makeSUT() -> SupabaseStorageClient {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [MockingURLProtocol.self]
-    let session = URLSession(configuration: configuration)
+    private func makeSUT() -> SupabaseStorageClient {
+      Mocker.removeAll()
 
-    return SupabaseStorageClient(
-      configuration: StorageClientConfiguration(
-        url: url,
-        headers: [
-          "apikey":
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
-        ],
-        session: StorageHTTPSession(
-          fetch: { try await session.data(for: $0) },
-          upload: { try await session.upload(for: $0, from: $1) }
-        ),
-        logger: nil
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.protocolClasses = [MockingURLProtocol.self]
+      let session = URLSession(configuration: configuration)
+
+      return SupabaseStorageClient(
+        configuration: StorageClientConfiguration(
+          url: url,
+          headers: [
+            "apikey":
+              "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
+          ],
+          session: StorageHTTPSession(
+            fetch: { try await session.data(for: $0) },
+            upload: { try await session.upload(for: $0, from: $1) }
+          ),
+          logger: nil
+        )
       )
-    )
-  }
+    }
 
-  @Test
-  func listFiles() async throws {
-    let storage = makeSUT()
+    @Test
+    func listFiles() async throws {
+      let storage = makeSUT()
 
-    Mock(
-      url: url.appendingPathComponent("object/list/bucket"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          [
+      Mock(
+        url: url.appendingPathComponent("object/list/bucket"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            [
+              {
+                "name": "test.txt",
+                "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+                "updatedAt": "2024-01-01T00:00:00Z",
+                "createdAt": "2024-01-01T00:00:00Z",
+                "lastAccessedAt": "2024-01-01T00:00:00Z",
+                "metadata": {}
+              }
+            ]
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 83" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
+        	"http://localhost:54321/storage/v1/object/list/bucket"
+        """#
+      }
+      .register()
+
+      let result = try await storage.from("bucket").list(path: "folder")
+      #expect(result.count == 1)
+      #expect(result[0].name == "test.txt")
+    }
+
+    @Test
+    func listFilesWithPartialSortByColumn() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/list/bucket"),
+        statusCode: 200,
+        data: [.post: Data("[]".utf8)]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 89" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"updated_at\",\"order\":\"asc\"}}" \
+        	"http://localhost:54321/storage/v1/object/list/bucket"
+        """#
+      }
+      .register()
+
+      _ = try await storage.from("bucket").list(
+        path: "folder",
+        options: SearchOptions(sortBy: SortBy(column: "updated_at"))
+      )
+    }
+
+    @Test
+    func listFilesWithPartialSortByOrder() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/list/bucket"),
+        statusCode: 200,
+        data: [.post: Data("[]".utf8)]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 84" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"desc\"}}" \
+        	"http://localhost:54321/storage/v1/object/list/bucket"
+        """#
+      }
+      .register()
+
+      _ = try await storage.from("bucket").list(
+        path: "folder",
+        options: SearchOptions(sortBy: SortBy(order: .descending))
+      )
+    }
+
+    @Test
+    func listFilesWithFullSortByOverride() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/list/bucket"),
+        statusCode: 200,
+        data: [.post: Data("[]".utf8)]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 90" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"updated_at\",\"order\":\"desc\"}}" \
+        	"http://localhost:54321/storage/v1/object/list/bucket"
+        """#
+      }
+      .register()
+
+      _ = try await storage.from("bucket").list(
+        path: "folder",
+        options: SearchOptions(sortBy: SortBy(column: "updated_at", order: .descending))
+      )
+    }
+
+    @Test
+    func listFilesPreservesDefaultLimitWhenOnlyOffsetProvided() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/list/bucket"),
+        statusCode: 200,
+        data: [.post: Data("[]".utf8)]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 84" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"limit\":100,\"offset\":10,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
+        	"http://localhost:54321/storage/v1/object/list/bucket"
+        """#
+      }
+      .register()
+
+      _ = try await storage.from("bucket").list(
+        path: "folder",
+        options: SearchOptions(offset: 10, sortBy: SortBy(column: "name", order: .ascending))
+      )
+    }
+
+    @Test
+    func listFilesPreservesDefaultOffsetWhenOnlyLimitProvided() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/list/bucket"),
+        statusCode: 200,
+        data: [.post: Data("[]".utf8)]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 82" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"limit\":50,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
+        	"http://localhost:54321/storage/v1/object/list/bucket"
+        """#
+      }
+      .register()
+
+      _ = try await storage.from("bucket").list(
+        path: "folder",
+        options: SearchOptions(limit: 50, sortBy: SortBy(column: "name", order: .ascending))
+      )
+    }
+
+    @Test
+    func listFilesWithExplicitZeroLimitIsNotTreatedAsMissing() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/list/bucket"),
+        statusCode: 200,
+        data: [.post: Data("[]".utf8)]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 81" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"limit\":0,\"offset\":5,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
+        	"http://localhost:54321/storage/v1/object/list/bucket"
+        """#
+      }
+      .register()
+
+      _ = try await storage.from("bucket").list(
+        path: "folder",
+        options: SearchOptions(
+          limit: 0, offset: 5, sortBy: SortBy(column: "name", order: .ascending))
+      )
+    }
+
+    @Test
+    func move() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/move"),
+        statusCode: 200,
+        data: [
+          .post: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 107" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"new\/path.txt\",\"sourceKey\":\"old\/path.txt\"}" \
+        	"http://localhost:54321/storage/v1/object/move"
+        """#
+      }
+      .register()
+
+      try await storage.from("bucket").move(
+        from: "old/path.txt",
+        to: "new/path.txt"
+      )
+    }
+
+    @Test
+    func copy() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/copy"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
             {
-              "name": "test.txt",
-              "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-              "updatedAt": "2024-01-01T00:00:00Z",
-              "createdAt": "2024-01-01T00:00:00Z",
-              "lastAccessedAt": "2024-01-01T00:00:00Z",
-              "metadata": {}
+              "Key": "object/dest/file.txt"
             }
-          ]
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 83" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
-      	"http://localhost:54321/storage/v1/object/list/bucket"
-      """#
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 111" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"dest\/file.txt\",\"sourceKey\":\"source\/file.txt\"}" \
+        	"http://localhost:54321/storage/v1/object/copy"
+        """#
+      }
+      .register()
+
+      let key = try await storage.from("bucket").copy(
+        from: "source/file.txt",
+        to: "dest/file.txt"
+      )
+
+      #expect(key == "object/dest/file.txt")
     }
-    .register()
 
-    let result = try await storage.from("bucket").list(path: "folder")
-    #expect(result.count == 1)
-    #expect(result[0].name == "test.txt")
-  }
+    @Test
+    func createSignedURL() async throws {
+      let storage = makeSUT()
 
-  @Test
-  func listFilesWithPartialSortByColumn() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/list/bucket"),
-      statusCode: 200,
-      data: [.post: Data("[]".utf8)]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 89" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"updated_at\",\"order\":\"asc\"}}" \
-      	"http://localhost:54321/storage/v1/object/list/bucket"
-      """#
-    }
-    .register()
-
-    _ = try await storage.from("bucket").list(
-      path: "folder",
-      options: SearchOptions(sortBy: SortBy(column: "updated_at"))
-    )
-  }
-
-  @Test
-  func listFilesWithPartialSortByOrder() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/list/bucket"),
-      statusCode: 200,
-      data: [.post: Data("[]".utf8)]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 84" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"desc\"}}" \
-      	"http://localhost:54321/storage/v1/object/list/bucket"
-      """#
-    }
-    .register()
-
-    _ = try await storage.from("bucket").list(
-      path: "folder",
-      options: SearchOptions(sortBy: SortBy(order: .descending))
-    )
-  }
-
-  @Test
-  func listFilesWithFullSortByOverride() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/list/bucket"),
-      statusCode: 200,
-      data: [.post: Data("[]".utf8)]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 90" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"limit\":100,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"updated_at\",\"order\":\"desc\"}}" \
-      	"http://localhost:54321/storage/v1/object/list/bucket"
-      """#
-    }
-    .register()
-
-    _ = try await storage.from("bucket").list(
-      path: "folder",
-      options: SearchOptions(sortBy: SortBy(column: "updated_at", order: .descending))
-    )
-  }
-
-  @Test
-  func listFilesPreservesDefaultLimitWhenOnlyOffsetProvided() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/list/bucket"),
-      statusCode: 200,
-      data: [.post: Data("[]".utf8)]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 84" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"limit\":100,\"offset\":10,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
-      	"http://localhost:54321/storage/v1/object/list/bucket"
-      """#
-    }
-    .register()
-
-    _ = try await storage.from("bucket").list(
-      path: "folder",
-      options: SearchOptions(offset: 10, sortBy: SortBy(column: "name", order: .ascending))
-    )
-  }
-
-  @Test
-  func listFilesPreservesDefaultOffsetWhenOnlyLimitProvided() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/list/bucket"),
-      statusCode: 200,
-      data: [.post: Data("[]".utf8)]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 82" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"limit\":50,\"offset\":0,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
-      	"http://localhost:54321/storage/v1/object/list/bucket"
-      """#
-    }
-    .register()
-
-    _ = try await storage.from("bucket").list(
-      path: "folder",
-      options: SearchOptions(limit: 50, sortBy: SortBy(column: "name", order: .ascending))
-    )
-  }
-
-  @Test
-  func listFilesWithExplicitZeroLimitIsNotTreatedAsMissing() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/list/bucket"),
-      statusCode: 200,
-      data: [.post: Data("[]".utf8)]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 81" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"limit\":0,\"offset\":5,\"prefix\":\"folder\",\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}" \
-      	"http://localhost:54321/storage/v1/object/list/bucket"
-      """#
-    }
-    .register()
-
-    _ = try await storage.from("bucket").list(
-      path: "folder",
-      options: SearchOptions(
-        limit: 0, offset: 5, sortBy: SortBy(column: "name", order: .ascending))
-    )
-  }
-
-  @Test
-  func move() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/move"),
-      statusCode: 200,
-      data: [
-        .post: Data()
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 107" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"new\/path.txt\",\"sourceKey\":\"old\/path.txt\"}" \
-      	"http://localhost:54321/storage/v1/object/move"
-      """#
-    }
-    .register()
-
-    try await storage.from("bucket").move(
-      from: "old/path.txt",
-      to: "new/path.txt"
-    )
-  }
-
-  @Test
-  func copy() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/copy"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "Key": "object/dest/file.txt"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 111" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"dest\/file.txt\",\"sourceKey\":\"source\/file.txt\"}" \
-      	"http://localhost:54321/storage/v1/object/copy"
-      """#
-    }
-    .register()
-
-    let key = try await storage.from("bucket").copy(
-      from: "source/file.txt",
-      to: "dest/file.txt"
-    )
-
-    #expect(key == "object/dest/file.txt")
-  }
-
-  @Test
-  func createSignedURL() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/sign/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 18" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"expiresIn\":3600}" \
-      	"http://localhost:54321/storage/v1/object/sign/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let url = try await storage.from("bucket").createSignedURL(
-      path: "file.txt",
-      expiresIn: 3600
-    )
-    #expect(
-      url.absoluteString == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
-  }
-
-  @Test
-  func createSignedURL_download() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/sign/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 18" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"expiresIn\":3600}" \
-      	"http://localhost:54321/storage/v1/object/sign/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let url = try await storage.from("bucket").createSignedURL(
-      path: "file.txt",
-      expiresIn: 3600,
-      download: true
-    )
-    #expect(
-      url.absoluteString
-        == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
-  }
-
-  @Test
-  func createSignedURLs() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/sign/bucket"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          [
+      Mock(
+        url: url.appendingPathComponent("object/sign/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
             {
-              "path": "file.txt",
               "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-            },
-            {
-              "path": "file2.txt",
-              "signedURL": "object/upload/sign/bucket/file2.txt?token=abc.def.ghi"
             }
-          ]
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 51" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"expiresIn\":3600,\"paths\":[\"file.txt\",\"file2.txt\"]}" \
-      	"http://localhost:54321/storage/v1/object/sign/bucket"
-      """#
-    }
-    .register()
-
-    let paths = ["file.txt", "file2.txt"]
-    let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
-      paths: paths,
-      expiresIn: 3600
-    )
-    #expect(results.count == 2)
-    guard case .success(let path0, let url0) = results[0] else {
-      Issue.record("Expected success for file.txt")
-      return
-    }
-    #expect(path0 == "file.txt")
-    #expect(
-      url0.absoluteString == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
-    guard case .success(let path1, let url1) = results[1] else {
-      Issue.record("Expected success for file2.txt")
-      return
-    }
-    #expect(path1 == "file2.txt")
-    #expect(
-      url1.absoluteString == "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi")
-  }
-
-  @Test
-  func createSignedURLs_download() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/sign/bucket"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          [
-            {
-              "path": "file.txt",
-              "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-            },
-            {
-              "path": "file2.txt",
-              "signedURL": "object/upload/sign/bucket/file2.txt?token=abc.def.ghi"
-            }
-          ]
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 51" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"expiresIn\":3600,\"paths\":[\"file.txt\",\"file2.txt\"]}" \
-      	"http://localhost:54321/storage/v1/object/sign/bucket"
-      """#
-    }
-    .register()
-
-    let paths = ["file.txt", "file2.txt"]
-    let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
-      paths: paths,
-      expiresIn: 3600,
-      download: true
-    )
-    #expect(results.count == 2)
-    guard case .success(_, let url0) = results[0] else {
-      Issue.record("Expected success for file.txt")
-      return
-    }
-    #expect(
-      url0.absoluteString
-        == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
-    guard case .success(_, let url1) = results[1] else {
-      Issue.record("Expected success for file2.txt")
-      return
-    }
-    #expect(
-      url1.absoluteString
-        == "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi&download=")
-  }
-
-  @Test
-  func createSignedURLs_withNullSignedURL() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/sign/bucket"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          [
-            {
-              "path": "file.txt",
-              "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-            },
-            {
-              "path": "missing.txt",
-              "signedURL": null,
-              "error": "Either the object does not exist or you do not have access to it"
-            }
-          ]
-          """.utf8
-        )
-      ]
-    )
-    .register()
-
-    let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
-      paths: ["file.txt", "missing.txt"],
-      expiresIn: 3600
-    )
-    #expect(results.count == 2)
-    guard case .success(let path0, _) = results[0] else {
-      Issue.record("Expected success for file.txt")
-      return
-    }
-    #expect(path0 == "file.txt")
-    guard case .failure(let path1, let error1) = results[1] else {
-      Issue.record("Expected failure for missing.txt")
-      return
-    }
-    #expect(path1 == "missing.txt")
-    #expect(error1 == "Either the object does not exist or you do not have access to it")
-  }
-
-  @Test
-  func remove() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket"),
-      statusCode: 204,
-      data: [
-        .delete: Data(
-          """
-          [
-            {
-              "name": "file1.txt",
-              "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-              "updatedAt": "2024-01-01T00:00:00Z",
-              "createdAt": "2024-01-01T00:00:00Z",
-              "lastAccessedAt": "2024-01-01T00:00:00Z",
-              "metadata": {}
-            },
-            {
-              "name": "file2.txt",
-              "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E00",
-              "updatedAt": "2024-01-01T00:00:00Z",
-              "createdAt": "2024-01-01T00:00:00Z",
-              "lastAccessedAt": "2024-01-01T00:00:00Z",
-              "metadata": {}
-            }
-          ]
-          """.utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request DELETE \
-      	--header "Content-Length: 38" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"prefixes\":[\"file1.txt\",\"file2.txt\"]}" \
-      	"http://localhost:54321/storage/v1/object/bucket"
-      """#
-    }
-    .register()
-
-    let objects = try await storage.from("bucket").remove(
-      paths: ["file1.txt", "file2.txt"]
-    )
-
-    #expect(objects[0].name == "file1.txt")
-    #expect(objects[1].name == "file2.txt")
-  }
-
-  @Test
-  func nonSuccessStatusCode() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/move"),
-      statusCode: 400,
-      data: [
-        .post: Data(
-          """
-          {
-            "message":"Error"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 98" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"destination\",\"sourceKey\":\"source\"}" \
-      	"http://localhost:54321/storage/v1/object/move"
-      """#
-    }
-    .register()
-
-    do {
-      try await storage.from("bucket")
-        .move(from: "source", to: "destination")
-      Issue.record()
-    } catch let error as StorageError {
-      #expect(error.message == "Error")
-    }
-  }
-
-  @Test
-  func nonSuccessStatusCodeWithNonJSONResponse() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/move"),
-      statusCode: 412,
-      data: [
-        .post: Data("error".utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Content-Length: 98" \
-      	--header "Content-Type: application/json" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"destination\",\"sourceKey\":\"source\"}" \
-      	"http://localhost:54321/storage/v1/object/move"
-      """#
-    }
-    .register()
-
-    do {
-      try await storage.from("bucket")
-        .move(from: "source", to: "destination")
-      Issue.record()
-    } catch let error as HTTPError {
-      #expect(error.data == Data("error".utf8))
-      #expect(error.response.statusCode == 412)
-    }
-  }
-
-  @Test
-  func updateFromData() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .put: Data(
-          """
-          {
-            "Id": "123",
-            "Key": "bucket/file.txt"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request PUT \
-      	--header "Cache-Control: max-age=3600" \
-      	--header "Content-Length: 390" \
-      	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "--alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"cacheControl\"\#r
-      \#r
-      3600\#r
-      --alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"metadata\"\#r
-      \#r
-      {\"mode\":\"test\"}\#r
-      --alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
-      Content-Type: text/plain\#r
-      \#r
-      hello world\#r
-      --alamofire.boundary.e56f43407f772505--\#r
-      " \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .update(
-        "file.txt",
-        data: Data("hello world".utf8),
-        options: FileOptions(
-          metadata: [
-            "mode": "test"
-          ]
-        )
+            """.utf8
+          )
+        ]
       )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 18" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"expiresIn\":3600}" \
+        	"http://localhost:54321/storage/v1/object/sign/bucket/file.txt"
+        """#
+      }
+      .register()
 
-    #expect(response.id == "123")
-    #expect(response.path == "file.txt")
-    #expect(response.fullPath == "bucket/file.txt")
-  }
-
-  @Test
-  func uploadReturnsCleanedPath() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/folder/file.txt"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "Id": "123",
-            "Key": "bucket/folder/file.txt"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .register()
-
-    let response = try await storage.from("bucket")
-      .upload(
-        "/folder//file.txt",
-        data: Data("hello world!".utf8),
-        options: FileOptions(contentType: "text/plain")
-      )
-
-    #expect(response.path == "folder/file.txt")
-    #expect(response.fullPath == "bucket/folder/file.txt")
-  }
-
-  @Test
-  func uploadFromURL_honorsContentType() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "Id": "123",
-            "Key": "bucket/file.txt"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "Cache-Control: max-age=3600" \
-      	--header "Content-Length: 284" \
-      	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--header "x-upsert: false" \
-      	--data "--alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"cacheControl\"\#r
-      \#r
-      3600\#r
-      --alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
-      Content-Type: image/png\#r
-      \#r
-      hello world!
-      \#r
-      --alamofire.boundary.e56f43407f772505--\#r
-      " \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .upload(
-        "file.txt",
-        fileURL: Bundle.module.url(forResource: "file", withExtension: "txt")!,
-        options: FileOptions(contentType: "image/png")
-      )
-
-    #expect(response.id == "123")
-    #expect(response.path == "file.txt")
-    #expect(response.fullPath == "bucket/file.txt")
-  }
-
-  @Test
-  func updateFromURL() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .put: Data(
-          """
-          {
-            "Id": "123",
-            "Key": "bucket/file.txt"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request PUT \
-      	--header "Cache-Control: max-age=3600" \
-      	--header "Content-Length: 392" \
-      	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--data "--alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"cacheControl\"\#r
-      \#r
-      3600\#r
-      --alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"metadata\"\#r
-      \#r
-      {\"mode\":\"test\"}\#r
-      --alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
-      Content-Type: text/plain\#r
-      \#r
-      hello world!
-      \#r
-      --alamofire.boundary.e56f43407f772505--\#r
-      " \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .update(
-        "file.txt",
-        fileURL: Bundle.module.url(forResource: "file", withExtension: "txt")!,
-        options: FileOptions(
-          metadata: [
-            "mode": "test"
-          ]
-        )
-      )
-
-    #expect(response.id == "123")
-    #expect(response.path == "file.txt")
-    #expect(response.fullPath == "bucket/file.txt")
-  }
-
-  @Test
-  func download() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .get: Data("hello world".utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let data = try await storage.from("bucket")
-      .download(path: "file.txt")
-
-    #expect(data == Data("hello world".utf8))
-  }
-
-  @Test
-  func downloadWithAdditionalQuery() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      ignoreQuery: true,
-      statusCode: 200,
-      data: [
-        .get: Data("hello world".utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt?version=1"
-      """#
-    }
-    .register()
-
-    let data = try await storage.from("bucket")
-      .download(
+      let url = try await storage.from("bucket").createSignedURL(
         path: "file.txt",
-        query: [URLQueryItem(name: "version", value: "1")]
+        expiresIn: 3600
       )
-
-    #expect(data == Data("hello world".utf8))
-  }
-
-  @Test
-  func download_withEmptyTransformOptions() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .get: Data("hello world".utf8)
-      ]
-    )
-    .register()
-
-    let data = try await storage.from("bucket")
-      .download(path: "file.txt", options: TransformOptions())
-
-    #expect(data == Data("hello world".utf8))
-  }
-
-  @Test
-  func getPublicURL_withEmptyTransformOptions() throws {
-    let storage = makeSUT()
-
-    let publicURL = try storage.from("bucket")
-      .getPublicURL(path: "image.png", options: TransformOptions())
-
-    #expect(
-      publicURL.absoluteString.contains("/object/public/"),
-      "Empty transform should use /object/public/ path, got: \(publicURL.absoluteString)"
-    )
-    #expect(
-      !publicURL.absoluteString.contains("/render/image/"),
-      "Empty transform should not use /render/image/ path, got: \(publicURL.absoluteString)"
-    )
-  }
-
-  @Test
-  func getPublicURL_withActualTransformOptions() throws {
-    let storage = makeSUT()
-
-    let publicURL = try storage.from("bucket")
-      .getPublicURL(path: "image.png", options: TransformOptions(width: 200))
-
-    #expect(
-      publicURL.absoluteString.contains("/render/image/"),
-      "Non-empty transform should use /render/image/ path, got: \(publicURL.absoluteString)"
-    )
-  }
-
-  @Test
-  func getPublicURLStripsLeadingSlash() throws {
-    let storage = makeSUT()
-
-    let publicURL = try storage.from("bucket")
-      .getPublicURL(path: "/folder/image.png")
-
-    #expect(
-      publicURL.absoluteString
-        == "http://localhost:54321/storage/v1/object/public/bucket/folder/image.png"
-    )
-  }
-
-  @Test
-  func downloadStripsLeadingSlash() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .get: Data("hello world".utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
-      """#
+      #expect(
+        url.absoluteString == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
     }
-    .register()
 
-    let data = try await storage.from("bucket")
-      .download(path: "/file.txt")
+    @Test
+    func createSignedURL_download() async throws {
+      let storage = makeSUT()
 
-    #expect(data == Data("hello world".utf8))
-  }
-
-  @Test
-  func download_withOptions() async throws {
-    let storage = makeSUT()
-
-    let imageData = try! Data(
-      contentsOf: Bundle.module.url(forResource: "sadcat", withExtension: "jpg")!)
-
-    Mock(
-      url: url.appendingPathComponent("render/image/authenticated/bucket/sadcat.txt"),
-      ignoreQuery: true,
-      statusCode: 200,
-      data: [
-        .get: imageData
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/render/image/authenticated/bucket/sadcat.txt?format=cover"
-      """#
-    }
-    .register()
-
-    let data = try await storage.from("bucket")
-      .download(
-        path: "sadcat.txt",
-        options: TransformOptions(format: "cover")
-      )
-
-    #expect(data == imageData)
-  }
-
-  @Test
-  func info() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/info/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .get: Data(
-          """
-          {
-            "name": "file.txt",
-            "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-            "version": "2"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/info/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let info = try await storage.from("bucket").info(path: "file.txt")
-
-    #expect(info.name == "file.txt")
-  }
-
-  @Test
-  func exists() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .head: Data()
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--head \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let exists = try await storage.from("bucket").exists(path: "file.txt")
-
-    #expect(exists)
-  }
-
-  @Test
-  func exists_400_error() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 400,
-      data: [
-        .head: Data()
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--head \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let exists = try await storage.from("bucket").exists(path: "file.txt")
-
-    #expect(!exists)
-  }
-
-  @Test
-  func exists_404_error() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      statusCode: 404,
-      data: [
-        .head: Data()
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--head \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let exists = try await storage.from("bucket").exists(path: "file.txt")
-
-    #expect(!exists)
-  }
-
-  @Test
-  func createSignedUploadURL() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "url": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .createSignedUploadURL(path: "file.txt")
-
-    #expect(response.path == "file.txt")
-    #expect(response.token == "abc.def.ghi")
-    #expect(
-      response.signedURL.absoluteString
-        == "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
-  }
-
-  @Test
-  func createSignedUploadURL_withUpsert() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "url": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--header "x-upsert: true" \
-      	"http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .createSignedUploadURL(
-        path: "file.txt",
-        options: CreateSignedUploadURLOptions(
-          upsert: true
-        )
-      )
-
-    #expect(response.path == "file.txt")
-    #expect(response.token == "abc.def.ghi")
-    #expect(
-      response.signedURL.absoluteString
-        == "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
-  }
-
-  @Test
-  func createSignedUploadURLCleansPath() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/upload/sign/bucket/folder/file.txt"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "url": "object/upload/sign/bucket/folder/file.txt?token=abc.def.ghi"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request POST \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/upload/sign/bucket/folder/file.txt"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .createSignedUploadURL(path: "/folder//file.txt")
-
-    #expect(response.path == "folder/file.txt")
-    #expect(response.token == "abc.def.ghi")
-  }
-
-  @Test
-  func uploadToSignedURLCleansPath() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/upload/sign/bucket/folder/file.txt"),
-      ignoreQuery: true,
-      statusCode: 200,
-      data: [
-        .put: Data(
-          """
-          {
-            "Key": "bucket/folder/file.txt"
-          }
-          """.utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request PUT \
-      	--header "Cache-Control: max-age=3600" \
-      	--header "Content-Length: 297" \
-      	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--header "x-upsert: false" \
-      	--data "--alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"cacheControl\"\#r
-      \#r
-      3600\#r
-      --alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
-      Content-Type: text/plain;charset=UTF-8\#r
-      \#r
-      hello world\#r
-      --alamofire.boundary.e56f43407f772505--\#r
-      " \
-      	"http://localhost:54321/storage/v1/object/upload/sign/bucket/folder/file.txt?token=abc.def.ghi"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .uploadToSignedURL("/folder//file.txt", token: "abc.def.ghi", data: Data("hello world".utf8))
-
-    #expect(response.path == "folder/file.txt")
-    #expect(response.fullPath == "bucket/folder/file.txt")
-  }
-
-  @Test
-  func uploadToSignedURL() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
-      ignoreQuery: true,
-      statusCode: 200,
-      data: [
-        .put: Data(
-          """
-          {
-            "Key": "bucket/file.txt"
-          }
-          """.utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request PUT \
-      	--header "Cache-Control: max-age=3600" \
-      	--header "Content-Length: 297" \
-      	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--header "x-upsert: false" \
-      	--data "--alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"cacheControl\"\#r
-      \#r
-      3600\#r
-      --alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
-      Content-Type: text/plain;charset=UTF-8\#r
-      \#r
-      hello world\#r
-      --alamofire.boundary.e56f43407f772505--\#r
-      " \
-      	"http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .uploadToSignedURL("file.txt", token: "abc.def.ghi", data: Data("hello world".utf8))
-
-    #expect(response.path == "file.txt")
-    #expect(response.fullPath == "bucket/file.txt")
-  }
-
-  @Test
-  func uploadToSignedURL_fromFileURL() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
-      ignoreQuery: true,
-      statusCode: 200,
-      data: [
-        .put: Data(
-          """
-          {
-            "Key": "bucket/file.txt"
-          }
-          """.utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--request PUT \
-      	--header "Cache-Control: max-age=3600" \
-      	--header "Content-Length: 285" \
-      	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "X-Mode: test" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	--header "x-upsert: false" \
-      	--data "--alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"cacheControl\"\#r
-      \#r
-      3600\#r
-      --alamofire.boundary.e56f43407f772505\#r
-      Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
-      Content-Type: text/plain\#r
-      \#r
-      hello world!
-      \#r
-      --alamofire.boundary.e56f43407f772505--\#r
-      " \
-      	"http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-      """#
-    }
-    .register()
-
-    let response = try await storage.from("bucket")
-      .uploadToSignedURL(
-        "file.txt",
-        token: "abc.def.ghi",
-        fileURL: Bundle.module.url(forResource: "file", withExtension: "txt")!,
-        options: FileOptions(
-          headers: ["X-Mode": "test"]
-        )
-      )
-
-    #expect(response.path == "file.txt")
-    #expect(response.fullPath == "bucket/file.txt")
-  }
-
-  @Test
-  func createSignedURL_cacheNonce() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/sign/bucket/file.txt"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          {
-            "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
-          }
-          """.utf8
-        )
-      ]
-    )
-    .register()
-
-    let url = try await storage.from("bucket").createSignedURL(
-      path: "file.txt",
-      expiresIn: 3600,
-      cacheNonce: "abc123"
-    )
-    #expect(
-      url.absoluteString
-        == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&cacheNonce=abc123")
-  }
-
-  @Test
-  func createSignedURLs_cacheNonce() async throws {
-    let storage = makeSUT()
-
-    Mock(
-      url: url.appendingPathComponent("object/sign/bucket"),
-      statusCode: 200,
-      data: [
-        .post: Data(
-          """
-          [
+      Mock(
+        url: url.appendingPathComponent("object/sign/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
             {
-              "path": "file.txt",
               "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
             }
-          ]
-          """.utf8
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 18" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"expiresIn\":3600}" \
+        	"http://localhost:54321/storage/v1/object/sign/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let url = try await storage.from("bucket").createSignedURL(
+        path: "file.txt",
+        expiresIn: 3600,
+        download: true
+      )
+      #expect(
+        url.absoluteString
+          == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
+    }
+
+    @Test
+    func createSignedURLs() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/sign/bucket"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            [
+              {
+                "path": "file.txt",
+                "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+              },
+              {
+                "path": "file2.txt",
+                "signedURL": "object/upload/sign/bucket/file2.txt?token=abc.def.ghi"
+              }
+            ]
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 51" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"expiresIn\":3600,\"paths\":[\"file.txt\",\"file2.txt\"]}" \
+        	"http://localhost:54321/storage/v1/object/sign/bucket"
+        """#
+      }
+      .register()
+
+      let paths = ["file.txt", "file2.txt"]
+      let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
+        paths: paths,
+        expiresIn: 3600
+      )
+      #expect(results.count == 2)
+      guard case .success(let path0, let url0) = results[0] else {
+        Issue.record("Expected success for file.txt")
+        return
+      }
+      #expect(path0 == "file.txt")
+      #expect(
+        url0.absoluteString == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
+      guard case .success(let path1, let url1) = results[1] else {
+        Issue.record("Expected success for file2.txt")
+        return
+      }
+      #expect(path1 == "file2.txt")
+      #expect(
+        url1.absoluteString == "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi")
+    }
+
+    @Test
+    func createSignedURLs_download() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/sign/bucket"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            [
+              {
+                "path": "file.txt",
+                "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+              },
+              {
+                "path": "file2.txt",
+                "signedURL": "object/upload/sign/bucket/file2.txt?token=abc.def.ghi"
+              }
+            ]
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 51" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"expiresIn\":3600,\"paths\":[\"file.txt\",\"file2.txt\"]}" \
+        	"http://localhost:54321/storage/v1/object/sign/bucket"
+        """#
+      }
+      .register()
+
+      let paths = ["file.txt", "file2.txt"]
+      let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
+        paths: paths,
+        expiresIn: 3600,
+        download: true
+      )
+      #expect(results.count == 2)
+      guard case .success(_, let url0) = results[0] else {
+        Issue.record("Expected success for file.txt")
+        return
+      }
+      #expect(
+        url0.absoluteString
+          == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&download=")
+      guard case .success(_, let url1) = results[1] else {
+        Issue.record("Expected success for file2.txt")
+        return
+      }
+      #expect(
+        url1.absoluteString
+          == "\(self.url)/object/upload/sign/bucket/file2.txt?token=abc.def.ghi&download=")
+    }
+
+    @Test
+    func createSignedURLs_withNullSignedURL() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/sign/bucket"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            [
+              {
+                "path": "file.txt",
+                "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+              },
+              {
+                "path": "missing.txt",
+                "signedURL": null,
+                "error": "Either the object does not exist or you do not have access to it"
+              }
+            ]
+            """.utf8
+          )
+        ]
+      )
+      .register()
+
+      let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
+        paths: ["file.txt", "missing.txt"],
+        expiresIn: 3600
+      )
+      #expect(results.count == 2)
+      guard case .success(let path0, _) = results[0] else {
+        Issue.record("Expected success for file.txt")
+        return
+      }
+      #expect(path0 == "file.txt")
+      guard case .failure(let path1, let error1) = results[1] else {
+        Issue.record("Expected failure for missing.txt")
+        return
+      }
+      #expect(path1 == "missing.txt")
+      #expect(error1 == "Either the object does not exist or you do not have access to it")
+    }
+
+    @Test
+    func remove() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket"),
+        statusCode: 204,
+        data: [
+          .delete: Data(
+            """
+            [
+              {
+                "name": "file1.txt",
+                "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+                "updatedAt": "2024-01-01T00:00:00Z",
+                "createdAt": "2024-01-01T00:00:00Z",
+                "lastAccessedAt": "2024-01-01T00:00:00Z",
+                "metadata": {}
+              },
+              {
+                "name": "file2.txt",
+                "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E00",
+                "updatedAt": "2024-01-01T00:00:00Z",
+                "createdAt": "2024-01-01T00:00:00Z",
+                "lastAccessedAt": "2024-01-01T00:00:00Z",
+                "metadata": {}
+              }
+            ]
+            """.utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request DELETE \
+        	--header "Content-Length: 38" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"prefixes\":[\"file1.txt\",\"file2.txt\"]}" \
+        	"http://localhost:54321/storage/v1/object/bucket"
+        """#
+      }
+      .register()
+
+      let objects = try await storage.from("bucket").remove(
+        paths: ["file1.txt", "file2.txt"]
+      )
+
+      #expect(objects[0].name == "file1.txt")
+      #expect(objects[1].name == "file2.txt")
+    }
+
+    @Test
+    func nonSuccessStatusCode() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/move"),
+        statusCode: 400,
+        data: [
+          .post: Data(
+            """
+            {
+              "message":"Error"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 98" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"destination\",\"sourceKey\":\"source\"}" \
+        	"http://localhost:54321/storage/v1/object/move"
+        """#
+      }
+      .register()
+
+      do {
+        try await storage.from("bucket")
+          .move(from: "source", to: "destination")
+        Issue.record()
+      } catch let error as StorageError {
+        #expect(error.message == "Error")
+      }
+    }
+
+    @Test
+    func nonSuccessStatusCodeWithNonJSONResponse() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/move"),
+        statusCode: 412,
+        data: [
+          .post: Data("error".utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Content-Length: 98" \
+        	--header "Content-Type: application/json" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"bucketId\":\"bucket\",\"destinationBucket\":null,\"destinationKey\":\"destination\",\"sourceKey\":\"source\"}" \
+        	"http://localhost:54321/storage/v1/object/move"
+        """#
+      }
+      .register()
+
+      do {
+        try await storage.from("bucket")
+          .move(from: "source", to: "destination")
+        Issue.record()
+      } catch let error as HTTPError {
+        #expect(error.data == Data("error".utf8))
+        #expect(error.response.statusCode == 412)
+      }
+    }
+
+    @Test
+    func updateFromData() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .put: Data(
+            """
+            {
+              "Id": "123",
+              "Key": "bucket/file.txt"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request PUT \
+        	--header "Cache-Control: max-age=3600" \
+        	--header "Content-Length: 390" \
+        	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "--alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"cacheControl\"\#r
+        \#r
+        3600\#r
+        --alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"metadata\"\#r
+        \#r
+        {\"mode\":\"test\"}\#r
+        --alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
+        Content-Type: text/plain\#r
+        \#r
+        hello world\#r
+        --alamofire.boundary.e56f43407f772505--\#r
+        " \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .update(
+          "file.txt",
+          data: Data("hello world".utf8),
+          options: FileOptions(
+            metadata: [
+              "mode": "test"
+            ]
+          )
         )
-      ]
-    )
-    .register()
 
-    let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
-      paths: ["file.txt"],
-      expiresIn: 3600,
-      cacheNonce: "abc123"
-    )
-    guard case .success(_, let url) = results[0] else {
-      Issue.record("Expected success for file.txt")
-      return
+      #expect(response.id == "123")
+      #expect(response.path == "file.txt")
+      #expect(response.fullPath == "bucket/file.txt")
     }
-    #expect(
-      url.absoluteString
-        == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&cacheNonce=abc123")
-  }
 
-  @Test
-  func getPublicURL_cacheNonce() throws {
-    let storage = makeSUT()
+    @Test
+    func uploadReturnsCleanedPath() async throws {
+      let storage = makeSUT()
 
-    let url = try storage.from("bucket").getPublicURL(
-      path: "file.txt",
-      cacheNonce: "abc123"
-    )
-    #expect(
-      url.absoluteString == "\(self.url)/object/public/bucket/file.txt?cacheNonce=abc123")
-  }
+      Mock(
+        url: url.appendingPathComponent("object/bucket/folder/file.txt"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "Id": "123",
+              "Key": "bucket/folder/file.txt"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .register()
 
-  @Test
-  func download_cacheNonce() async throws {
-    let storage = makeSUT()
+      let response = try await storage.from("bucket")
+        .upload(
+          "/folder//file.txt",
+          data: Data("hello world!".utf8),
+          options: FileOptions(contentType: "text/plain")
+        )
 
-    Mock(
-      url: url.appendingPathComponent("object/bucket/file.txt"),
-      ignoreQuery: true,
-      statusCode: 200,
-      data: [
-        .get: Data("hello world".utf8)
-      ]
-    )
-    .snapshotRequest {
-      #"""
-      curl \
-      	--header "X-Client-Info: storage-swift/0.0.0" \
-      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
-      	"http://localhost:54321/storage/v1/object/bucket/file.txt?cacheNonce=abc123"
-      """#
+      #expect(response.path == "folder/file.txt")
+      #expect(response.fullPath == "bucket/folder/file.txt")
     }
-    .register()
 
-    let data = try await storage.from("bucket")
-      .download(path: "file.txt", cacheNonce: "abc123")
+    @Test
+    func uploadFromURL_honorsContentType() async throws {
+      let storage = makeSUT()
 
-    #expect(data == Data("hello world".utf8))
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "Id": "123",
+              "Key": "bucket/file.txt"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Cache-Control: max-age=3600" \
+        	--header "Content-Length: 284" \
+        	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--header "x-upsert: false" \
+        	--data "--alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"cacheControl\"\#r
+        \#r
+        3600\#r
+        --alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
+        Content-Type: image/png\#r
+        \#r
+        hello world!
+        \#r
+        --alamofire.boundary.e56f43407f772505--\#r
+        " \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .upload(
+          "file.txt",
+          fileURL: Bundle.module.url(forResource: "file", withExtension: "txt")!,
+          options: FileOptions(contentType: "image/png")
+        )
+
+      #expect(response.id == "123")
+      #expect(response.path == "file.txt")
+      #expect(response.fullPath == "bucket/file.txt")
+    }
+
+    @Test
+    func updateFromURL() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .put: Data(
+            """
+            {
+              "Id": "123",
+              "Key": "bucket/file.txt"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request PUT \
+        	--header "Cache-Control: max-age=3600" \
+        	--header "Content-Length: 392" \
+        	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "--alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"cacheControl\"\#r
+        \#r
+        3600\#r
+        --alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"metadata\"\#r
+        \#r
+        {\"mode\":\"test\"}\#r
+        --alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
+        Content-Type: text/plain\#r
+        \#r
+        hello world!
+        \#r
+        --alamofire.boundary.e56f43407f772505--\#r
+        " \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .update(
+          "file.txt",
+          fileURL: Bundle.module.url(forResource: "file", withExtension: "txt")!,
+          options: FileOptions(
+            metadata: [
+              "mode": "test"
+            ]
+          )
+        )
+
+      #expect(response.id == "123")
+      #expect(response.path == "file.txt")
+      #expect(response.fullPath == "bucket/file.txt")
+    }
+
+    @Test
+    func download() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .get: Data("hello world".utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let data = try await storage.from("bucket")
+        .download(path: "file.txt")
+
+      #expect(data == Data("hello world".utf8))
+    }
+
+    @Test
+    func downloadWithAdditionalQuery() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [
+          .get: Data("hello world".utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt?version=1"
+        """#
+      }
+      .register()
+
+      let data = try await storage.from("bucket")
+        .download(
+          path: "file.txt",
+          query: [URLQueryItem(name: "version", value: "1")]
+        )
+
+      #expect(data == Data("hello world".utf8))
+    }
+
+    @Test
+    func download_withEmptyTransformOptions() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .get: Data("hello world".utf8)
+        ]
+      )
+      .register()
+
+      let data = try await storage.from("bucket")
+        .download(path: "file.txt", options: TransformOptions())
+
+      #expect(data == Data("hello world".utf8))
+    }
+
+    @Test
+    func getPublicURL_withEmptyTransformOptions() throws {
+      let storage = makeSUT()
+
+      let publicURL = try storage.from("bucket")
+        .getPublicURL(path: "image.png", options: TransformOptions())
+
+      #expect(
+        publicURL.absoluteString.contains("/object/public/"),
+        "Empty transform should use /object/public/ path, got: \(publicURL.absoluteString)"
+      )
+      #expect(
+        !publicURL.absoluteString.contains("/render/image/"),
+        "Empty transform should not use /render/image/ path, got: \(publicURL.absoluteString)"
+      )
+    }
+
+    @Test
+    func getPublicURL_withActualTransformOptions() throws {
+      let storage = makeSUT()
+
+      let publicURL = try storage.from("bucket")
+        .getPublicURL(path: "image.png", options: TransformOptions(width: 200))
+
+      #expect(
+        publicURL.absoluteString.contains("/render/image/"),
+        "Non-empty transform should use /render/image/ path, got: \(publicURL.absoluteString)"
+      )
+    }
+
+    @Test
+    func getPublicURLStripsLeadingSlash() throws {
+      let storage = makeSUT()
+
+      let publicURL = try storage.from("bucket")
+        .getPublicURL(path: "/folder/image.png")
+
+      #expect(
+        publicURL.absoluteString
+          == "http://localhost:54321/storage/v1/object/public/bucket/folder/image.png"
+      )
+    }
+
+    @Test
+    func downloadStripsLeadingSlash() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .get: Data("hello world".utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let data = try await storage.from("bucket")
+        .download(path: "/file.txt")
+
+      #expect(data == Data("hello world".utf8))
+    }
+
+    @Test
+    func download_withOptions() async throws {
+      let storage = makeSUT()
+
+      let imageData = try! Data(
+        contentsOf: Bundle.module.url(forResource: "sadcat", withExtension: "jpg")!)
+
+      Mock(
+        url: url.appendingPathComponent("render/image/authenticated/bucket/sadcat.txt"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [
+          .get: imageData
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/render/image/authenticated/bucket/sadcat.txt?format=cover"
+        """#
+      }
+      .register()
+
+      let data = try await storage.from("bucket")
+        .download(
+          path: "sadcat.txt",
+          options: TransformOptions(format: "cover")
+        )
+
+      #expect(data == imageData)
+    }
+
+    @Test
+    func info() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/info/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .get: Data(
+            """
+            {
+              "name": "file.txt",
+              "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+              "version": "2"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/info/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let info = try await storage.from("bucket").info(path: "file.txt")
+
+      #expect(info.name == "file.txt")
+    }
+
+    @Test
+    func exists() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .head: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--head \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let exists = try await storage.from("bucket").exists(path: "file.txt")
+
+      #expect(exists)
+    }
+
+    @Test
+    func exists_400_error() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 400,
+        data: [
+          .head: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--head \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let exists = try await storage.from("bucket").exists(path: "file.txt")
+
+      #expect(!exists)
+    }
+
+    @Test
+    func exists_404_error() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        statusCode: 404,
+        data: [
+          .head: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--head \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let exists = try await storage.from("bucket").exists(path: "file.txt")
+
+      #expect(!exists)
+    }
+
+    @Test
+    func createSignedUploadURL() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "url": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .createSignedUploadURL(path: "file.txt")
+
+      #expect(response.path == "file.txt")
+      #expect(response.token == "abc.def.ghi")
+      #expect(
+        response.signedURL.absoluteString
+          == "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+      )
+    }
+
+    @Test
+    func createSignedUploadURL_withUpsert() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "url": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--header "x-upsert: true" \
+        	"http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .createSignedUploadURL(
+          path: "file.txt",
+          options: CreateSignedUploadURLOptions(
+            upsert: true
+          )
+        )
+
+      #expect(response.path == "file.txt")
+      #expect(response.token == "abc.def.ghi")
+      #expect(
+        response.signedURL.absoluteString
+          == "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+      )
+    }
+
+    @Test
+    func createSignedUploadURLCleansPath() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/upload/sign/bucket/folder/file.txt"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "url": "object/upload/sign/bucket/folder/file.txt?token=abc.def.ghi"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/upload/sign/bucket/folder/file.txt"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .createSignedUploadURL(path: "/folder//file.txt")
+
+      #expect(response.path == "folder/file.txt")
+      #expect(response.token == "abc.def.ghi")
+    }
+
+    @Test
+    func uploadToSignedURLCleansPath() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/upload/sign/bucket/folder/file.txt"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [
+          .put: Data(
+            """
+            {
+              "Key": "bucket/folder/file.txt"
+            }
+            """.utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request PUT \
+        	--header "Cache-Control: max-age=3600" \
+        	--header "Content-Length: 297" \
+        	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--header "x-upsert: false" \
+        	--data "--alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"cacheControl\"\#r
+        \#r
+        3600\#r
+        --alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
+        Content-Type: text/plain;charset=UTF-8\#r
+        \#r
+        hello world\#r
+        --alamofire.boundary.e56f43407f772505--\#r
+        " \
+        	"http://localhost:54321/storage/v1/object/upload/sign/bucket/folder/file.txt?token=abc.def.ghi"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .uploadToSignedURL(
+          "/folder//file.txt", token: "abc.def.ghi", data: Data("hello world".utf8))
+
+      #expect(response.path == "folder/file.txt")
+      #expect(response.fullPath == "bucket/folder/file.txt")
+    }
+
+    @Test
+    func uploadToSignedURL() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [
+          .put: Data(
+            """
+            {
+              "Key": "bucket/file.txt"
+            }
+            """.utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request PUT \
+        	--header "Cache-Control: max-age=3600" \
+        	--header "Content-Length: 297" \
+        	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--header "x-upsert: false" \
+        	--data "--alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"cacheControl\"\#r
+        \#r
+        3600\#r
+        --alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
+        Content-Type: text/plain;charset=UTF-8\#r
+        \#r
+        hello world\#r
+        --alamofire.boundary.e56f43407f772505--\#r
+        " \
+        	"http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .uploadToSignedURL("file.txt", token: "abc.def.ghi", data: Data("hello world".utf8))
+
+      #expect(response.path == "file.txt")
+      #expect(response.fullPath == "bucket/file.txt")
+    }
+
+    @Test
+    func uploadToSignedURL_fromFileURL() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [
+          .put: Data(
+            """
+            {
+              "Key": "bucket/file.txt"
+            }
+            """.utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request PUT \
+        	--header "Cache-Control: max-age=3600" \
+        	--header "Content-Length: 285" \
+        	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "X-Mode: test" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--header "x-upsert: false" \
+        	--data "--alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"cacheControl\"\#r
+        \#r
+        3600\#r
+        --alamofire.boundary.e56f43407f772505\#r
+        Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
+        Content-Type: text/plain\#r
+        \#r
+        hello world!
+        \#r
+        --alamofire.boundary.e56f43407f772505--\#r
+        " \
+        	"http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+        """#
+      }
+      .register()
+
+      let response = try await storage.from("bucket")
+        .uploadToSignedURL(
+          "file.txt",
+          token: "abc.def.ghi",
+          fileURL: Bundle.module.url(forResource: "file", withExtension: "txt")!,
+          options: FileOptions(
+            headers: ["X-Mode": "test"]
+          )
+        )
+
+      #expect(response.path == "file.txt")
+      #expect(response.fullPath == "bucket/file.txt")
+    }
+
+    @Test
+    func createSignedURL_cacheNonce() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/sign/bucket/file.txt"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {
+              "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .register()
+
+      let url = try await storage.from("bucket").createSignedURL(
+        path: "file.txt",
+        expiresIn: 3600,
+        cacheNonce: "abc123"
+      )
+      #expect(
+        url.absoluteString
+          == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&cacheNonce=abc123")
+    }
+
+    @Test
+    func createSignedURLs_cacheNonce() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/sign/bucket"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            [
+              {
+                "path": "file.txt",
+                "signedURL": "object/upload/sign/bucket/file.txt?token=abc.def.ghi"
+              }
+            ]
+            """.utf8
+          )
+        ]
+      )
+      .register()
+
+      let results: [SignedURLResult] = try await storage.from("bucket").createSignedURLs(
+        paths: ["file.txt"],
+        expiresIn: 3600,
+        cacheNonce: "abc123"
+      )
+      guard case .success(_, let url) = results[0] else {
+        Issue.record("Expected success for file.txt")
+        return
+      }
+      #expect(
+        url.absoluteString
+          == "\(self.url)/object/upload/sign/bucket/file.txt?token=abc.def.ghi&cacheNonce=abc123")
+    }
+
+    @Test
+    func getPublicURL_cacheNonce() throws {
+      let storage = makeSUT()
+
+      let url = try storage.from("bucket").getPublicURL(
+        path: "file.txt",
+        cacheNonce: "abc123"
+      )
+      #expect(
+        url.absoluteString == "\(self.url)/object/public/bucket/file.txt?cacheNonce=abc123")
+    }
+
+    @Test
+    func download_cacheNonce() async throws {
+      let storage = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("object/bucket/file.txt"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [
+          .get: Data("hello world".utf8)
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--header "X-Client-Info: storage-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/storage/v1/object/bucket/file.txt?cacheNonce=abc123"
+        """#
+      }
+      .register()
+
+      let data = try await storage.from("bucket")
+        .download(path: "file.txt", cacheNonce: "abc123")
+
+      #expect(data == Data("hello world".utf8))
+    }
   }
 }

--- a/Tests/StorageTests/SupabaseStorageTests.swift
+++ b/Tests/StorageTests/SupabaseStorageTests.swift
@@ -1,8 +1,7 @@
 import ConcurrencyExtras
-import CustomDump
 import Foundation
 import InlineSnapshotTesting
-import XCTest
+import Testing
 import XCTestDynamicOverlay
 
 @testable import Storage
@@ -11,22 +10,19 @@ import XCTestDynamicOverlay
   import FoundationNetworking
 #endif
 
-final class SupabaseStorageTests: XCTestCase {
+@Suite
+struct SupabaseStorageTests {
   let supabaseURL = URL(string: "http://localhost:54321/storage/v1")!
   let bucketId = "tests"
 
-  var sessionMock = StorageHTTPSession(
-    fetch: unimplemented("StorageHTTPSession.fetch"),
-    upload: unimplemented("StorageHTTPSession.upload")
-  )
-
-  func testGetPublicURL() throws {
+  @Test
+  func getPublicURL() throws {
     let sut = makeSUT()
 
     let path = "README.md"
 
     let baseUrl = try sut.from(bucketId).getPublicURL(path: path)
-    XCTAssertEqual(baseUrl.absoluteString, "\(supabaseURL)/object/public/\(bucketId)/\(path)")
+    #expect(baseUrl.absoluteString == "\(supabaseURL)/object/public/\(bucketId)/\(path)")
 
     let baseUrlWithDownload = try sut.from(bucketId).getPublicURL(
       path: path,
@@ -58,92 +54,22 @@ final class SupabaseStorageTests: XCTestCase {
     }
   }
 
-  func testCreateSignedURLs() async throws {
-    sessionMock.fetch = { _ in
-      (
-        """
-        [
-          {
-            "path": "file1.txt",
-            "signedURL": "/sign/file1.txt?token=abc.def.ghi"
-          },
-          {
-            "path": "file2.txt",
-            "signedURL": "/sign/file2.txt?token=abc.def.ghi"
-          }
-        ]
-        """.data(using: .utf8)!,
-        HTTPURLResponse(
-          url: self.supabaseURL,
-          statusCode: 200,
-          httpVersion: nil,
-          headerFields: nil
-        )!
-      )
-    }
-
-    let sut = makeSUT()
-    let results: [SignedURLResult] = try await sut.from(bucketId).createSignedURLs(
-      paths: ["file1.txt", "file2.txt"],
-      expiresIn: 60
-    )
-
-    XCTAssertEqual(results.count, 2)
-    guard case .success(let path0, let url0) = results[0] else {
-      return XCTFail("Expected success for file1.txt")
-    }
-    XCTAssertEqual(path0, "file1.txt")
-    XCTAssertEqual(
-      url0.absoluteString,
-      "http://localhost:54321/storage/v1/sign/file1.txt?token=abc.def.ghi")
-    guard case .success(let path1, let url1) = results[1] else {
-      return XCTFail("Expected success for file2.txt")
-    }
-    XCTAssertEqual(path1, "file2.txt")
-    XCTAssertEqual(
-      url1.absoluteString,
-      "http://localhost:54321/storage/v1/sign/file2.txt?token=abc.def.ghi")
-  }
-
-  #if !os(Linux) && !os(Android)
-    func testUploadData() async throws {
-      testingBoundary.setValue("alamofire.boundary.c21f947c1c7b0c57")
-
-      sessionMock.fetch = { request in
-        assertInlineSnapshot(of: request, as: .curl) {
-          #"""
-          curl \
-          	--request POST \
-          	--header "Apikey: test.api.key" \
-          	--header "Authorization: Bearer test.api.key" \
-          	--header "Cache-Control: max-age=14400" \
-          	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.c21f947c1c7b0c57" \
-          	--header "X-Client-Info: storage-swift/x.y.z" \
-          	--header "x-upsert: false" \
-          	--data "--alamofire.boundary.c21f947c1c7b0c57\#r
-          Content-Disposition: form-data; name=\"cacheControl\"\#r
-          \#r
-          14400\#r
-          --alamofire.boundary.c21f947c1c7b0c57\#r
-          Content-Disposition: form-data; name=\"metadata\"\#r
-          \#r
-          {\"key\":\"value\"}\#r
-          --alamofire.boundary.c21f947c1c7b0c57\#r
-          Content-Disposition: form-data; name=\"\"; filename=\"file1.txt\"\#r
-          Content-Type: text/plain\#r
-          \#r
-          test data\#r
-          --alamofire.boundary.c21f947c1c7b0c57--\#r
-          " \
-          	"http://localhost:54321/storage/v1/object/tests/file1.txt"
-          """#
-        }
-        return (
+  @Test
+  func createSignedURLs() async throws {
+    let sessionMock = StorageHTTPSession(
+      fetch: { _ in
+        (
           """
-          {
-            "Id": "tests/file1.txt",
-            "Key": "tests/file1.txt"
-          }
+          [
+            {
+              "path": "file1.txt",
+              "signedURL": "/sign/file1.txt?token=abc.def.ghi"
+            },
+            {
+              "path": "file2.txt",
+              "signedURL": "/sign/file2.txt?token=abc.def.ghi"
+            }
+          ]
           """.data(using: .utf8)!,
           HTTPURLResponse(
             url: self.supabaseURL,
@@ -152,9 +78,89 @@ final class SupabaseStorageTests: XCTestCase {
             headerFields: nil
           )!
         )
-      }
+      },
+      upload: unimplemented("StorageHTTPSession.upload")
+    )
 
-      let sut = makeSUT()
+    let sut = makeSUT(session: sessionMock)
+    let results: [SignedURLResult] = try await sut.from(bucketId).createSignedURLs(
+      paths: ["file1.txt", "file2.txt"],
+      expiresIn: 60
+    )
+
+    #expect(results.count == 2)
+    guard case .success(let path0, let url0) = results[0] else {
+      Issue.record("Expected success for file1.txt")
+      return
+    }
+    #expect(path0 == "file1.txt")
+    #expect(
+      url0.absoluteString
+        == "http://localhost:54321/storage/v1/sign/file1.txt?token=abc.def.ghi")
+    guard case .success(let path1, let url1) = results[1] else {
+      Issue.record("Expected success for file2.txt")
+      return
+    }
+    #expect(path1 == "file2.txt")
+    #expect(
+      url1.absoluteString
+        == "http://localhost:54321/storage/v1/sign/file2.txt?token=abc.def.ghi")
+  }
+
+  #if !os(Linux) && !os(Android)
+    @Test
+    func uploadData() async throws {
+      testingBoundary.setValue("alamofire.boundary.c21f947c1c7b0c57")
+
+      let sessionMock = StorageHTTPSession(
+        fetch: { request in
+          assertInlineSnapshot(of: request, as: .curl) {
+            #"""
+            curl \
+            	--request POST \
+            	--header "Apikey: test.api.key" \
+            	--header "Authorization: Bearer test.api.key" \
+            	--header "Cache-Control: max-age=14400" \
+            	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.c21f947c1c7b0c57" \
+            	--header "X-Client-Info: storage-swift/x.y.z" \
+            	--header "x-upsert: false" \
+            	--data "--alamofire.boundary.c21f947c1c7b0c57\#r
+            Content-Disposition: form-data; name=\"cacheControl\"\#r
+            \#r
+            14400\#r
+            --alamofire.boundary.c21f947c1c7b0c57\#r
+            Content-Disposition: form-data; name=\"metadata\"\#r
+            \#r
+            {\"key\":\"value\"}\#r
+            --alamofire.boundary.c21f947c1c7b0c57\#r
+            Content-Disposition: form-data; name=\"\"; filename=\"file1.txt\"\#r
+            Content-Type: text/plain\#r
+            \#r
+            test data\#r
+            --alamofire.boundary.c21f947c1c7b0c57--\#r
+            " \
+            	"http://localhost:54321/storage/v1/object/tests/file1.txt"
+            """#
+          }
+          return (
+            """
+            {
+              "Id": "tests/file1.txt",
+              "Key": "tests/file1.txt"
+            }
+            """.data(using: .utf8)!,
+            HTTPURLResponse(
+              url: self.supabaseURL,
+              statusCode: 200,
+              httpVersion: nil,
+              headerFields: nil
+            )!
+          )
+        },
+        upload: unimplemented("StorageHTTPSession.upload")
+      )
+
+      let sut = makeSUT(session: sessionMock)
 
       try await sut.from(bucketId)
         .upload(
@@ -167,40 +173,44 @@ final class SupabaseStorageTests: XCTestCase {
         )
     }
 
-    func testUploadFileURL() async throws {
+    @Test
+    func uploadFileURL() async throws {
       testingBoundary.setValue("alamofire.boundary.c21f947c1c7b0c57")
 
-      sessionMock.fetch = { request in
-        assertInlineSnapshot(of: request, as: .curl) {
-          #"""
-          curl \
-          	--request POST \
-          	--header "Apikey: test.api.key" \
-          	--header "Authorization: Bearer test.api.key" \
-          	--header "Cache-Control: max-age=3600" \
-          	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.c21f947c1c7b0c57" \
-          	--header "X-Client-Info: storage-swift/x.y.z" \
-          	--header "x-upsert: false" \
-          	"http://localhost:54321/storage/v1/object/tests/sadcat.jpg"
-          """#
-        }
-        return (
-          """
-          {
-            "Id": "tests/file1.txt",
-            "Key": "tests/file1.txt"
+      let sessionMock = StorageHTTPSession(
+        fetch: { request in
+          assertInlineSnapshot(of: request, as: .curl) {
+            #"""
+            curl \
+            	--request POST \
+            	--header "Apikey: test.api.key" \
+            	--header "Authorization: Bearer test.api.key" \
+            	--header "Cache-Control: max-age=3600" \
+            	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.c21f947c1c7b0c57" \
+            	--header "X-Client-Info: storage-swift/x.y.z" \
+            	--header "x-upsert: false" \
+            	"http://localhost:54321/storage/v1/object/tests/sadcat.jpg"
+            """#
           }
-          """.data(using: .utf8)!,
-          HTTPURLResponse(
-            url: self.supabaseURL,
-            statusCode: 200,
-            httpVersion: nil,
-            headerFields: nil
-          )!
-        )
-      }
+          return (
+            """
+            {
+              "Id": "tests/file1.txt",
+              "Key": "tests/file1.txt"
+            }
+            """.data(using: .utf8)!,
+            HTTPURLResponse(
+              url: self.supabaseURL,
+              statusCode: 200,
+              httpVersion: nil,
+              headerFields: nil
+            )!
+          )
+        },
+        upload: unimplemented("StorageHTTPSession.upload")
+      )
 
-      let sut = makeSUT()
+      let sut = makeSUT(session: sessionMock)
 
       try await sut.from(bucketId)
         .upload(
@@ -213,133 +223,151 @@ final class SupabaseStorageTests: XCTestCase {
     }
   #endif
 
-  private func makeSUT() -> SupabaseStorageClient {
+  private func makeSUT(
+    session: StorageHTTPSession = StorageHTTPSession(
+      fetch: unimplemented("StorageHTTPSession.fetch"),
+      upload: unimplemented("StorageHTTPSession.upload")
+    )
+  ) -> SupabaseStorageClient {
     SupabaseStorageClient.test(
       supabaseURL: supabaseURL.absoluteString,
       apiKey: "test.api.key",
-      session: sessionMock
+      session: session
     )
   }
 
   private func uploadFileURL(_ fileName: String) -> URL {
-    URL(fileURLWithPath: #file)
+    URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .appendingPathComponent(fileName)
   }
 
   // MARK: - setValue(_:forHTTPHeaderField:) Tests
 
-  func testSetHeader_setsHeaderOnRequest() async throws {
+  @Test
+  func setHeader_setsHeaderOnRequest() async throws {
     let capturedRequest = LockIsolated(URLRequest?.none)
-    sessionMock.fetch = { request in
-      capturedRequest.setValue(request)
-      return (
-        """
-        [
-          {
-            "name": "test.txt",
-            "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-            "updatedAt": "2024-01-01T00:00:00Z",
-            "createdAt": "2024-01-01T00:00:00Z",
-            "lastAccessedAt": "2024-01-01T00:00:00Z",
-            "metadata": {}
-          }
-        ]
-        """.data(using: .utf8)!,
-        HTTPURLResponse(
-          url: self.supabaseURL,
-          statusCode: 200,
-          httpVersion: nil,
-          headerFields: nil
-        )!
-      )
-    }
+    let sessionMock = StorageHTTPSession(
+      fetch: { request in
+        capturedRequest.setValue(request)
+        return (
+          """
+          [
+            {
+              "name": "test.txt",
+              "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+              "updatedAt": "2024-01-01T00:00:00Z",
+              "createdAt": "2024-01-01T00:00:00Z",
+              "lastAccessedAt": "2024-01-01T00:00:00Z",
+              "metadata": {}
+            }
+          ]
+          """.data(using: .utf8)!,
+          HTTPURLResponse(
+            url: self.supabaseURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      },
+      upload: unimplemented("StorageHTTPSession.upload")
+    )
 
-    let sut = makeSUT()
+    let sut = makeSUT(session: sessionMock)
 
     _ = try await sut.from(bucketId)
       .setHeader("custom-value", forKey: "X-Custom-Header")
       .list()
 
-    XCTAssertEqual(
-      capturedRequest.value?.value(forHTTPHeaderField: "X-Custom-Header"), "custom-value")
+    #expect(
+      capturedRequest.value?.value(forHTTPHeaderField: "X-Custom-Header") == "custom-value")
   }
 
-  func testSetHeader_supportsMethodChaining() async throws {
+  @Test
+  func setHeader_supportsMethodChaining() async throws {
     let capturedRequest = LockIsolated(URLRequest?.none)
-    sessionMock.fetch = { request in
-      capturedRequest.setValue(request)
-      return (
-        """
-        [
-          {
-            "name": "test.txt",
-            "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-            "updatedAt": "2024-01-01T00:00:00Z",
-            "createdAt": "2024-01-01T00:00:00Z",
-            "lastAccessedAt": "2024-01-01T00:00:00Z",
-            "metadata": {}
-          }
-        ]
-        """.data(using: .utf8)!,
-        HTTPURLResponse(
-          url: self.supabaseURL,
-          statusCode: 200,
-          httpVersion: nil,
-          headerFields: nil
-        )!
-      )
-    }
+    let sessionMock = StorageHTTPSession(
+      fetch: { request in
+        capturedRequest.setValue(request)
+        return (
+          """
+          [
+            {
+              "name": "test.txt",
+              "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+              "updatedAt": "2024-01-01T00:00:00Z",
+              "createdAt": "2024-01-01T00:00:00Z",
+              "lastAccessedAt": "2024-01-01T00:00:00Z",
+              "metadata": {}
+            }
+          ]
+          """.data(using: .utf8)!,
+          HTTPURLResponse(
+            url: self.supabaseURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      },
+      upload: unimplemented("StorageHTTPSession.upload")
+    )
 
-    let sut = makeSUT()
+    let sut = makeSUT(session: sessionMock)
 
     _ = try await sut.from(bucketId)
       .setHeader("value-a", forKey: "X-Header-A")
       .setHeader("value-b", forKey: "X-Header-B")
       .list()
 
-    XCTAssertEqual(capturedRequest.value?.value(forHTTPHeaderField: "X-Header-A"), "value-a")
-    XCTAssertEqual(capturedRequest.value?.value(forHTTPHeaderField: "X-Header-B"), "value-b")
+    #expect(capturedRequest.value?.value(forHTTPHeaderField: "X-Header-A") == "value-a")
+    #expect(capturedRequest.value?.value(forHTTPHeaderField: "X-Header-B") == "value-b")
   }
 
-  func testSetHeader_overridesExistingHeader() async throws {
+  @Test
+  func setHeader_overridesExistingHeader() async throws {
     let capturedRequest = LockIsolated(URLRequest?.none)
-    sessionMock.fetch = { request in
-      capturedRequest.setValue(request)
-      return (
-        """
-        [
-          {
-            "name": "test.txt",
-            "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-            "updatedAt": "2024-01-01T00:00:00Z",
-            "createdAt": "2024-01-01T00:00:00Z",
-            "lastAccessedAt": "2024-01-01T00:00:00Z",
-            "metadata": {}
-          }
-        ]
-        """.data(using: .utf8)!,
-        HTTPURLResponse(
-          url: self.supabaseURL,
-          statusCode: 200,
-          httpVersion: nil,
-          headerFields: nil
-        )!
-      )
-    }
+    let sessionMock = StorageHTTPSession(
+      fetch: { request in
+        capturedRequest.setValue(request)
+        return (
+          """
+          [
+            {
+              "name": "test.txt",
+              "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+              "updatedAt": "2024-01-01T00:00:00Z",
+              "createdAt": "2024-01-01T00:00:00Z",
+              "lastAccessedAt": "2024-01-01T00:00:00Z",
+              "metadata": {}
+            }
+          ]
+          """.data(using: .utf8)!,
+          HTTPURLResponse(
+            url: self.supabaseURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      },
+      upload: unimplemented("StorageHTTPSession.upload")
+    )
 
-    let sut = makeSUT()
+    let sut = makeSUT(session: sessionMock)
 
     _ = try await sut.from(bucketId)
       .setHeader("initial-value", forKey: "X-Custom-Header")
       .setHeader("updated-value", forKey: "X-Custom-Header")
       .list()
 
-    XCTAssertEqual(
-      capturedRequest.value?.value(forHTTPHeaderField: "X-Custom-Header"), "updated-value")
+    #expect(
+      capturedRequest.value?.value(forHTTPHeaderField: "X-Custom-Header") == "updated-value")
   }
 
-  func testSetHeader_doesNotMutateParentClientHeaders() async throws {
+  @Test
+  func setHeader_doesNotMutateParentClientHeaders() async throws {
     let capturedRequests = LockIsolated<[URLRequest]>([])
 
     let listResponse = """
@@ -355,31 +383,33 @@ final class SupabaseStorageTests: XCTestCase {
       ]
       """
 
-    // Setup mock to capture requests
-    sessionMock.fetch = { [self] request in
-      capturedRequests.withValue { $0.append(request) }
+    let sessionMock = StorageHTTPSession(
+      fetch: { request in
+        capturedRequests.withValue { $0.append(request) }
 
-      return (
-        listResponse.data(using: .utf8)!,
-        HTTPURLResponse(
-          url: self.supabaseURL,
-          statusCode: 200,
-          httpVersion: nil,
-          headerFields: nil
-        )!
-      )
-    }
+        return (
+          listResponse.data(using: .utf8)!,
+          HTTPURLResponse(
+            url: self.supabaseURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      },
+      upload: unimplemented("StorageHTTPSession.upload")
+    )
 
-    let sut = makeSUT()
+    let sut = makeSUT(session: sessionMock)
 
     // First, make a request with setHeader on StorageFileApi
     _ = try await sut.from(bucketId)
       .setHeader("child-value", forKey: "X-Child-Header")
       .list()
 
-    XCTAssertEqual(
-      capturedRequests[0].value(forHTTPHeaderField: "X-Child-Header"),
-      "child-value"
+    #expect(
+      capturedRequests[0].value(forHTTPHeaderField: "X-Child-Header")
+        == "child-value"
     )
 
     // Then make a request from a new StorageFileApi instance (via sut.from())
@@ -387,6 +417,6 @@ final class SupabaseStorageTests: XCTestCase {
     _ = try await sut.from(bucketId).list()
 
     // The new StorageFileApi instance should NOT have the previous instance's header
-    XCTAssertNil(capturedRequests[1].value(forHTTPHeaderField: "X-Child-Header"))
+    #expect(capturedRequests[1].value(forHTTPHeaderField: "X-Child-Header") == nil)
   }
 }

--- a/Tests/StorageTests/TransformOptionsTests.swift
+++ b/Tests/StorageTests/TransformOptionsTests.swift
@@ -1,43 +1,53 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import Storage
 
-final class TransformOptionsTests: XCTestCase {
-  func testDefaultInitialization() {
+@Suite
+struct TransformOptionsTests {
+  @Test
+  func defaultInitialization() {
     let options = TransformOptions()
 
-    XCTAssertNil(options.width)
-    XCTAssertNil(options.height)
-    XCTAssertNil(options.resize)
-    XCTAssertNil(options.quality)
-    XCTAssertNil(options.format)
+    #expect(options.width == nil)
+    #expect(options.height == nil)
+    #expect(options.resize == nil)
+    #expect(options.quality == nil)
+    #expect(options.format == nil)
   }
 
-  func testIsEmpty_defaultOptions() {
-    XCTAssertTrue(TransformOptions().isEmpty)
+  @Test
+  func isEmpty_defaultOptions() {
+    #expect(TransformOptions().isEmpty)
   }
 
-  func testIsEmpty_withWidth() {
-    XCTAssertFalse(TransformOptions(width: 200).isEmpty)
+  @Test
+  func isEmpty_withWidth() {
+    #expect(!TransformOptions(width: 200).isEmpty)
   }
 
-  func testIsEmpty_withHeight() {
-    XCTAssertFalse(TransformOptions(height: 300).isEmpty)
+  @Test
+  func isEmpty_withHeight() {
+    #expect(!TransformOptions(height: 300).isEmpty)
   }
 
-  func testIsEmpty_withResize() {
-    XCTAssertFalse(TransformOptions(resize: "cover").isEmpty)
+  @Test
+  func isEmpty_withResize() {
+    #expect(!TransformOptions(resize: "cover").isEmpty)
   }
 
-  func testIsEmpty_withQuality() {
-    XCTAssertFalse(TransformOptions(quality: 90).isEmpty)
+  @Test
+  func isEmpty_withQuality() {
+    #expect(!TransformOptions(quality: 90).isEmpty)
   }
 
-  func testIsEmpty_withFormat() {
-    XCTAssertFalse(TransformOptions(format: "webp").isEmpty)
+  @Test
+  func isEmpty_withFormat() {
+    #expect(!TransformOptions(format: "webp").isEmpty)
   }
 
-  func testCustomInitialization() {
+  @Test
+  func customInitialization() {
     let options = TransformOptions(
       width: 100,
       height: 200,
@@ -46,14 +56,15 @@ final class TransformOptionsTests: XCTestCase {
       format: "webp"
     )
 
-    XCTAssertEqual(options.width, 100)
-    XCTAssertEqual(options.height, 200)
-    XCTAssertEqual(options.resize, "cover")
-    XCTAssertEqual(options.quality, 90)
-    XCTAssertEqual(options.format, "webp")
+    #expect(options.width == 100)
+    #expect(options.height == 200)
+    #expect(options.resize == "cover")
+    #expect(options.quality == 90)
+    #expect(options.format == "webp")
   }
 
-  func testQueryItemsGeneration() {
+  @Test
+  func queryItemsGeneration() {
     let options = TransformOptions(
       width: 100,
       height: 200,
@@ -64,35 +75,36 @@ final class TransformOptionsTests: XCTestCase {
 
     let queryItems = options.queryItems
 
-    XCTAssertEqual(queryItems.count, 5)
+    #expect(queryItems.count == 5)
 
-    XCTAssertEqual(queryItems[0].name, "width")
-    XCTAssertEqual(queryItems[0].value, "100")
+    #expect(queryItems[0].name == "width")
+    #expect(queryItems[0].value == "100")
 
-    XCTAssertEqual(queryItems[1].name, "height")
-    XCTAssertEqual(queryItems[1].value, "200")
+    #expect(queryItems[1].name == "height")
+    #expect(queryItems[1].value == "200")
 
-    XCTAssertEqual(queryItems[2].name, "resize")
-    XCTAssertEqual(queryItems[2].value, "cover")
+    #expect(queryItems[2].name == "resize")
+    #expect(queryItems[2].value == "cover")
 
-    XCTAssertEqual(queryItems[3].name, "quality")
-    XCTAssertEqual(queryItems[3].value, "90")
+    #expect(queryItems[3].name == "quality")
+    #expect(queryItems[3].value == "90")
 
-    XCTAssertEqual(queryItems[4].name, "format")
-    XCTAssertEqual(queryItems[4].value, "webp")
+    #expect(queryItems[4].name == "format")
+    #expect(queryItems[4].value == "webp")
   }
 
-  func testPartialQueryItemsGeneration() {
+  @Test
+  func partialQueryItemsGeneration() {
     let options = TransformOptions(width: 100, quality: 75)
 
     let queryItems = options.queryItems
 
-    XCTAssertEqual(queryItems.count, 2)
+    #expect(queryItems.count == 2)
 
-    XCTAssertEqual(queryItems[0].name, "width")
-    XCTAssertEqual(queryItems[0].value, "100")
+    #expect(queryItems[0].name == "width")
+    #expect(queryItems[0].value == "100")
 
-    XCTAssertEqual(queryItems[1].name, "quality")
-    XCTAssertEqual(queryItems[1].value, "75")
+    #expect(queryItems[1].name == "quality")
+    #expect(queryItems[1].value == "75")
   }
 }

--- a/Tests/StorageTests/ValueTypesTests.swift
+++ b/Tests/StorageTests/ValueTypesTests.swift
@@ -1,184 +1,219 @@
 import Foundation
-import XCTest
+import Testing
 
 @testable import Storage
 
 // MARK: - StorageByteCount
 
-final class StorageByteCountTests: XCTestCase {
-  func testIntegerInit() {
+@Suite
+struct StorageByteCountTests {
+  @Test
+  func integerInit() {
     let count = StorageByteCount(5_000_000)
-    XCTAssertEqual(count.intValue, 5_000_000)
+    #expect(count.intValue == 5_000_000)
   }
 
-  func testIntegerLiteral() {
+  @Test
+  func integerLiteral() {
     let count: StorageByteCount = 2048
-    XCTAssertEqual(count.intValue, 2048)
+    #expect(count.intValue == 2048)
   }
 
-  func testEquality() {
-    XCTAssertEqual(StorageByteCount(1_000_000), StorageByteCount(1_000_000))
+  @Test
+  func equality() {
+    #expect(StorageByteCount(1_000_000) == StorageByteCount(1_000_000))
   }
 
-  func testKilobytes() {
+  @Test
+  func kilobytes() {
     let count = StorageByteCount.kilobytes(500)
-    XCTAssertNil(count.intValue)
-    XCTAssertEqual(count.stringValue, "500kb")
+    #expect(count.intValue == nil)
+    #expect(count.stringValue == "500kb")
   }
 
-  func testMegabytes() {
+  @Test
+  func megabytes() {
     let count = StorageByteCount.megabytes(1.5)
-    XCTAssertNil(count.intValue)
-    XCTAssertEqual(count.stringValue, "1.5mb")
+    #expect(count.intValue == nil)
+    #expect(count.stringValue == "1.5mb")
   }
 
-  func testGigabytes() {
+  @Test
+  func gigabytes() {
     let count = StorageByteCount.gigabytes(2)
-    XCTAssertNil(count.intValue)
-    XCTAssertEqual(count.stringValue, "2gb")
+    #expect(count.intValue == nil)
+    #expect(count.stringValue == "2gb")
   }
 
-  func testStringLiteralNumeric() {
+  @Test
+  func stringLiteralNumeric() {
     let count: StorageByteCount = "1000000"
-    XCTAssertEqual(count.intValue, 1_000_000)
+    #expect(count.intValue == 1_000_000)
   }
 
-  func testStringLiteralHumanReadable() {
+  @Test
+  func stringLiteralHumanReadable() {
     let count: StorageByteCount = "1mb"
-    XCTAssertNil(count.intValue)
+    #expect(count.intValue == nil)
   }
 
-  func testEncodesAsNumber() throws {
+  @Test
+  func encodesAsNumber() throws {
     let encoded = try JSONEncoder().encode(StorageByteCount(1_000_000))
     let json = String(decoding: encoded, as: UTF8.self)
-    XCTAssertEqual(json, "1000000")
+    #expect(json == "1000000")
   }
 
-  func testEncodesAsString() throws {
+  @Test
+  func encodesAsString() throws {
     let count: StorageByteCount = "1mb"
     let encoded = try JSONEncoder().encode(count)
     let json = String(decoding: encoded, as: UTF8.self)
-    XCTAssertEqual(json, "\"1mb\"")
+    #expect(json == "\"1mb\"")
   }
 
-  func testGigabytesWholeValueOutsideInt64Range() {
+  @Test
+  func gigabytesWholeValueOutsideInt64Range() {
     let count = StorageByteCount.gigabytes(1e19)
-    XCTAssertEqual(count.stringValue, "1e+19gb")
+    #expect(count.stringValue == "1e+19gb")
   }
 }
 
 // MARK: - SortBy
 
-final class SortByTests: XCTestCase {
-  func testInitWithDefaultedOrder() {
+@Suite
+struct SortByTests {
+  @Test
+  func initWithDefaultedOrder() {
     let sortBy = SortBy(column: "name")
-    XCTAssertEqual(sortBy.column, "name")
-    XCTAssertNil(sortBy.order)
+    #expect(sortBy.column == "name")
+    #expect(sortBy.order == nil)
   }
 
-  func testInitWithSortOrder() {
+  @Test
+  func initWithSortOrder() {
     let sortBy = SortBy(column: "name", order: .ascending)
-    XCTAssertEqual(sortBy.order, "asc")
+    #expect(sortBy.order == "asc")
   }
 
-  func testDeprecatedInitWithStringVariable() {
+  @Test
+  func deprecatedInitWithStringVariable() {
     let order: String? = "desc"
     let sortBy = SortBy(column: "name", order: order)
-    XCTAssertEqual(sortBy.order, "desc")
+    #expect(sortBy.order == "desc")
   }
 
-  func testDeprecatedInitWithOrderVariableOnly() {
+  @Test
+  func deprecatedInitWithOrderVariableOnly() {
     let order: String? = "asc"
     let sortBy = SortBy(order: order)
-    XCTAssertNil(sortBy.column)
-    XCTAssertEqual(sortBy.order, "asc")
+    #expect(sortBy.column == nil)
+    #expect(sortBy.order == "asc")
   }
 }
 
 // MARK: - ResizeMode
 
-final class ResizeModeTests: XCTestCase {
-  func testStaticConstants() {
-    XCTAssertEqual(ResizeMode.cover.rawValue, "cover")
-    XCTAssertEqual(ResizeMode.contain.rawValue, "contain")
-    XCTAssertEqual(ResizeMode.fill.rawValue, "fill")
+@Suite
+struct ResizeModeTests {
+  @Test
+  func staticConstants() {
+    #expect(ResizeMode.cover.rawValue == "cover")
+    #expect(ResizeMode.contain.rawValue == "contain")
+    #expect(ResizeMode.fill.rawValue == "fill")
   }
 
-  func testStringLiteral() {
+  @Test
+  func stringLiteral() {
     let mode: ResizeMode = "cover"
-    XCTAssertEqual(mode, .cover)
+    #expect(mode == .cover)
   }
 
-  func testCustomValue() {
+  @Test
+  func customValue() {
     let mode = ResizeMode(rawValue: "custom")
-    XCTAssertEqual(mode.rawValue, "custom")
+    #expect(mode.rawValue == "custom")
   }
 
-  func testEncodes() throws {
+  @Test
+  func encodes() throws {
     let encoded = try JSONEncoder().encode(ResizeMode.cover)
-    XCTAssertEqual(String(data: encoded, encoding: .utf8), "\"cover\"")
+    #expect(String(data: encoded, encoding: .utf8) == "\"cover\"")
   }
 
-  func testDecodes() throws {
+  @Test
+  func decodes() throws {
     let data = "\"contain\"".data(using: .utf8)!
     let mode = try JSONDecoder().decode(ResizeMode.self, from: data)
-    XCTAssertEqual(mode, .contain)
+    #expect(mode == .contain)
   }
 }
 
 // MARK: - ImageFormat
 
-final class ImageFormatTests: XCTestCase {
-  func testStaticConstants() {
-    XCTAssertEqual(ImageFormat.origin.rawValue, "origin")
-    XCTAssertEqual(ImageFormat.webp.rawValue, "webp")
-    XCTAssertEqual(ImageFormat.avif.rawValue, "avif")
+@Suite
+struct ImageFormatTests {
+  @Test
+  func staticConstants() {
+    #expect(ImageFormat.origin.rawValue == "origin")
+    #expect(ImageFormat.webp.rawValue == "webp")
+    #expect(ImageFormat.avif.rawValue == "avif")
   }
 
-  func testStringLiteral() {
+  @Test
+  func stringLiteral() {
     let format: ImageFormat = "webp"
-    XCTAssertEqual(format, .webp)
+    #expect(format == .webp)
   }
 
-  func testEncodes() throws {
+  @Test
+  func encodes() throws {
     let encoded = try JSONEncoder().encode(ImageFormat.webp)
-    XCTAssertEqual(String(data: encoded, encoding: .utf8), "\"webp\"")
+    #expect(String(data: encoded, encoding: .utf8) == "\"webp\"")
   }
 
-  func testDecodes() throws {
+  @Test
+  func decodes() throws {
     let data = "\"avif\"".data(using: .utf8)!
     let format = try JSONDecoder().decode(ImageFormat.self, from: data)
-    XCTAssertEqual(format, .avif)
+    #expect(format == .avif)
   }
 }
 
 // MARK: - SortOrder
 
-final class SortOrderTests: XCTestCase {
-  func testStaticConstants() {
-    XCTAssertEqual(Storage.SortOrder.ascending.rawValue, "asc")
-    XCTAssertEqual(Storage.SortOrder.descending.rawValue, "desc")
+@Suite
+struct SortOrderTests {
+  @Test
+  func staticConstants() {
+    #expect(Storage.SortOrder.ascending.rawValue == "asc")
+    #expect(Storage.SortOrder.descending.rawValue == "desc")
   }
 
-  func testStringLiteral() {
+  @Test
+  func stringLiteral() {
     let order: Storage.SortOrder = "asc"
-    XCTAssertEqual(order, .ascending)
+    #expect(order == .ascending)
   }
 
-  func testEncodes() throws {
+  @Test
+  func encodes() throws {
     let encoded = try JSONEncoder().encode(Storage.SortOrder.descending)
-    XCTAssertEqual(String(data: encoded, encoding: .utf8), "\"desc\"")
+    #expect(String(data: encoded, encoding: .utf8) == "\"desc\"")
   }
 }
 
 // MARK: - DownloadBehavior
 
-final class DownloadBehaviorValueTests: XCTestCase {
-  func testWithOriginalNameQueryValue() {
-    XCTAssertEqual(DownloadBehavior.withOriginalName.queryValue, "")
+@Suite
+struct DownloadBehaviorValueTests {
+  @Test
+  func withOriginalNameQueryValue() {
+    #expect(DownloadBehavior.withOriginalName.queryValue == "")
   }
 
-  func testNamedQueryValue() {
-    XCTAssertEqual(DownloadBehavior.named("report.pdf").queryValue, "report.pdf")
+  @Test
+  func namedQueryValue() {
+    #expect(DownloadBehavior.named("report.pdf").queryValue == "report.pdf")
   }
 }

--- a/Tests/StorageTests/__Snapshots__/StorageBucketAPITests/StorageBucketAPITests-testCreateBucket.1.txt
+++ b/Tests/StorageTests/__Snapshots__/StorageBucketAPITests/StorageBucketAPITests-testCreateBucket.1.txt
@@ -1,6 +1,0 @@
-curl \
-	--request POST \
-	--header "Content-Type: application/json" \
-	--header "X-Client-Info: storage-swift/2.24.4" \
-	--data "{\"public\":true,\"id\":\"newbucket\",\"name\":\"newbucket\"}" \
-	"http://example.com/bucket"


### PR DESCRIPTION
## Summary

Migrates `Tests/StorageTests` (11 files) from XCTest to Swift Testing (`@Suite`/`@Test`), per the repo-wide Swift Testing migration plan (SDK-435) and the conventions decided in Phase 0 (SDK-1247, SDK-1091). Keeps Mocker for HTTP mocking — Replay isn't proven yet for all our cases, so we're sticking with Mocker for now (may revisit later).

## Changes

- **Package.swift**: Moved `StorageTests` out of the blanket `.swiftLanguageMode(.v5)` pin into the `swift6TestTargets` set, so it now compiles under full Swift 6 language mode with the same strict-concurrency settings as production targets. Dropped the unused `CustomDump` dependency; kept `Mocker`/`TestHelpers`/`InlineSnapshotTesting`/`XCTestDynamicOverlay` (all still used). No new package dependency.
- **Tests/StorageTests/**: All 11 files converted. Pure-unit files (`BucketOptionsTests`, `FileOptionsTests`, `TransformOptionsTests`, `ValueTypesTests`, `StorageErrorTests`, `MultipartFormDataTests`) are mechanical conversions. `DownloadBehaviorTests`' `setUp` became `init()`. `StorageBucketAPITests`/`StorageFileAPITests` (the Mocker-heavy files) converted to `@Suite(.serialized) struct` with a per-test `makeSUT()` helper (fresh `URLSessionConfiguration` + `MockingURLProtocol` each call), keeping every existing `Mock(...).snapshotRequest { ... }.register()` curl-body assertion as-is — including for `move`/`copy`/`remove`, no new matching mechanism needed. `.serialized` is required: Mocker's mock registry is process-global with no per-test isolation, and Swift Testing runs suites in parallel by default. `SupabaseStorageTests` keeps its existing closure-based `StorageHTTPSession` mocking (already framework-agnostic) but drops `XCTestCase`.
- Removed one orphaned/stale snapshot fixture (`StorageBucketAPITests-testCreateBucket.1.txt`, didn't match any current test — that test uses an inline `.snapshotRequest` instead). With the directory now empty, dropped the now-dangling `exclude: ["__Snapshots__"]` from the target too.

## Root cause note (bug found during migration)

While migrating `SupabaseStorageTests.uploadData`/`uploadFileURL`, found that the original XCTest mocks wired their response-producing closure to `StorageHTTPSession.fetch`, not `.upload` — confirmed this is correct because production `Storage` code (`StorageApi.swift`) only ever calls `configuration.session.fetch`; `.upload` is currently dead code for all Storage HTTP calls including multipart uploads. Preserved that wiring in the migrated tests.

## Test plan

- [x] `swift test --filter StorageTests`: 145/145 tests pass (139 from the original conversion + 6 added to `main` since), run twice to rule out Mocker registry races under parallel execution.
- [x] `swift test` (full suite, minus `IntegrationTests` which needs a local Supabase instance per `AGENTS.md`): 0 failures.
- [x] Zero `import XCTest` remaining in `Tests/StorageTests`.
- [x] `./scripts/format.sh` clean.

## Linear

Closes SDK-1250
