### PR TITLE
fix(storage): clean path in signed upload URL and response

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -855,9 +855,12 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
       headers[.xUpsert] = "true"
     }
 
+    let cleanPath = _removeEmptyFolders(path)
+
     let response = try await execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/upload/sign/\(bucketId)/\(path)"),
+        url: configuration.url.appendingPathComponent(
+          "object/upload/sign/\(bucketId)/\(cleanPath)"),
         method: .post,
         headers: headers
       )
@@ -880,7 +883,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
 
     return SignedUploadURL(
       signedURL: url,
-      path: path,
+      path: cleanPath,
       token: token
     )
   }
@@ -964,10 +967,12 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
       let Key: String
     }
 
+    let cleanPath = _removeEmptyFolders(path)
+
     let fullPath = try await execute(
       HTTPRequest(
         url: configuration.url
-          .appendingPathComponent("object/upload/sign/\(bucketId)/\(path)"),
+          .appendingPathComponent("object/upload/sign/\(bucketId)/\(cleanPath)"),
         method: .put,
         query: [URLQueryItem(name: "token", value: token)],
         formData: formData,
@@ -978,7 +983,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     .decoded(as: UploadResponse.self, decoder: configuration.decoder)
     .Key
 
-    return SignedURLUploadResponse(path: path, fullPath: fullPath)
+    return SignedURLUploadResponse(path: cleanPath, fullPath: fullPath)
   }
 
   private func _getFinalPath(_ path: String) -> String {

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -1100,6 +1100,85 @@ final class StorageFileAPITests: XCTestCase {
       "http://localhost:54321/storage/v1/object/upload/sign/bucket/file.txt?token=abc.def.ghi")
   }
 
+  func testCreateSignedUploadURLCleansPath() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/upload/sign/bucket/folder/file.txt"),
+      statusCode: 200,
+      data: [
+        .post: Data(
+          """
+          {
+            "url": "object/upload/sign/bucket/folder/file.txt?token=abc.def.ghi"
+          }
+          """.utf8
+        )
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/storage/v1/object/upload/sign/bucket/folder/file.txt"
+      """#
+    }
+    .register()
+
+    let response = try await storage.from("bucket")
+      .createSignedUploadURL(path: "/folder//file.txt")
+
+    XCTAssertEqual(response.path, "folder/file.txt")
+    XCTAssertEqual(response.token, "abc.def.ghi")
+  }
+
+  func testUploadToSignedURLCleansPath() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/upload/sign/bucket/folder/file.txt"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .put: Data(
+          """
+          {
+            "Key": "bucket/folder/file.txt"
+          }
+          """.utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request PUT \
+      	--header "Cache-Control: max-age=3600" \
+      	--header "Content-Length: 297" \
+      	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	--header "x-upsert: false" \
+      	--data "--alamofire.boundary.e56f43407f772505\#r
+      Content-Disposition: form-data; name=\"cacheControl\"\#r
+      \#r
+      3600\#r
+      --alamofire.boundary.e56f43407f772505\#r
+      Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
+      Content-Type: text/plain;charset=UTF-8\#r
+      \#r
+      hello world\#r
+      --alamofire.boundary.e56f43407f772505--\#r
+      " \
+      	"http://localhost:54321/storage/v1/object/upload/sign/bucket/folder/file.txt?token=abc.def.ghi"
+      """#
+    }
+    .register()
+
+    let response = try await storage.from("bucket")
+      .uploadToSignedURL("/folder//file.txt", token: "abc.def.ghi", data: Data("hello world".utf8))
+
+    XCTAssertEqual(response.path, "folder/file.txt")
+    XCTAssertEqual(response.fullPath, "bucket/folder/file.txt")
+  }
+
   func testUploadToSignedURL() async throws {
     Mock(
       url: url.appendingPathComponent("object/upload/sign/bucket/file.txt"),


### PR DESCRIPTION
### Problem

`createSignedUploadURL(path:)` and `uploadToSignedURL(_:token:...)` interpolate the raw `path` straight into the request URL and echo it back in the response, unlike `upload(...)`, which cleans the path first. A path with leading or duplicate slashes produces a malformed URL and a returned `path` that does not match the stored key.

```swift
let signed = try await storage.from("bucket").createSignedUploadURL(path: "/folder//file.txt")
// request URL: .../object/upload/sign/bucket//folder//file.txt  (doubled slashes)
// signed.path: "/folder//file.txt"                              (raw)
```

storage-js runs `_removeEmptyFolders` in both methods and returns the cleaned path.

### Fix

Clean the path with `_removeEmptyFolders` before building the URL, and use the cleaned value for both the request and the returned `path`, matching `upload(...)` and storage-js.

### Tests

Added `testCreateSignedUploadURLCleansPath` and `testUploadToSignedURLCleansPath`, which pass `/folder//file.txt` and assert the request goes to `.../bucket/folder/file.txt` and the response `path` is `folder/file.txt`. Both fail before this change (the request keeps the doubled slashes) and pass after. Full `StorageTests` suite passes (141 tests). No public API change.
