### PR TITLE
feat(postgrest): add notIn filter, dryRun and maybeSingle modifiers

### DIFF
--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -47,6 +47,9 @@ public class PostgrestBuilder: @unchecked Sendable {
 
     /// An error to throw when execute() is called, set when an invalid method combination is detected.
     var pendingError: String?
+
+    /// Whether a `PGRST116` error should be returned as a `nil` value instead of being thrown.
+    var isMaybeSingle: Bool = false
   }
 
   let mutableState: LockIsolated<MutableState>
@@ -170,11 +173,11 @@ public class PostgrestBuilder: @unchecked Sendable {
     options: FetchOptions,
     decode: @Sendable (Data) throws -> T
   ) async throws -> PostgrestResponse<T> {
-    let (baseRequest, retryEnabled) = try mutableState.withValue {
+    let (baseRequest, retryEnabled, isMaybeSingle) = try mutableState.withValue {
       if let message = $0.pendingError {
         throw PostgrestError(message: message)
       }
-      return ($0.request, $0.retryEnabled)
+      return ($0.request, $0.retryEnabled, $0.isMaybeSingle)
     }
     var request = baseRequest
 
@@ -240,6 +243,12 @@ public class PostgrestBuilder: @unchecked Sendable {
       }
 
       if let error = try? configuration.decoder.decode(PostgrestError.self, from: response.data) {
+        // `maybeSingle()` turns the "no/too many rows" error (PGRST116) into a `nil` value.
+        if isMaybeSingle, error.code == "PGRST116" {
+          let value = try decode(Data("null".utf8))
+          return PostgrestResponse(
+            data: response.data, response: response.underlyingResponse, value: value)
+        }
         throw error
       }
       throw HTTPError(data: response.data, response: response.underlyingResponse)

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -58,6 +58,19 @@ public final class PostgrestClient: Sendable {
   /// Provide a custom ``FetchHandler`` through ``Configuration`` when you need to intercept,
   /// mock, or otherwise customize the HTTP transport layer. The default implementation uses
   /// `URLSession.shared`.
+  ///
+  /// For example, apply a custom timeout by mutating the `URLRequest` before sending it:
+  ///
+  /// ```swift
+  /// let configuration = PostgrestClient.Configuration(
+  ///   url: url,
+  ///   fetch: { request in
+  ///     var request = request
+  ///     request.timeoutInterval = 10
+  ///     return try await URLSession.shared.data(for: request)
+  ///   }
+  /// )
+  /// ```
   public typealias FetchHandler =
     @Sendable (_ request: URLRequest) async throws -> (
       Data, URLResponse

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -35,6 +35,7 @@ import Helpers
 /// - ``is(_:value:)``
 /// - ``isDistinct(_:value:)``
 /// - ``in(_:values:)``
+/// - ``notIn(_:values:)``
 /// - ``match(_:)-6h9ou``
 ///
 /// ### Comparison Filters
@@ -595,6 +596,35 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
         URLQueryItem(
           name: column,
           value: "in.(\(queryValues.joined(separator: ",")))"
+        )
+      )
+    }
+    return self
+  }
+
+  /// Matches only rows where `column` is not one of the values in `values`.
+  ///
+  /// The negation of ``in(_:values:)``.
+  ///
+  /// ```swift
+  /// // Rows where status is NOT "archived" or "deleted"
+  /// .notIn("status", values: ["archived", "deleted"])
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - column: The column to filter on.
+  ///   - values: The list of values to exclude.
+  /// - Returns: The same builder instance so calls can be chained.
+  public func notIn(
+    _ column: String,
+    values: [any PostgrestFilterValue]
+  ) -> PostgrestFilterBuilder {
+    let queryValues = values.map { escapePostgRESTFilterValue($0.rawValue) }
+    mutableState.withValue {
+      $0.request.query.append(
+        URLQueryItem(
+          name: column,
+          value: "not.in.(\(queryValues.joined(separator: ",")))"
         )
       )
     }

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -27,6 +27,7 @@ import HTTPTypes
 /// ### Response Format
 ///
 /// - ``single()``
+/// - ``maybeSingle()``
 /// - ``csv()``
 /// - ``geojson()``
 /// - ``stripNulls()``
@@ -38,6 +39,10 @@ import HTTPTypes
 /// ### Limiting Affected Rows
 ///
 /// - ``maxAffected(_:)``
+///
+/// ### Testing Mutations
+///
+/// - ``dryRun()``
 public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   /// Requests that the server return the modified rows from a write operation.
   ///
@@ -197,6 +202,36 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     return self
   }
 
+  /// Instructs PostgREST to return a single JSON object, returning `nil` when no row matches.
+  ///
+  /// Like ``single()``, this sets the `application/vnd.pgrst.object+json` accept header so the
+  /// server enforces a single result. Unlike ``single()``, when the query does not match exactly
+  /// one row the resulting `PGRST116` error is not thrown — ``PostgrestResponse/value`` is `nil`
+  /// instead. Decode into an optional type to observe the `nil`.
+  ///
+  /// > Note: PostgREST returns `PGRST116` both when zero rows match and when more than one row
+  /// > matches. This method returns `nil` for either case; use ``single()`` for the strict variant
+  /// > that always throws when the query does not match exactly one row.
+  ///
+  /// ```swift
+  /// let todo: Todo? = try await client
+  ///   .from("todos")
+  ///   .select()
+  ///   .eq("id", value: 42)
+  ///   .maybeSingle()
+  ///   .execute()
+  ///   .value
+  /// ```
+  ///
+  /// - Returns: The same builder instance so calls can be chained.
+  public func maybeSingle() -> PostgrestTransformBuilder {
+    mutableState.withValue {
+      $0.request.headers[.accept] = "application/vnd.pgrst.object+json"
+      $0.isMaybeSingle = true
+    }
+    return self
+  }
+
   /// Sets the response format to CSV.
   ///
   /// The raw CSV text is available in ``PostgrestResponse/data``. Convert it to a `String`
@@ -314,6 +349,34 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     mutableState.withValue {
       $0.request.headers.appendOrUpdate(.prefer, value: "handling=strict")
       $0.request.headers.appendOrUpdate(.prefer, value: "max-affected=\(value)")
+    }
+    return self
+  }
+
+  /// Executes the query but rolls back the transaction instead of committing it.
+  ///
+  /// The mutation runs and its result (including any side effects such as triggers) is returned
+  /// in the response, but the transaction is rolled back afterward, so no changes are persisted.
+  /// This is useful for testing mutations without touching real data.
+  ///
+  /// Requires PostgREST's `db-tx-end` setting to allow client-controlled transaction rollback.
+  ///
+  /// ```swift
+  /// let wouldBeUpdated: [Todo] = try await client
+  ///   .from("todos")
+  ///   .update(["done": true])
+  ///   .eq("id", value: 1)
+  ///   .select()
+  ///   .dryRun()
+  ///   .execute()
+  ///   .value
+  /// // Row is not actually updated in the database.
+  /// ```
+  ///
+  /// - Returns: The same builder instance so calls can be chained.
+  public func dryRun() -> PostgrestTransformBuilder {
+    mutableState.withValue {
+      $0.request.headers.appendOrUpdate(.prefer, value: "tx=rollback")
     }
     return self
   }

