### PR TITLE
fix: drop unverifiable symbols from sdk-compliance.yaml

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -118,7 +118,6 @@ features:
     status: implemented
     symbols:
       - AuthMFA.enroll
-      - AuthMFA.enrollWebAuthnFactor
   auth.mfa.challenge:
     status: implemented
     symbols:
@@ -127,7 +126,6 @@ features:
     status: implemented
     symbols:
       - AuthMFA.verify
-      - AuthMFA.verifyWebAuthnFactor
   auth.mfa.unenroll:
     status: implemented
     symbols:
@@ -179,18 +177,10 @@ features:
   auth.admin.get_provider: not_implemented
   auth.admin.list_providers: not_implemented
 
-  auth.passkey.register_passkey:
-    status: implemented
-    symbols:
-      - AuthClient.registerPasskey
-      - AuthClient.getPasskeyRegistrationOptions
-      - AuthClient.verifyPasskeyRegistration
-  auth.passkey.sign_in_with_passkey:
-    status: implemented
-    symbols:
-      - AuthClient.signInWithPasskey
-      - AuthClient.getPasskeyAuthenticationOptions
-      - AuthClient.verifyPasskeyAuthentication
+  # AuthClient+Passkey.swift methods are all @_spi(Experimental), so the public
+  # symbol graph the compliance scanner reads from never contains them.
+  auth.passkey.register_passkey: implemented
+  auth.passkey.sign_in_with_passkey: implemented
 
   auth.passkey_admin.list_passkeys: not_implemented
   auth.passkey_admin.delete_passkey: not_implemented
@@ -422,7 +412,6 @@ features:
     status: implemented
     symbols:
       - BroadcastJoinConfig.replicationReady
-      - BroadcastJoinConfig.encode
   realtime.subscriptions.postgres_changes: implemented
   realtime.subscriptions.subscribe_presence: implemented
   realtime.subscriptions.postgres_changes_filter:


### PR DESCRIPTION
## Summary

Fixes the capability-matrix drift warning from https://github.com/supabase/supabase-swift/pull/1094#issuecomment-5026054957.

All flagged symbols actually exist in the codebase — the drift is a false positive in how the compliance scanner extracts the symbol graph:

```
swift package dump-symbol-graph --minimum-access-level public --skip-synthesized-members
```

- `--minimum-access-level public` excludes `@_spi(Experimental)` declarations, which is what every method in `AuthClient+Passkey.swift` and the WebAuthn MFA helpers (`AuthMFA+WebAuthn.swift`) is marked with.
- `--skip-synthesized-members` excludes compiler-synthesized `Codable` members, which is what `BroadcastJoinConfig.encode(to:)` is (no hand-written `encode` method — it's synthesized from the `Codable` conformance).

None of these symbols can ever show up in the scanned symbol graph, so listing them in `sdk-compliance.yaml` produces permanent false-positive drift. This PR removes them:

- `auth.mfa.enroll` / `auth.mfa.verify`: drop the SPI-only WebAuthn variants, keep the existing public `AuthMFA.enroll` / `AuthMFA.verify` symbols that already justify `implemented`.
- `auth.passkey.register_passkey` / `auth.passkey.sign_in_with_passkey`: all underlying symbols are SPI-only, so switch to the plain `implemented` shorthand (same pattern already used elsewhere in this file for capabilities without verifiable symbols).
- `realtime.subscriptions.broadcast`: drop `BroadcastJoinConfig.encode`, keep `BroadcastJoinConfig.replicationReady` which is a real (non-synthesized) member.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('sdk-compliance.yaml'))"` — valid YAML
- [x] Manually confirmed each removed symbol is real in source but unreachable by the scanner's flags (`@_spi(Experimental)` or synthesized `Codable` member)