### PR TITLE
test(integration): migrate IntegrationTests to Swift Testing (Phase 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
       - name: "Run Integration Tests"
         env:
           INTEGRATION_TESTS: 1
-        run: swift test --filter IntegrationTests
+        run: swift test --filter IntegrationTests --no-parallel
       - name: "Stop Supabase"
         working-directory: Tests/IntegrationTests
         if: always()

--- a/Package.swift
+++ b/Package.swift
@@ -243,6 +243,7 @@ let package = Package(
 // phase lands (see SDK-435).
 let swift6TestTargets: Set<String> = [
   "SupabaseTests", "HelpersTests", "StorageTests", "PostgRESTTests", "AuthTests", "FunctionsTests",
+  "IntegrationTests",
 ]
 
 for target in package.targets {

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -7,9 +7,10 @@
 
 import ConcurrencyExtras
 import CustomDump
+import Foundation
 import InlineSnapshotTesting
 import TestHelpers
-import XCTest
+import Testing
 
 @_spi(Experimental) @testable import Auth
 
@@ -17,17 +18,9 @@ import XCTest
   import FoundationNetworking
 #endif
 
-final class AuthClientIntegrationTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+struct AuthClientIntegrationTests {
   let authClient = makeClient()
-
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-  }
 
   static func makeClient(serviceRole: Bool = false) -> AuthClient {
     let key = serviceRole ? DotEnv.SUPABASE_SECRET_KEY : DotEnv.SUPABASE_PUBLISHABLE_KEY
@@ -44,7 +37,8 @@ final class AuthClientIntegrationTests: XCTestCase {
     )
   }
 
-  func testMultipleAuthInstances() async throws {
+  @Test
+  func multipleAuthInstances() async throws {
     try await signUpIfNeededOrSignIn(email: mockEmail(), password: mockPassword())
 
     let client2 = Self.makeClient()
@@ -60,8 +54,9 @@ final class AuthClientIntegrationTests: XCTestCase {
     expectNoDifference(sessionFromClient1.expiresAt, sessionFromClient2.expiresAt)
   }
 
-  func testSignUpAndSignInWithEmail() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn, .signedOut, .signedIn]) {
+  @Test
+  func signUpAndSignInWithEmail() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn, .signedOut, .signedIn]) {
       let email = mockEmail()
       let password = mockPassword()
 
@@ -75,9 +70,9 @@ final class AuthClientIntegrationTests: XCTestCase {
         data: metadata
       )
 
-      XCTAssertNotNil(response.session)
-      XCTAssertEqual(response.user.email, email)
-      XCTAssertEqual(response.user.userMetadata["test"], 42)
+      #expect(response.session != nil)
+      #expect(response.user.email == email)
+      #expect(response.user.userMetadata["test"] == 42)
 
       try await authClient.signOut()
 
@@ -103,18 +98,19 @@ final class AuthClientIntegrationTests: XCTestCase {
   //    }
   //  }
 
-  func testSignInWithEmail_invalidEmail() async throws {
+  @Test
+  func signInWithEmail_invalidEmail() async throws {
     let email = mockEmail()
     let password = mockPassword()
 
     do {
       try await authClient.signIn(email: email, password: password)
-      XCTFail("Expect failure")
+      Issue.record("Expect failure")
     } catch {
       if let error = error as? AuthError {
-        XCTAssertEqual(error.localizedDescription, "Invalid login credentials")
+        #expect(error.localizedDescription == "Invalid login credentials")
       } else {
-        XCTFail("Unexpected error: \(error)")
+        Issue.record("Unexpected error: \(error)")
       }
     }
   }
@@ -126,8 +122,9 @@ final class AuthClientIntegrationTests: XCTestCase {
   //    try await authClient.verifyOTP(email: email, token: "123456", type: .magiclink)
   //  }
 
-  func testSignOut_otherScope_shouldSignOutLocally() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn]) {
+  @Test
+  func signOut_otherScope_shouldSignOutLocally() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn]) {
       let email = mockEmail()
       let password = mockPassword()
 
@@ -136,7 +133,8 @@ final class AuthClientIntegrationTests: XCTestCase {
     }
   }
 
-  func testReauthenticate() async throws {
+  @Test
+  func reauthenticate() async throws {
     let email = mockEmail()
     let password = mockPassword()
 
@@ -144,16 +142,18 @@ final class AuthClientIntegrationTests: XCTestCase {
     try await authClient.reauthenticate()
   }
 
-  func testUser() async throws {
+  @Test
+  func user() async throws {
     let email = mockEmail()
     let password = mockPassword()
 
     try await signUpIfNeededOrSignIn(email: email, password: password)
     let user = try await authClient.user()
-    XCTAssertEqual(user.email, email)
+    #expect(user.email == email)
   }
 
-  func testUserWithCustomJWT() async throws {
+  @Test
+  func userWithCustomJWT() async throws {
     let firstUserSession = try await signUpIfNeededOrSignIn(
       email: mockEmail(),
       password: mockPassword()
@@ -165,20 +165,22 @@ final class AuthClientIntegrationTests: XCTestCase {
 
     let user = try await authClient.user(jwt: firstUserSession?.accessToken)
 
-    XCTAssertEqual(user.id, firstUserSession?.user.id)
-    XCTAssertNotEqual(user.id, secondUserSession.user.id)
+    #expect(user.id == firstUserSession?.user.id)
+    #expect(user.id != secondUserSession.user.id)
   }
 
-  func testUpdateUser() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn, .userUpdated]) {
+  @Test
+  func updateUser() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn, .userUpdated]) {
       try await signUpIfNeededOrSignIn(email: mockEmail(), password: mockPassword())
 
       let updatedUser = try await authClient.update(user: .init(data: ["test": .integer(42)]))
-      XCTAssertEqual(updatedUser.userMetadata["test"], 42)
+      #expect(updatedUser.userMetadata["test"] == 42)
     }
   }
 
-  func testUserIdentities() async throws {
+  @Test
+  func userIdentities() async throws {
     let session = try await signUpIfNeededOrSignIn(email: mockEmail(), password: mockPassword())
     let identities = try await authClient.userIdentities()
     expectNoDifference(
@@ -187,56 +189,62 @@ final class AuthClientIntegrationTests: XCTestCase {
     )
   }
 
-  func testUnlinkIdentity_withOnlyOneIdentity() async throws {
+  @Test
+  func unlinkIdentity_withOnlyOneIdentity() async throws {
     let identities = try await signUpIfNeededOrSignIn(email: mockEmail(), password: mockPassword())
       .user.identities
-    let identity = try XCTUnwrap(identities?.first)
+    let identity = try #require(identities?.first)
 
     do {
       try await authClient.unlinkIdentity(identity)
-      XCTFail("Expect failure")
+      Issue.record("Expect failure")
     } catch let error as AuthError {
-      XCTAssertEqual(error.errorCode, .singleIdentityNotDeletable)
+      #expect(error.errorCode == .singleIdentityNotDeletable)
     }
   }
 
-  func testResetPasswordForEmail() async throws {
+  @Test
+  func resetPasswordForEmail() async throws {
     let email = mockEmail()
     try await authClient.resetPasswordForEmail(email)
   }
 
-  func testRefreshToken() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn, .tokenRefreshed]) {
+  @Test
+  func refreshToken() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn, .tokenRefreshed]) {
       try await signUpIfNeededOrSignIn(email: mockEmail(), password: mockPassword())
 
       let refreshedSession = try await authClient.refreshSession()
       let currentStoredSession = try await authClient.session
 
-      XCTAssertEqual(currentStoredSession.accessToken, refreshedSession.accessToken)
+      #expect(currentStoredSession.accessToken == refreshedSession.accessToken)
     }
   }
 
-  func testSignInAnonymous() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn]) {
+  @Test
+  func signInAnonymous() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn]) {
       try await authClient.signInAnonymously()
     }
   }
 
-  func testSignInAnonymousAndLinkUserWithEmail() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn, .userUpdated]) {
+  @Test
+  func signInAnonymousAndLinkUserWithEmail() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn, .userUpdated]) {
       try await authClient.signInAnonymously()
 
       let email = mockEmail()
       let user = try await authClient.update(user: UserAttributes(email: email))
 
-      XCTAssertEqual(user.email, email)
+      #expect(user.email == email)
     }
   }
 
