### PR TITLE
feat(realtime): add serverTrustHandler to RealtimeClientOptions for WebSocket certificate pinning

### DIFF
--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -223,10 +223,11 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
     self.init(
       url: url,
       options: options,
-      wsTransport: { url, headers in
+      wsTransport: { [serverTrustHandler = options.serverTrustHandler] url, headers in
         return try await URLSessionWebSocket.connect(
           to: url,
-          headers: headers
+          headers: headers,
+          serverTrustHandler: serverTrustHandler
         )
       },
       http: HTTPClient(

--- a/Sources/RealtimeV2/Types.swift
+++ b/Sources/RealtimeV2/Types.swift
@@ -96,6 +96,18 @@ public struct RealtimeClientOptions: Sendable {
   package var accessToken: (@Sendable () async throws -> String?)?
   package var logger: (any SupabaseLogger)?
 
+  /// Optional handler for evaluating server trust on WebSocket connections.
+  /// Use this to implement certificate pinning for Realtime WebSocket connections.
+  /// The handler receives the URLSession, the authentication challenge, and a completion handler
+  /// that must be called with the disposition and optional credential.
+  public var serverTrustHandler: (
+    @Sendable (
+      _ session: URLSession,
+      _ challenge: URLAuthenticationChallenge,
+      _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) -> Void
+  )?
+
   /// Default interval, in seconds, between heartbeat messages sent to keep the connection alive.
   public static let defaultHeartbeatInterval: TimeInterval = 25
 
@@ -163,7 +175,14 @@ public struct RealtimeClientOptions: Sendable {
     fetch: (@Sendable (_ request: URLRequest) async throws -> (Data, URLResponse))? = nil,
     accessToken: (@Sendable () async throws -> String?)? = nil,
     logger: (any SupabaseLogger)? = nil,
-    handleAppLifecycle: Bool = Self.defaultHandleAppLifecycle
+    handleAppLifecycle: Bool = Self.defaultHandleAppLifecycle,
+    serverTrustHandler: (
+      @Sendable (
+        _ session: URLSession,
+        _ challenge: URLAuthenticationChallenge,
+        _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+      ) -> Void
+    )? = nil
   ) {
     self.headers = HTTPFields(headers)
     self.heartbeatInterval = heartbeatInterval
@@ -179,6 +198,7 @@ public struct RealtimeClientOptions: Sendable {
     self.fetch = fetch
     self.accessToken = accessToken
     self.logger = logger
+    self.serverTrustHandler = serverTrustHandler
   }
 
   /// Backward-compatible initializer preserving the pre-`vsn` signature.

--- a/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift
+++ b/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift
@@ -59,7 +59,14 @@ final class URLSessionWebSocket: WebSocket {
     to url: URL,
     protocols: [String]? = nil,
     headers: [String: String]? = nil,
-    configuration: URLSessionConfiguration? = nil
+    configuration: URLSessionConfiguration? = nil,
+    serverTrustHandler: (
+      @Sendable (
+        _ session: URLSession,
+        _ challenge: URLAuthenticationChallenge,
+        _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+      ) -> Void
+    )? = nil
   ) async throws -> URLSessionWebSocket {
     guard url.scheme == "ws" || url.scheme == "wss" else {
       preconditionFailure("only ws: and wss: schemes are supported")
@@ -74,6 +81,7 @@ final class URLSessionWebSocket: WebSocket {
 
     let session = URLSession.sessionWithConfiguration(
       configuration ?? .default,
+      serverTrustHandler: serverTrustHandler,
       onComplete: { session, task, error in
         mutableState.withValue {
           if let webSocket = $0.webSocket {
@@ -403,6 +411,13 @@ extension URLSession {
   /// - Returns: A configured URLSession instance.
   static func sessionWithConfiguration(
     _ configuration: URLSessionConfiguration,
+    serverTrustHandler: (
+      @Sendable (
+        _ session: URLSession,
+        _ challenge: URLAuthenticationChallenge,
+        _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+      ) -> Void
+    )? = nil,
     onComplete: (@Sendable (URLSession, URLSessionTask, (any Error)?) -> Void)? = nil,
     onWebSocketTaskOpened: (@Sendable (URLSession, URLSessionWebSocketTask, String?) -> Void)? =
       nil,
@@ -414,11 +429,13 @@ extension URLSession {
 
     let hasDelegate =
       onComplete != nil || onWebSocketTaskOpened != nil || onWebSocketTaskClosed != nil
+        || serverTrustHandler != nil
 
     if hasDelegate {
       return URLSession(
         configuration: configuration,
         delegate: _Delegate(
+          serverTrustHandler: serverTrustHandler,
           onComplete: onComplete,
           onWebSocketTaskOpened: onWebSocketTaskOpened,
           onWebSocketTaskClosed: onWebSocketTaskClosed
@@ -440,6 +457,14 @@ extension URLSession {
 final class _Delegate: NSObject, URLSessionDelegate, URLSessionDataDelegate, URLSessionTaskDelegate,
   URLSessionWebSocketDelegate
 {
+  /// Callback for server trust authentication challenges (certificate pinning).
+  let serverTrustHandler: (
+    @Sendable (
+      _ session: URLSession,
+      _ challenge: URLAuthenticationChallenge,
+      _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) -> Void
+  )?
   /// Callback for task completion events.
   let onComplete: (@Sendable (URLSession, URLSessionTask, (any Error)?) -> Void)?
   /// Callback for WebSocket connection opened events.
@@ -448,6 +473,13 @@ final class _Delegate: NSObject, URLSessionDelegate, URLSessionDataDelegate, URL
   let onWebSocketTaskClosed: (@Sendable (URLSession, URLSessionWebSocketTask, Int?, Data?) -> Void)?
 
   init(
+    serverTrustHandler: (
+      @Sendable (
+        _ session: URLSession,
+        _ challenge: URLAuthenticationChallenge,
+        _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+      ) -> Void
+    )? = nil,
     onComplete: (@Sendable (URLSession, URLSessionTask, (any Error)?) -> Void)?,
     onWebSocketTaskOpened: (
       @Sendable (URLSession, URLSessionWebSocketTask, String?) -> Void
@@ -456,9 +488,23 @@ final class _Delegate: NSObject, URLSessionDelegate, URLSessionDataDelegate, URL
       @Sendable (URLSession, URLSessionWebSocketTask, Int?, Data?) -> Void
     )?
   ) {
+    self.serverTrustHandler = serverTrustHandler
     self.onComplete = onComplete
     self.onWebSocketTaskOpened = onWebSocketTaskOpened
     self.onWebSocketTaskClosed = onWebSocketTaskClosed
+  }
+
+  /// Called when the session receives an authentication challenge (e.g. server trust / cert pinning).
+  func urlSession(
+    _ session: URLSession,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {
+    if let serverTrustHandler {
+      serverTrustHandler(session, challenge, completionHandler)
+    } else {
+      completionHandler(.performDefaultHandling, nil)
+    }
   }
 
   /// Called when a task completes, with or without error.


### PR DESCRIPTION
## Motivation

The Realtime WebSocket transport (`URLSessionWebSocket`) creates its own internal `URLSession`, which bypasses any `URLSessionDelegate`-based certificate pinning an app configures on its main Supabase client session. Apps that SPKI-pin their REST / Auth / Storage traffic therefore have **no way to pin the Realtime WebSocket connection** — the channel silently connects unpinned, a security downgrade for apps where pinning is a requirement. There's currently no public hook to evaluate server trust on the Realtime session.

## What this does

Adds an optional `serverTrustHandler` closure to `RealtimeClientOptions`, forwarded to the WebSocket `URLSession`'s delegate and invoked from `urlSession(_:didReceive:completionHandler:)`, so apps can implement certificate pinning (or any server-trust evaluation) on Realtime WebSocket connections.

- **`RealtimeClientOptions`** — new public `serverTrustHandler` property + init parameter (defaulted `nil`).
- **`URLSessionWebSocket.connect(...)` / `URLSession.sessionWithConfiguration(...)`** — accept and forward the handler.
- **`_Delegate`** — implements `urlSession(_:didReceive:completionHandler:)`: calls the handler if set, otherwise `.performDefaultHandling`.
- **`RealtimeClientV2`** — passes `options.serverTrustHandler` into the `wsTransport` closure.

## Compatibility

Fully backwards-compatible: the property and parameter default to `nil`, and with no handler the delegate performs default handling exactly as today. No behavior change for existing users. +71 lines across 3 files; `swift build` passes.

## Usage

```swift
let options = RealtimeClientOptions(
  serverTrustHandler: { _, challenge, completionHandler in
    guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
          let trust = challenge.protectionSpace.serverTrust else {
      completionHandler(.performDefaultHandling, nil); return
    }
    if myPinValidator.isValid(trust) {
      completionHandler(.useCredential, URLCredential(trust: trust))
    } else {
      completionHandler(.cancelAuthenticationChallenge, nil)
    }
  }
)
```

## Notes

- This patch has been running in production in a downstream fork since v2.46.0 (rebased here onto current `main`).
- Happy to add tests or adjust the API shape (e.g. a narrower pinning-specific type rather than the raw challenge closure) if the maintainers prefer.