--- a/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
@@ -187,6 +187,57 @@ final class PostgrestTransformsTests: XCTestCase {
     }
   }
 
+  func testMaybeSingle() async throws {
+    let res =
+      try await client.from("users")
+      .select("age_range,catchphrase,data,status,username")
+      .eq("username", value: "supabot")
+      .maybeSingle()
+      .execute().value as AnyJSON
+
+    assertInlineSnapshot(of: res, as: .json) {
+      """
+      {
+        "age_range" : "[1,2)",
+        "catchphrase" : "'cat' 'fat'",
+        "data" : null,
+        "status" : "ONLINE",
+        "username" : "supabot"
+      }
+      """
+    }
+  }
+
+  func testMaybeSingleReturnsNilOnZeroRows() async throws {
+    let res: AnyJSON? =
+      try await client.from("users")
+      .select("username")
+      .eq("username", value: "does-not-exist")
+      .maybeSingle()
+      .execute().value
+
+    XCTAssertNil(res)
+  }
+
+  func testDryRunOnUpdate() async throws {
+    // `Prefer: tx=rollback` only takes effect when the server has PostgREST's `db-tx-end`
+    // setting enabled, which the local Supabase CLI dev config doesn't expose — so this can't
+    // assert the mutation was actually rolled back. It targets a scratch row (auto-cleaned by
+    // `setUp`, since it has a non-null email) rather than shared seed data, so if this
+    // environment ends up committing anyway it doesn't corrupt other tests. The `Prefer` header
+    // itself is verified by the unit tests in PostgrestTransformBuilderTests.
+    try await client.from("users").insert([
+      "username": "dry-run-scratch", "email": "dry-run-scratch@example.com",
+    ])
+    .execute()
+
+    _ = try await client.from("users")
+      .update(["catchphrase": "temporary"])
+      .eq("username", value: "dry-run-scratch")
+      .dryRun()
+      .execute()
+  }
+
   func testSingleOnInsert() async throws {
     let res =
       try await client.from("users")

--- a/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
@@ -220,12 +220,8 @@ final class PostgrestTransformsTests: XCTestCase {
   }
 
   func testDryRunOnUpdate() async throws {
-    // `Prefer: tx=rollback` only takes effect when the server has PostgREST's `db-tx-end`
-    // setting enabled, which the local Supabase CLI dev config doesn't expose — so this can't
-    // assert the mutation was actually rolled back. It targets a scratch row (auto-cleaned by
-    // `setUp`, since it has a non-null email) rather than shared seed data, so if this
-    // environment ends up committing anyway it doesn't corrupt other tests. The `Prefer` header
-    // itself is verified by the unit tests in PostgrestTransformBuilderTests.
+    // Requires `pgrst.db_tx_end = 'commit-allow-override'` on the `authenticator` role
+    // (see migrations/20240101000000_initial_schema.sql) so `Prefer: tx=rollback` is honored.
     try await client.from("users").insert([
       "username": "dry-run-scratch", "email": "dry-run-scratch@example.com",
     ])
@@ -236,6 +232,21 @@ final class PostgrestTransformsTests: XCTestCase {
       .eq("username", value: "dry-run-scratch")
       .dryRun()
       .execute()
+
+    let after =
+      try await client.from("users")
+      .select("catchphrase")
+      .eq("username", value: "dry-run-scratch")
+      .single()
+      .execute().value as AnyJSON
+
+    assertInlineSnapshot(of: after, as: .json) {
+      """
+      {
+        "catchphrase" : null
+      }
+      """
+    }
   }
 
   func testSingleOnInsert() async throws {

--- a/Tests/IntegrationTests/Postgrest/PostgrestFilterTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgrestFilterTests.swift
@@ -368,6 +368,29 @@ final class PostgrestFilterTests: XCTestCase {
     }
   }
 
+  func testNotIn() async throws {
+    let res =
+      try await client.from("users").select("status").notIn("status", values: ["OFFLINE"])
+      .execute()
+      .value as AnyJSON
+
+    assertInlineSnapshot(of: res, as: .json) {
+      """
+      [
+        {
+          "status" : "ONLINE"
+        },
+        {
+          "status" : "ONLINE"
+        },
+        {
+          "status" : "ONLINE"
+        }
+      ]
+      """
+    }
+  }
+
   func testContains() async throws {
     let res =
       try await client.from("users").select("age_range").contains("age_range", value: "[1,2)")

--- a/Tests/IntegrationTests/supabase/migrations/20240101000000_initial_schema.sql
+++ b/Tests/IntegrationTests/supabase/migrations/20240101000000_initial_schema.sql
@@ -1,3 +1,6 @@
+-- Allow Prefer: tx=rollback to actually roll back (default stays commit).
+ALTER ROLE authenticator SET pgrst.db_tx_end TO 'commit-allow-override';
+
 -- Create custom types
 CREATE TYPE user_status AS ENUM ('ONLINE', 'OFFLINE');
 

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -254,6 +254,7 @@ final class BuildURLRequestTests: XCTestCase {
     let clientInfoHeader = client.configuration.headers["X-Client-Info"]
     XCTAssertNotNil(clientInfoHeader)
   }
+
 }
 
 extension URLResponse {

--- a/Tests/PostgRESTTests/PostgrestBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestBuilderTests.swift
@@ -79,6 +79,65 @@ final class PostgrestBuilderTests: PostgrestQueryTests {
     }
   }
 
+  func testMaybeSingleReturnsNilOnZeroRows() async throws {
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 406,
+      data: [
+        .get: Data(
+          """
+          {
+            "code": "PGRST116",
+            "message": "JSON object requested, multiple (or no) rows returned"
+          }
+          """.utf8
+        )
+      ]
+    )
+    .register()
+
+    let user: User? =
+      try await sut
+      .from("users")
+      .select()
+      .maybeSingle()
+      .execute()
+      .value
+
+    XCTAssertNil(user)
+  }
+
+  func testMaybeSingleReturnsValueOnSingleRow() async throws {
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .get: Data(
+          """
+          {
+            "id": 1,
+            "username": "admin"
+          }
+          """.utf8
+        )
+      ]
+    )
+    .register()
+
+    let user: User? =
+      try await sut
+      .from("users")
+      .select()
+      .maybeSingle()
+      .execute()
+      .value
+
+    XCTAssertEqual(user?.id, 1)
+    XCTAssertEqual(user?.username, "admin")
+  }
+
   func testExecuteWithHead() async throws {
     Mock(
       url: url.appendingPathComponent("users"),

--- a/Tests/PostgRESTTests/PostgrestFilterBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterBuilderTests.swift
@@ -288,6 +288,33 @@ final class PostgrestFilterBuilderTests: PostgrestQueryTests {
       .execute()
   }
 
+  func testNotInFilter() async throws {
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [.get: Data("[]".utf8)]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "Accept: application/json" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/users?select=*&status=not.in.(archived,deleted)"
+      """#
+    }
+    .register()
+
+    _ =
+      try await sut
+      .from("users")
+      .select()
+      .notIn("status", values: ["archived", "deleted"])
+      .execute()
+  }
+
   func testInFilterQuotesValuesWithReservedCharacters() async throws {
     Mock(
       url: url.appendingPathComponent("users"),

--- a/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
@@ -306,6 +306,44 @@ final class PostgrestTransformBuilderTests: PostgrestQueryTests {
     XCTAssertEqual(country["name"], "United States")
   }
 
+  func testMaybeSingle() async throws {
+    Mock(
+      url: url.appendingPathComponent("countries"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .get: Data(
+          """
+          {
+            "name": "United States"
+          }
+          """.utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "Accept: application/vnd.pgrst.object+json" \
+      	--header "Content-Type: application/json" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/countries?limit=1&select=name"
+      """#
+    }
+    .register()
+
+    let country =
+      try await sut
+      .from("countries")
+      .select("name")
+      .limit(1)
+      .maybeSingle()
+      .execute()
+      .value as [String: String]
+
+    XCTAssertEqual(country["name"], "United States")
+  }
+
   func testCSV() async throws {
     Mock(
       url: url.appendingPathComponent("countries"),
@@ -656,5 +694,67 @@ final class PostgrestTransformBuilderTests: PostgrestQueryTests {
     } catch let error as PostgrestError {
       XCTAssertEqual(error.message, "`.csv()` cannot be combined with `.stripNulls()`")
     }
+  }
+
+  func testDryRun() async throws {
+    Mock(
+      url: url.appendingPathComponent("countries"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .get: Data("[]".utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--header "Accept: application/json" \
+      	--header "Content-Type: application/json" \
+      	--header "Prefer: tx=rollback" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:54321/rest/v1/countries?select=*"
+      """#
+    }
+    .register()
+
+    try await sut
+      .from("countries")
+      .select()
+      .dryRun()
+      .execute()
+  }
+
+  func testDryRunOnUpdate() async throws {
+    Mock(
+      url: url.appendingPathComponent("users"),
+      ignoreQuery: true,
+      statusCode: 200,
+      data: [
+        .patch: Data("[]".utf8)
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request PATCH \
+      	--header "Accept: application/json" \
+      	--header "Content-Length: 20" \
+      	--header "Content-Type: application/json" \
+      	--header "Prefer: return=representation,tx=rollback" \
+      	--header "X-Client-Info: postgrest-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	--data "{\"username\":\"admin\"}" \
+      	"http://localhost:54321/rest/v1/users?id=eq.1"
+      """#
+    }
+    .register()
+
+    try await sut
+      .from("users")
+      .update(["username": "admin"])
+      .eq("id", value: 1)
+      .dryRun()
+      .execute()
   }
 }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -284,7 +284,10 @@ features:
   database.using_filters.regex: implemented
   database.using_filters.regex_icase: implemented
   database.using_filters.is_distinct: implemented
-  database.using_filters.not_in: not_implemented
+  database.using_filters.not_in:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.notIn
   database.using_filters.like_all: implemented
   database.using_filters.like_any: implemented
   database.using_filters.ilike_all: implemented
@@ -294,7 +297,10 @@ features:
   database.using_modifiers.limit: implemented
   database.using_modifiers.range: implemented
   database.using_modifiers.single_row: implemented
-  database.using_modifiers.maybe_single_row: not_implemented
+  database.using_modifiers.maybe_single_row:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.maybeSingle
   database.using_modifiers.strip_nulls: implemented
   database.using_modifiers.format_csv: implemented
   database.using_modifiers.format_geojson: implemented
@@ -307,7 +313,10 @@ features:
   database.using_modifiers.relationship_embed:
     status: partially_implemented
     note: "Supported via query-string syntax in select() (e.g. 'user(*)'); no dedicated relationship builder API."
-  database.using_modifiers.dry_run: not_implemented
+  database.using_modifiers.dry_run:
+    status: implemented
+    symbols:
+      - PostgrestTransformBuilder.dryRun
 
   database.configuration.auto_retry: implemented
   database.configuration.request_timeout: not_implemented


### PR DESCRIPTION
## Summary

Closes [SDK-1298](https://linear.app/supabase/issue/SDK-1298/database-query-filter-modifier-and-timeout-gaps) — closes the remaining PostgREST query builder gaps against the SDK compliance matrix:

- **`notIn(_:values:)`** filter (`PostgrestFilterBuilder`) — dedicated `not.in.(...)` convenience, mirrors `in(_:values:)`.
- **`dryRun()`** modifier (`PostgrestTransformBuilder`) — sends `Prefer: tx=rollback` so a mutation executes and returns a response but doesn't persist.
- **`maybeSingle()`** modifier (`PostgrestTransformBuilder`) — like `single()` but returns `nil` instead of throwing when the query matches zero rows (touches the shared `execute()` decode path in `PostgrestBuilder`).
- **Relationship embed builder** — decided **no apply**. Raw `select("user(*)")` string syntax already covers this; JS/Flutter/Python SDKs all rely on the same string syntax rather than a dedicated builder, so a typed builder would be speculative API surface over something already supported.
- **Request timeout config** — decided **no apply** as a new `PostgrestClient.Configuration` knob (reverted from an earlier draft of this PR per review). Documented the `fetch` handler as the existing escape hatch for per-request timeouts via `URLRequest.timeoutInterval`, since the transport already supports it.

## Testing

- Unit tests (Mocker-based) for all three new capabilities in `Tests/PostgRESTTests`.
- Integration tests in `Tests/IntegrationTests/Postgrest/`, verified end-to-end against a local Supabase instance:
  - `testDryRunOnUpdate` genuinely asserts the mutation is rolled back — required adding `ALTER ROLE authenticator SET pgrst.db_tx_end = 'commit-allow-override'` to the test schema migration (same mechanism postgrest-js uses in its own test suite), since `db-tx-end` is off by default and otherwise a `dryRun()` update would actually persist.
  - `testMaybeSingle` filters by an explicit column rather than relying on `.limit(1)` row-order, which is otherwise undefined without `ORDER BY`.

## Test plan

- [x] `swift test --filter PostgRESTTests` — 107 passed, 0 failures
- [x] `INTEGRATION_TESTS=1 swift test --filter Postgrest` against local `supabase start` — 61 passed, 0 failures
- [x] `./scripts/format.sh` — clean
- [x] `./scripts/spell-check.sh` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)