### PR TITLE
fix(postgrest): preserve existing Prefer header in select(count:)

### DIFF
--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -99,7 +99,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
       $0.request.query.appendOrUpdate(URLQueryItem(name: "select", value: cleanedColumns))
 
       if let count {
-        $0.request.headers[.prefer] = "count=\(count.rawValue)"
+        $0.request.headers.appendOrUpdate(.prefer, value: "count=\(count.rawValue)")
       }
       if head {
         $0.request.method = .head

--- a/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
@@ -157,6 +157,43 @@ final class PostgrestQueryBuilderTests: PostgrestQueryTests {
     XCTAssertEqual(count, 10)
   }
 
+  func testSelectWithExistingPreferHeader() async throws {
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .head: Data()
+      ],
+      additionalHeaders: [
+        "Content-Range": "0-9/10"
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--head \
+      	--header "Accept: application/json" \
+      	--header "Content-Type: application/json" \
+      	--header "Prefer: existing=value,count=exact" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/users?select=*"
+      """#
+    }
+    .register()
+
+    let count =
+      try await sut
+      .from("users")
+      .setHeader(name: "Prefer", value: "existing=value")
+      .select(head: true, count: .exact)
+      .execute()
+      .count
+
+    XCTAssertEqual(count, 10)
+  }
+
   func testInsert() async throws {
     Mock(
       url: url.appendingPathComponent("users"),


### PR DESCRIPTION
### Problem

`select(_:head:count:)` sets the `Prefer` header by assignment, so passing `count:` overwrites any `Prefer` already on the request:

```swift
let client = PostgrestClient(url: url, headers: ["Prefer": "timezone=UTC"])
client.from("t").select("*", count: .exact)
// Prefer: count=exact   (timezone=UTC dropped)
```

`insert`, `update`, `upsert`, and `delete` in the same file all preserve an existing `Prefer` before adding their own directives; only `select` replaces it. postgrest-js appends (`headers.append('Prefer', ...)`), keeping both.

### Fix

Use `appendOrUpdate(.prefer, ...)`, the same helper the other builders rely on, so `count` is added to any existing `Prefer` (and replaces a prior `count=` directive) instead of clobbering it.

```swift
// Prefer: timezone=UTC,count=exact
```

### Tests

Added `testSelectWithExistingPreferHeader`: sets `Prefer: existing=value`, calls `.select(head: true, count: .exact)`, and asserts the outgoing header is `Prefer: existing=value,count=exact`. It fails before this change (the header is `count=exact`) and passes after. Full `PostgRESTTests` suite passes (98 tests). No public API change.
