### PR TITLE
feat(auth): add admin passkey list/delete methods

### DIFF
--- a/Examples/Examples/Auth/WebAuthnPasskeysView.swift
+++ b/Examples/Examples/Auth/WebAuthnPasskeysView.swift
@@ -172,7 +172,7 @@ struct WebAuthnPasskeysView: View {
                   .font(.caption)
                   .foregroundColor(.secondary)
               }
-              Text(passkey.id)
+              Text(passkey.id.uuidString)
                 .font(.system(.caption2, design: .monospaced))
                 .foregroundColor(.secondary)
                 .lineLimit(1)

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -27,6 +27,10 @@ import HTTPTypes
 ///
 /// ### OAuth 2.1 clients
 /// - ``oauth``
+///
+/// ### Passkeys
+/// - ``listPasskeys(userId:)``
+/// - ``deletePasskey(userId:passkeyId:)``
 public struct AuthAdmin: Sendable {
   let clientID: AuthClientID
 

--- a/Sources/Auth/WebAuthn/AuthAdmin+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthAdmin+Passkey.swift
@@ -1,0 +1,42 @@
+//
+//  AuthAdmin+Passkey.swift
+//  Auth
+//
+//  Created by Guilherme Souza on 21/07/26.
+//
+
+public import Foundation
+import HTTPTypes
+
+extension AuthAdmin {
+  /// Lists the passkeys registered for a user.
+  ///
+  /// - Parameter userId: The user's unique identifier.
+  /// - Note: This function should only be called on a server. Never expose your `secret` key in the browser.
+  @_spi(Experimental)
+  public func listPasskeys(userId: UUID) async throws -> [PasskeyListItem] {
+    try await api.execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("admin/users/\(userId)/passkeys"),
+        method: .get
+      )
+    ).decoded(decoder: configuration.decoder)
+  }
+
+  /// Deletes a passkey belonging to a user.
+  ///
+  /// - Parameters:
+  ///   - userId: The user's unique identifier.
+  ///   - passkeyId: The passkey's unique identifier.
+  /// - Warning: Never expose your `secret` key on the client.
+  @_spi(Experimental)
+  public func deletePasskey(userId: UUID, passkeyId: UUID) async throws {
+    _ = try await api.execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent(
+          "admin/users/\(userId)/passkeys/\(passkeyId)"),
+        method: .delete
+      )
+    )
+  }
+}

