### PR TITLE
ci: weekly SDK compliance sync via supabase/sdk reusable workflow

### DIFF
--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@d9f43f5be4056adc33c65fe54f1c9ed1714d67e0
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@main
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af # main
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -1,0 +1,16 @@
+name: Sync SDK Compliance Matrix
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@main
+    secrets:
+      app-id: ${{ secrets.APP_ID }}
+      private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af # main
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
Adds a weekly workflow that keeps this repo's `sdk-compliance.yaml` in sync with new capability IDs from the canonical spec at https://github.com/supabase/sdk.

It's a thin caller for the reusable workflow added in supabase/sdk#65, mirroring the existing `validate-capabilities.yml` pattern. On a weekly cron it checks out the canonical spec, inserts any missing feature IDs as `not_implemented` next to their `area.group.` siblings, and opens a PR here for triage.

- Runs Mondays 06:00 UTC (and on manual dispatch).
- Uses this repo's own GitHub App credentials (app-id `APP_ID` / `PRIVATE_KEY`) to open the PR, so no cross-repo permissions are needed.
- Only adds new IDs as `not_implemented`; real status and symbols are triaged by a maintainer.

Depends on supabase/sdk#65 merging first (the `@main` reference resolves once it lands).