### PR TITLE
fix(helpers): await full retry backoff delay instead of truncating to whole seconds

### DIFF
--- a/Sources/Helpers/HTTP/RetryRequestInterceptor.swift
+++ b/Sources/Helpers/HTTP/RetryRequestInterceptor.swift
@@ -63,6 +63,8 @@ package actor RetryRequestInterceptor: HTTPClientInterceptor {
   package let retryableHTTPStatusCodes: Set<Int>
   /// The set of retryable URL error codes.
   package let retryableErrorCodes: Set<URLError.Code>
+  /// The clock used to wait between retries.
+  package let clock: any Clock<Duration>
 
   /// Creates a `RetryRequestInterceptor` instance.
   ///
@@ -73,6 +75,7 @@ package actor RetryRequestInterceptor: HTTPClientInterceptor {
   ///   - retryableHTTPMethods: The set of retryable HTTP methods. Default includes common methods.
   ///   - retryableHTTPStatusCodes: The set of retryable HTTP status codes. Default includes common status codes.
   ///   - retryableErrorCodes: The set of retryable URL error codes. Default includes common error codes.
+  ///   - clock: The clock used to wait between retries. Default is `ContinuousClock()`.
   package init(
     retryLimit: Int = RetryRequestInterceptor.defaultRetryLimit,
     exponentialBackoffBase: UInt = RetryRequestInterceptor.defaultExponentialBackoffBase,
@@ -80,7 +83,8 @@ package actor RetryRequestInterceptor: HTTPClientInterceptor {
     retryableHTTPMethods: Set<HTTPTypes.HTTPRequest.Method> = RetryRequestInterceptor
       .defaultRetryableHTTPMethods,
     retryableHTTPStatusCodes: Set<Int> = RetryRequestInterceptor.defaultRetryableHTTPStatusCodes,
-    retryableErrorCodes: Set<URLError.Code> = RetryRequestInterceptor.defaultRetryableURLErrorCodes
+    retryableErrorCodes: Set<URLError.Code> = RetryRequestInterceptor.defaultRetryableURLErrorCodes,
+    clock: any Clock<Duration> = ContinuousClock()
   ) {
     precondition(
       exponentialBackoffBase >= 2,
@@ -93,6 +97,7 @@ package actor RetryRequestInterceptor: HTTPClientInterceptor {
     self.retryableHTTPMethods = retryableHTTPMethods
     self.retryableHTTPStatusCodes = retryableHTTPStatusCodes
     self.retryableErrorCodes = retryableErrorCodes
+    self.clock = clock
   }
 
   /// Intercepts an HTTP request and automatically retries it in case of failure.
@@ -143,8 +148,7 @@ package actor RetryRequestInterceptor: HTTPClientInterceptor {
           Double(retryCount)
         ) * exponentialBackoffScale
 
-      let nanoseconds = UInt64(retryDelay)
-      try? await Task.sleep(nanoseconds: NSEC_PER_SEC * nanoseconds)
+      try? await clock.sleep(for: .seconds(retryDelay))
 
       if !Task.isCancelled {
         return try await retry(request, retryCount: retryCount + 1, next: next)

--- a/Tests/HelpersTests/RetryRequestInterceptorTests.swift
+++ b/Tests/HelpersTests/RetryRequestInterceptorTests.swift
@@ -152,4 +152,46 @@ struct RetryRequestInterceptorTests {
     #expect(response.statusCode == 520)
     #expect(callCount.value == 2, "Should not exceed retryLimit")
   }
+
+  // MARK: - Backoff delay
+
+  @Test
+  func awaitsFullFractionalBackoffDelay() async throws {
+    let clock = RecordingClock()
+    let interceptor = RetryRequestInterceptor(
+      retryLimit: 2,
+      exponentialBackoffBase: 2,
+      exponentialBackoffScale: 0.3,
+      clock: clock
+    )
+
+    let callCount = LockIsolated(0)
+    let response = try await interceptor.intercept(makeRequest()) { _ in
+      callCount.withValue { $0 += 1 }
+      return self.makeResponse(statusCode: callCount.value < 2 ? 503 : 200)
+    }
+
+    #expect(response.statusCode == 200)
+    #expect(callCount.value == 2)
+    #expect(clock.durations.value == [.seconds(pow(2.0, 1.0) * 0.3)])
+  }
+}
+
+/// A clock that records the durations it is asked to sleep for, without
+/// waiting. `now` is fixed so recorded durations are exact.
+struct RecordingClock: Clock {
+  let anchor: ContinuousClock.Instant
+  let durations: LockIsolated<[Duration]>
+
+  init() {
+    anchor = ContinuousClock().now
+    durations = LockIsolated([])
+  }
+
+  var now: ContinuousClock.Instant { anchor }
+  var minimumResolution: Duration { .zero }
+
+  func sleep(until deadline: ContinuousClock.Instant, tolerance: Duration?) async throws {
+    durations.withValue { $0.append(anchor.duration(to: deadline)) }
+  }
 }


### PR DESCRIPTION
## What

`RetryRequestInterceptor` computes an exponential backoff delay as `Double` seconds, then sleeps like this:

```swift
let retryDelay = pow(Double(exponentialBackoffBase), Double(retryCount)) * exponentialBackoffScale
let nanoseconds = UInt64(retryDelay)
try? await Task.sleep(nanoseconds: NSEC_PER_SEC * nanoseconds)
```

`UInt64(retryDelay)` truncates the delay to whole seconds **before** it is scaled to nanoseconds. Any configuration whose computed delay is sub-second collapses to `0` and the request is retried with no backoff at all. For example `exponentialBackoffScale: 0.3` gives a first-retry delay of `pow(2, 1) * 0.3 = 0.6s`, which becomes `UInt64(0.6) == 0`. (The default `scale: 0.5, base: 2` happens to produce whole-second delays, so defaults are unaffected — but any custom scale/base that yields a fractional delay is.)

## Fix

Sleep on an injected `Clock` with `.seconds(retryDelay)`, which preserves the fractional value instead of truncating:

```swift
try? await clock.sleep(for: .seconds(retryDelay))
```

The clock is injected through the initializer and defaults to `ContinuousClock()`, so there are no call-site changes (the interceptor's only construction site keeps working unchanged). This mirrors the explicit clock injection recently added to `PostgrestBuilder` in #1103, and it lets tests assert the delay deterministically without wall-clock timing.

No public API change (the type and its initializer are `package`, the new parameter is defaulted).

## Testing

Added `awaitsFullFractionalBackoffDelay`, which injects a recording clock (fixed `now`, records the durations it is asked to sleep for) and asserts the interceptor sleeps for the full `pow(2, 1) * 0.3 = 0.6s` on the first retry. The test **fails** if the delay is truncated (recorded `0.0s`) and **passes** with the fix — deterministically, with no real waiting.

- `swift test --filter HelpersTests` — 91 passing
- `swift test --filter AuthClientTests` — passing (Auth is the interceptor's only consumer)
- `./scripts/format.sh` — clean