### PR TITLE
docs(examples): add Sign in with MetaMask (SIWE) example

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		79FEFFC52B078D7900D36347 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FEFFC42B078D7900D36347 /* Models.swift */; };
 		79FEFFC72B078FB000D36347 /* SwiftUIHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FEFFC62B078FB000D36347 /* SwiftUIHelpers.swift */; };
 		79FEFFC92B0797F600D36347 /* AvatarImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FEFFC82B0797F600D36347 /* AvatarImage.swift */; };
+		E23A07C8FCD6A470BA41A3F9 /* metamask-ios-sdk in Frameworks */ = {isa = PBXBuildFile; productRef = 82A0B5B97246DF189941A2A7 /* metamask-ios-sdk */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -121,14 +122,94 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		793D8EAD2E983112006B6969 /* Auth */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Auth; sourceTree = "<group>"; };
-		793D8EB42E983112006B6969 /* Database */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Database; sourceTree = "<group>"; };
-		793D8EBA2E983112006B6969 /* Functions */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Functions; sourceTree = "<group>"; };
-		793D8EC02E983112006B6969 /* Preview Content */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Preview Content"; sourceTree = "<group>"; };
-		793D8EC52E983112006B6969 /* Profile */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Profile; sourceTree = "<group>"; };
-		793D8ECB2E983112006B6969 /* Realtime */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Realtime; sourceTree = "<group>"; };
-		793D8ED02E983112006B6969 /* Storage */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Storage; sourceTree = "<group>"; };
-		793D8F1E2E984184006B6969 /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
+		793D8EAD2E983112006B6969 /* Auth */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		793D8EB42E983112006B6969 /* Database */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Database;
+			sourceTree = "<group>";
+		};
+		793D8EBA2E983112006B6969 /* Functions */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Functions;
+			sourceTree = "<group>";
+		};
+		793D8EC02E983112006B6969 /* Preview Content */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		793D8EC52E983112006B6969 /* Profile */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		793D8ECB2E983112006B6969 /* Realtime */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Realtime;
+			sourceTree = "<group>";
+		};
+		793D8ED02E983112006B6969 /* Storage */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Storage;
+			sourceTree = "<group>";
+		};
+		793D8F1E2E984184006B6969 /* Shared */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +225,7 @@
 				79E2B55A2B97890F0042CD21 /* GoogleSignInSwift in Frameworks */,
 				7962989D2AEBC6F9000AA957 /* SVGView in Frameworks */,
 				79719ECE2ADF26C400737804 /* Supabase in Frameworks */,
+				E23A07C8FCD6A470BA41A3F9 /* metamask-ios-sdk in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -325,6 +407,7 @@
 				79E2B5592B97890F0042CD21 /* GoogleSignInSwift */,
 				79BE42A02D942EFD00B9DDF4 /* Clerk */,
 				795FA98D2DF354B000F67AFF /* FacebookLogin */,
+				82A0B5B97246DF189941A2A7 /* metamask-ios-sdk */,
 			);
 			productName = Examples;
 			productReference = 793895C62954ABFF0044F2B8 /* Examples.app */;
@@ -408,6 +491,7 @@
 				79E2B5562B97890F0042CD21 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				79BE429F2D942EFD00B9DDF4 /* XCRemoteSwiftPackageReference "clerk-ios" */,
 				795FA98C2DF354B000F67AFF /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */,
+				6C93F238922618E376616E2E /* XCRemoteSwiftPackageReference "metamask-ios-sdk" */,
 			);
 			productRefGroup = 793895C72954ABFF0044F2B8 /* Products */;
 			projectDirPath = "";
@@ -922,6 +1006,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		6C93F238922618E376616E2E /* XCRemoteSwiftPackageReference "metamask-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/MetaMask/metamask-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.8.10;
+			};
+		};
 		7956406B2955B3500088A06F /* XCRemoteSwiftPackageReference "swiftui-navigation" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation.git";
@@ -1024,6 +1116,11 @@
 		79FEFFBB2B07874000D36347 /* Supabase */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Supabase;
