### PR TITLE
fix(realtime): reset channel state on phx_error

### DIFF
--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -717,6 +717,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
         logger?.error(
           "Received an error in channel \(message.topic). That could be as a result of an invalid access token"
         )
+        await stateManager.didReceiveClose()
 
       case .presenceDiff:
         let joins = try message.payload["joins"]?.decode(as: [String: PresenceV2].self) ?? [:]

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -807,6 +807,65 @@ final class RealtimeChannelTests: XCTestCase {
       )
     }
   }
+
+  #if canImport(Darwin)
+    @MainActor
+    func testChannelErrorResetsSubscribedStatus() async {
+      let (client, server) = FakeWebSocket.fakes()
+      let socket = RealtimeClientV2(
+        url: URL(string: "https://localhost:54321/realtime/v1")!,
+        options: RealtimeClientOptions(
+          headers: ["apikey": "test-key"],
+          accessToken: { "test-token" }
+        ),
+        wsTransport: { _, _ in client },
+        http: HTTPClientMock(),
+        clock: ContinuousClock()
+      )
+
+      let channel = socket.channel("test-topic")
+
+      let serverTask = Task { @Sendable [server] in
+        for await event in server.events {
+          guard let msg = event.realtimeMessage else { continue }
+          if msg.event == "phx_join" {
+            server.send(
+              RealtimeMessageV2(
+                joinRef: msg.joinRef,
+                ref: msg.ref,
+                topic: "realtime:test-topic",
+                event: "phx_reply",
+                payload: [
+                  "response": ["postgres_changes": []],
+                  "status": "ok",
+                ]
+              )
+            )
+          }
+        }
+      }
+      defer { serverTask.cancel() }
+
+      await socket.connect()
+      try? await channel.subscribeWithError()
+      XCTAssertEqual(channel.status, .subscribed)
+
+      server.send(
+        RealtimeMessageV2(
+          joinRef: nil,
+          ref: nil,
+          topic: "realtime:test-topic",
+          event: "phx_error",
+          payload: [:]
+        )
+      )
+
+      await waitForChannelStatus(.unsubscribed, channel: channel, timeout: 2.0)
+      XCTAssertEqual(channel.status, .unsubscribed)
+
+      socket.disconnect()
+    }
+  #endif
 }
 
 extension RealtimeChannelTests {


### PR DESCRIPTION
### Problem

When a subscribed channel receives a `phx_error` frame (a channel-level error the server sends without closing the socket, for example a replication error or an authorization change), `onMessage` only logs it. The channel stays `.subscribed` even though it is dead server-side, so `status` never reflects the error and observers keep waiting for events that never arrive. During a subscribe attempt a `phx_error` is likewise ignored, so the join waits out the full timeout instead of failing fast.

realtime-js treats `phx_error` as a channel error and drops the channel so it can rejoin.

### Fix

Route `.error` through the existing `didReceiveClose()`, the same reset the `.close` case uses. Its own doc already covers this case ("phx_close or system error that should drop the channel"): it clears the join ref and pending pushes and moves the channel to `.unsubscribed`. The channel stays registered on the socket, so it rejoins on the next reconnect.

If you would prefer the channel to also schedule an immediate per-channel rejoin (as realtime-js does) rather than waiting for the next socket reconnect, I am happy to add that.

### Tests

Added `testChannelErrorResetsSubscribedStatus`: drives a channel to `.subscribed` over a fake socket, sends a `phx_error` frame, and asserts the channel transitions to `.unsubscribed`. It fails before this change (the channel stays `.subscribed`) and passes after. Full `RealtimeTests` suite passes (241 tests). No public API change.
