### PR TITLE
ci: pin sdk workflow ref to supabase/sdk#60 for testing

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   validate:

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@main
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@cbc7e5afea5399c8a6e98e4672afddd44c1feb74

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,4 +12,6 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@cbc7e5afea5399c8a6e98e4672afddd44c1feb74
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@56f138c4d8eab31b4605c8a61d9419d0acec03da
+    with:
+      sdk-ref: claude/sdk-993-e2e-test

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,6 +12,4 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@56f138c4d8eab31b4605c8a61d9419d0acec03da
-    with:
-      sdk-ref: claude/sdk-993-e2e-test
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@cbc7e5afea5399c8a6e98e4672afddd44c1feb74


### PR DESCRIPTION
Temporarily points validate-capabilities.yml at the sdk-993-ci-drift-warning branch SHA so CI exercises supabase/sdk PR #60 before it merges. Revert to @main once that PR lands.