### PR TITLE
fix(storage): return cleaned path in upload response

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -172,7 +172,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
 
     return FileUploadResponse(
       id: response.Id,
-      path: path,
+      path: cleanPath,
       fullPath: response.Key
     )
   }

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -709,6 +709,34 @@ final class StorageFileAPITests: XCTestCase {
     XCTAssertEqual(response.fullPath, "bucket/file.txt")
   }
 
+  func testUploadReturnsCleanedPath() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/bucket/folder/file.txt"),
+      statusCode: 200,
+      data: [
+        .post: Data(
+          """
+          {
+            "Id": "123",
+            "Key": "bucket/folder/file.txt"
+          }
+          """.utf8
+        )
+      ]
+    )
+    .register()
+
+    let response = try await storage.from("bucket")
+      .upload(
+        "/folder//file.txt",
+        data: Data("hello world!".utf8),
+        options: FileOptions(contentType: "text/plain")
+      )
+
+    XCTAssertEqual(response.path, "folder/file.txt")
+    XCTAssertEqual(response.fullPath, "bucket/folder/file.txt")
+  }
+
   func testUpdateFromURL() async throws {
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),


### PR DESCRIPTION
### Problem

`upload(_:data:)` and `upload(_:fileURL:)` clean the path before building the request URL, but the returned `FileUploadResponse.path` echoes the raw argument instead of the cleaned path. So the returned `path` does not match the object key that was actually written.

```swift
let response = try await storage.from("bucket").upload("/folder//file.txt", data: data)
response.path      // "/folder//file.txt"     (raw argument)
response.fullPath  // "bucket/folder/file.txt" (cleaned)
```

The request uploads to `object/bucket/folder/file.txt`, so `path` and `fullPath` disagree about where the file went. storage-js returns the cleaned path.

### Fix

Return `cleanPath`, the value already used to build the request URL, instead of the raw `path`.

### Tests

Added `testUploadReturnsCleanedPath`, which uploads to `/folder//file.txt` and asserts the response `path` is `folder/file.txt` and `fullPath` is `bucket/folder/file.txt`. It fails before this change (returns the raw `/folder//file.txt`) and passes after. Full `StorageTests` suite passes (139 tests). No public API change.
