### PR TITLE
fix(storage): strip leading slash from object paths

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -387,7 +387,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
 
     let response = try await execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/sign/\(bucketId)/\(path)"),
+        url: configuration.url.appendingPathComponent("object/sign/\(_getFinalPath(path))"),
         method: .post,
         body: encoder.encode(
           Body(expiresIn: expiresIn, transform: transform)
@@ -713,7 +713,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     do {
       try await execute(
         HTTPRequest(
-          url: configuration.url.appendingPathComponent("object/\(bucketId)/\(path)"),
+          url: configuration.url.appendingPathComponent("object/\(_getFinalPath(path))"),
           method: .head
         )
       )
@@ -776,7 +776,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
 
     let renderPath = options.map { !$0.isEmpty } == true ? "render/image" : "object"
 
-    components.path += "/\(renderPath)/public/\(bucketId)/\(path)"
+    components.path += "/\(renderPath)/public/\(_getFinalPath(path))"
     components.queryItems = !queryItems.isEmpty ? queryItems : nil
 
     guard let generatedUrl = components.url else {
@@ -987,7 +987,10 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   }
 
   private func _getFinalPath(_ path: String) -> String {
-    "\(bucketId)/\(path)"
+    let strippedPath = path.replacingOccurrences(
+      of: "^/+", with: "", options: .regularExpression
+    )
+    return "\(bucketId)/\(strippedPath)"
   }
 
   private func _removeEmptyFolders(_ path: String) -> String {

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -890,6 +890,40 @@ final class StorageFileAPITests: XCTestCase {
     )
   }
 
+  func testGetPublicURLStripsLeadingSlash() throws {
+    let publicURL = try storage.from("bucket")
+      .getPublicURL(path: "/folder/image.png")
+
+    XCTAssertEqual(
+      publicURL.absoluteString,
+      "http://localhost:54321/storage/v1/object/public/bucket/folder/image.png"
+    )
+  }
+
+  func testDownloadStripsLeadingSlash() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/bucket/file.txt"),
+      statusCode: 200,
+      data: [
+        .get: Data("hello world".utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+      """#
+    }
+    .register()
+
+    let data = try await storage.from("bucket")
+      .download(path: "/file.txt")
+
+    XCTAssertEqual(data, Data("hello world".utf8))
+  }
+
   func testDownload_withOptions() async throws {
     let imageData = try! Data(
       contentsOf: Bundle.module.url(forResource: "sadcat", withExtension: "jpg")!)


### PR DESCRIPTION
### Problem

`_getFinalPath` builds the object key as `"\(bucketId)/\(path)"` without stripping a leading slash, and `getPublicURL`, `exists`, and `createSignedURL` interpolate the raw path the same way. A path with a leading slash produces a double slash in the request URL:

```swift
try await storage.from("avatars").download(path: "/a.png")
// request URL: .../object/avatars//a.png
storage.from("avatars").getPublicURL(path: "/a.png")
// .../object/public/avatars//a.png
```

The Storage server treats `//a.png` as a distinct (empty-segment) key, so a leading-slash path that works in storage-js returns 404 here. storage-js normalizes this in `_getFinalPath` with `path.replace(/^\/+/, '')`.

### Fix

Strip leading slashes in `_getFinalPath`, and route `getPublicURL`, `exists`, and `createSignedURL` through it so every object path is normalized the same way (`download` and `info` already use it).

### Tests

Added `testGetPublicURLStripsLeadingSlash` and `testDownloadStripsLeadingSlash`, which pass `/folder/image.png` and `/file.txt` and assert the generated URL contains `bucket/folder/image.png` and `bucket/file.txt`, not `bucket//...`. Both fail before this change (the double slash is kept) and pass after. Full `StorageTests` suite passes (143 tests). No public API change.
