### PR TITLE
fix(realtime): don't leak disconnected heartbeat status to consumers

### DIFF
--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -619,7 +619,8 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
 
   private func sendHeartbeat() async {
     if status != .connected {
-      heartbeatSubject.yield(.disconnected)
+      // Don't leak `.disconnected` to `heartbeat`/`onHeartbeat(_:)` consumers — it's not
+      // a heartbeat outcome, just this cycle bailing out early.
       return
     }
 

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -570,6 +570,51 @@ import XCTest
       )
     }
 
+    /// Regression test for SDK-1330: a heartbeat tick that lands while the
+    /// client is mid-reconnect (external close, not one triggered by the
+    /// heartbeat timer itself) must not publish `.disconnected` to
+    /// `onHeartbeat(_:)`/`heartbeat` consumers — it's an internal bookkeeping
+    /// signal, not a heartbeat outcome.
+    func testHeartbeat_doesNotLeakDisconnectedStatus() async throws {
+      let (client, server) = FakeWebSocket.fakes()
+      let sut = RealtimeClientV2(
+        url: url,
+        options: RealtimeClientOptions(
+          headers: ["apikey": apiKey],
+          heartbeatInterval: 1,
+          reconnectDelay: 10,
+          accessToken: { "custom.access.token" }
+        ),
+        wsTransport: { _, _ in client },
+        http: http,
+        clock: testClock
+      )
+      defer { sut.disconnect() }
+
+      let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
+      let subscription = sut.onHeartbeat { status in
+        heartbeatStatuses.withValue { $0.append(status) }
+      }
+      defer { subscription.cancel() }
+
+      await sut.connect()
+
+      // Server drops the connection out from under us — unrelated to the
+      // heartbeat timer, which is still sleeping out its first interval.
+      server.close(code: nil, reason: "boom")
+      await Task.megaYield()
+
+      // The heartbeat timer ticks while the reconnect is still sleeping out
+      // its 10s `reconnectDelay` — the still-alive old heartbeat task must
+      // not observe `status != .connected` and publish `.disconnected`.
+      await testClock.advance(by: .seconds(1))
+
+      XCTAssertFalse(
+        heartbeatStatuses.value.contains(.disconnected),
+        "heartbeat status leaked .disconnected to consumers: \(heartbeatStatuses.value)"
+      )
+    }
+
     func testHeartbeat_timeout() async throws {
       let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
       let s1 = sut.onHeartbeat { status in


### PR DESCRIPTION
## Summary

- `sendHeartbeat()` published `.disconnected` into the same subject backing `heartbeat`/`onHeartbeat(_:)` whenever a heartbeat tick landed while the client wasn't connected. Nothing internal reads that value — it only existed to notify public consumers.
- `.disconnected` is bookkeeping ("can't send, not connected"), not a heartbeat outcome, and it could leak during the window between an external disconnect (e.g. server-initiated close) and the reconnect completing — the still-running heartbeat task ticks before the replacement connection's `startHeartbeating()` cancels it.
- Mirrors the fix already shipped in supabase-js's `RealtimeClient` (`_wrapHeartbeatCallback` filters out `'disconnected'` before it reaches the user callback).

## Fix

`sendHeartbeat()` now just returns early without yielding when not connected. `HeartbeatStatus.disconnected` stays in the enum for API stability; it's simply never emitted.

## Test plan

- [x] Added `testHeartbeat_doesNotLeakDisconnectedStatus` (deterministic via `TestClock`): forces an external server close during a reconnect window with `heartbeatInterval` shorter than `reconnectDelay`, so the stale heartbeat task ticks mid-reconnect. Verified it fails on the pre-fix code and passes after the fix.
- [x] Full `RealtimeTests` suite (242 tests) passes.
- [x] `./scripts/format.sh` — no changes needed beyond the diff.

Fixes [SDK-1330](https://linear.app/supabase/issue/SDK-1330/parityrealtime-heartbeat-callback-must-not-leak-disconnected-status).