### PR TITLE
fix(functions): check x-relay-error before response status

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -243,13 +243,13 @@ public final class FunctionsClient: Sendable {
     let request = buildRequest(functionName: functionName, options: invokeOptions)
     let response = try await http.send(request)
 
-    guard 200..<300 ~= response.statusCode else {
-      throw FunctionsError.httpError(code: response.statusCode, data: response.data)
-    }
-
     let isRelayError = response.headers[.xRelayError] == "true"
     if isRelayError {
       throw FunctionsError.relayError
+    }
+
+    guard 200..<300 ~= response.statusCode else {
+      throw FunctionsError.httpError(code: response.statusCode, data: response.data)
     }
 
     return response
@@ -342,6 +342,12 @@ final class StreamResponseDelegate: NSObject, URLSessionDataDelegate, Sendable {
       return
     }
 
+    let isRelayError = httpResponse.value(forHTTPHeaderField: "x-relay-error") == "true"
+    if isRelayError {
+      continuation.finish(throwing: FunctionsError.relayError)
+      return
+    }
+
     guard 200..<300 ~= httpResponse.statusCode else {
       let error = FunctionsError.httpError(
         code: httpResponse.statusCode,
@@ -349,11 +355,6 @@ final class StreamResponseDelegate: NSObject, URLSessionDataDelegate, Sendable {
       )
       continuation.finish(throwing: error)
       return
-    }
-
-    let isRelayError = httpResponse.value(forHTTPHeaderField: "x-relay-error") == "true"
-    if isRelayError {
-      continuation.finish(throwing: FunctionsError.relayError)
     }
   }
 }

--- a/Tests/FunctionsTests/FunctionsClientTests.swift
+++ b/Tests/FunctionsTests/FunctionsClientTests.swift
@@ -324,6 +324,35 @@ final class FunctionsClientTests: XCTestCase {
     }
   }
 
+  func testInvoke_relayErrorWithNon2xxStatus_shouldThrowRelayError() async {
+    Mock(
+      url: url.appendingPathComponent("hello_world"),
+      statusCode: 500,
+      data: [.post: Data()],
+      additionalHeaders: [
+        "x-relay-error": "true"
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "X-Client-Info: functions-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:5432/functions/v1/hello_world"
+      """#
+    }
+    .register()
+
+    do {
+      try await sut.invoke("hello_world")
+      XCTFail("Invoke should fail.")
+    } catch FunctionsError.relayError {
+    } catch {
+      XCTFail("Unexpected error thrown \(error)")
+    }
+  }
+
   func test_setAuth() {
     sut.setAuth(token: "access.token")
     XCTAssertEqual(sut.headers[.authorization], "Bearer access.token")
@@ -388,6 +417,36 @@ final class FunctionsClientTests: XCTestCase {
     Mock(
       url: url.appendingPathComponent("stream"),
       statusCode: 200,
+      data: [.post: Data()],
+      additionalHeaders: [
+        "x-relay-error": "true"
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "X-Client-Info: functions-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:5432/functions/v1/stream"
+      """#
+    }
+    .register()
+
+    let stream = sut._invokeWithStreamedResponse("stream")
+
+    do {
+      for try await _ in stream {
+        XCTFail("should throw error")
+      }
+    } catch FunctionsError.relayError {
+    }
+  }
+
+  func testInvokeWithStreamedResponseRelayErrorWithNon2xxStatus() async throws {
+    Mock(
+      url: url.appendingPathComponent("stream"),
+      statusCode: 500,
       data: [.post: Data()],
       additionalHeaders: [
         "x-relay-error": "true"


### PR DESCRIPTION
### Problem

`invoke` checks the response status before the `x-relay-error` header:

```swift
guard 200..<300 ~= response.statusCode else {
  throw FunctionsError.httpError(code: response.statusCode, data: response.data)
}
let isRelayError = response.headers[.xRelayError] == "true"
if isRelayError { throw FunctionsError.relayError }
```

A relay failure carries a non-2xx status, so it hits the status guard first and surfaces as `FunctionsError.httpError` instead of `FunctionsError.relayError`. Callers that switch on the error type to detect relay failures never see `.relayError`. The streamed path (`_invokeWithStreamedResponse`) has the same inverted order.

functions-js checks the relay header before the status:

```ts
const isRelayError = response.headers.get('x-relay-error')
if (isRelayError && isRelayError === 'true') throw new FunctionsRelayError(response)
if (!response.ok) throw new FunctionsHttpError(response)
```

The existing tests only covered a relay error with a 200 status, where the ordering doesn't matter, so the bug stayed hidden.

### Fix

Evaluate `x-relay-error` before the status guard in both `rawInvoke` and the streamed response delegate.

### Tests

Added `testInvoke_relayErrorWithNon2xxStatus_shouldThrowRelayError` and `testInvokeWithStreamedResponseRelayErrorWithNon2xxStatus`, each returning status 500 with `x-relay-error: true` and asserting the thrown error is `.relayError`. Both fail before this change (they get `.httpError(code: 500)`) and pass after. Full `FunctionsTests` suite passes (30 tests). No public API change.