+		};
+		82A0B5B97246DF189941A2A7 /* metamask-ios-sdk */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6C93F238922618E376616E2E /* XCRemoteSwiftPackageReference "metamask-ios-sdk" */;
+			productName = "metamask-ios-sdk";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Examples/Examples/Auth/AuthExamplesView.swift
+++ b/Examples/Examples/Auth/AuthExamplesView.swift
@@ -110,6 +110,18 @@ struct AuthExamplesView: View {
           )
         }
       }
+
+      #if canImport(UIKit)
+        Section("Web3") {
+          NavigationLink(destination: SignInWithMetaMaskView()) {
+            ExampleRow(
+              title: "Sign in with MetaMask",
+              description: "Sign in with an Ethereum wallet via Sign-In-With-Ethereum (SIWE)",
+              icon: "wallet.pass.fill"
+            )
+          }
+        }
+      #endif
     }
     .navigationTitle("Authentication")
   }

--- a/Examples/Examples/Auth/SignInWithMetaMask.swift
+++ b/Examples/Examples/Auth/SignInWithMetaMask.swift
@@ -103,7 +103,13 @@
     }
 
     private func siweMessage(address: String, chainId: String) -> String {
-      let domain = "supabase.com"
+      // The backend validates this URI against the target Supabase project's Site URL /
+      // Additional Redirect URLs allow-list — it must match something the project owner has
+      // explicitly allowed, or the request is rejected with "invalid_grant". `localhost:3000`
+      // is exempt from the usual https-only requirement and is the same placeholder already
+      // documented for this example's setup (see Examples/README.md) — add
+      // `http://localhost:3000` to your Supabase project's Additional Redirect URLs.
+      let domain = "localhost:3000"
       let nonce = String((0..<12).map { _ in "0123456789abcdef".randomElement()! })
       let issuedAt = ISO8601DateFormatter().string(from: Date())
       let decimalChainId = decimalChainId(from: chainId)
@@ -113,7 +119,7 @@
 
         Sign in to the Supabase Examples app.
 
-        URI: https://\(domain)
+        URI: http://\(domain)
         Version: 1
         Chain ID: \(decimalChainId)
         Nonce: \(nonce)

--- a/Examples/Examples/Auth/SignInWithMetaMask.swift
+++ b/Examples/Examples/Auth/SignInWithMetaMask.swift
@@ -60,7 +60,7 @@
       switch result {
       case .success(let accounts):
         guard let address = accounts.first else {
-          error = RequestError.responseError
+          error = RequestError(from: ["code": -1, "message": "No accounts returned by MetaMask"])
           state = .disconnected
           return
         }
@@ -106,6 +106,7 @@
       let domain = "supabase.com"
       let nonce = String((0..<12).map { _ in "0123456789abcdef".randomElement()! })
       let issuedAt = ISO8601DateFormatter().string(from: Date())
+      let decimalChainId = decimalChainId(from: chainId)
       return """
         \(domain) wants you to sign in with your Ethereum account:
         \(address)
@@ -114,10 +115,17 @@
 
         URI: https://\(domain)
         Version: 1
-        Chain ID: \(chainId)
+        Chain ID: \(decimalChainId)
         Nonce: \(nonce)
         Issued At: \(issuedAt)
         """
+    }
+
+    private func decimalChainId(from chainId: String) -> String {
+      if chainId.hasPrefix("0x"), let value = Int(chainId.dropFirst(2), radix: 16) {
+        return String(value)
+      }
+      return chainId
     }
   }
 

