### PR TITLE
test: align Web3 integration tests with Swift Testing migration

### DIFF
--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -83,8 +83,9 @@ struct AuthClientIntegrationTests {
     }
   }
 
-  func testSignInWithWeb3Solana() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn]) {
+  @Test
+  func signInWithWeb3Solana() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn]) {
       let privateKey = Curve25519.Signing.PrivateKey()
       let address = base58Encode(privateKey.publicKey.rawRepresentation)
       let issuedAt = ISO8601DateFormatter().string(from: Date())
@@ -110,12 +111,13 @@ struct AuthClientIntegrationTests {
         )
       )
 
-      XCTAssertFalse(session.accessToken.isEmpty)
+      #expect(!session.accessToken.isEmpty)
     }
   }
 
-  func testSignInWithWeb3Ethereum() async throws {
-    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn]) {
+  @Test
+  func signInWithWeb3Ethereum() async throws {
+    try await expectAuthChangeEvents([.initialSession, .signedIn]) {
       // Throwaway test-only key, never used outside this test, no funds associated.
       let privateKeyHex = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
       let address = "0x2c7536E3605D9C16a7a3D7b1898e529396a65c23"
@@ -144,12 +146,12 @@ struct AuthClientIntegrationTests {
         )
       )
 
-      XCTAssertFalse(session.accessToken.isEmpty)
+      #expect(!session.accessToken.isEmpty)
     }
   }
 
   //  func testSignUpAndSignInWithPhone() async throws {
-  //    try await XCTAssertAuthChangeEvents([.initialSession, .signedIn, .signedOut, .signedIn]) {
+  //    try await expectAuthChangeEvents([.initialSession, .signedIn, .signedOut, .signedIn]) {
   //      let phone = mockPhoneNumber()
   //      let password = mockPassword()
   //      let metadata: [String: AnyJSON] = [


### PR DESCRIPTION
## Summary

`main`'s \`Linux\`/\`Integration Tests (Linux)\` CI checks have been failing since `signInWithWeb3` merged (#1138) — confirmed by checking the merge commit itself and current `main` tip directly, not something introduced by a later PR.

Root cause: the two Web3 integration tests (`testSignInWithWeb3Solana`/`testSignInWithWeb3Ethereum`) were written against the pre-migration, `XCTestCase`-based version of `AuthClientIntegrationTests.swift`. They landed on `main` around the same time as that file's own "Phase 6: migrate IntegrationTests to Swift Testing" PR, and the two never got reconciled:

- `XCTAssertAuthChangeEvents(...)` — never actually defined anywhere in the repo. The real helper (used by every other test in the file) is `expectAuthChangeEvents(...)`, identical signature.
- `XCTAssertFalse(...)` — no `XCTest` import in this file anymore; every other test uses `#expect(...)`.
- Neither function had `@Test`, and both kept the `testXxx` naming this repo dropped when migrating (per `AGENTS.md`'s testing conventions) — so even past the compile error, neither would have been picked up as a test case by the Swift Testing runner.

`swift build` doesn't compile test targets, which is why this passed silently everywhere except the two CI jobs that actually run `swift test`.

## Changes

- Added `@Test`, dropped the `test` prefix, switched to `expectAuthChangeEvents`/`#expect` — matching every other test in the file exactly.
- No behavior change to the actual sign-in logic, chain fixtures, or SIWE/SIWS message construction.

## Test plan

- [x] `swift build --build-tests` — clean, zero errors (previously: `cannot find 'XCTAssertAuthChangeEvents' in scope`, `cannot find 'XCTAssertFalse' in scope`).
- [x] `./scripts/format.sh`, `./scripts/spell-check.sh` — clean.
- [ ] Full `swift test` execution wasn't verifiable in this environment (unrelated toolchain issue causes a runtime crash on any real network round-trip here, independent of this fix) — CI should confirm the actual Linux/Integration Tests (Linux) jobs go green.