-  func testDeleteAccountAndSignOut() async throws {
+  @Test
+  func deleteAccountAndSignOut() async throws {
     let response = try await signUpIfNeededOrSignIn(email: mockEmail(), password: mockPassword())
 
-    let session = try XCTUnwrap(response.session)
+    let session = try #require(response.session)
 
     var request = URLRequest(url: URL(string: "\(DotEnv.SUPABASE_URL)/rest/v1/rpc/delete_user")!)
     request.httpMethod = "POST"
@@ -245,31 +253,31 @@ final class AuthClientIntegrationTests: XCTestCase {
 
     _ = try await URLSession.shared.data(for: request)
 
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedOut]) {
+    try await expectAuthChangeEvents([.initialSession, .signedOut]) {
       try await authClient.signOut()
     }
   }
 
-  func testLinkIdentity() async throws {
+  @Test
+  func linkIdentity() async throws {
     try await signUpIfNeededOrSignIn(email: mockEmail(), password: mockPassword())
 
     try await authClient.linkIdentity(provider: .apple) { url in
-      XCTAssertTrue(url.absoluteString.contains("apple.com"))
+      #expect(url.absoluteString.contains("apple.com"))
     }
   }
 
-  func testListUsers() async throws {
-    // Skip: Requires pre-seeded users and secret key configuration
-    // that may not be available in all CI environments
-    try XCTSkipIf(true, "Requires secret key and pre-seeded users")
+  @Test(.disabled("Requires secret key and pre-seeded users"))
+  func listUsers() async throws {
     let client = Self.makeClient(serviceRole: true)
     let pagination = try await client.admin.listUsers(params: PageParams(perPage: 10))
-    XCTAssertEqual(pagination.users.count, 10)
-    XCTAssertEqual(pagination.aud, "authenticated")
-    XCTAssertEqual(pagination.nextPage, 2)
+    #expect(pagination.users.count == 10)
+    #expect(pagination.aud == "authenticated")
+    #expect(pagination.nextPage == 2)
   }
 
-  func testAdminListPasskeysEmptyForNewUser() async throws {
+  @Test
+  func adminListPasskeysEmptyForNewUser() async throws {
     let email = mockEmail()
     let password = mockPassword()
     try await signUpIfNeededOrSignIn(email: email, password: password)
@@ -277,10 +285,11 @@ final class AuthClientIntegrationTests: XCTestCase {
 
     let client = Self.makeClient(serviceRole: true)
     let passkeys = try await client.admin.listPasskeys(userId: session.user.id)
-    XCTAssertTrue(passkeys.isEmpty)
+    #expect(passkeys.isEmpty)
   }
 
-  func testAdminDeletePasskeyNotFound() async throws {
+  @Test
+  func adminDeletePasskeyNotFound() async throws {
     let email = mockEmail()
     let password = mockPassword()
     try await signUpIfNeededOrSignIn(email: email, password: password)
@@ -289,33 +298,34 @@ final class AuthClientIntegrationTests: XCTestCase {
     let client = Self.makeClient(serviceRole: true)
     do {
       try await client.admin.deletePasskey(userId: session.user.id, passkeyId: UUID())
-      XCTFail("Expected deletePasskey to throw for a nonexistent passkey")
+      Issue.record("Expected deletePasskey to throw for a nonexistent passkey")
     } catch let error as AuthError {
       guard case .api(_, _, _, let response) = error else {
-        XCTFail("Expected AuthError.api, got \(error)")
+        Issue.record("Expected AuthError.api, got \(error)")
         return
       }
       // Backend returns 404 when the passkey doesn't exist or belongs to another user.
-      XCTAssertEqual(response.statusCode, 404)
+      #expect(response.statusCode == 404)
     }
   }
 
-  func testSignOut() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn, .signedOut]) {
+  @Test
+  func signOut() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn, .signedOut]) {
       try await signUpIfNeededOrSignIn(email: mockEmail(), password: mockPassword())
 
       _ = try await authClient.session
-      XCTAssertNotNil(authClient.currentSession)
+      #expect(authClient.currentSession != nil)
 
       try await authClient.signOut()
 
       do {
         _ = try await authClient.session
-        XCTFail("Expected to throw AuthError.sessionMissing")
+        Issue.record("Expected to throw AuthError.sessionMissing")
       } catch let error as AuthError {
-        XCTAssertEqual(error, .sessionMissing)
+        #expect(error == .sessionMissing)
       }
-      XCTAssertNil(authClient.currentSession)
+      #expect(authClient.currentSession == nil)
     }
   }
 
@@ -432,27 +442,25 @@ final class AuthClientIntegrationTests: XCTestCase {
     return password
   }
 
-  private func XCTAssertAuthChangeEvents(
+  private func expectAuthChangeEvents(
     _ events: [AuthChangeEvent],
-    function: StaticString = #function,
     block: () async throws -> Void
   ) async rethrows {
-    let expectation = expectation(description: "\(function)-onAuthStateChange")
-    expectation.expectedFulfillmentCount = events.count
-
     let receivedEvents = LockIsolated<[AuthChangeEvent]>([])
 
     let token = await authClient.onAuthStateChange { event, _ in
       receivedEvents.withValue {
         $0.append(event)
       }
-
-      expectation.fulfill()
     }
 
     try await block()
 
-    await fulfillment(of: [expectation], timeout: 0.5)
+    // Poll until we've collected the expected number of events or time out.
+    let deadline = Date().addingTimeInterval(0.5)
+    while receivedEvents.value.count < events.count, Date() < deadline {
+      try? await Task.sleep(nanoseconds: 10_000_000)  // 10ms
+    }
 
     expectNoDifference(events, receivedEvents.value)
 

--- a/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
@@ -6,11 +6,13 @@
 //
 
 // cspell:ignore nsupabot nkiwicopple nawailas ndragarcia
+import Foundation
 import InlineSnapshotTesting
 import PostgREST
-import XCTest
+import Testing
 
-final class PostgrestTransformsTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+struct PostgrestTransformsTests {
   let client = PostgrestClient(
     configuration: PostgrestClient.Configuration(
       url: URL(string: "\(DotEnv.SUPABASE_URL)/rest/v1")!,
@@ -21,21 +23,15 @@ final class PostgrestTransformsTests: XCTestCase {
     )
   )
 
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-
+  init() async throws {
     // Clean up test data before running tests.
     // Delete users with email (test data), preserving seed data (users with username only).
     try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
       .execute()
   }
 
-  func testOrder() async throws {
+  @Test
+  func order() async throws {
     let res =
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
@@ -78,7 +74,8 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
-  func testOrderOnMultipleColumns() async throws {
+  @Test
+  func orderOnMultipleColumns() async throws {
     let res =
       try await client.from("messages")
       .select()
@@ -108,7 +105,8 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
-  func testLimit() async throws {
+  @Test
+  func limit() async throws {
     let res =
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
@@ -130,7 +128,8 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
-  func testRange() async throws {
+  @Test
+  func range() async throws {
     let res =
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
@@ -166,7 +165,8 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
-  func testSingle() async throws {
+  @Test
+  func single() async throws {
     let res =
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
@@ -187,7 +187,8 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
-  func testMaybeSingle() async throws {
+  @Test
+  func maybeSingle() async throws {
     let res =
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
@@ -208,7 +209,8 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
-  func testMaybeSingleReturnsNilOnZeroRows() async throws {
+  @Test
+  func maybeSingleReturnsNilOnZeroRows() async throws {
     let res: AnyJSON? =
       try await client.from("users")
       .select("username")
@@ -216,10 +218,11 @@ final class PostgrestTransformsTests: XCTestCase {
       .maybeSingle()
       .execute().value
 
-    XCTAssertNil(res)
+    #expect(res == nil)
   }
 
-  func testDryRunOnUpdate() async throws {
+  @Test
+  func dryRunOnUpdate() async throws {
     // Requires `pgrst.db_tx_end = 'commit-allow-override'` on the `authenticator` role
     // (see migrations/20240101000000_initial_schema.sql) so `Prefer: tx=rollback` is honored.
     try await client.from("users").insert([
@@ -249,7 +252,8 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
-  func testSingleOnInsert() async throws {
+  @Test
+  func singleOnInsert() async throws {
     let res =
       try await client.from("users")
       .insert(["username": "foo"])
@@ -275,7 +279,8 @@ final class PostgrestTransformsTests: XCTestCase {
       .execute()
   }
 
-  func testSelectOnInsert() async throws {
+  @Test
+  func selectOnInsert() async throws {
     let res =
       try await client.from("users")
       .insert(["username": "foo"])
@@ -298,7 +303,8 @@ final class PostgrestTransformsTests: XCTestCase {
       .execute()
   }
 
-  func testSelectOnRpc() async throws {
+  @Test
+  func selectOnRpc() async throws {
     let res =
       try await client.rpc("get_username_and_status", params: ["name_param": "supabot"])
       .select("status")
@@ -315,7 +321,8 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
-  func testRpcWithArray() async throws {
+  @Test
+  func rpcWithArray() async throws {
     struct Params: Encodable {
       let arr: [Int]
       let index: Int
@@ -323,10 +330,11 @@ final class PostgrestTransformsTests: XCTestCase {
     let res =
       try await client.rpc("get_array_element", params: Params(arr: [37, 420, 64], index: 2))
       .execute().value as Int
-    XCTAssertEqual(res, 420)
+    #expect(res == 420)
   }
 
-  func testRpcWithReadOnlyAccessMode() async throws {
+  @Test
+  func rpcWithReadOnlyAccessMode() async throws {
     struct Params: Encodable {
       let arr: [Int]
       let index: Int
@@ -335,10 +343,11 @@ final class PostgrestTransformsTests: XCTestCase {
       try await client.rpc(
         "get_array_element", params: Params(arr: [37, 420, 64], index: 2), get: true
       ).execute().value as Int
-    XCTAssertEqual(res, 420)
+    #expect(res == 420)
   }
 
-  func testCsv() async throws {
+  @Test
+  func csv() async throws {
     let res = try await client.from("users").select("username,data,age_range,status,catchphrase")
       .csv().execute().string()
     assertInlineSnapshot(of: res, as: .json) {

--- a/Tests/IntegrationTests/Postgrest/PostgrestBasicTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgrestBasicTests.swift
@@ -5,11 +5,13 @@
 //  Created by Guilherme Souza on 06/05/24.
 //
 
+import Foundation
 import InlineSnapshotTesting
 import PostgREST
-import XCTest
+import Testing
 
-final class PostgrestBasicTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+struct PostgrestBasicTests {
   let client = PostgrestClient(
     configuration: PostgrestClient.Configuration(
       url: URL(string: "\(DotEnv.SUPABASE_URL)/rest/v1")!,
@@ -20,14 +22,7 @@ final class PostgrestBasicTests: XCTestCase {
     )
   )
 
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-
+  init() async throws {
     // Clean up test data before running tests.
     // Delete users with email (test data), preserving seed data (users with username only).
     try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
@@ -36,7 +31,8 @@ final class PostgrestBasicTests: XCTestCase {
     try await client.from("messages").delete().gt("id", value: 2).execute()
   }
 
-  func testBasicSelectTable() async throws {
+  @Test
+  func basicSelectTable() async throws {
     let response =
       try await client.from("users").select("age_range,catchphrase,data,status,username").execute()
       .value as AnyJSON
@@ -76,7 +72,8 @@ final class PostgrestBasicTests: XCTestCase {
     }
   }
 
-  func testBasicSelectView() async throws {
+  @Test
+  func basicSelectView() async throws {
     let response = try await client.from("updatable_view").select().execute().value as AnyJSON
     assertInlineSnapshot(of: response, as: .json) {
       """
@@ -102,7 +99,8 @@ final class PostgrestBasicTests: XCTestCase {
     }
   }
 
-  func testRPC() async throws {
+  @Test
+  func rpc() async throws {
     let response =
       try await client.rpc("get_status", params: ["name_param": "supabot"]).execute().value
       as AnyJSON
@@ -113,12 +111,14 @@ final class PostgrestBasicTests: XCTestCase {
     }
   }
 
-  func testRPCReturnsVoid() async throws {
+  @Test
+  func rPCReturnsVoid() async throws {
     let response = try await client.rpc("void_func").execute().data
-    XCTAssertEqual(response, Data())
+    #expect(response == Data())
   }
 
-  func testIgnoreDuplicates_upsert() async throws {
+  @Test
+  func ignoreDuplicates_upsert() async throws {
     let response =
       try await client.from("users")
       .upsert(["username": "dragarcia"], onConflict: "username", ignoreDuplicates: true)
@@ -132,7 +132,8 @@ final class PostgrestBasicTests: XCTestCase {
     }
   }
 
-  func testBasicInsertUpdateAndDelete() async throws {
+  @Test
+  func basicInsertUpdateAndDelete() async throws {
     // Basic insert
     var response =
       try await client.from("messages")

--- a/Tests/IntegrationTests/Postgrest/PostgrestFilterTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgrestFilterTests.swift
@@ -5,11 +5,13 @@
 //  Created by Guilherme Souza on 06/05/24.
 //
 
+import Foundation
 import InlineSnapshotTesting
 import PostgREST
-import XCTest
+import Testing
 
-final class PostgrestFilterTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+struct PostgrestFilterTests {
   let client = PostgrestClient(
     configuration: PostgrestClient.Configuration(
       url: URL(string: "\(DotEnv.SUPABASE_URL)/rest/v1")!,
@@ -20,21 +22,15 @@ final class PostgrestFilterTests: XCTestCase {
     )
   )
 
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-
+  init() async throws {
     // Clean up test data before running tests.
     // Delete users with email (test data), preserving seed data (users with username only).
     try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
       .execute()
   }
 
-  func testNot() async throws {
+  @Test
+  func not() async throws {
     let res =
       try await client.from("users")
       .select("status")
@@ -58,7 +54,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testOr() async throws {
+  @Test
+  func or() async throws {
     let res =
       try await client.from("users")
       .select("status,username")
@@ -81,7 +78,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testEq() async throws {
+  @Test
+  func eq() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -99,7 +97,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testNeq() async throws {
+  @Test
+  func neq() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -123,7 +122,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testGt() async throws {
+  @Test
+  func gt() async throws {
     let res =
       try await client.from("messages")
       .select("id")
@@ -141,7 +141,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testGte() async throws {
+  @Test
+  func gte() async throws {
     let res =
       try await client.from("messages")
       .select("id")
@@ -162,7 +163,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testLe() async throws {
+  @Test
+  func le() async throws {
     let res =
       try await client.from("messages")
       .select("id")
@@ -180,7 +182,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testLte() async throws {
+  @Test
+  func lte() async throws {
     let res =
       try await client.from("messages")
       .select("id")
@@ -201,7 +204,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testLike() async throws {
+  @Test
+  func like() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -219,7 +223,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testLikeAllOf() async throws {
+  @Test
+  func likeAllOf() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -237,7 +242,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testLikeAnyOf() async throws {
+  @Test
+  func likeAnyOf() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -258,7 +264,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testIlike() async throws {
+  @Test
+  func ilike() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -276,7 +283,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testIlikeAllOf() async throws {
+  @Test
+  func ilikeAllOf() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -294,7 +302,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testIlikeAnyOf() async throws {
+  @Test
+  func ilikeAnyOf() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -315,7 +324,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testIs() async throws {
+  @Test
+  func `is`() async throws {
     let res =
       try await client.from("users").select("data").is("data", value: nil)
       .execute()
@@ -341,7 +351,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testIn() async throws {
+  @Test
+  func `in`() async throws {
     let statuses = ["ONLINE", "OFFLINE"]
     let res =
       try await client.from("users").select("status").in("status", values: statuses)
@@ -368,7 +379,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testNotIn() async throws {
+  @Test
+  func notIn() async throws {
     let res =
       try await client.from("users").select("status").notIn("status", values: ["OFFLINE"])
       .execute()
@@ -391,7 +403,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testContains() async throws {
+  @Test
+  func contains() async throws {
     let res =
       try await client.from("users").select("age_range").contains("age_range", value: "[1,2)")
       .execute()
@@ -408,7 +421,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testContainedBy() async throws {
+  @Test
+  func containedBy() async throws {
     let res =
       try await client.from("users").select("age_range").containedBy("age_range", value: "[1,2)")
       .execute()
@@ -425,7 +439,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testRangeLt() async throws {
+  @Test
+  func rangeLt() async throws {
     let res =
       try await client.from("users").select("age_range").rangeLt("age_range", range: "[2,25)")
       .execute()
@@ -442,7 +457,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testRangeGt() async throws {
+  @Test
+  func rangeGt() async throws {
     let res =
       try await client.from("users").select("age_range").rangeGt("age_range", range: "[2,25)")
       .execute()
@@ -462,7 +478,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testRangeLte() async throws {
+  @Test
+  func rangeLte() async throws {
     let res =
       try await client.from("users").select("age_range").rangeLte("age_range", range: "[2,25)")
       .execute()
@@ -479,7 +496,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testRangeGte() async throws {
+  @Test
+  func rangeGte() async throws {
     let res =
       try await client.from("users").select("age_range").rangeGte("age_range", range: "[2,25)")
       .execute()
@@ -502,7 +520,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testRangeAdjacent() async throws {
+  @Test
+  func rangeAdjacent() async throws {
     let res =
       try await client.from("users").select("age_range").rangeAdjacent("age_range", range: "[2,25)")
       .execute()
@@ -525,7 +544,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testOverlaps() async throws {
+  @Test
+  func overlaps() async throws {
     let res =
       try await client.from("users").select("age_range").overlaps("age_range", value: "[2,25)")
       .execute()
@@ -542,7 +562,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testTextSearch() async throws {
+  @Test
+  func textSearch() async throws {
     let res =
       try await client.from("users").select("catchphrase")
       .textSearch("catchphrase", query: "'fat' & 'cat'", config: "english")
@@ -560,7 +581,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testTextSearchWithPlain() async throws {
+  @Test
+  func textSearchWithPlain() async throws {
     let res =
       try await client.from("users").select("catchphrase")
       .textSearch("catchphrase", query: "'fat' & 'cat'", config: "english", type: .plain)
@@ -578,7 +600,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testTextSearchWithPhrase() async throws {
+  @Test
+  func textSearchWithPhrase() async throws {
     let res =
       try await client.from("users").select("catchphrase")
       .textSearch("catchphrase", query: "cat", config: "english", type: .phrase)
@@ -599,7 +622,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testTextSearchWithWebsearch() async throws {
+  @Test
+  func textSearchWithWebsearch() async throws {
     let res =
       try await client.from("users").select("catchphrase")
       .textSearch("catchphrase", query: "'fat' & 'cat'", config: "english", type: .websearch)
@@ -617,7 +641,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testMultipleFilters() async throws {
+  @Test
+  func multipleFilters() async throws {
     let res =
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
@@ -644,7 +669,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testFilter() async throws {
+  @Test
+  func filter() async throws {
     let res =
       try await client.from("users")
       .select("username")
@@ -663,7 +689,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testMatch() async throws {
+  @Test
+  func match() async throws {
     let res =
       try await client.from("users")
       .select("username,status")
@@ -683,7 +710,8 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
-  func testFilterOnRpc() async throws {
+  @Test
+  func filterOnRpc() async throws {
     let res =
       try await client.rpc("get_username_and_status", params: ["name_param": "supabot"])
       .neq("status", value: "ONLINE")

--- a/Tests/IntegrationTests/Postgrest/PostgrestResourceEmbeddingTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgrestResourceEmbeddingTests.swift
@@ -5,11 +5,13 @@
 //  Created by Guilherme Souza on 07/05/24.
 //
 
+import Foundation
 import InlineSnapshotTesting
 import PostgREST
-import XCTest
+import Testing
 
-final class PostgrestResourceEmbeddingTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+struct PostgrestResourceEmbeddingTests {
   let client = PostgrestClient(
     configuration: PostgrestClient.Configuration(
       url: URL(string: "\(DotEnv.SUPABASE_URL)/rest/v1")!,
@@ -20,21 +22,15 @@ final class PostgrestResourceEmbeddingTests: XCTestCase {
     )
   )
 
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-
+  init() async throws {
     // Clean up test data before running tests.
     // Delete users with email (test data), preserving seed data (users with username only).
     try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
       .execute()
   }
 
-  func testEmbeddedSelect() async throws {
+  @Test
+  func embeddedSelect() async throws {
     let res = try await client.from("users").select("messages(*)").execute().value as AnyJSON
 
     assertInlineSnapshot(of: res, as: .json) {
@@ -78,7 +74,8 @@ final class PostgrestResourceEmbeddingTests: XCTestCase {
     }
   }
 
-  func testEmbeddedEq() async throws {
+  @Test
+  func embeddedEq() async throws {
     let res =
       try await client.from("users")
       .select("messages(*)")
@@ -119,7 +116,8 @@ final class PostgrestResourceEmbeddingTests: XCTestCase {
     }
   }
 
-  func testEmbeddedOr() async throws {
+  @Test
+  func embeddedOr() async throws {
     let res =
       try await client.from("users")
       .select("messages(*)")
@@ -167,7 +165,8 @@ final class PostgrestResourceEmbeddingTests: XCTestCase {
     }
   }
 
-  func testEmbeddedOrWithAnd() async throws {
+  @Test
+  func embeddedOrWithAnd() async throws {
     let res =
       try await client.from("users")
       .select("messages(*)")
@@ -218,7 +217,8 @@ final class PostgrestResourceEmbeddingTests: XCTestCase {
     }
   }
 
-  func testEmbeddedOrder() async throws {
+  @Test
+  func embeddedOrder() async throws {
     let res =
       try await client.from("users")
       .select("messages(*)")
@@ -266,7 +266,8 @@ final class PostgrestResourceEmbeddingTests: XCTestCase {
     }
   }
 
-  func testEmbeddedOrderOnMultipleColumns() async throws {
+  @Test
+  func embeddedOrderOnMultipleColumns() async throws {
     let res =
       try await client.from("users")
       .select("messages(*)")
@@ -315,7 +316,8 @@ final class PostgrestResourceEmbeddingTests: XCTestCase {
     }
   }
 
-  func testEmbeddedLimit() async throws {
+  @Test
+  func embeddedLimit() async throws {
     let res =
       try await client.from("users")
       .select("messages(*)")
@@ -356,7 +358,8 @@ final class PostgrestResourceEmbeddingTests: XCTestCase {
     }
   }
 
-  func testEmbeddedRange() async throws {
+  @Test
+  func embeddedRange() async throws {
     let res =
       try await client.from("users")
       .select("messages(*)")

--- a/Tests/IntegrationTests/PostgrestIntegrationTests.swift
+++ b/Tests/IntegrationTests/PostgrestIntegrationTests.swift
@@ -1,5 +1,6 @@
+import Foundation
 import PostgREST
-import XCTest
+import Testing
 
 struct Todo: Codable, Hashable {
   let id: UUID
@@ -33,7 +34,8 @@ struct User: Codable, Hashable {
   let email: String
 }
 
-final class IntegrationTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+struct PostgrestIntegrationTests {
   let client = PostgrestClient(
     url: URL(string: "\(DotEnv.SUPABASE_URL)/rest/v1")!,
     headers: [
@@ -42,14 +44,7 @@ final class IntegrationTests: XCTestCase {
     logger: nil
   )
 
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-
+  init() async throws {
     // Run fresh test by deleting test data. Delete without a where clause isn't supported, so have
     // to do this `neq` trick to delete all data. For users, only delete rows with email (test data),
     // leaving seed data with username intact.
@@ -58,9 +53,10 @@ final class IntegrationTests: XCTestCase {
       .execute()
   }
 
-  func testIntegration() async throws {
+  @Test
+  func integration() async throws {
     var todos: [Todo] = try await client.from("todos").select().execute().value
-    XCTAssertEqual(todos, [])
+    #expect(todos == [])
 
     let insertedTodo: Todo = try await client.from("todos")
       .insert(
@@ -75,7 +71,7 @@ final class IntegrationTests: XCTestCase {
       .value
 
     todos = try await client.from("todos").select().execute().value
-    XCTAssertEqual(todos, [insertedTodo])
+    #expect(todos == [insertedTodo])
 
     let insertedTodos: [Todo] = try await client.from("todos")
       .insert(
@@ -89,7 +85,7 @@ final class IntegrationTests: XCTestCase {
       .value
 
     todos = try await client.from("todos").select().execute().value
-    XCTAssertEqual(todos, [insertedTodo] + insertedTodos)
+    #expect(todos == [insertedTodo] + insertedTodos)
 
     let drinkCoffeeTodo = insertedTodos[1]
     let updatedTodo: Todo = try await client.from("todos")
@@ -98,25 +94,26 @@ final class IntegrationTests: XCTestCase {
       .single()
       .execute()
       .value
-    XCTAssertTrue(updatedTodo.isComplete)
+    #expect(updatedTodo.isComplete)
 
     let completedTodos: [Todo] = try await client.from("todos")
       .select()
       .eq("is_complete", value: true)
       .execute()
       .value
-    XCTAssertEqual(completedTodos, [updatedTodo])
+    #expect(completedTodos == [updatedTodo])
 
     try await client.from("todos").delete().eq("is_complete", value: true).execute()
     todos = try await client.from("todos").select().execute().value
-    XCTAssertTrue(completedTodos.allSatisfy { todo in !todos.contains(todo) })
+    #expect(completedTodos.allSatisfy { todo in !todos.contains(todo) })
 
     let todosWithSpecificTag: [Todo] = try await client.from("todos").select()
       .contains("tags", value: ["tag 01"]).execute().value
-    XCTAssertEqual(todosWithSpecificTag, [insertedTodo, insertedTodos[0]])
+    #expect(todosWithSpecificTag == [insertedTodo, insertedTodos[0]])
   }
 
-  func testQueryWithPlusSign() async throws {
+  @Test
+  func queryWithPlusSign() async throws {
     let users = [
       User(email: "johndoe@mail.com"),
       User(email: "johndoe+test1@mail.com"),
@@ -127,9 +124,6 @@ final class IntegrationTests: XCTestCase {
 
     let fetchedUsers: [User] = try await client.from("users").select()
       .ilike("email", value: "johndoe+test%").execute().value
-    XCTAssertEqual(
-      fetchedUsers[...],
-      users[1...2]
-    )
+    #expect(fetchedUsers[...] == users[1...2])
   }
 }

--- a/Tests/IntegrationTests/PostgrestIntegrationTests.swift
+++ b/Tests/IntegrationTests/PostgrestIntegrationTests.swift
@@ -34,7 +34,10 @@ struct User: Codable, Hashable {
   let email: String
 }
 
-@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+@Suite(
+  .serialized,
+  .enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil)
+)
 struct PostgrestIntegrationTests {
   let client = PostgrestClient(
     url: URL(string: "\(DotEnv.SUPABASE_URL)/rest/v1")!,

--- a/Tests/IntegrationTests/RealtimeIntegrationTests.swift
+++ b/Tests/IntegrationTests/RealtimeIntegrationTests.swift
@@ -22,7 +22,10 @@
   // the same local Supabase instance — Swift Testing runs `@Test`s in the same suite concurrently
   // by default, unlike XCTest's implicit one-class-at-a-time execution. Use a class (not a
   // struct) so `deinit` can disconnect both clients afterward, mirroring the old `tearDown()`.
-  @Suite(.serialized)
+  @Suite(
+    .serialized,
+    .enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil)
+  )
   final class RealtimeIntegrationTests: Sendable {
     let testClock = TestClock<Duration>()
 

--- a/Tests/IntegrationTests/RealtimeIntegrationTests.swift
+++ b/Tests/IntegrationTests/RealtimeIntegrationTests.swift
@@ -13,25 +13,23 @@
   import OSLog
   import Supabase
   import TestHelpers
-  import XCTest
+  import Testing
 
   @testable import Realtime
   @testable import RealtimeV2
 
-  final class RealtimeIntegrationTests: XCTestCase {
+  // Serialize this suite so concurrent tests don't open competing realtime connections against
+  // the same local Supabase instance — Swift Testing runs `@Test`s in the same suite concurrently
+  // by default, unlike XCTest's implicit one-class-at-a-time execution. Use a class (not a
+  // struct) so `deinit` can disconnect both clients afterward, mirroring the old `tearDown()`.
+  @Suite(.serialized)
+  final class RealtimeIntegrationTests: Sendable {
     let testClock = TestClock<Duration>()
 
-    var client: SupabaseClient!
-    var client2: SupabaseClient!
+    let client: SupabaseClient
+    let client2: SupabaseClient
 
-    override func setUp() async throws {
-      try await super.setUp()
-
-      //      try XCTSkipUnless(
-      //        ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      //        "INTEGRATION_TESTS not defined. Set this environment variable to run integration tests."
-      //      )
-
+    init() async throws {
       client = SupabaseClient(
         supabaseURL: URL(string: DotEnv.SUPABASE_URL) ?? URL(string: "http://127.0.0.1:54321")!,
         supabaseKey: DotEnv.SUPABASE_PUBLISHABLE_KEY,
@@ -65,477 +63,533 @@
         .execute()
     }
 
-    override func tearDown() async throws {
-      // Clean up channels and disconnect
-      await client.realtimeV2.removeAllChannels()
-      client.realtimeV2.disconnect()
+    // Async cleanup can outlive the test if the process exits immediately after — acceptable for
+    // local dev/CI cleanup against an ephemeral local Supabase instance, not correctness-critical.
+    deinit {
+      let client = client
+      let client2 = client2
+      Task {
+        await client.realtimeV2.removeAllChannels()
+        client.realtimeV2.disconnect()
 
-      await client2.realtimeV2.removeAllChannels()
-      client2.realtimeV2.disconnect()
-
-      try await super.tearDown()
-    }
-
-    #if !os(Windows) && !os(Linux) && !os(Android)
-      override func invokeTest() {
-        withMainSerialExecutor {
-          super.invokeTest()
-        }
+        await client2.realtimeV2.removeAllChannels()
+        client2.realtimeV2.disconnect()
       }
-    #endif
+    }
 
     // MARK: - Connection Management Tests
 
-    func testConnectionAndDisconnection() async throws {
-      XCTAssertEqual(client.realtimeV2.status, .disconnected)
+    @Test
+    func connectionAndDisconnection() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        #expect(client.realtimeV2.status == .disconnected)
 
-      await client.realtimeV2.connect()
-      XCTAssertEqual(client.realtimeV2.status, .connected)
+        await client.realtimeV2.connect()
+        #expect(client.realtimeV2.status == .connected)
 
-      client.realtimeV2.disconnect()
-      XCTAssertEqual(client.realtimeV2.status, .disconnected)
-    }
-
-    func testConnectionStatusChanges() async throws {
-      let statuses = LockIsolated<[RealtimeClientStatus]>([])
-
-      let subscription = client.realtimeV2.onStatusChange { status in
-        statuses.withValue { $0.append(status) }
+        client.realtimeV2.disconnect()
+        #expect(client.realtimeV2.status == .disconnected)
       }
-
-      await client.realtimeV2.connect()
-      client.realtimeV2.disconnect()
-
-      // Wait a bit for all status changes
-      await Task.megaYield()
-
-      subscription.cancel()
-
-      // Should have at least connecting and connected
-      XCTAssertTrue(statuses.value.contains(.connecting))
-      XCTAssertTrue(statuses.value.contains(.connected))
-      XCTAssertTrue(statuses.value.contains(.disconnected))
     }
 
-    func testManualDisconnectShouldNotReconnect() async throws {
-      await client.realtimeV2.connect()
-      XCTAssertEqual(client.realtimeV2.status, .connected)
+    @Test
+    func connectionStatusChanges() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        let statuses = LockIsolated<[RealtimeClientStatus]>([])
 
-      client.realtimeV2.disconnect()
+        let subscription = client.realtimeV2.onStatusChange { status in
+          statuses.withValue { $0.append(status) }
+        }
 
-      // Wait for potential reconnection delay
-      await testClock.advance(by: .seconds(RealtimeClientOptions.defaultReconnectDelay + 1))
+        await client.realtimeV2.connect()
+        client.realtimeV2.disconnect()
 
-      XCTAssertEqual(client.realtimeV2.status, .disconnected)
+        // Wait a bit for all status changes
+        await Task.megaYield()
+
+        subscription.cancel()
+
+        // Should have at least connecting and connected
+        #expect(statuses.value.contains(.connecting))
+        #expect(statuses.value.contains(.connected))
+        #expect(statuses.value.contains(.disconnected))
+      }
     }
 
-    func testMultipleConnectCalls() async throws {
-      await client.realtimeV2.connect()
-      XCTAssertEqual(client.realtimeV2.status, .connected)
+    @Test
+    func manualDisconnectShouldNotReconnect() async throws {
+      let client = client
+      let testClock = testClock
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
+        #expect(client.realtimeV2.status == .connected)
 
-      // Multiple connect calls should be idempotent
-      await client.realtimeV2.connect()
-      await client.realtimeV2.connect()
+        client.realtimeV2.disconnect()
 
-      XCTAssertEqual(client.realtimeV2.status, .connected)
+        // Wait for potential reconnection delay
+        await testClock.advance(by: .seconds(RealtimeClientOptions.defaultReconnectDelay + 1))
+
+        #expect(client.realtimeV2.status == .disconnected)
+      }
+    }
+
+    @Test
+    func multipleConnectCalls() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
+        #expect(client.realtimeV2.status == .connected)
+
+        // Multiple connect calls should be idempotent
+        await client.realtimeV2.connect()
+        await client.realtimeV2.connect()
+
+        #expect(client.realtimeV2.status == .connected)
+      }
     }
 
     // MARK: - Channel Management Tests
 
-    func testChannelStatusChanges() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func channelStatusChanges() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel = client.realtimeV2.channel("test-channel")
-      let statuses = LockIsolated<[RealtimeChannelStatus]>([])
+        let channel = client.realtimeV2.channel("test-channel")
+        let statuses = LockIsolated<[RealtimeChannelStatus]>([])
 
-      let subscription = channel.onStatusChange { status in
-        statuses.withValue { $0.append(status) }
+        let subscription = channel.onStatusChange { status in
+          statuses.withValue { $0.append(status) }
+        }
+        defer { subscription.cancel() }
+
+        try await channel.subscribeWithError()
+        await channel.unsubscribe()
+
+        #expect(
+          statuses.value
+            == [.unsubscribed, .subscribing, .subscribed, .unsubscribing, .unsubscribed]
+        )
       }
-      defer { subscription.cancel() }
-
-      try await channel.subscribeWithError()
-      await channel.unsubscribe()
-
-      XCTAssertEqual(
-        statuses.value,
-        [.unsubscribed, .subscribing, .subscribed, .unsubscribing, .unsubscribed]
-      )
     }
 
-    func testMultipleChannels() async throws {
-      // Do not connect client, let first channel subscription do it.
+    @Test
+    func multipleChannels() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        // Do not connect client, let first channel subscription do it.
 
-      let channel1 = client.realtimeV2.channel("channel-1")
-      let channel2 = client.realtimeV2.channel("channel-2")
-      let channel3 = client.realtimeV2.channel("channel-3")
+        let channel1 = client.realtimeV2.channel("channel-1")
+        let channel2 = client.realtimeV2.channel("channel-2")
+        let channel3 = client.realtimeV2.channel("channel-3")
 
-      try await subscribeMany([channel1, channel2, channel3])
+        try await subscribeMany([channel1, channel2, channel3])
 
-      XCTAssertEqual(channel1.status, .subscribed)
-      XCTAssertEqual(channel2.status, .subscribed)
-      XCTAssertEqual(channel3.status, .subscribed)
+        #expect(channel1.status == .subscribed)
+        #expect(channel2.status == .subscribed)
+        #expect(channel3.status == .subscribed)
 
-      XCTAssertEqual(client.realtimeV2.channels.count, 3)
+        #expect(client.realtimeV2.channels.count == 3)
 
-      await unsubscribeMany([channel1, channel2, channel3])
+        await unsubscribeMany([channel1, channel2, channel3])
+      }
     }
 
-    func testChannelReuse() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func channelReuse() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel1 = client.realtimeV2.channel("reuse-channel")
-      try await channel1.subscribeWithError()
+        let channel1 = client.realtimeV2.channel("reuse-channel")
+        try await channel1.subscribeWithError()
 
-      // Getting the same channel should return the existing instance
-      let channel2 = client.realtimeV2.channel("reuse-channel")
-      XCTAssertTrue(channel1 === channel2)
-      XCTAssertEqual(channel2.status, .subscribed)
+        // Getting the same channel should return the existing instance
+        let channel2 = client.realtimeV2.channel("reuse-channel")
+        #expect(channel1 === channel2)
+        #expect(channel2.status == .subscribed)
 
-      await channel1.unsubscribe()
+        await channel1.unsubscribe()
 
-      // Unsubscribing channel1 should unsubscribe channel2
-      XCTAssertEqual(channel2.status, .unsubscribed)
+        // Unsubscribing channel1 should unsubscribe channel2
+        #expect(channel2.status == .unsubscribed)
+      }
     }
 
-    func testRemoveChannel() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func removeChannel() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel = client.realtimeV2.channel("remove-test")
-      try await channel.subscribeWithError()
+        let channel = client.realtimeV2.channel("remove-test")
+        try await channel.subscribeWithError()
 
-      await client.realtimeV2.removeChannel(channel)
+        await client.realtimeV2.removeChannel(channel)
 
-      XCTAssertEqual(channel.status, .unsubscribed)
-      XCTAssertFalse(client.realtimeV2.channels.keys.contains(channel.topic))
+        #expect(channel.status == .unsubscribed)
+        #expect(!client.realtimeV2.channels.keys.contains(channel.topic))
+      }
     }
 
-    func testRemoveAllChannels() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func removeAllChannels() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel1 = client.realtimeV2.channel("all-1")
-      let channel2 = client.realtimeV2.channel("all-2")
-      let channel3 = client.realtimeV2.channel("all-3")
+        let channel1 = client.realtimeV2.channel("all-1")
+        let channel2 = client.realtimeV2.channel("all-2")
+        let channel3 = client.realtimeV2.channel("all-3")
 
-      try await subscribeMany([channel1, channel2, channel3])
+        try await subscribeMany([channel1, channel2, channel3])
 
-      await client.realtimeV2.removeAllChannels()
+        await client.realtimeV2.removeAllChannels()
 
-      XCTAssertEqual(channel1.status, .unsubscribed)
-      XCTAssertEqual(channel2.status, .unsubscribed)
-      XCTAssertEqual(channel3.status, .unsubscribed)
-      XCTAssertEqual(client.realtimeV2.channels.count, 0)
+        #expect(channel1.status == .unsubscribed)
+        #expect(channel2.status == .unsubscribed)
+        #expect(channel3.status == .unsubscribed)
+        #expect(client.realtimeV2.channels.count == 0)
 
-      XCTAssertEqual(
-        client.realtimeV2.status,
-        .disconnected,
-        "Should disconnect client if all channels are removed"
-      )
+        #expect(
+          client.realtimeV2.status == .disconnected,
+          "Should disconnect client if all channels are removed"
+        )
+      }
     }
 
     // MARK: - Broadcast Tests
 
-    func testBroadcastSendAndReceive() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func broadcastSendAndReceive() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel = client.realtimeV2.channel("broadcast-test") {
-        $0.broadcast.receiveOwnBroadcasts = true
+        let channel = client.realtimeV2.channel("broadcast-test") {
+          $0.broadcast.receiveOwnBroadcasts = true
+        }
+
+        struct Message: Codable, Sendable {
+          let value: Int
+          let text: String
+        }
+
+        let receivedMessagesTask = Task {
+          await channel.broadcastStream(event: "test-event").prefix(3).collect()
+        }
+
+        try await channel.subscribeWithError()
+
+        try await channel.broadcast(event: "test-event", message: Message(value: 1, text: "first"))
+        try await channel.broadcast(
+          event: "test-event", message: Message(value: 2, text: "second"))
+        await channel.broadcast(event: "test-event", message: ["value": 3, "text": "third"])
+
+        let receivedMessages = try await withTimeout(interval: 5) {
+          await receivedMessagesTask.value
+        }
+
+        #expect(receivedMessages.count == 3)
+
+        let firstMessage = receivedMessages[0]
+        #expect(firstMessage["event"]?.stringValue == "test-event")
+        #expect(firstMessage["payload"]?.objectValue?["value"]?.intValue == 1)
+        #expect(firstMessage["payload"]?.objectValue?["text"]?.stringValue == "first")
+
+        // Clean up
+
+        await channel.unsubscribe()
       }
-
-      struct Message: Codable {
-        let value: Int
-        let text: String
-      }
-
-      let receivedMessagesTask = Task {
-        await channel.broadcastStream(event: "test-event").prefix(3).collect()
-      }
-
-      try await channel.subscribeWithError()
-
-      try await channel.broadcast(event: "test-event", message: Message(value: 1, text: "first"))
-      try await channel.broadcast(event: "test-event", message: Message(value: 2, text: "second"))
-      await channel.broadcast(event: "test-event", message: ["value": 3, "text": "third"])
-
-      let receivedMessages = try await withTimeout(interval: 5) {
-        await receivedMessagesTask.value
-      }
-
-      XCTAssertEqual(receivedMessages.count, 3)
-
-      let firstMessage = receivedMessages[0]
-      XCTAssertEqual(firstMessage["event"]?.stringValue, "test-event")
-      XCTAssertEqual(firstMessage["payload"]?.objectValue?["value"]?.intValue, 1)
-      XCTAssertEqual(firstMessage["payload"]?.objectValue?["text"]?.stringValue, "first")
-
-      // Clean up
-
-      await channel.unsubscribe()
     }
 
-    func testBroadcastMultipleEvents() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func broadcastMultipleEvents() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel = client.realtimeV2.channel("broadcast-multi") {
-        $0.broadcast.receiveOwnBroadcasts = true
+        let channel = client.realtimeV2.channel("broadcast-multi") {
+          $0.broadcast.receiveOwnBroadcasts = true
+        }
+
+        let event1Messages = Task {
+          await channel.broadcastStream(event: "event-1").prefix(2).collect()
+        }
+
+        let event2Messages = Task {
+          await channel.broadcastStream(event: "event-2").prefix(2).collect()
+        }
+
+        try await channel.subscribeWithError()
+
+        try await channel.broadcast(event: "event-1", message: ["data": "1"])
+        try await channel.broadcast(event: "event-2", message: ["data": "2"])
+        try await channel.broadcast(event: "event-1", message: ["data": "3"])
+        try await channel.broadcast(event: "event-2", message: ["data": "4"])
+
+        let event1 = try await withTimeout(interval: 5) {
+          await event1Messages.value
+        }
+
+        let event2 = try await withTimeout(interval: 5) {
+          await event2Messages.value
+        }
+
+        #expect(event1.count == 2)
+        #expect(event2.count == 2)
+
+        await channel.unsubscribe()
       }
-
-      let event1Messages = Task {
-        await channel.broadcastStream(event: "event-1").prefix(2).collect()
-      }
-
-      let event2Messages = Task {
-        await channel.broadcastStream(event: "event-2").prefix(2).collect()
-      }
-
-      try await channel.subscribeWithError()
-
-      try await channel.broadcast(event: "event-1", message: ["data": "1"])
-      try await channel.broadcast(event: "event-2", message: ["data": "2"])
-      try await channel.broadcast(event: "event-1", message: ["data": "3"])
-      try await channel.broadcast(event: "event-2", message: ["data": "4"])
-
-      let event1 = try await withTimeout(interval: 5) {
-        await event1Messages.value
-      }
-
-      let event2 = try await withTimeout(interval: 5) {
-        await event2Messages.value
-      }
-
-      XCTAssertEqual(event1.count, 2)
-      XCTAssertEqual(event2.count, 2)
-
-      await channel.unsubscribe()
     }
 
-    func testBroadcastWithoutOwnBroadcasts() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func broadcastWithoutOwnBroadcasts() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel = client.realtimeV2.channel("broadcast-no-own") {
-        $0.broadcast.receiveOwnBroadcasts = false
+        let channel = client.realtimeV2.channel("broadcast-no-own") {
+          $0.broadcast.receiveOwnBroadcasts = false
+        }
+
+        let receivedCount = LockIsolated<Int>(0)
+        let subscription = channel.onBroadcast(event: "test") { _ in
+          receivedCount.withValue { $0 += 1 }
+        }
+
+        try await channel.subscribeWithError()
+
+        // Send broadcast - should not receive it
+        try await channel.broadcast(event: "test", message: ["data": "test"])
+
+        // Wait a bit
+        try await Task.sleep(nanoseconds: 500_000_000)  // 0.5 seconds
+
+        #expect(receivedCount.value == 0)
+
+        subscription.cancel()
+        await channel.unsubscribe()
       }
-
-      let receivedCount = LockIsolated<Int>(0)
-      let subscription = channel.onBroadcast(event: "test") { _ in
-        receivedCount.withValue { $0 += 1 }
-      }
-
-      try await channel.subscribeWithError()
-
-      // Send broadcast - should not receive it
-      try await channel.broadcast(event: "test", message: ["data": "test"])
-
-      // Wait a bit
-      try await Task.sleep(nanoseconds: 500_000_000)  // 0.5 seconds
-
-      XCTAssertEqual(receivedCount.value, 0)
-
-      subscription.cancel()
-      await channel.unsubscribe()
     }
 
     // MARK: - Postgres Changes Tests
 
-    func testPostgresAllChanges() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func postgresAllChanges() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel = client.realtimeV2.channel("postgres-all")
+        let channel = client.realtimeV2.channel("postgres-all")
 
-      struct Entry: Codable, Equatable {
-        let key: String
-        let value: AnyJSON
+        struct Entry: Codable, Equatable {
+          let key: String
+          let value: AnyJSON
+        }
+
+        let allChangesTask = Task {
+          await channel.postgresChange(AnyAction.self, schema: "public", table: "key_value_storage")
+            .prefix(3).collect()
+        }
+
+        try await channel.subscribeWithError()
+
+        // Wait for subscription
+        _ = await channel.system().first(where: { _ in true })
+
+        let testKey = UUID().uuidString
+
+        // Insert
+        _ = try await client.from("key_value_storage")
+          .insert(["key": testKey, "value": "value1"]).select().single().execute()
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Update
+        try await client.from("key_value_storage").update(["value": "value2"]).eq(
+          "key",
+          value: testKey
+        )
+        .execute()
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Delete
+        try await client.from("key_value_storage").delete().eq("key", value: testKey).execute()
+
+        let received = try await withTimeout(interval: 5) {
+          await allChangesTask.value
+        }
+
+        #expect(received.count == 3)
+
+        // Verify action types
+        if case .insert(let action) = received[0] {
+          let record = try action.decodeRecord(as: Entry.self, decoder: .supabase())
+          #expect(record.key == testKey)
+        } else {
+          Issue.record("Expected insert action")
+        }
+
+        if case .update(let action) = received[1] {
+          let record = try action.decodeRecord(as: Entry.self, decoder: .supabase())
+          #expect(record.value.stringValue == "value2")
+        } else {
+          Issue.record("Expected update action")
+        }
+
+        if case .delete(let action) = received[2] {
+          let oldRecordKey = action.oldRecord["key"]?.stringValue
+          #expect(oldRecordKey == testKey)
+        } else {
+          Issue.record("Expected delete action")
+        }
+
+        await channel.unsubscribe()
       }
-
-      let allChangesTask = Task {
-        await channel.postgresChange(AnyAction.self, schema: "public", table: "key_value_storage")
-          .prefix(3).collect()
-      }
-
-      try await channel.subscribeWithError()
-
-      // Wait for subscription
-      _ = await channel.system().first(where: { _ in true })
-
-      let testKey = UUID().uuidString
-
-      // Insert
-      _ = try await client.from("key_value_storage")
-        .insert(["key": testKey, "value": "value1"]).select().single().execute()
-
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // Update
-      try await client.from("key_value_storage").update(["value": "value2"]).eq(
-        "key",
-        value: testKey
-      )
-      .execute()
-
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // Delete
-      try await client.from("key_value_storage").delete().eq("key", value: testKey).execute()
-
-      let received = try await withTimeout(interval: 5) {
-        await allChangesTask.value
-      }
-
-      XCTAssertEqual(received.count, 3)
-
-      // Verify action types
-      if case .insert(let action) = received[0] {
-        let record = try action.decodeRecord(as: Entry.self, decoder: .supabase())
-        XCTAssertEqual(record.key, testKey)
-      } else {
-        XCTFail("Expected insert action")
-      }
-
-      if case .update(let action) = received[1] {
-        let record = try action.decodeRecord(as: Entry.self, decoder: .supabase())
-        XCTAssertEqual(record.value.stringValue, "value2")
-      } else {
-        XCTFail("Expected update action")
-      }
-
-      if case .delete(let action) = received[2] {
-        let oldRecordKey = action.oldRecord["key"]?.stringValue
-        XCTAssertEqual(oldRecordKey, testKey)
-      } else {
-        XCTFail("Expected delete action")
-      }
-
-      await channel.unsubscribe()
     }
 
-    func testPostgresChangesWithFilter() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func postgresChangesWithFilter() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel = client.realtimeV2.channel("postgres-filter")
+        let channel = client.realtimeV2.channel("postgres-filter")
 
-      struct Entry: Codable, Equatable {
-        let key: String
-        let value: AnyJSON
+        struct Entry: Codable, Equatable {
+          let key: String
+          let value: AnyJSON
+        }
+
+        let testKey1 = UUID().uuidString
+        let testKey2 = UUID().uuidString
+
+        // Set up filter for specific key
+        let filteredTask = Task {
+          await channel.postgresChange(
+            InsertAction.self,
+            schema: "public",
+            table: "key_value_storage",
+            filter: .eq("key", value: testKey1)
+          ).prefix(1).collect()
+        }
+
+        try await channel.subscribeWithError()
+
+        // Wait for subscription
+        _ = await channel.system().first(where: { _ in true })
+
+        // Insert with key1 - should be received
+        _ = try await client.from("key_value_storage")
+          .insert(["key": testKey1, "value": "filtered"]).select().single().execute()
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Insert with key2 - should NOT be received
+        _ = try await client.from("key_value_storage")
+          .insert(["key": testKey2, "value": "not-filtered"]).select().single().execute()
+
+        let received = try await withTimeout(interval: 5) {
+          await filteredTask.value
+        }
+
+        #expect(received.count == 1)
+        let record = try received[0].decodeRecord(as: Entry.self, decoder: .supabase())
+        #expect(record.key == testKey1)
+        #expect(record.key != testKey2)
+
+        await channel.unsubscribe()
       }
-
-      let testKey1 = UUID().uuidString
-      let testKey2 = UUID().uuidString
-
-      // Set up filter for specific key
-      let filteredTask = Task {
-        await channel.postgresChange(
-          InsertAction.self,
-          schema: "public",
-          table: "key_value_storage",
-          filter: .eq("key", value: testKey1)
-        ).prefix(1).collect()
-      }
-
-      try await channel.subscribeWithError()
-
-      // Wait for subscription
-      _ = await channel.system().first(where: { _ in true })
-
-      // Insert with key1 - should be received
-      _ = try await client.from("key_value_storage")
-        .insert(["key": testKey1, "value": "filtered"]).select().single().execute()
-
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // Insert with key2 - should NOT be received
-      _ = try await client.from("key_value_storage")
-        .insert(["key": testKey2, "value": "not-filtered"]).select().single().execute()
-
-      let received = try await withTimeout(interval: 5) {
-        await filteredTask.value
-      }
-
-      XCTAssertEqual(received.count, 1)
-      let record = try received[0].decodeRecord(as: Entry.self, decoder: .supabase())
-      XCTAssertEqual(record.key, testKey1)
-      XCTAssertNotEqual(record.key, testKey2)
-
-      await channel.unsubscribe()
     }
 
-    func testPostgresChangesMultipleSubscriptions() async throws {
-      await client.realtimeV2.connect()
+    @Test
+    func postgresChangesMultipleSubscriptions() async throws {
+      let client = client
+      try await withMainSerialExecutor {
+        await client.realtimeV2.connect()
 
-      let channel = client.realtimeV2.channel("postgres-multi")
+        let channel = client.realtimeV2.channel("postgres-multi")
 
-      struct Entry: Codable, Equatable {
-        let key: String
-        let value: AnyJSON
-      }
+        struct Entry: Codable, Equatable {
+          let key: String
+          let value: AnyJSON
+        }
 
-      let insertTask = Task {
-        await channel.postgresChange(
-          InsertAction.self,
-          schema: "public",
-          table: "key_value_storage"
+        let insertTask = Task {
+          await channel.postgresChange(
+            InsertAction.self,
+            schema: "public",
+            table: "key_value_storage"
+          )
+          .prefix(1).collect()
+        }
+
+        let updateTask = Task {
+          await channel.postgresChange(
+            UpdateAction.self,
+            schema: "public",
+            table: "key_value_storage"
+          )
+          .prefix(1).collect()
+        }
+
+        let deleteTask = Task {
+          await channel.postgresChange(
+            DeleteAction.self,
+            schema: "public",
+            table: "key_value_storage"
+          )
+          .prefix(1).collect()
+        }
+
+        try await channel.subscribeWithError()
+
+        // Wait for subscription
+        _ = await channel.system().first(where: { _ in true })
+
+        let testKey = UUID().uuidString
+
+        // Insert
+        _ = try await client.from("key_value_storage")
+          .insert(["key": testKey, "value": "value1"]).select().single().execute()
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Update
+        try await client.from("key_value_storage").update(["value": "value2"]).eq(
+          "key",
+          value: testKey
         )
-        .prefix(1).collect()
+        .execute()
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Delete
+        try await client.from("key_value_storage").delete().eq("key", value: testKey).execute()
+
+        let inserts = try await withTimeout(interval: 5) {
+          await insertTask.value
+        }
+
+        let updates = try await withTimeout(interval: 5) {
+          await updateTask.value
+        }
+
+        let deletes = try await withTimeout(interval: 5) {
+          await deleteTask.value
+        }
+
+        #expect(inserts.count == 1)
+        #expect(updates.count == 1)
+        #expect(deletes.count == 1)
+
+        await channel.unsubscribe()
       }
-
-      let updateTask = Task {
-        await channel.postgresChange(
-          UpdateAction.self,
-          schema: "public",
-          table: "key_value_storage"
-        )
-        .prefix(1).collect()
-      }
-
-      let deleteTask = Task {
-        await channel.postgresChange(
-          DeleteAction.self,
-          schema: "public",
-          table: "key_value_storage"
-        )
-        .prefix(1).collect()
-      }
-
-      try await channel.subscribeWithError()
-
-      // Wait for subscription
-      _ = await channel.system().first(where: { _ in true })
-
-      let testKey = UUID().uuidString
-
-      // Insert
-      _ = try await client.from("key_value_storage")
-        .insert(["key": testKey, "value": "value1"]).select().single().execute()
-
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // Update
-      try await client.from("key_value_storage").update(["value": "value2"]).eq(
-        "key",
-        value: testKey
-      )
-      .execute()
-
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // Delete
-      try await client.from("key_value_storage").delete().eq("key", value: testKey).execute()
-
-      let inserts = try await withTimeout(interval: 5) {
-        await insertTask.value
-      }
-
-      let updates = try await withTimeout(interval: 5) {
-        await updateTask.value
-      }
-
-      let deletes = try await withTimeout(interval: 5) {
-        await deleteTask.value
-      }
-
-      XCTAssertEqual(inserts.count, 1)
-      XCTAssertEqual(updates.count, 1)
-      XCTAssertEqual(deletes.count, 1)
-
-      await channel.unsubscribe()
     }
 
     // MARK: - Error Handling Tests
@@ -610,217 +664,222 @@
     /// - Users join and track their presence
     /// - Users exchange messages via broadcast
     /// - Users can see each other's presence changes
-    func testRealApplicationScenario_BroadcastAndPresence() async throws {
-      // User state models
-      struct UserPresence: Codable, Equatable {
-        let userId: String
-        let username: String
-        let status: String  // "online", "typing", "away"
-        let lastSeen: Date
+    @Test
+    func realApplicationScenario_BroadcastAndPresence() async throws {
+      let client = client
+      let client2 = client2
+      try await withMainSerialExecutor {
+        // User state models
+        struct UserPresence: Codable, Equatable, Sendable {
+          let userId: String
+          let username: String
+          let status: String  // "online", "typing", "away"
+          let lastSeen: Date
+        }
+
+        struct ChatMessage: Codable, Equatable, Sendable {
+          let messageId: String
+          let userId: String
+          let username: String
+          let text: String
+          let timestamp: Date
+        }
+
+        // Connect both clients
+        await client.realtimeV2.connect()
+        await client2.realtimeV2.connect()
+
+        // Both users join the same channel (e.g., a chat room or workspace)
+        let channel1 = client.realtimeV2.channel("app-room") {
+          $0.broadcast.receiveOwnBroadcasts = true
+        }
+
+        let channel2 = client2.realtimeV2.channel("app-room") {
+          $0.broadcast.receiveOwnBroadcasts = true
+        }
+
+        // Set up presence tracking for both users
+        let user1Id = UUID().uuidString
+        let user2Id = UUID().uuidString
+
+        let user1Presence = UserPresence(
+          userId: user1Id,
+          username: "Alice",
+          status: "online",
+          lastSeen: Date()
+        )
+
+        let user2Presence = UserPresence(
+          userId: user2Id,
+          username: "Bob",
+          status: "online",
+          lastSeen: Date()
+        )
+
+        // Set up listeners for presence changes
+        let client1PresenceChanges = Task {
+          await channel1.presenceChange().prefix(5).collect()
+        }
+
+        let client2PresenceChanges = Task {
+          await channel2.presenceChange().prefix(5).collect()
+        }
+
+        // Set up listeners for chat messages
+        let client1Messages = Task {
+          await channel1.broadcastStream(event: "chat-message").prefix(3).collect()
+        }
+
+        let client2Messages = Task {
+          await channel2.broadcastStream(event: "chat-message").prefix(3).collect()
+        }
+
+        // Subscribe both clients
+        try await channel1.subscribeWithError()
+        try await channel2.subscribeWithError()
+
+        // Wait for subscriptions to be ready
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // User 1 joins and tracks presence
+        try await channel1.track(user1Presence)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // User 2 joins and tracks presence
+        try await channel2.track(user2Presence)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // User 1 sends a message
+        let message1 = ChatMessage(
+          messageId: UUID().uuidString,
+          userId: user1Id,
+          username: "Alice",
+          text: "Hello, Bob! How are you?",
+          timestamp: Date()
+        )
+        try await channel1.broadcast(event: "chat-message", message: message1)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // User 2 updates presence to "typing"
+        let user2Typing = UserPresence(
+          userId: user2Id,
+          username: "Bob",
+          status: "typing",
+          lastSeen: Date()
+        )
+        try await channel2.track(user2Typing)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // User 2 sends a reply
+        let message2 = ChatMessage(
+          messageId: UUID().uuidString,
+          userId: user2Id,
+          username: "Bob",
+          text: "Hi Alice! I'm doing great, thanks!",
+          timestamp: Date()
+        )
+        try await channel2.broadcast(event: "chat-message", message: message2)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // User 2 updates presence back to "online"
+        let user2Online = UserPresence(
+          userId: user2Id,
+          username: "Bob",
+          status: "online",
+          lastSeen: Date()
+        )
+        try await channel2.track(user2Online)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // User 1 sends another message
+        let message3 = ChatMessage(
+          messageId: UUID().uuidString,
+          userId: user1Id,
+          username: "Alice",
+          text: "Great to hear! Let's work on the project together.",
+          timestamp: Date()
+        )
+        try await channel1.broadcast(event: "chat-message", message: message3)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // User 1 leaves (untracks presence)
+        await channel1.untrack()
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Collect all events
+        let presenceChanges1 = try await withTimeout(interval: 5) {
+          await client1PresenceChanges.value
+        }
+
+        let presenceChanges2 = try await withTimeout(interval: 5) {
+          await client2PresenceChanges.value
+        }
+
+        let messages1 = try await withTimeout(interval: 5) {
+          await client1Messages.value
+        }
+
+        let messages2 = try await withTimeout(interval: 5) {
+          await client2Messages.value
+        }
+
+        // Verify presence changes
+        // Client 1 should see:
+        // 1. Initial state (empty)
+        // 2. User 1 joins (themselves)
+        // 3. User 2 joins
+        // 4. User 2 status changes to "typing"
+        // 5. User 2 status changes back to "online"
+        #expect(presenceChanges1.count >= 3, "Client 1 should see presence changes")
+
+        // Client 2 should see:
+        // 1. Initial state (empty)
+        // 2. User 1 joins
+        // 3. User 2 joins (themselves)
+        // 4. User 2 status changes to "typing"
+        // 5. User 2 status changes back to "online"
+        // 6. User 1 leaves
+        #expect(presenceChanges2.count >= 3, "Client 2 should see presence changes")
+
+        // Verify both clients can decode presence
+        // Note: Due to timing, exact presence changes may vary, but structure should be correct
+        #expect(presenceChanges1.count > 0, "Client 1 should receive presence changes")
+
+        // Verify messages were received by both clients
+        #expect(messages1.count == 3, "Client 1 should receive all 3 messages")
+        #expect(messages2.count == 3, "Client 2 should receive all 3 messages")
+
+        // Verify message content
+        let receivedMessage1 = try messages1[0]["payload"]?.objectValue?.decode(
+          as: ChatMessage.self,
+          decoder: .supabase()
+        )
+        #expect(receivedMessage1?.text == "Hello, Bob! How are you?")
+        #expect(receivedMessage1?.username == "Alice")
+
+        let receivedMessage2 = try messages2[0]["payload"]?.objectValue?.decode(
+          as: ChatMessage.self,
+          decoder: .supabase()
+        )
+        #expect(receivedMessage2?.text == "Hello, Bob! How are you?")
+        #expect(receivedMessage2?.username == "Alice")
+
+        // Verify the last message
+        let receivedMessage3 = try messages1[2]["payload"]?.objectValue?.decode(
+          as: ChatMessage.self,
+          decoder: .supabase()
+        )
+        #expect(receivedMessage3?.text == "Great to hear! Let's work on the project together.")
+        #expect(receivedMessage3?.username == "Alice")
+
+        // Verify user 1 leaving is detected by user 2
+        // Note: Due to timing, exact presence changes may vary, but structure should be correct
+        #expect(presenceChanges2.count > 0, "Client 2 should receive presence changes")
+
+        // Cleanup
+        await channel1.unsubscribe()
+        await channel2.unsubscribe()
       }
-
-      struct ChatMessage: Codable, Equatable {
-        let messageId: String
-        let userId: String
-        let username: String
-        let text: String
-        let timestamp: Date
-      }
-
-      // Connect both clients
-      await client.realtimeV2.connect()
-      await client2.realtimeV2.connect()
-
-      // Both users join the same channel (e.g., a chat room or workspace)
-      let channel1 = client.realtimeV2.channel("app-room") {
-        $0.broadcast.receiveOwnBroadcasts = true
-      }
-
-      let channel2 = client2.realtimeV2.channel("app-room") {
-        $0.broadcast.receiveOwnBroadcasts = true
-      }
-
-      // Set up presence tracking for both users
-      let user1Id = UUID().uuidString
-      let user2Id = UUID().uuidString
-
-      let user1Presence = UserPresence(
-        userId: user1Id,
-        username: "Alice",
-        status: "online",
-        lastSeen: Date()
-      )
-
-      let user2Presence = UserPresence(
-        userId: user2Id,
-        username: "Bob",
-        status: "online",
-        lastSeen: Date()
-      )
-
-      // Set up listeners for presence changes
-      let client1PresenceChanges = Task {
-        await channel1.presenceChange().prefix(5).collect()
-      }
-
-      let client2PresenceChanges = Task {
-        await channel2.presenceChange().prefix(5).collect()
-      }
-
-      // Set up listeners for chat messages
-      let client1Messages = Task {
-        await channel1.broadcastStream(event: "chat-message").prefix(3).collect()
-      }
-
-      let client2Messages = Task {
-        await channel2.broadcastStream(event: "chat-message").prefix(3).collect()
-      }
-
-      // Subscribe both clients
-      try await channel1.subscribeWithError()
-      try await channel2.subscribeWithError()
-
-      // Wait for subscriptions to be ready
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // User 1 joins and tracks presence
-      try await channel1.track(user1Presence)
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // User 2 joins and tracks presence
-      try await channel2.track(user2Presence)
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // User 1 sends a message
-      let message1 = ChatMessage(
-        messageId: UUID().uuidString,
-        userId: user1Id,
-        username: "Alice",
-        text: "Hello, Bob! How are you?",
-        timestamp: Date()
-      )
-      try await channel1.broadcast(event: "chat-message", message: message1)
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // User 2 updates presence to "typing"
-      let user2Typing = UserPresence(
-        userId: user2Id,
-        username: "Bob",
-        status: "typing",
-        lastSeen: Date()
-      )
-      try await channel2.track(user2Typing)
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // User 2 sends a reply
-      let message2 = ChatMessage(
-        messageId: UUID().uuidString,
-        userId: user2Id,
-        username: "Bob",
-        text: "Hi Alice! I'm doing great, thanks!",
-        timestamp: Date()
-      )
-      try await channel2.broadcast(event: "chat-message", message: message2)
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // User 2 updates presence back to "online"
-      let user2Online = UserPresence(
-        userId: user2Id,
-        username: "Bob",
-        status: "online",
-        lastSeen: Date()
-      )
-      try await channel2.track(user2Online)
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // User 1 sends another message
-      let message3 = ChatMessage(
-        messageId: UUID().uuidString,
-        userId: user1Id,
-        username: "Alice",
-        text: "Great to hear! Let's work on the project together.",
-        timestamp: Date()
-      )
-      try await channel1.broadcast(event: "chat-message", message: message3)
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // User 1 leaves (untracks presence)
-      await channel1.untrack()
-      try await Task.sleep(nanoseconds: 500_000_000)
-
-      // Collect all events
-      let presenceChanges1 = try await withTimeout(interval: 5) {
-        await client1PresenceChanges.value
-      }
-
-      let presenceChanges2 = try await withTimeout(interval: 5) {
-        await client2PresenceChanges.value
-      }
-
-      let messages1 = try await withTimeout(interval: 5) {
-        await client1Messages.value
-      }
-
-      let messages2 = try await withTimeout(interval: 5) {
-        await client2Messages.value
-      }
-
-      // Verify presence changes
-      // Client 1 should see:
-      // 1. Initial state (empty)
-      // 2. User 1 joins (themselves)
-      // 3. User 2 joins
-      // 4. User 2 status changes to "typing"
-      // 5. User 2 status changes back to "online"
-      XCTAssertTrue(presenceChanges1.count >= 3, "Client 1 should see presence changes")
-
-      // Client 2 should see:
-      // 1. Initial state (empty)
-      // 2. User 1 joins
-      // 3. User 2 joins (themselves)
-      // 4. User 2 status changes to "typing"
-      // 5. User 2 status changes back to "online"
-      // 6. User 1 leaves
-      XCTAssertTrue(presenceChanges2.count >= 3, "Client 2 should see presence changes")
-
-      // Verify both clients can decode presence
-      // Note: Due to timing, exact presence changes may vary, but structure should be correct
-      XCTAssertTrue(presenceChanges1.count > 0, "Client 1 should receive presence changes")
-
-      // Verify messages were received by both clients
-      XCTAssertEqual(messages1.count, 3, "Client 1 should receive all 3 messages")
-      XCTAssertEqual(messages2.count, 3, "Client 2 should receive all 3 messages")
-
-      // Verify message content
-      let receivedMessage1 = try messages1[0]["payload"]?.objectValue?.decode(
-        as: ChatMessage.self,
-        decoder: .supabase()
-      )
-      XCTAssertEqual(receivedMessage1?.text, "Hello, Bob! How are you?")
-      XCTAssertEqual(receivedMessage1?.username, "Alice")
-
-      let receivedMessage2 = try messages2[0]["payload"]?.objectValue?.decode(
-        as: ChatMessage.self,
-        decoder: .supabase()
-      )
-      XCTAssertEqual(receivedMessage2?.text, "Hello, Bob! How are you?")
-      XCTAssertEqual(receivedMessage2?.username, "Alice")
-
-      // Verify the last message
-      let receivedMessage3 = try messages1[2]["payload"]?.objectValue?.decode(
-        as: ChatMessage.self,
-        decoder: .supabase()
-      )
-      XCTAssertEqual(receivedMessage3?.text, "Great to hear! Let's work on the project together.")
-      XCTAssertEqual(receivedMessage3?.username, "Alice")
-
-      // Verify user 1 leaving is detected by user 2
-      // Note: Due to timing, exact presence changes may vary, but structure should be correct
-      XCTAssertTrue(presenceChanges2.count > 0, "Client 2 should receive presence changes")
-
-      // Cleanup
-      await channel1.unsubscribe()
-      await channel2.unsubscribe()
     }
 
     // MARK: - Helpers
@@ -844,6 +903,5 @@
         await group.waitForAll()
       }
     }
-
   }
 #endif

--- a/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -5,11 +5,13 @@
 //  Created by Guilherme Souza on 07/05/24.
 //
 
+import Foundation
 import InlineSnapshotTesting
 import Storage
-import XCTest
+import Testing
 
-final class StorageClientIntegrationTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+struct StorageClientIntegrationTests {
   let storage = SupabaseStorageClient(
     configuration: StorageClientConfiguration(
       url: URL(string: "\(DotEnv.SUPABASE_URL)/storage/v1")!,
@@ -20,14 +22,7 @@ final class StorageClientIntegrationTests: XCTestCase {
     )
   )
 
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-
+  init() async throws {
     // Clean up test-bucket if it exists from a previous failed run
     // to make tests idempotent
     let testBucketName = "test-bucket"
@@ -44,38 +39,40 @@ final class StorageClientIntegrationTests: XCTestCase {
     }
   }
 
-  func testBucket_CRUD() async throws {
+  @Test
+  func bucket_CRUD() async throws {
     let bucketName = "test-bucket"
 
     var buckets = try await storage.listBuckets()
-    XCTAssertFalse(buckets.contains(where: { $0.name == bucketName }))
+    #expect(!buckets.contains(where: { $0.name == bucketName }))
 
     try await storage.createBucket(bucketName, options: .init(public: true))
 
     var bucket = try await storage.getBucket(bucketName)
-    XCTAssertEqual(bucket.name, bucketName)
-    XCTAssertEqual(bucket.id, bucketName)
-    XCTAssertEqual(bucket.isPublic, true)
+    #expect(bucket.name == bucketName)
+    #expect(bucket.id == bucketName)
+    #expect(bucket.isPublic == true)
 
     buckets = try await storage.listBuckets()
-    XCTAssertTrue(buckets.contains { $0.id == bucket.id })
+    #expect(buckets.contains { $0.id == bucket.id })
 
     try await storage.updateBucket(
       bucketName, options: BucketOptions(isPublic: false, allowedMimeTypes: ["image/jpeg"]))
 
     bucket = try await storage.getBucket(bucketName)
-    XCTAssertEqual(bucket.allowedMimeTypes, ["image/jpeg"])
+    #expect(bucket.allowedMimeTypes == ["image/jpeg"])
 
     try await storage.deleteBucket(bucketName)
 
     buckets = try await storage.listBuckets()
-    XCTAssertFalse(buckets.contains { $0.id == bucket.id })
+    #expect(!buckets.contains { $0.id == bucket.id })
   }
 
-  func testGetBucketWithWrongId() async {
+  @Test
+  func getBucketWithWrongId() async {
     do {
       _ = try await storage.getBucket("not-exist-id")
-      XCTFail("Unexpected success")
+      Issue.record("Unexpected success")
     } catch {
       assertInlineSnapshot(of: error, as: .dump) {
         """

--- a/Tests/IntegrationTests/StorageFileIntegrationTests.swift
+++ b/Tests/IntegrationTests/StorageFileIntegrationTests.swift
@@ -5,15 +5,17 @@
 //  Created by Guilherme Souza on 07/05/24.
 //
 
+import Foundation
 import InlineSnapshotTesting
 import Storage
-import XCTest
+import Testing
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 
-final class StorageFileIntegrationTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+final class StorageFileIntegrationTests {
   let storage = SupabaseStorageClient(
     configuration: StorageClientConfiguration(
       url: URL(string: "\(DotEnv.SUPABASE_URL)/storage/v1")!,
@@ -28,95 +30,100 @@ final class StorageFileIntegrationTests: XCTestCase {
   var file = Data()
   var uploadPath = ""
 
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-
+  init() async throws {
     bucketName = try await newBucket()
     file = try Data(contentsOf: uploadFileURL("sadcat.jpg"))
     uploadPath = "testpath/file-\(UUID().uuidString).jpg"
   }
 
-  override func tearDown() async throws {
-    try? await storage.emptyBucket(bucketName)
-    try? await storage.deleteBucket(bucketName)
-
-    try await super.tearDown()
+  // Async cleanup can outlive the test if the process exits immediately after — acceptable for
+  // local dev/CI cleanup, not correctness-critical.
+  deinit {
+    let storage = storage
+    let bucketName = bucketName
+    Task {
+      try? await storage.emptyBucket(bucketName)
+      try? await storage.deleteBucket(bucketName)
+    }
   }
 
-  func testGetPublicURL() throws {
+  @Test
+  func getPublicURL() throws {
     let publicURL = try storage.from(bucketName).getPublicURL(path: uploadPath)
-    XCTAssertEqual(
-      publicURL.absoluteString,
-      "\(DotEnv.SUPABASE_URL)/storage/v1/object/public/\(bucketName)/\(uploadPath)"
+    #expect(
+      publicURL.absoluteString
+        == "\(DotEnv.SUPABASE_URL)/storage/v1/object/public/\(bucketName)/\(uploadPath)"
     )
   }
 
-  func testGetPublicURLWithDownloadQueryString() throws {
+  @Test
+  func getPublicURLWithDownloadQueryString() throws {
     let publicURL = try storage.from(bucketName).getPublicURL(path: uploadPath, download: true)
-    XCTAssertEqual(
-      publicURL.absoluteString,
-      "\(DotEnv.SUPABASE_URL)/storage/v1/object/public/\(bucketName)/\(uploadPath)?download="
+    #expect(
+      publicURL.absoluteString
+        == "\(DotEnv.SUPABASE_URL)/storage/v1/object/public/\(bucketName)/\(uploadPath)?download="
     )
   }
 
-  func testGetPublicURLWithCustomDownload() throws {
+  @Test
+  func getPublicURLWithCustomDownload() throws {
     let publicURL = try storage.from(bucketName).getPublicURL(
       path: uploadPath, download: "test.jpg")
-    XCTAssertEqual(
-      publicURL.absoluteString,
-      "\(DotEnv.SUPABASE_URL)/storage/v1/object/public/\(bucketName)/\(uploadPath)?download=test.jpg"
+    #expect(
+      publicURL.absoluteString
+        == "\(DotEnv.SUPABASE_URL)/storage/v1/object/public/\(bucketName)/\(uploadPath)?download=test.jpg"
     )
   }
 
-  func testSignURL() async throws {
+  @Test
+  func signURL() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
     let url = try await storage.from(bucketName).createSignedURL(path: uploadPath, expiresIn: 2000)
-    XCTAssertTrue(
+    #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
     )
   }
 
-  func testSignURL_withDownloadQueryString() async throws {
+  @Test
+  func signURL_withDownloadQueryString() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
     let url = try await storage.from(bucketName).createSignedURL(
       path: uploadPath, expiresIn: 2000, download: true)
-    XCTAssertTrue(
+    #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
     )
-    XCTAssertTrue(url.absoluteString.contains("&download="))
+    #expect(url.absoluteString.contains("&download="))
   }
 
-  func testSignURL_withCustomFilenameForDownload() async throws {
+  @Test
+  func signURL_withCustomFilenameForDownload() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
     let url = try await storage.from(bucketName).createSignedURL(
       path: uploadPath, expiresIn: 2000, download: "test.jpg")
-    XCTAssertTrue(
+    #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
     )
-    XCTAssertTrue(url.absoluteString.contains("&download=test.jpg"))
+    #expect(url.absoluteString.contains("&download=test.jpg"))
   }
 
-  func testUploadAndUpdateFile() async throws {
+  @Test
+  func uploadAndUpdateFile() async throws {
     let file2 = try Data(contentsOf: uploadFileURL("file-2.txt"))
 
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
     let res = try await storage.from(bucketName).update(uploadPath, data: file2)
-    XCTAssertEqual(res.path, uploadPath)
+    #expect(res.path == uploadPath)
   }
 
-  func testUploadFileWithinFileSizeLimit() async throws {
+  @Test
+  func uploadFileWithinFileSizeLimit() async throws {
     bucketName = try await newBucket(
       prefix: "with-limit",
       options: BucketOptions(isPublic: true, fileSizeLimit: .megabytes(1))
@@ -125,7 +132,8 @@ final class StorageFileIntegrationTests: XCTestCase {
     try await storage.from(bucketName).upload(uploadPath, data: file)
   }
 
-  func testUploadFileThatExceedFileSizeLimit() async throws {
+  @Test
+  func uploadFileThatExceedFileSizeLimit() async throws {
     bucketName = try await newBucket(
       prefix: "with-limit",
       options: BucketOptions(isPublic: true, fileSizeLimit: .kilobytes(1))
@@ -133,7 +141,7 @@ final class StorageFileIntegrationTests: XCTestCase {
 
     do {
       try await storage.from(bucketName).upload(uploadPath, data: file)
-      XCTFail("Unexpected success")
+      Issue.record("Unexpected success")
     } catch {
       assertInlineSnapshot(of: error, as: .dump) {
         """
@@ -149,7 +157,8 @@ final class StorageFileIntegrationTests: XCTestCase {
     }
   }
 
-  func testUploadFileWithValidMimeType() async throws {
+  @Test
+  func uploadFileWithValidMimeType() async throws {
     bucketName = try await newBucket(
       prefix: "with-mimetype",
       options: BucketOptions(public: true, allowedMimeTypes: ["image/jpeg"])
@@ -164,7 +173,8 @@ final class StorageFileIntegrationTests: XCTestCase {
     )
   }
 
-  func testUploadFileWithInvalidMimeType() async throws {
+  @Test
+  func uploadFileWithInvalidMimeType() async throws {
     bucketName = try await newBucket(
       prefix: "with-mimetype",
       options: BucketOptions(public: true, allowedMimeTypes: ["image/png"])
@@ -178,7 +188,7 @@ final class StorageFileIntegrationTests: XCTestCase {
           contentType: "image/jpeg"
         )
       )
-      XCTFail("Unexpected success")
+      Issue.record("Unexpected success")
     } catch {
       assertInlineSnapshot(of: error, as: .dump) {
         """
@@ -194,42 +204,46 @@ final class StorageFileIntegrationTests: XCTestCase {
     }
   }
 
-  func testSignedURLForUpload() async throws {
+  @Test
+  func signedURLForUpload() async throws {
     let res = try await storage.from(bucketName).createSignedUploadURL(path: uploadPath)
-    XCTAssertEqual(res.path, uploadPath)
-    XCTAssertTrue(
+    #expect(res.path == uploadPath)
+    #expect(
       res.signedURL.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/upload/sign/\(bucketName)/\(uploadPath)"
       )
     )
   }
 
-  func testCanUploadWithSignedURLForUpload() async throws {
+  @Test
+  func canUploadWithSignedURLForUpload() async throws {
     let res = try await storage.from(bucketName).createSignedUploadURL(path: uploadPath)
 
     let uploadRes = try await storage.from(bucketName).uploadToSignedURL(
       res.path, token: res.token, data: file)
-    XCTAssertEqual(uploadRes.path, uploadPath)
+    #expect(uploadRes.path == uploadPath)
   }
 
-  func testCanUploadOverwritingFilesWithSignedURL() async throws {
+  @Test
+  func canUploadOverwritingFilesWithSignedURL() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
     let res = try await storage.from(bucketName).createSignedUploadURL(
       path: uploadPath, options: CreateSignedUploadURLOptions(upsert: true))
     let uploadRes = try await storage.from(bucketName).uploadToSignedURL(
       res.path, token: res.token, data: file)
-    XCTAssertEqual(uploadRes.path, uploadPath)
+    #expect(uploadRes.path == uploadPath)
   }
 
-  func testCannotUploadToSignedURLTwice() async throws {
+  @Test
+  func cannotUploadToSignedURLTwice() async throws {
     let res = try await storage.from(bucketName).createSignedUploadURL(path: uploadPath)
 
     try await storage.from(bucketName).uploadToSignedURL(res.path, token: res.token, data: file)
 
     do {
       try await storage.from(bucketName).uploadToSignedURL(res.path, token: res.token, data: file)
-      XCTFail("Unexpected success")
+      Issue.record("Unexpected success")
     } catch {
       assertInlineSnapshot(of: error, as: .dump) {
         """
@@ -245,22 +259,25 @@ final class StorageFileIntegrationTests: XCTestCase {
     }
   }
 
-  func testListObjects() async throws {
+  @Test
+  func listObjects() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
     let res = try await storage.from(bucketName).list(path: "testpath")
 
-    XCTAssertEqual(res.count, 1)
-    XCTAssertEqual(res[0].name, uploadPath.replacingOccurrences(of: "testpath/", with: ""))
+    #expect(res.count == 1)
+    #expect(res[0].name == uploadPath.replacingOccurrences(of: "testpath/", with: ""))
   }
 
-  func testMoveObjectToDifferentPath() async throws {
+  @Test
+  func moveObjectToDifferentPath() async throws {
     let newPath = "testpath/file-moved-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
     try await storage.from(bucketName).move(from: uploadPath, to: newPath)
   }
 
-  func testMoveObjectsAcrossBucketsInDifferentPath() async throws {
+  @Test
+  func moveObjectsAcrossBucketsInDifferentPath() async throws {
     let newBucketName = "bucket-move"
     try await findOrCreateBucket(name: newBucketName)
 
@@ -276,14 +293,16 @@ final class StorageFileIntegrationTests: XCTestCase {
     _ = try await storage.from(newBucketName).download(path: newPath)
   }
 
-  func testCopyObjectToDifferentPath() async throws {
+  @Test
+  func copyObjectToDifferentPath() async throws {
     let newPath = "testpath/file-moved-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
     try await storage.from(bucketName).copy(from: uploadPath, to: newPath)
   }
 
-  func testCopyObjectsAcrossBucketsInDifferentPath() async throws {
+  @Test
+  func copyObjectsAcrossBucketsInDifferentPath() async throws {
     let newBucketName = "bucket-copy"
     try await findOrCreateBucket(name: newBucketName)
 
@@ -299,23 +318,26 @@ final class StorageFileIntegrationTests: XCTestCase {
     _ = try await storage.from(newBucketName).download(path: newPath)
   }
 
-  func testDownloadsAnObject() async throws {
+  @Test
+  func downloadsAnObject() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
     let res = try await storage.from(bucketName).download(path: uploadPath)
-    XCTAssertGreaterThan(res.count, 0)
+    #expect(res.count > 0)
   }
 
-  func testRemovesAnObject() async throws {
+  @Test
+  func removesAnObject() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
     let res = try await storage.from(bucketName).remove(paths: [uploadPath])
-    XCTAssertEqual(res.count, 1)
-    XCTAssertEqual(res[0].bucketId, bucketName)
-    XCTAssertEqual(res[0].name, uploadPath)
+    #expect(res.count == 1)
+    #expect(res[0].bucketId == bucketName)
+    #expect(res[0].name == uploadPath)
   }
 
-  func testGetPublishURLWithTransformationOptions() throws {
+  @Test
+  func getPublishURLWithTransformationOptions() throws {
     let res = try storage.from(bucketName).getPublicURL(
       path: uploadPath,
       options: TransformOptions(
@@ -325,13 +347,14 @@ final class StorageFileIntegrationTests: XCTestCase {
       )
     )
 
-    XCTAssertEqual(
-      res.absoluteString,
-      "\(DotEnv.SUPABASE_URL)/storage/v1/render/image/public/\(bucketName)/\(uploadPath)?width=700&height=300&quality=70"
+    #expect(
+      res.absoluteString
+        == "\(DotEnv.SUPABASE_URL)/storage/v1/render/image/public/\(bucketName)/\(uploadPath)?width=700&height=300&quality=70"
     )
   }
 
-  func testCreateAndLoadEmptyFolder() async throws {
+  @Test
+  func createAndLoadEmptyFolder() async throws {
     let path = "empty-folder/.placeholder"
     try await storage.from(bucketName).upload(path, data: Data())
 
@@ -347,7 +370,8 @@ final class StorageFileIntegrationTests: XCTestCase {
     }
   }
 
-  func testInfo() async throws {
+  @Test
+  func info() async throws {
     try await storage.from(bucketName).upload(
       uploadPath,
       data: file,
@@ -357,21 +381,23 @@ final class StorageFileIntegrationTests: XCTestCase {
     )
 
     let info = try await storage.from(bucketName).info(path: uploadPath)
-    XCTAssertEqual(info.name, uploadPath)
-    XCTAssertEqual(info.metadata, ["value": 42])
+    #expect(info.name == uploadPath)
+    #expect(info.metadata == ["value": 42])
   }
 
-  func testExists() async throws {
+  @Test
+  func exists() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
     var exists = try await storage.from(bucketName).exists(path: uploadPath)
-    XCTAssertTrue(exists)
+    #expect(exists)
 
     exists = try await storage.from(bucketName).exists(path: "invalid.jpg")
-    XCTAssertFalse(exists)
+    #expect(!exists)
   }
 
-  func testUploadWithCacheControl() async throws {
+  @Test
+  func uploadWithCacheControl() async throws {
     try await storage.from(bucketName).upload(
       uploadPath,
       data: file,
@@ -383,19 +409,20 @@ final class StorageFileIntegrationTests: XCTestCase {
     let publicURL = try storage.from(bucketName).getPublicURL(path: uploadPath)
 
     let (_, response) = try await URLSession.shared.data(from: publicURL)
-    let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
-    let cacheControl = try XCTUnwrap(httpResponse.value(forHTTPHeaderField: "cache-control"))
+    let httpResponse = try #require(response as? HTTPURLResponse)
+    let cacheControl = try #require(httpResponse.value(forHTTPHeaderField: "cache-control"))
 
-    XCTAssertEqual(cacheControl, "max-age=14400")
+    #expect(cacheControl == "max-age=14400")
   }
 
-  func testUploadWithFileURL() async throws {
+  @Test
+  func uploadWithFileURL() async throws {
     try await storage.from(bucketName)
       .upload(uploadPath, fileURL: uploadFileURL("sadcat.jpg"))
 
     let uploadedFile = try await storage.from(bucketName).download(path: uploadPath)
 
-    XCTAssertEqual(uploadedFile, file)
+    #expect(uploadedFile == file)
   }
 
   private func newBucket(

--- a/Tests/IntegrationTests/StorageFileIntegrationTests.swift
+++ b/Tests/IntegrationTests/StorageFileIntegrationTests.swift
@@ -448,7 +448,7 @@ final class StorageFileIntegrationTests {
   }
 
   private func uploadFileURL(_ fileName: String) -> URL {
-    URL(fileURLWithPath: #file)
+    URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .appendingPathComponent("Fixtures/Upload")
       .appendingPathComponent(fileName)

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 (cd Tests/IntegrationTests && supabase start && supabase db reset)
-swift test --filter IntegrationTests
+swift test --filter IntegrationTests --no-parallel
 (cd Tests/IntegrationTests && supabase stop)


### PR DESCRIPTION
## Summary

Migrates all 10 files in `Tests/IntegrationTests` from XCTest to Swift Testing (`@Suite`/`@Test`), per the SDK-435 migration plan and the Phase 0 conventions decided in SDK-1247. This target has the heaviest `setUp`/`tearDown` usage in the repo (11 total) and orchestrates a real local Supabase instance rather than mocking, so it needed its own lifecycle patterns rather than reusing Phase 2-4's Mocker→Replay work (unrelated — no Mocker/Replay usage here at all).

## Changes

- `XCTSkipUnless(INTEGRATION_TESTS)` in every `setUp` becomes a `@Suite(.enabled(if:))` trait, evaluated once per suite instead of once per test method.
- `setUp`/`tearDown` become `init()`/`deinit()`. Files with only read-only shared state per test (the 4 Postgrest files, `PostgrestIntegrationTests`, `AuthClientIntegrationTests`, `StorageClientIntegrationTests`) convert to `struct`s — no teardown needed.
- `StorageFileIntegrationTests` and `RealtimeIntegrationTests` need real async teardown (delete a test bucket / disconnect realtime channels), so they stay `final class` with a `deinit` that fires cleanup in a best-effort detached `Task`, mirroring the original `try?`-swallowed `tearDown` semantics (documented inline — this is an accepted tradeoff for ephemeral local test resources, not correctness-critical).
- `RealtimeIntegrationTests` additionally needs `@Suite(.serialized)` because it swaps the process-global `_clock` seam (`Sources/Helpers/_Clock.swift`) per test — mirrors the Phase 4 `PostgrestBuilderTests` precedent — plus `Sendable` conformance on the class since `withMainSerialExecutor`'s closure parameter is `@Sendable` outside DEBUG/Concurrency-availability builds under Swift 6 strict checking.
- `AuthClientIntegrationTests`' custom `XCTAssertAuthChangeEvents` helper (built on `XCTestExpectation`) is replaced with a `LockIsolated` + short polling loop, since Swift Testing has no direct expectation-fulfillment equivalent.
- Moves `IntegrationTests` out of the blanket Swift 5 language-mode pin (`Package.swift`) into full Swift 6 mode, matching production targets' `swiftSettings`. No other `Sendable`/isolation diagnostics needed fixing beyond the `RealtimeIntegrationTests` case above.

## Test plan

- [x] `swift build --target IntegrationTests` compiles clean under full Swift 6 mode.
- [x] `swift test --filter IntegrationTests`: all 8 `INTEGRATION_TESTS`-gated suites (Postgrest x4, `PostgrestIntegrationTests`, `AuthClientIntegrationTests`, `StorageClientIntegrationTests`, `StorageFileIntegrationTests`) correctly skip via the new `.enabled(if:)` trait — confirms that gate is equivalent to the old per-test `XCTSkipUnless`.
- [ ] `RealtimeIntegrationTests` fails in this environment with `CancellationError` (no local Supabase instance reachable) — this is pre-existing: its `XCTSkipUnless` was already commented out in the original XCTest file (predates this PR), so it has always attempted a live connection unconditionally. Not a regression from this migration. Full live verification (`./scripts/test-integration.sh` against `supabase start`) needs a local Supabase instance and wasn't run in this environment.

## Linear

Closes SDK-1253