--- a/Examples/Examples/Auth/SignInWithMetaMask.swift
+++ b/Examples/Examples/Auth/SignInWithMetaMask.swift
@@ -1,0 +1,194 @@
+//
+//  SignInWithMetaMask.swift
+//  Examples
+//
+//  Demonstrates signing in with Supabase Auth using a Sign-In-With-Ethereum (SIWE) message
+//  signed by the MetaMask wallet app
+//
+
+#if canImport(UIKit)
+
+  import Auth
+  @preconcurrency import metamask_ios_sdk
+  import SwiftUI
+  import UIKit
+
+  @MainActor
+  @Observable
+  final class SignInWithMetaMaskController {
+    enum State {
+      case disconnected
+      case notInstalled
+      case connecting
+      case connected(address: String, chainId: String)
+      case signing
+      case signedIn(Session)
+    }
+
+    static let appStoreURL = URL(
+      string: "https://apps.apple.com/us/app/metamask-blockchain-wallet/id1438144202"
+    )!
+
+    var state: State = .disconnected
+    var error: Error?
+
+    private let metamaskSDK = MetaMaskSDK.shared(
+      AppMetadata(name: "Supabase Examples", url: "https://supabase.com"),
+      transport: .deeplinking(dappScheme: "com.supabase.swift-examples.metamask"),
+      sdkOptions: nil
+    )
+
+    func handleOpenURL(_ url: URL) {
+      guard url.host == "mmsdk" else { return }
+      metamaskSDK.handleUrl(url)
+    }
+
+    func connect() async {
+      error = nil
+
+      guard let metamaskURL = URL(string: "metamask://"),
+        UIApplication.shared.canOpenURL(metamaskURL)
+      else {
+        state = .notInstalled
+        return
+      }
+
+      state = .connecting
+
+      let result = await metamaskSDK.connect()
+
+      switch result {
+      case .success(let accounts):
+        guard let address = accounts.first else {
+          error = RequestError.responseError
+          state = .disconnected
+          return
+        }
+        state = .connected(address: address, chainId: metamaskSDK.chainId)
+      case .failure(let requestError):
+        error = requestError
+        state = .disconnected
+      }
+    }
+
+    func signIn() async {
+      guard case .connected(let address, let chainId) = state else { return }
+
+      error = nil
+      state = .signing
+
+      let message = siweMessage(address: address, chainId: chainId)
+      let signRequest = EthereumRequest(method: .personalSign, params: [message, address])
+      let signResult = await metamaskSDK.request(signRequest)
+
+      switch signResult {
+      case .success(let signature):
+        do {
+          let session = try await supabase.auth.signInWithWeb3(
+            credentials: Web3Credentials(
+              chain: .ethereum,
+              message: message,
+              signature: signature
+            )
+          )
+          state = .signedIn(session)
+        } catch {
+          self.error = error
+          state = .connected(address: address, chainId: chainId)
+        }
+      case .failure(let requestError):
+        error = requestError
+        state = .connected(address: address, chainId: chainId)
+      }
+    }
+
+    private func siweMessage(address: String, chainId: String) -> String {
+      let domain = "supabase.com"
+      let nonce = String((0..<12).map { _ in "0123456789abcdef".randomElement()! })
+      let issuedAt = ISO8601DateFormatter().string(from: Date())
+      return """
+        \(domain) wants you to sign in with your Ethereum account:
+        \(address)
+
+        Sign in to the Supabase Examples app.
+
+        URI: https://\(domain)
+        Version: 1
+        Chain ID: \(chainId)
+        Nonce: \(nonce)
+        Issued At: \(issuedAt)
+        """
+    }
+  }
+
+  struct SignInWithMetaMaskView: View {
+    @State private var controller = SignInWithMetaMaskController()
+
+    var body: some View {
+      List {
+        Section {
+          Text("Sign in with your Ethereum account using the MetaMask wallet app.")
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+        }
+
+        switch controller.state {
+        case .disconnected:
+          Section {
+            Button("Connect Wallet") {
+              Task { await controller.connect() }
+            }
+          }
+
+        case .notInstalled:
+          Section {
+            Text("MetaMask isn't installed on this device.")
+              .foregroundColor(.secondary)
+            Link("Install MetaMask", destination: SignInWithMetaMaskController.appStoreURL)
+          }
+
+        case .connecting:
+          Section {
+            ProgressView("Connecting to MetaMask...")
+          }
+
+        case .connected(let address, let chainId):
+          Section("Connected") {
+            Text(address).font(.footnote.monospaced())
+            Text("Chain ID: \(chainId)").font(.caption).foregroundColor(.secondary)
+          }
+          Section {
+            Button("Sign In") {
+              Task { await controller.signIn() }
+            }
+          }
+
+        case .signing:
+          Section {
+            ProgressView("Waiting for signature...")
+          }
+
+        case .signedIn(let session):
+          Section("Signed In") {
+            Text(session.user.id.uuidString).font(.footnote.monospaced())
+          }
+        }
+
+        if let error = controller.error {
+          Section {
+            ErrorText(error)
+          }
+        }
+      }
+      .navigationTitle("Sign in with MetaMask")
+      .onOpenURL { controller.handleOpenURL($0) }
+    }
+  }
+
+  #Preview {
+    NavigationStack {
+      SignInWithMetaMaskView()
+    }
+  }
+
+#endif

