### PR TITLE
fix(storage): honor options.contentType for fileURL uploads

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -44,7 +44,12 @@ enum FileUpload {
       )
 
     case .url(let url):
-      formData.append(url, withName: "")
+      formData.append(
+        url,
+        withName: "",
+        fileName: url.lastPathComponent,
+        mimeType: options.contentType ?? mimeType(forPathExtension: url.pathExtension)
+      )
     }
   }
 }

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -737,6 +737,60 @@ final class StorageFileAPITests: XCTestCase {
     XCTAssertEqual(response.fullPath, "bucket/folder/file.txt")
   }
 
+  func testUploadFromURL_honorsContentType() async throws {
+    Mock(
+      url: url.appendingPathComponent("object/bucket/file.txt"),
+      statusCode: 200,
+      data: [
+        .post: Data(
+          """
+          {
+            "Id": "123",
+            "Key": "bucket/file.txt"
+          }
+          """.utf8
+        )
+      ]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "Cache-Control: max-age=3600" \
+      	--header "Content-Length: 284" \
+      	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
+      	--header "X-Client-Info: storage-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	--header "x-upsert: false" \
+      	--data "--alamofire.boundary.e56f43407f772505\#r
+      Content-Disposition: form-data; name=\"cacheControl\"\#r
+      \#r
+      3600\#r
+      --alamofire.boundary.e56f43407f772505\#r
+      Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
+      Content-Type: image/png\#r
+      \#r
+      hello world!
+      \#r
+      --alamofire.boundary.e56f43407f772505--\#r
+      " \
+      	"http://localhost:54321/storage/v1/object/bucket/file.txt"
+      """#
+    }
+    .register()
+
+    let response = try await storage.from("bucket")
+      .upload(
+        "file.txt",
+        fileURL: Bundle.module.url(forResource: "file", withExtension: "txt")!,
+        options: FileOptions(contentType: "image/png")
+      )
+
+    XCTAssertEqual(response.id, "123")
+    XCTAssertEqual(response.path, "file.txt")
+    XCTAssertEqual(response.fullPath, "bucket/file.txt")
+  }
+
   func testUpdateFromURL() async throws {
     Mock(
       url: url.appendingPathComponent("object/bucket/file.txt"),


### PR DESCRIPTION
## What

When uploading from a file URL, `FileUpload.encode` routes the `.url` case through the 2-argument `MultipartFormData.append(_:withName:)`:

```swift
case .url(let url):
  formData.append(url, withName: "")
```

That overload derives the part's MIME type **solely from the file URL's extension** and **ignores `options.contentType`** — unlike the sibling `.data` branch, which honors it:

```swift
case .data(let data):
  formData.append(
    data,
    withName: "",
    fileName: path.fileName,
    mimeType: options.contentType ?? mimeType(forPathExtension: path.pathExtension)
  )
```

Two consequences:

1. **`options.contentType` is silently ignored** for `fileURL` uploads — the stored object gets a type inferred from the URL's extension regardless of what the caller requested.
2. The 2-arg overload **throws `bodyPartFilenameInvalid`** when the URL has no path extension (e.g. a temporary file with no suffix), so an upload with an explicit `contentType` fails outright.

## Fix

Route `.url` through the 4-arg overload and thread `options.contentType` through, falling back to the URL-derived type (preserving the previous inference when no content type is supplied):

```swift
case .url(let url):
  formData.append(
    url,
    withName: "",
    fileName: url.lastPathComponent,
    mimeType: options.contentType ?? mimeType(forPathExtension: url.pathExtension)
  )
```

This keeps the existing filename/MIME derivation for URLs that already carry an extension (existing snapshots are unchanged), and additionally (a) honors an explicit `contentType` and (b) no longer throws for extensionless URLs.

## Testing

Added `testUploadFromURL_honorsContentType`, which uploads a `.txt` fixture with `contentType: "image/png"` and snapshots the multipart body. It **fails on `main`** (`Content-Type: text/plain`) and **passes with this change** (`Content-Type: image/png`).

- `swift test --filter StorageTests` — 144 passing (existing fileURL snapshots unchanged)
- `./scripts/format.sh` — clean