### PR TITLE
fix(realtime): invalidate dedicated session when connect fails before opening

### DIFF
--- a/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift
+++ b/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift
@@ -96,6 +96,10 @@ final class URLSessionWebSocket: WebSocket {
             reason: Data("abnormal close".utf8)
           )
         } else if let error {
+          // No `URLSessionWebSocket` was ever created to own this session (connection
+          // failed before `onWebSocketTaskOpened`), so invalidate it here — otherwise
+          // it (and its task/delegate) leak.
+          session.finishTasksAndInvalidate()
           $0.continuation.resume(
             throwing: WebSocketError.connection(
               message: "connection ended unexpectedly",


### PR DESCRIPTION
## Summary

Follow-up to #1123 (already merged) addressing a Copilot review comment that got lost in the shuffle when the PR branch was rebased/merged: [`onComplete`](https://github.com/supabase/supabase-swift/blob/main/Sources/RealtimeV2/WebSocket/URLSessionWebSocket.swift)'s error path resumed the connection's continuation without invalidating the dedicated `URLSession` it had created.

When a connection fails before `onWebSocketTaskOpened` fires (e.g. TLS handshake/cert rejection, network error before upgrade), no `URLSessionWebSocket` instance is ever created — so nothing owns calling `finishTasksAndInvalidate()` on the dedicated session. It (and its task/delegate) leaked.

Fix: call `session.finishTasksAndInvalidate()` in that branch before resuming the continuation. `session` here is the callback's own parameter — it's the dedicated session itself, so no extra capture is needed.

## Test plan

- [x] `swift build`
- [x] `swift test --filter RealtimeTests` — all pass
- [x] `./scripts/format.sh`, `./scripts/spell-check.sh` clean