### PR TITLE
fix(client,functions): warn instead of throw on unrecognized sb_ key subtype; never send new-format key as Bearer

### DIFF
--- a/Sources/Helpers/APIKeyFormat.swift
+++ b/Sources/Helpers/APIKeyFormat.swift
@@ -1,0 +1,74 @@
+//
+//  APIKeyFormat.swift
+//  Supabase
+//
+//  Created by Claude on 16/07/26.
+//
+
+import ConcurrencyExtras
+import IssueReporting
+
+/// Classifies and validates the format of a Supabase API key.
+///
+/// New-format keys (`sb_publishable_…` / `sb_secret_…`) are not JWTs and must never be sent
+/// as a Bearer token — they belong only in the `apikey` header. Legacy JWT keys (no `sb_`
+/// prefix) and platform-issued temporary keys (`sb_temp_…`) keep the existing Bearer fallback.
+package enum APIKeyFormat {
+  private static let newFormatPrefixes = ["sb_publishable_", "sb_secret_"]
+  private static let temporaryKeyPrefix = "sb_temp_"
+
+  /// Whether `key` is a new-format key (`sb_publishable_…` / `sb_secret_…`).
+  package static func isNew(_ key: String) -> Bool {
+    newFormatPrefixes.contains { key.hasPrefix($0) }
+  }
+
+  private static let warnedSubtypes = LockIsolated<Set<String>>([])
+
+  /// Warns (once per subtype) when `key` has the `sb_` prefix but an unrecognized subtype.
+  /// Never throws — the server, not the SDK, decides key validity. The key value is never
+  /// included in the message.
+  package static func checkFormat(_ key: String) {
+    guard shouldWarn(for: key) else { return }
+    reportIssue(
+      """
+      Unrecognized Supabase API key format. The client will proceed and send this key as-is; \
+      if you see authentication errors you may need to upgrade supabase-swift to a version \
+      that recognizes this key type.
+      """
+    )
+  }
+
+  /// Decides whether `checkFormat` should warn for `key`, and records the subtype as warned
+  /// as a side effect. Split out from `checkFormat` so the classification/dedup logic is
+  /// unit-testable without exercising `reportIssue` directly (calling `reportIssue` from a
+  /// Swift Testing `@Test` function is known to crash the Xcode test runner — see the
+  /// `clientInitWithCustomAccessToken` test comment in Tests/SupabaseTests/SupabaseClientTests.swift
+  /// for a documented instance of the same constraint).
+  package static func shouldWarn(for key: String) -> Bool {
+    guard key.hasPrefix("sb_"), !isNew(key), !key.hasPrefix(temporaryKeyPrefix) else {
+      return false
+    }
+    let subtype = subtypeToken(for: key)
+    return warnedSubtypes.withValue { $0.insert(subtype).inserted }
+  }
+
+  /// The `Authorization` Bearer token an Edge Functions request should use, given the raw
+  /// `accessToken` fallback logic and the client's `supabaseKey`. New-format keys must never
+  /// appear as a Bearer token: when there is no real session and `accessToken` is just the
+  /// raw key fallback, this returns `nil` so the caller omits the header entirely instead of
+  /// sending the new-format key as a Bearer token. A genuine session token (which will never
+  /// equal `supabaseKey`) and legacy JWT key fallbacks are returned unchanged.
+  package static func functionsBearerToken(accessToken: String, supabaseKey: String) -> String? {
+    accessToken == supabaseKey && isNew(supabaseKey) ? nil : accessToken
+  }
+
+  private static func subtypeToken(for key: String) -> String {
+    let remainder = key.dropFirst("sb_".count)
+    guard let underscoreIndex = remainder.firstIndex(of: "_") else { return "unknown" }
+    let candidate = remainder[..<underscoreIndex]
+    guard !candidate.isEmpty, candidate.allSatisfy({ $0.isLetter || $0.isNumber }) else {
+      return "unknown"
+    }
+    return String(candidate)
+  }
+}

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -149,9 +149,13 @@ public final class SupabaseClient: Sendable {
   public var functions: FunctionsClient {
     mutableState.withValue {
       if $0.functions == nil {
+        var functionsHeaders = _headers
+        if APIKeyFormat.isNew(supabaseKey) {
+          functionsHeaders[.authorization] = nil
+        }
         $0.functions = FunctionsClient(
           url: functionsURL,
-          headers: headers,
+          headers: functionsHeaders.dictionary,
           region: options.functions.region,
           logger: options.global.logger,
           fetch: fetchWithAuth,
@@ -232,6 +236,8 @@ public final class SupabaseClient: Sendable {
     self.supabaseKey = supabaseKey
     self.options = options
     self.clock = clock
+
+    APIKeyFormat.checkFormat(supabaseKey)
 
     storageURL = supabaseURL.appendingPathComponent("/storage/v1")
     databaseURL = supabaseURL.appendingPathComponent("/rest/v1")
@@ -479,7 +485,9 @@ public final class SupabaseClient: Sendable {
     }
 
     if let accessToken {
-      functions.setAuth(token: accessToken)
+      functions.setAuth(
+        token: APIKeyFormat.functionsBearerToken(accessToken: accessToken, supabaseKey: supabaseKey)
+      )
       realtime.setAuth(accessToken)
       await realtimeV2.setAuth(accessToken)
     }

--- a/Tests/HelpersTests/APIKeyFormatTests.swift
+++ b/Tests/HelpersTests/APIKeyFormatTests.swift
@@ -1,0 +1,86 @@
+import Helpers
+import Testing
+
+@Suite
+struct APIKeyFormatTests {
+  @Test(arguments: [
+    "sb_publishable_abc123",
+    "sb_secret_abc123",
+  ])
+  func isNewRecognizesNewFormatKeys(key: String) {
+    #expect(APIKeyFormat.isNew(key))
+  }
+
+  @Test(arguments: [
+    "sb_temp_nonce123_payload456",
+    "sb_unknown_abc123",
+    "header.payload.signature",
+    "anon-key",
+  ])
+  func isNewRejectsNonNewFormatKeys(key: String) {
+    #expect(!APIKeyFormat.isNew(key))
+  }
+
+  @Test
+  func shouldWarnAcceptsRecognizedAndLegacyKeysSilently() {
+    #expect(!APIKeyFormat.shouldWarn(for: "sb_publishable_shouldwarn1"))
+    #expect(!APIKeyFormat.shouldWarn(for: "sb_secret_shouldwarn1"))
+    #expect(!APIKeyFormat.shouldWarn(for: "sb_temp_shouldwarn1_payload"))
+    #expect(!APIKeyFormat.shouldWarn(for: "header.payload.signature"))
+    #expect(!APIKeyFormat.shouldWarn(for: "anon-key"))
+  }
+
+  @Test
+  func shouldWarnOnceForUnrecognizedSubtype() {
+    // NOTE: `warnedSubtypes` dedup state is module-scoped, so every distinct subtype used in
+    // this file must be unique to this test (mirrors the same constraint in supabase-js's
+    // fetch.test.ts `checkApiKeyFormat` suite).
+    #expect(APIKeyFormat.shouldWarn(for: "sb_uniquesubtypeA_key1"))
+    #expect(!APIKeyFormat.shouldWarn(for: "sb_uniquesubtypeA_key2"))
+  }
+
+  @Test
+  func shouldWarnTreatsDifferentSubtypesIndependently() {
+    #expect(APIKeyFormat.shouldWarn(for: "sb_uniquesubtypeB_key1"))
+    #expect(APIKeyFormat.shouldWarn(for: "sb_uniquesubtypeC_key1"))
+  }
+
+  @Test
+  func shouldWarnGroupsUnparseableSubtypesTogether() {
+    // Keys with no second underscore share the 'unknown' dedup bucket.
+    #expect(APIKeyFormat.shouldWarn(for: "sb_"))
+    #expect(!APIKeyFormat.shouldWarn(for: "sb_uniqueunparseabletype"))
+  }
+
+  @Test
+  func functionsBearerTokenSuppressesNewFormatKeyFallback() {
+    // no-session + new-key: accessToken fallback equals the raw new-format key -> suppressed.
+    #expect(
+      APIKeyFormat.functionsBearerToken(
+        accessToken: "sb_publishable_abc123",
+        supabaseKey: "sb_publishable_abc123"
+      ) == nil
+    )
+  }
+
+  @Test
+  func functionsBearerTokenKeepsLegacyKeyFallback() {
+    // no-session + legacy-key: unchanged existing behavior.
+    #expect(
+      APIKeyFormat.functionsBearerToken(
+        accessToken: "legacy-jwt-key", supabaseKey: "legacy-jwt-key")
+        == "legacy-jwt-key"
+    )
+  }
+
+  @Test
+  func functionsBearerTokenPassesThroughRealSessionToken() {
+    // has-session: a genuine session JWT is always sent, regardless of key format.
+    #expect(
+      APIKeyFormat.functionsBearerToken(
+        accessToken: "real.session.jwt",
+        supabaseKey: "sb_publishable_abc123"
+      ) == "real.session.jwt"
+    )
+  }
+}

--- a/Tests/HelpersTests/APIKeyFormatTests.swift
+++ b/Tests/HelpersTests/APIKeyFormatTests.swift
@@ -46,7 +46,7 @@ struct APIKeyFormatTests {
   }
 
   @Test
-  func shouldWarnGroupsUnparseableSubtypesTogether() {
+  func shouldWarnGroupsUnparsableSubtypesTogether() {
     // Keys with no second underscore share the 'unknown' dedup bucket.
     #expect(APIKeyFormat.shouldWarn(for: "sb_"))
     #expect(!APIKeyFormat.shouldWarn(for: "sb_uniqueunparseabletype"))

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -232,7 +232,7 @@ struct SupabaseClientTests {
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,
       supabaseKey: "sb_publishable_abc123",
-      options: SupabaseClientOptions()
+      options: SupabaseClientOptions(auth: .init(storage: AuthLocalStorageMock()))
     )
 
     #expect(client.functions.headers.dictionary["Authorization"] == nil)
@@ -244,7 +244,7 @@ struct SupabaseClientTests {
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,
       supabaseKey: "legacy-jwt-key",
-      options: SupabaseClientOptions()
+      options: SupabaseClientOptions(auth: .init(storage: AuthLocalStorageMock()))
     )
 
     #expect(client.functions.headers.dictionary["Authorization"] == "Bearer legacy-jwt-key")

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -226,4 +226,26 @@ struct SupabaseClientTests {
     // Tracked as a migration-wide risk in SDK-435 for any later phase whose tests exercise
     // `reportIssue`-instrumented production code.
   }
+
+  @Test
+  func functionsOmitsAuthorizationBearerForNewFormatKey() {
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "sb_publishable_abc123"
+    )
+
+    #expect(client.functions.headers.dictionary["Authorization"] == nil)
+    #expect(client.functions.headers.dictionary["Apikey"] == "sb_publishable_abc123")
+  }
+
+  @Test
+  func functionsKeepsAuthorizationBearerForLegacyKey() {
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "legacy-jwt-key"
+    )
+
+    #expect(client.functions.headers.dictionary["Authorization"] == "Bearer legacy-jwt-key")
+    #expect(client.functions.headers.dictionary["Apikey"] == "legacy-jwt-key")
+  }
 }

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -231,7 +231,8 @@ struct SupabaseClientTests {
   func functionsOmitsAuthorizationBearerForNewFormatKey() {
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,
-      supabaseKey: "sb_publishable_abc123"
+      supabaseKey: "sb_publishable_abc123",
+      options: SupabaseClientOptions()
     )
 
     #expect(client.functions.headers.dictionary["Authorization"] == nil)
@@ -242,7 +243,8 @@ struct SupabaseClientTests {
   func functionsKeepsAuthorizationBearerForLegacyKey() {
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,
-      supabaseKey: "legacy-jwt-key"
+      supabaseKey: "legacy-jwt-key",
+      options: SupabaseClientOptions()
     )
 
     #expect(client.functions.headers.dictionary["Authorization"] == "Bearer legacy-jwt-key")


### PR DESCRIPTION
## Summary

Parity with supabase-js for the new Supabase API key format (`sb_publishable_…` / `sb_secret_…`), which are not JWTs and must never be sent as an `Authorization: Bearer` token.

- **[SDK-1328](https://linear.app/supabase/issue/SDK-1328)**: `SupabaseClient` now warns once per unrecognized `sb_`-prefixed key subtype at construction instead of doing nothing (previously there was no key-format handling at all). Never throws — the server, not the SDK, decides key validity. The key value is never logged.
- **[SDK-1329](https://linear.app/supabase/issue/SDK-1329)**: the `Functions` client never falls back to a new-format key as `Authorization: Bearer` — neither at construction (headers built with `Authorization` stripped) nor on auth state changes (`handleTokenChanged`). A genuine session JWT is still sent normally. Legacy JWT keys and Realtime are unaffected — this fix is scoped to Functions only, matching supabase-js's own scoping.

Reference implementations: supabase-js commits `c23e1ab3` and `558c1f5`.

## Changes

- `Sources/Helpers/APIKeyFormat.swift` (new): shared key classification (`isNew`), warn-once dedup logic (`checkFormat`/`shouldWarn`), and the Functions Bearer-suppression decision (`functionsBearerToken`).
- `Sources/Supabase/SupabaseClient.swift`: calls `APIKeyFormat.checkFormat` at init; `functions` getter omits `Authorization` for new-format keys; `handleTokenChanged` routes `functions.setAuth` through `functionsBearerToken`.
- Tests added in `Tests/HelpersTests/APIKeyFormatTests.swift` and `Tests/SupabaseTests/SupabaseClientTests.swift`.

## Test plan

- [x] `swift build` — clean
- [x] `swift test --filter HelpersTests` — passes, incl. new `APIKeyFormatTests`
- [x] `swift test --filter SupabaseTests` — passes, incl. new Functions-header tests
- [x] `./scripts/format.sh` run