### PR TITLE
refactor(postgrest): inject clock explicitly into PostgrestBuilder

### DIFF
--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -37,6 +37,7 @@ public class PostgrestBuilder: @unchecked Sendable {
   /// The configuration for the PostgREST client.
   let configuration: PostgrestClient.Configuration
   let http: any HTTPClientType
+  let clock: any Clock<Duration>
 
   struct MutableState {
     var request: Helpers.HTTPRequest
@@ -52,9 +53,11 @@ public class PostgrestBuilder: @unchecked Sendable {
 
   init(
     configuration: PostgrestClient.Configuration,
-    request: Helpers.HTTPRequest
+    request: Helpers.HTTPRequest,
+    clock: any Clock<Duration>
   ) {
     self.configuration = configuration
+    self.clock = clock
 
     var interceptors: [any HTTPClientInterceptor] = []
     if let logger = configuration.logger {
@@ -74,7 +77,8 @@ public class PostgrestBuilder: @unchecked Sendable {
   convenience init(_ other: PostgrestBuilder) {
     self.init(
       configuration: other.configuration,
-      request: other.mutableState.value.request
+      request: other.mutableState.value.request,
+      clock: other.clock
     )
     mutableState.withValue { $0.retryEnabled = other.mutableState.value.retryEnabled }
   }
@@ -213,7 +217,7 @@ public class PostgrestBuilder: @unchecked Sendable {
           request: currentRequest, response: nil, error: error, retryEnabled: retryEnabled,
           attempt: attempt)
         {
-          try await _clock.sleep(for: .seconds(retryDelay(attempt: attempt)))
+          try await clock.sleep(for: .seconds(retryDelay(attempt: attempt)))
           attempt += 1
           continue
         }
@@ -230,7 +234,7 @@ public class PostgrestBuilder: @unchecked Sendable {
         request: currentRequest, response: response, error: nil, retryEnabled: retryEnabled,
         attempt: attempt)
       {
-        try await _clock.sleep(for: .seconds(retryDelay(attempt: attempt)))
+        try await clock.sleep(for: .seconds(retryDelay(attempt: attempt)))
         attempt += 1
         continue
       }

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -159,6 +159,7 @@ public final class PostgrestClient: Sendable {
   }
 
   private let _configuration: LockIsolated<Configuration>
+  let clock: any Clock<Duration>
 
   /// The current configuration of this client.
   ///
@@ -170,11 +171,16 @@ public final class PostgrestClient: Sendable {
   /// Creates a ``PostgrestClient`` from an existing ``Configuration``.
   ///
   /// - Parameter configuration: The configuration to use.
-  public init(configuration: Configuration) {
+  public convenience init(configuration: Configuration) {
+    self.init(configuration: configuration, clock: ContinuousClock())
+  }
+
+  init(configuration: Configuration, clock: any Clock<Duration>) {
     _configuration = LockIsolated(configuration)
     _configuration.withValue {
       $0.headers.merge(Configuration.defaultHeaders) { l, _ in l }
     }
+    self.clock = clock
   }
 
   /// Creates a ``PostgrestClient`` with individual configuration parameters.
@@ -249,7 +255,8 @@ public final class PostgrestClient: Sendable {
         url: configuration.url.appendingPathComponent(table),
         method: .get,
         headers: HTTPFields(configuration.headers)
-      )
+      ),
+      clock: clock
     )
   }
 
@@ -314,7 +321,8 @@ public final class PostgrestClient: Sendable {
 
     return PostgrestFilterBuilder(
       configuration: configuration,
-      request: request
+      request: request,
+      clock: clock
     )
   }
 
@@ -360,7 +368,7 @@ public final class PostgrestClient: Sendable {
   public func schema(_ schema: String) -> PostgrestClient {
     var configuration = configuration
     configuration.schema = schema
-    return PostgrestClient(configuration: configuration)
+    return PostgrestClient(configuration: configuration, clock: clock)
   }
 
   private func queryValue(for value: AnyJSON) -> String {

--- a/Tests/PostgRESTTests/PostgrestBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestBuilderTests.swift
@@ -233,20 +233,6 @@ final class PostgrestBuilderTests: PostgrestQueryTests {
 
   // MARK: - Retry tests
 
-  override func setUp() {
-    super.setUp()
-    #if DEBUG
-      _clock = ImmediateRetryTestClock()
-    #endif
-  }
-
-  override func tearDown() {
-    super.tearDown()
-    #if DEBUG
-      _clock = ContinuousClock()
-    #endif
-  }
-
   func testRetryOn520ForGETRequest() async throws {
     struct MutableState {
       var callCount = 0
@@ -277,6 +263,34 @@ final class PostgrestBuilderTests: PostgrestQueryTests {
       XCTAssertEqual(state.capturedHeaders[2]["X-Retry-Count"], "2")
       XCTAssertTrue(result.value.isEmpty)
     }
+  }
+
+  func testRetryAfterSchemaChangeUsesInjectedClock() async throws {
+    let callCount = LockIsolated(0)
+
+    let sut = makeSUTWithCustomFetch { _ in
+      callCount.withValue { $0 += 1 }
+      if callCount.value < 3 {
+        return (Data(), self.makeHTTPURLResponse(statusCode: 520))
+      }
+      return (Data("[]".utf8), self.makeHTTPURLResponse(statusCode: 200))
+    }
+
+    let clock = ContinuousClock()
+    let start = clock.now
+    let result: PostgrestResponse<[User]> =
+      try await sut
+      .schema("private")
+      .from("users")
+      .select()
+      .execute()
+    let elapsed = clock.now - start
+
+    XCTAssertEqual(callCount.value, 3)
+    XCTAssertTrue(result.value.isEmpty)
+    XCTAssertLessThan(
+      elapsed, .seconds(1),
+      "schema(_:) must propagate the injected clock instead of falling back to the real one")
   }
 
   func testRetryOn520ForHEADRequest() async throws {
@@ -466,7 +480,10 @@ final class PostgrestBuilderTests: PostgrestQueryTests {
     retryEnabled: Bool = true,
     fetch: @escaping PostgrestClient.FetchHandler
   ) -> PostgrestClient {
-    PostgrestClient(url: url, fetch: fetch, retryEnabled: retryEnabled)
+    PostgrestClient(
+      configuration: .init(url: url, fetch: fetch, retryEnabled: retryEnabled),
+      clock: ImmediateRetryTestClock()
+    )
   }
 
   private func makeHTTPURLResponse(statusCode: Int) -> HTTPURLResponse {


### PR DESCRIPTION
## Summary

`PostgrestBuilder`'s retry loop read the DEBUG-settable global `_clock` directly instead of receiving a clock through its initializer, which is a source of test fragility (see SDK-1227). This PR threads an explicit `clock: any Clock<Duration>` from `PostgrestClient` down through `PostgrestBuilder` instead, with no change to `PostgrestClient`'s public initializer signatures.

This is **PR 1 of 2** for SDK-1227. Realtime's clock DI (`withTimeout`, `ChannelStateManager`, `RealtimeClientV2`/`ConnectionManager` default removal, and deletion of the global itself) will land in a follow-up PR, since `Sources/Helpers/_Clock.swift` can only be deleted once both land.

## Changes

- `PostgrestBuilder`: added a stored `clock` property; `execute()`'s retry loop now calls `clock.sleep(...)` instead of the global `_clock.sleep(...)`. The copy-init `init(_ other:)` forwards `other.clock`.
- `PostgrestClient`: added an internal (non-public) `init(configuration:clock:)` that the public `init(configuration:)` delegates to with `ContinuousClock()`. `from(_:)`, `rpc(_:params:...)`, and `schema(_:)` all thread `clock` through to the builders/clients they construct.
- Tests: `PostgrestBuilderTests` now injects `ImmediateRetryTestClock` directly via the internal init instead of mutating the global `_clock` in `setUp`/`tearDown` (which also had no `tearDown` reset issue elsewhere in the codebase, though this file already reset it).
- Added `testRetryAfterSchemaChangeUsesInjectedClock`, which caught a real bug during review: `schema(_:)` was rebuilding the client via the public convenience init and silently dropping the injected clock, falling back to real `ContinuousClock()` timing. Confirmed red (test failed at ~3s of real backoff) before the fix, green after (<1s).

## Root cause

`Sources/PostgREST/PostgrestBuilder.swift` had no `clock` parameter on its initializer, so `execute()` could only reach the global `package var _clock` in `Sources/Helpers/_Clock.swift`. Fixed by making `clock` an injected, non-optional dependency threaded from `PostgrestClient`.

## Test plan

- [x] Regression test added and red/green verified: `Tests/PostgRESTTests/PostgrestBuilderTests.swift` (`testRetryAfterSchemaChangeUsesInjectedClock`)
- [x] Full `PostgRESTTests` suite green: `swift test --filter PostgRESTTests` (98/98)
- [x] Full suite green via `PLATFORM=IOS XCODEBUILD_ARGUMENT=test ./scripts/xcodebuild.sh`
- [x] No public API breakage: `swift package diagnose-api-breaking-changes origin/main` — "No breaking changes detected in PostgREST"
- [x] `./scripts/format.sh` clean

## Linear

Part of SDK-1227