--- a/Examples/Examples/Info.plist
+++ b/Examples/Examples/Info.plist
@@ -26,6 +26,14 @@
       <string>fb{{ FACEBOOK APP ID }}</string>
     </array>
     </dict>
+	    <dict>
+	      <key>CFBundleTypeRole</key>
+	      <string>Editor</string>
+	      <key>CFBundleURLSchemes</key>
+	      <array>
+	        <string>com.supabase.swift-examples.metamask</string>
+	      </array>
+	    </dict>
 	</array>
 	<key>GIDClientID</key>
 	<string>{{ YOUR_IOS_CLIENT_ID }}</string>
@@ -41,6 +49,7 @@
   <array>
     <string>fbapi</string>
     <string>fb-messenger-share-api</string>
+    <string>metamask</string>
   </array>
 </dict>
 </plist>

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -319,8 +319,9 @@ Apple Sign-In should work out of the box on iOS devices. Ensure:
 
 The Web3 MetaMask sign-in example requires:
 1. **Supabase Configuration**: Enable the `[auth.web3.ethereum]` authentication method in your Supabase project settings
-2. **Physical Device**: Install the [MetaMask Mobile app](https://metamask.io/download/) on a physical test device — the MetaMask app-to-app handoff isn't usable on the iOS Simulator
-3. **App-to-App Deep Linking**: The example reaches MetaMask directly via the MetaMask SDK's deep links, not a browser redirect
+2. **Redirect URL allow-list**: Add `http://localhost:3000` to your Supabase project's Authentication → URL Configuration → Additional Redirect URLs. The signed SIWE message's `URI` is hardcoded to this value in `SignInWithMetaMask.swift` — the backend rejects the message with `invalid_grant` if this exact URL isn't allow-listed on the target project (it does **not** need to be a URL your app actually serves; it's only checked as an allow-listed string)
+3. **Physical Device**: Install the [MetaMask Mobile app](https://metamask.io/download/) on a physical test device — the MetaMask app-to-app handoff isn't usable on the iOS Simulator
+4. **App-to-App Deep Linking**: The example reaches MetaMask directly via the MetaMask SDK's deep links, not a browser redirect
 
 The custom URL scheme `com.supabase.swift-examples.metamask` is already configured in the app's `Info.plist` for the MetaMask SDK callback — no manual setup is needed.
 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -319,10 +319,10 @@ Apple Sign-In should work out of the box on iOS devices. Ensure:
 
 The Web3 MetaMask sign-in example requires:
 1. **Supabase Configuration**: Enable the `[auth.web3.ethereum]` authentication method in your Supabase project settings
-2. **Test Device/Simulator**: Install the [MetaMask Mobile app](https://metamask.io/download/) on your test device or simulator
-3. **Browser Deep Linking**: The example uses Web3 auth which redirects through a browser and returns via app deep links
+2. **Physical Device**: Install the [MetaMask Mobile app](https://metamask.io/download/) on a physical test device — the MetaMask app-to-app handoff isn't usable on the iOS Simulator
+3. **App-to-App Deep Linking**: The example reaches MetaMask directly via the MetaMask SDK's deep links, not a browser redirect
 
-Ensure the custom URL scheme `com.supabase.swift-examples://` is properly configured in the app's `Info.plist` for auth callbacks.
+The custom URL scheme `com.supabase.swift-examples.metamask` is already configured in the app's `Info.plist` for the MetaMask SDK callback — no manual setup is needed.
 
 ## Project Structure
 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -315,6 +315,15 @@ Apple Sign-In should work out of the box on iOS devices. Ensure:
 - Sign in with Apple capability is enabled in Xcode
 - Proper bundle identifier is configured
 
+### Sign in with MetaMask
+
+The Web3 MetaMask sign-in example requires:
+1. **Supabase Configuration**: Enable the `[auth.web3.ethereum]` authentication method in your Supabase project settings
+2. **Test Device/Simulator**: Install the [MetaMask Mobile app](https://metamask.io/download/) on your test device or simulator
+3. **Browser Deep Linking**: The example uses Web3 auth which redirects through a browser and returns via app deep links
+
+Ensure the custom URL scheme `com.supabase.swift-examples://` is properly configured in the app's `Info.plist` for auth callbacks.
+
 ## Project Structure
 
 ```

--- a/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "68a31593121bf823182bc731b17208689dafb38f7cb085035de5e74a0ed41e89",
+  "originHash" : "5e68a3cf2de6edf2abec2dfb983a8393d24cb9fc0b0786db3b5f16fa4672d712",
   "pins" : [
     {
       "identity" : "appauth-ios",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "1ab675fa2551729016b5f222c8c161e0cff1b366",
         "version" : "0.52.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {
@@ -74,6 +83,15 @@
       }
     },
     {
+      "identity" : "metamask-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MetaMask/metamask-ios-sdk",
+      "state" : {
+        "revision" : "924d91bb3e98a5383c3082d6d5ba3ddac9e1c565",
+        "version" : "0.8.10"
+      }
+    },
+    {
       "identity" : "mocker",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/WeTransfer/Mocker",
@@ -89,6 +107,24 @@
       "state" : {
         "revision" : "b694f155907b189bc82e93586695a26f558c742f",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "socket.io-client-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/socketio/socket.io-client-swift",
+      "state" : {
+        "revision" : "42da871d9369f290d6ec4930636c40672143905b",
+        "version" : "16.1.1"
+      }
+    },
+    {
+      "identity" : "starscream",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daltoniam/Starscream",
+      "state" : {
+        "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
+        "version" : "4.0.8"
       }
     },
     {
@@ -179,6 +215,15 @@
       "state" : {
         "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-secp256k1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/21-DOT-DEV/swift-secp256k1.git",
+      "state" : {
+        "revision" : "e70a10e036a55fffea31568f0af92d69b6d449cd",
+        "version" : "0.23.2"
       }
     },
     {

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -29,11 +29,13 @@ cloudflare
 confirmer
 corelibs
 CREDENTIALW
+dapp
 datastructure
 Dedup
 dedup
 dedupe
 decoratee
+deeplinking
 discardable
 dollarsign
 dont
@@ -87,8 +89,10 @@ LinkedIn
 lnbm
 magiclink
 magnifyingglass
+metamask
 metas
 Metas
+mmsdk
 newbucket
 newkey
 niled


### PR DESCRIPTION
## Summary

Stacked on [#1138](<https://github.com/supabase/supabase-swift/pull/1138>) (adds `AuthClient.signInWithWeb3`) — this PR adds an end-to-end example of that API to the `Examples/Examples` demo app.

* Adds the [MetaMask iOS SDK](<https://github.com/MetaMask/metamask-ios-sdk>) (0.8.10) as a package dependency of the existing `Examples` Xcode target — no new target.
* New `Examples/Examples/Auth/SignInWithMetaMask.swift`: connects a real MetaMask wallet, builds a SIWE (EIP-4361) message, gets it signed via `personal_sign`, and calls `AuthClient.signInWithWeb3`.
* Wired into the Auth examples list under a new "Web3" section.
* Ethereum/MetaMask only (no Solana, no WalletConnect) — see the design spec for the reasoning.
* iOS-only (`#if canImport(UIKit)`-gated), matching the existing `SignInWithOAuthViewController` example's platform scoping.

Two non-obvious correctness details worth knowing about, both verified against the MetaMask SDK's real source and this repo's own `signInWithWeb3` backend contract:

* `personal_sign` params are sent as `[message, address]` — the SDK's own `personalSign(message:address:)` convenience method sends the opposite order (`[address, message]`), which contradicts both the JSON-RPC spec and the SDK's own example app. This PR builds the request manually with the correct order.
* The wallet's `chainId` is hex (e.g. `0x1`) but SIWE requires decimal — converted before building the message (caught in review; without this the backend's SIWE parser would reject the message).

## Test plan

- [X] `xcodebuild -workspace Supabase.xcworkspace -scheme Examples -destination 'generic/platform=iOS' build` — `** BUILD SUCCEEDED **`, verified independently multiple times including after the final review fixes.
- [X] Confirmed the two new dependencies (MetaMask SDK + transitive deps) don't affect any other target.

## Manual e2e test

https://github.com/user-attachments/assets/0142124e-3090-4bcb-9108-60ae0df481aa