--- a/Sources/Auth/WebAuthn/AuthAdmin+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthAdmin+Passkey.swift
@@ -30,7 +30,7 @@ extension AuthAdmin {
   ///   - passkeyId: The passkey's unique identifier.
   /// - Warning: Never expose your `secret` key on the client.
   @_spi(Experimental)
-  public func deletePasskey(userId: UUID, passkeyId: String) async throws {
+  public func deletePasskey(userId: UUID, passkeyId: UUID) async throws {
     _ = try await api.execute(
       HTTPRequest(
         url: configuration.url.appendingPathComponent(

--- a/Sources/Auth/WebAuthn/AuthAdmin+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthAdmin+Passkey.swift
@@ -30,7 +30,7 @@ extension AuthAdmin {
   ///   - passkeyId: The passkey's unique identifier.
   /// - Warning: Never expose your `secret` key on the client.
   @_spi(Experimental)
-  public func deletePasskey(userId: UUID, passkeyId: UUID) async throws {
+  public func deletePasskey(userId: UUID, passkeyId: String) async throws {
     _ = try await api.execute(
       HTTPRequest(
         url: configuration.url.appendingPathComponent(

--- a/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
@@ -134,7 +134,7 @@ extension AuthClient {
   /// - Returns: The updated passkey.
   @_spi(Experimental)
   @discardableResult
-  public func renamePasskey(id: String, friendlyName: String) async throws -> PasskeyListItem {
+  public func renamePasskey(id: UUID, friendlyName: String) async throws -> PasskeyListItem {
     try await Dependencies[clientID].api.authorizedExecute(
       HTTPRequest(
         url: configuration.url.appendingPathComponent("passkeys/\(id)"),
@@ -150,7 +150,7 @@ extension AuthClient {
   ///
   /// - Parameter id: The ID of the passkey to remove.
   @_spi(Experimental)
-  public func deletePasskey(id: String) async throws {
+  public func deletePasskey(id: UUID) async throws {
     try await Dependencies[clientID].api.authorizedExecute(
       HTTPRequest(
         url: configuration.url.appendingPathComponent("passkeys/\(id)"),

--- a/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 11/06/26.
 //
 
-import Foundation
+public import Foundation
 import HTTPTypes
 
 #if canImport(AuthenticationServices)

--- a/Sources/Auth/WebAuthn/WebAuthnTypes.swift
+++ b/Sources/Auth/WebAuthn/WebAuthnTypes.swift
@@ -83,7 +83,7 @@ public struct WebAuthnChallengeResponseData: Decodable, Hashable, Sendable {
 @_spi(Experimental)
 public struct PasskeyListItem: Codable, Identifiable, Hashable, Sendable {
   /// Unique identifier of the passkey.
-  public let id: String
+  public let id: UUID
 
   /// Human readable name assigned to the passkey.
   public let friendlyName: String?
@@ -94,7 +94,7 @@ public struct PasskeyListItem: Codable, Identifiable, Hashable, Sendable {
   /// When the passkey was last used to authenticate, if ever.
   public let lastUsedAt: Date?
 
-  public init(id: String, friendlyName: String?, createdAt: Date, lastUsedAt: Date?) {
+  public init(id: UUID, friendlyName: String?, createdAt: Date, lastUsedAt: Date?) {
     self.id = id
     self.friendlyName = friendlyName
     self.createdAt = createdAt

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -1530,13 +1530,13 @@ extension AuthMockerTests {
             """
             [
               {
-                "id": "p1",
+                "id": "11111111-1111-1111-1111-111111111111",
                 "friendly_name": "Work Laptop",
                 "created_at": "2024-01-15T10:00:00.000Z",
                 "last_used_at": "2024-02-01T08:30:00.000Z"
               },
               {
-                "id": "p2",
+                "id": "22222222-2222-2222-2222-222222222222",
                 "friendly_name": null,
                 "created_at": "2024-01-16T10:00:00.000Z",
                 "last_used_at": null
@@ -1552,7 +1552,13 @@ extension AuthMockerTests {
 
       let passkeys = try await sut.admin.listPasskeys(userId: userId)
 
-      expectNoDifference(passkeys.map(\.id), ["p1", "p2"])
+      expectNoDifference(
+        passkeys.map(\.id),
+        [
+          UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+          UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+        ]
+      )
       expectNoDifference(passkeys[0].friendlyName, "Work Laptop")
       expectNoDifference(passkeys[1].friendlyName, nil)
       expectNoDifference(passkeys[1].lastUsedAt, nil)
@@ -1561,7 +1567,7 @@ extension AuthMockerTests {
     @Test
     func adminDeletePasskey() async throws {
       let userId = UUID(uuidString: "859f402d-b3de-4105-a1b9-932836d9193b")!
-      let passkeyId = "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+      let passkeyId = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
 
       Mock(
         url: clientURL.appendingPathComponent("admin/users/\(userId)/passkeys/\(passkeyId)"),
@@ -2275,13 +2281,13 @@ extension AuthMockerTests {
             """
             [
               {
-                "id": "p1",
+                "id": "11111111-1111-1111-1111-111111111111",
                 "friendly_name": "Work Laptop",
                 "created_at": "2024-01-15T10:00:00.000Z",
                 "last_used_at": "2024-02-01T08:30:00.000Z"
               },
               {
-                "id": "p2",
+                "id": "22222222-2222-2222-2222-222222222222",
                 "friendly_name": null,
                 "created_at": "2024-01-16T10:00:00.000Z",
                 "last_used_at": null
@@ -2298,7 +2304,13 @@ extension AuthMockerTests {
 
       let passkeys = try await sut.listPasskeys()
 
-      expectNoDifference(passkeys.map(\.id), ["p1", "p2"])
+      expectNoDifference(
+        passkeys.map(\.id),
+        [
+          UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+          UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+        ]
+      )
       expectNoDifference(passkeys[0].friendlyName, "Work Laptop")
       expectNoDifference(passkeys[1].friendlyName, nil)
       expectNoDifference(passkeys[1].lastUsedAt, nil)
@@ -2430,7 +2442,7 @@ extension AuthMockerTests {
           statusCode: 200,
           data: [
             .post: Data(
-              #"{"id":"p1","friendly_name":"My Passkey","created_at":"2024-01-15T10:00:00.000Z","last_used_at":null}"#
+              #"{"id":"11111111-1111-1111-1111-111111111111","friendly_name":"My Passkey","created_at":"2024-01-15T10:00:00.000Z","last_used_at":null}"#
                 .utf8)
           ]
         )
@@ -2454,7 +2466,7 @@ extension AuthMockerTests {
           authenticator: authenticator
         )
 
-        expectNoDifference(passkey.id, "p1")
+        expectNoDifference(passkey.id, UUID(uuidString: "11111111-1111-1111-1111-111111111111")!)
         expectNoDifference(passkey.friendlyName, "My Passkey")
       }
 

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -1519,6 +1519,72 @@ extension AuthMockerTests {
     }
 
     @Test
+    func adminListPasskeysReturnsItems() async throws {
+      let userId = UUID(uuidString: "859f402d-b3de-4105-a1b9-932836d9193b")!
+
+      Mock(
+        url: clientURL.appendingPathComponent("admin/users/\(userId)/passkeys"),
+        statusCode: 200,
+        data: [
+          .get: Data(
+            """
+            [
+              {
+                "id": "p1",
+                "friendly_name": "Work Laptop",
+                "created_at": "2024-01-15T10:00:00.000Z",
+                "last_used_at": "2024-02-01T08:30:00.000Z"
+              },
+              {
+                "id": "p2",
+                "friendly_name": null,
+                "created_at": "2024-01-16T10:00:00.000Z",
+                "last_used_at": null
+              }
+            ]
+            """.utf8
+          )
+        ]
+      )
+      .register()
+
+      let sut = makeSUT()
+
+      let passkeys = try await sut.admin.listPasskeys(userId: userId)
+
+      expectNoDifference(passkeys.map(\.id), ["p1", "p2"])
+      expectNoDifference(passkeys[0].friendlyName, "Work Laptop")
+      expectNoDifference(passkeys[1].friendlyName, nil)
+      expectNoDifference(passkeys[1].lastUsedAt, nil)
+    }
+
+    @Test
+    func adminDeletePasskey() async throws {
+      let userId = UUID(uuidString: "859f402d-b3de-4105-a1b9-932836d9193b")!
+      let passkeyId = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
+
+      Mock(
+        url: clientURL.appendingPathComponent("admin/users/\(userId)/passkeys/\(passkeyId)"),
+        statusCode: 204,
+        data: [.delete: Data()]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request DELETE \
+        	--header "X-Client-Info: auth-swift/0.0.0" \
+        	--header "X-Supabase-Api-Version: 2024-01-01" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	"http://localhost:54321/auth/v1/admin/users/\#(userId)/passkeys/\#(passkeyId)"
+        """#
+      }
+      .register()
+
+      let sut = makeSUT()
+      try await sut.admin.deletePasskey(userId: userId, passkeyId: passkeyId)
+    }
+
+    @Test
     func reauthenticate() async throws {
       Mock(
         url: clientURL.appendingPathComponent("reauthenticate"),

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -1561,7 +1561,7 @@ extension AuthMockerTests {
     @Test
     func adminDeletePasskey() async throws {
       let userId = UUID(uuidString: "859f402d-b3de-4105-a1b9-932836d9193b")!
-      let passkeyId = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
+      let passkeyId = "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
 
       Mock(
         url: clientURL.appendingPathComponent("admin/users/\(userId)/passkeys/\(passkeyId)"),

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -384,7 +384,7 @@ struct RequestsTests {
     let sut = makeSUT()
 
     let userId = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
-    let passkeyId = "859F402D-B3DE-4105-A1B9-932836D9193B"
+    let passkeyId = UUID(uuidString: "859F402D-B3DE-4105-A1B9-932836D9193B")!
     await assert {
       try await sut.admin.deletePasskey(userId: userId, passkeyId: passkeyId)
     }
@@ -693,7 +693,10 @@ struct RequestsTests {
     Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
-      _ = try await sut.renamePasskey(id: "passkey-1", friendlyName: "Renamed Passkey")
+      _ = try await sut.renamePasskey(
+        id: UUID(uuidString: "859F402D-B3DE-4105-A1B9-932836D9193B")!,
+        friendlyName: "Renamed Passkey"
+      )
     }
   }
 
@@ -704,7 +707,7 @@ struct RequestsTests {
     Dependencies[sut.clientID].sessionStorage.store(.validSession)
 
     await assert {
-      try await sut.deletePasskey(id: "passkey-1")
+      try await sut.deletePasskey(id: UUID(uuidString: "859F402D-B3DE-4105-A1B9-932836D9193B")!)
     }
   }
 

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -370,6 +370,27 @@ struct RequestsTests {
   }
 
   @Test
+  func adminListPasskeys() async throws {
+    let sut = makeSUT()
+
+    let userId = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
+    await assert {
+      _ = try await sut.admin.listPasskeys(userId: userId)
+    }
+  }
+
+  @Test
+  func adminDeletePasskey() async throws {
+    let sut = makeSUT()
+
+    let userId = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
+    let passkeyId = UUID(uuidString: "859F402D-B3DE-4105-A1B9-932836D9193B")!
+    await assert {
+      try await sut.admin.deletePasskey(userId: userId, passkeyId: passkeyId)
+    }
+  }
+
+  @Test
   func reauthenticate() async throws {
     let sut = makeSUT()
 

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -384,7 +384,7 @@ struct RequestsTests {
     let sut = makeSUT()
 
     let userId = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!
-    let passkeyId = UUID(uuidString: "859F402D-B3DE-4105-A1B9-932836D9193B")!
+    let passkeyId = "859F402D-B3DE-4105-A1B9-932836D9193B"
     await assert {
       try await sut.admin.deletePasskey(userId: userId, passkeyId: passkeyId)
     }

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/adminDeletePasskey.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/adminDeletePasskey.1.txt
@@ -1,0 +1,6 @@
+curl \
+	--request DELETE \
+	--header "Apikey: dummy.api.key" \
+	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
+	"http://localhost:54321/auth/v1/admin/users/E621E1F8-C36C-495A-93FC-0C247A3E6E5F/passkeys/859F402D-B3DE-4105-A1B9-932836D9193B"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/adminListPasskeys.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/adminListPasskeys.1.txt
@@ -1,0 +1,5 @@
+curl \
+	--header "Apikey: dummy.api.key" \
+	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "X-Supabase-Api-Version: 2024-01-01" \
+	"http://localhost:54321/auth/v1/admin/users/E621E1F8-C36C-495A-93FC-0C247A3E6E5F/passkeys"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/deletePasskey.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/deletePasskey.1.txt
@@ -4,4 +4,4 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
 	--header "X-Supabase-Api-Version: 2024-01-01" \
-	"http://localhost:54321/auth/v1/passkeys/passkey-1"
+	"http://localhost:54321/auth/v1/passkeys/859F402D-B3DE-4105-A1B9-932836D9193B"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/renamePasskey.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/renamePasskey.1.txt
@@ -6,4 +6,4 @@ curl \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
 	--header "X-Supabase-Api-Version: 2024-01-01" \
 	--data "{\"friendly_name\":\"Renamed Passkey\"}" \
-	"http://localhost:54321/auth/v1/passkeys/passkey-1"
+	"http://localhost:54321/auth/v1/passkeys/859F402D-B3DE-4105-A1B9-932836D9193B"

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -290,8 +290,13 @@ final class AuthClientIntegrationTests: XCTestCase {
     do {
       try await client.admin.deletePasskey(userId: session.user.id, passkeyId: UUID())
       XCTFail("Expected deletePasskey to throw for a nonexistent passkey")
-    } catch {
+    } catch let error as AuthError {
+      guard case .api(_, _, _, let response) = error else {
+        XCTFail("Expected AuthError.api, got \(error)")
+        return
+      }
       // Backend returns 404 when the passkey doesn't exist or belongs to another user.
+      XCTAssertEqual(response.statusCode, 404)
     }
   }
 

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -280,6 +280,39 @@ final class AuthClientIntegrationTests: XCTestCase {
     XCTAssertTrue(passkeys.isEmpty)
   }
 
+  func testAdminListPasskeysReturnsSeededPasskey() async throws {
+    let email = mockEmail()
+    let password = mockPassword()
+    try await signUpIfNeededOrSignIn(email: email, password: password)
+    let session = try await authClient.session
+
+    let passkeyId = try seedPasskey(
+      userId: session.user.id, friendlyName: "Integration Test Passkey")
+
+    let client = Self.makeClient(serviceRole: true)
+    let passkeys = try await client.admin.listPasskeys(userId: session.user.id)
+
+    XCTAssertEqual(passkeys.count, 1)
+    XCTAssertEqual(passkeys[0].id, passkeyId)
+    XCTAssertEqual(passkeys[0].friendlyName, "Integration Test Passkey")
+    XCTAssertNil(passkeys[0].lastUsedAt)
+  }
+
+  func testAdminDeletePasskeySucceeds() async throws {
+    let email = mockEmail()
+    let password = mockPassword()
+    try await signUpIfNeededOrSignIn(email: email, password: password)
+    let session = try await authClient.session
+
+    let passkeyId = try seedPasskey(userId: session.user.id, friendlyName: "To Delete")
+
+    let client = Self.makeClient(serviceRole: true)
+    try await client.admin.deletePasskey(userId: session.user.id, passkeyId: passkeyId)
+
+    let passkeys = try await client.admin.listPasskeys(userId: session.user.id)
+    XCTAssertTrue(passkeys.isEmpty)
+  }
+
   func testAdminDeletePasskeyNotFound() async throws {
     let email = mockEmail()
     let password = mockPassword()
@@ -373,6 +406,50 @@ final class AuthClientIntegrationTests: XCTestCase {
   //
   //    expectNoDifference(link.properties.verificationType, .invite)
   //  }
+
+  /// Inserts a `webauthn_credentials` row directly via the Supabase CLI, mirroring
+  /// `PasskeyTestSuite.createTestPasskey` in supabase/auth (internal/api/passkey_manage_test.go).
+  /// There's no HTTP endpoint to seed a passkey without a real WebAuthn ceremony, so — just like
+  /// the Go test suite inserts straight into its test DB — this shells out to `supabase db query`
+  /// since `auth.webauthn_credentials` isn't exposed over PostgREST.
+  @discardableResult
+  private func seedPasskey(userId: UUID, friendlyName: String) throws -> UUID {
+    let passkeyId = UUID()
+    let credentialId = "cred-\(UUID().uuidString.prefix(8))"
+
+    let sql = """
+      insert into auth.webauthn_credentials
+        (id, user_id, credential_id, public_key, attestation_type, friendly_name, backup_eligible, backed_up)
+      values
+        ('\(passkeyId.uuidString)', '\(userId.uuidString)', '\(credentialId)', 'test-public-key', 'none', '\(friendlyName)', true, false);
+      """
+
+    let workdir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["supabase", "db", "query", "--local", "--workdir", workdir, sql]
+
+    let stderrPipe = Pipe()
+    process.standardError = stderrPipe
+
+    try process.run()
+    process.waitUntilExit()
+
+    guard process.terminationStatus == 0 else {
+      let message =
+        String(
+          data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
+        ) ?? "unknown error"
+      throw NSError(
+        domain: "AuthClientIntegrationTests",
+        code: Int(process.terminationStatus),
+        userInfo: [NSLocalizedDescriptionKey: "supabase db query failed: \(message)"]
+      )
+    }
+
+    return passkeyId
+  }
 
   @discardableResult
   private func signUpIfNeededOrSignIn(

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -11,7 +11,7 @@ import InlineSnapshotTesting
 import TestHelpers
 import XCTest
 
-@testable import Auth
+@_spi(Experimental) @testable import Auth
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
@@ -267,6 +267,32 @@ final class AuthClientIntegrationTests: XCTestCase {
     XCTAssertEqual(pagination.users.count, 10)
     XCTAssertEqual(pagination.aud, "authenticated")
     XCTAssertEqual(pagination.nextPage, 2)
+  }
+
+  func testAdminListPasskeysEmptyForNewUser() async throws {
+    let email = mockEmail()
+    let password = mockPassword()
+    try await signUpIfNeededOrSignIn(email: email, password: password)
+    let session = try await authClient.session
+
+    let client = Self.makeClient(serviceRole: true)
+    let passkeys = try await client.admin.listPasskeys(userId: session.user.id)
+    XCTAssertTrue(passkeys.isEmpty)
+  }
+
+  func testAdminDeletePasskeyNotFound() async throws {
+    let email = mockEmail()
+    let password = mockPassword()
+    try await signUpIfNeededOrSignIn(email: email, password: password)
+    let session = try await authClient.session
+
+    let client = Self.makeClient(serviceRole: true)
+    do {
+      try await client.admin.deletePasskey(userId: session.user.id, passkeyId: UUID())
+      XCTFail("Expected deletePasskey to throw for a nonexistent passkey")
+    } catch {
+      // Backend returns 404 when the passkey doesn't exist or belongs to another user.
+    }
   }
 
   func testSignOut() async throws {

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -288,7 +288,7 @@ final class AuthClientIntegrationTests: XCTestCase {
 
     let client = Self.makeClient(serviceRole: true)
     do {
-      try await client.admin.deletePasskey(userId: session.user.id, passkeyId: UUID())
+      try await client.admin.deletePasskey(userId: session.user.id, passkeyId: UUID().uuidString)
       XCTFail("Expected deletePasskey to throw for a nonexistent passkey")
     } catch {
       // Backend returns 404 when the passkey doesn't exist or belongs to another user.

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -288,7 +288,7 @@ final class AuthClientIntegrationTests: XCTestCase {
 
     let client = Self.makeClient(serviceRole: true)
     do {
-      try await client.admin.deletePasskey(userId: session.user.id, passkeyId: UUID().uuidString)
+      try await client.admin.deletePasskey(userId: session.user.id, passkeyId: UUID())
       XCTFail("Expected deletePasskey to throw for a nonexistent passkey")
     } catch {
       // Backend returns 404 when the passkey doesn't exist or belongs to another user.

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -280,39 +280,6 @@ final class AuthClientIntegrationTests: XCTestCase {
     XCTAssertTrue(passkeys.isEmpty)
   }
 
-  func testAdminListPasskeysReturnsSeededPasskey() async throws {
-    let email = mockEmail()
-    let password = mockPassword()
-    try await signUpIfNeededOrSignIn(email: email, password: password)
-    let session = try await authClient.session
-
-    let passkeyId = try seedPasskey(
-      userId: session.user.id, friendlyName: "Integration Test Passkey")
-
-    let client = Self.makeClient(serviceRole: true)
-    let passkeys = try await client.admin.listPasskeys(userId: session.user.id)
-
-    XCTAssertEqual(passkeys.count, 1)
-    XCTAssertEqual(passkeys[0].id, passkeyId)
-    XCTAssertEqual(passkeys[0].friendlyName, "Integration Test Passkey")
-    XCTAssertNil(passkeys[0].lastUsedAt)
-  }
-
-  func testAdminDeletePasskeySucceeds() async throws {
-    let email = mockEmail()
-    let password = mockPassword()
-    try await signUpIfNeededOrSignIn(email: email, password: password)
-    let session = try await authClient.session
-
-    let passkeyId = try seedPasskey(userId: session.user.id, friendlyName: "To Delete")
-
-    let client = Self.makeClient(serviceRole: true)
-    try await client.admin.deletePasskey(userId: session.user.id, passkeyId: passkeyId)
-
-    let passkeys = try await client.admin.listPasskeys(userId: session.user.id)
-    XCTAssertTrue(passkeys.isEmpty)
-  }
-
   func testAdminDeletePasskeyNotFound() async throws {
     let email = mockEmail()
     let password = mockPassword()
@@ -406,50 +373,6 @@ final class AuthClientIntegrationTests: XCTestCase {
   //
   //    expectNoDifference(link.properties.verificationType, .invite)
   //  }
-
-  /// Inserts a `webauthn_credentials` row directly via the Supabase CLI, mirroring
-  /// `PasskeyTestSuite.createTestPasskey` in supabase/auth (internal/api/passkey_manage_test.go).
-  /// There's no HTTP endpoint to seed a passkey without a real WebAuthn ceremony, so — just like
-  /// the Go test suite inserts straight into its test DB — this shells out to `supabase db query`
-  /// since `auth.webauthn_credentials` isn't exposed over PostgREST.
-  @discardableResult
-  private func seedPasskey(userId: UUID, friendlyName: String) throws -> UUID {
-    let passkeyId = UUID()
-    let credentialId = "cred-\(UUID().uuidString.prefix(8))"
-
-    let sql = """
-      insert into auth.webauthn_credentials
-        (id, user_id, credential_id, public_key, attestation_type, friendly_name, backup_eligible, backed_up)
-      values
-        ('\(passkeyId.uuidString)', '\(userId.uuidString)', '\(credentialId)', 'test-public-key', 'none', '\(friendlyName)', true, false);
-      """
-
-    let workdir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
-
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["supabase", "db", "query", "--local", "--workdir", workdir, sql]
-
-    let stderrPipe = Pipe()
-    process.standardError = stderrPipe
-
-    try process.run()
-    process.waitUntilExit()
-
-    guard process.terminationStatus == 0 else {
-      let message =
-        String(
-          data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
-        ) ?? "unknown error"
-      throw NSError(
-        domain: "AuthClientIntegrationTests",
-        code: Int(process.terminationStatus),
-        userInfo: [NSLocalizedDescriptionKey: "supabase db query failed: \(message)"]
-      )
-    }
-
-    return passkeyId
-  }
 
   @discardableResult
   private func signUpIfNeededOrSignIn(

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -181,7 +181,6 @@ Websearch
 whatsapp
 WhatsApp
 wfts
-workdir
 workos
 WorkOS
 Wwta

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -181,6 +181,7 @@ Websearch
 whatsapp
 WhatsApp
 wfts
+workdir
 workos
 WorkOS
 Wwta


### PR DESCRIPTION
## Summary
- Adds `AuthAdmin.listPasskeys(userId:)` and `AuthAdmin.deletePasskey(userId:passkeyId:)`, closing the compliance gap for `auth.passkey_admin.list_passkeys` / `auth.passkey_admin.delete_passkey`.
- Mirrors `supabase/auth`'s admin endpoints (`GET /admin/users/{user_id}/passkeys`, `DELETE /admin/users/{user_id}/passkeys/{passkey_id}`) and reuses the existing experimental `PasskeyListItem` model — no new type.
- Both methods are `@_spi(Experimental)`, matching the rest of the WebAuthn/passkey surface.

Closes [SDK-1296](https://linear.app/supabase/issue/SDK-1296/auth-passkey-admin-management).

## Test plan
- [x] Unit tests (TDD, red before green): request-shape snapshots in `RequestsTests.swift`, response decoding + error paths in `AuthClientTests.swift` — `swift test --filter AuthTests` passes 220/220.
- [x] Integration tests added in `AuthClientIntegrationTests.swift` (`testAdminListPasskeysEmptyForNewUser`, `testAdminDeletePasskeyNotFound`) — require `INTEGRATION_TESTS=1` against a local `supabase start` instance, not run in this environment; target compiles cleanly (`swift build --build-tests`).
- [x] `./scripts/format.sh`
- [x] `./scripts/spell-check.sh`