### PR TITLE
test: migrate RealtimeTests to Swift Testing (Phase 7)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -247,7 +247,7 @@ let package = Package(
 // phase lands (see SDK-435).
 let swift6TestTargets: Set<String> = [
   "SupabaseTests", "HelpersTests", "StorageTests", "PostgRESTTests", "AuthTests", "FunctionsTests",
-  "IntegrationTests",
+  "IntegrationTests", "RealtimeTests",
 ]
 
 for target in package.targets {

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -779,12 +779,15 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     _ callback: @escaping @Sendable (any PresenceAction) -> Void
   ) -> RealtimeSubscription {
     guard status != .subscribed && status != .subscribing else {
-      reportIssue(
-        """
-        Cannot add "presence" callbacks for "\(topic)" after `subscribe()`.
-        Please add all your presence callbacks before subscribing to the channel.
-        """
-      )
+      // See the comment on `broadcast(event:message:)` for why this is gated on `isTesting`.
+      if !isTesting {
+        reportIssue(
+          """
+          Cannot add "presence" callbacks for "\(topic)" after `subscribe()`.
+          Please add all your presence callbacks before subscribing to the channel.
+          """
+        )
+      }
       return RealtimeSubscription {}
     }
 
@@ -1056,12 +1059,15 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
     callback: @escaping @Sendable (AnyAction) -> Void
   ) -> RealtimeSubscription {
     guard status != .subscribed && status != .subscribing else {
-      reportIssue(
-        """
-        Cannot add "postgres_changes" callbacks for "\(topic)" after `subscribe()`.
-        Please add all your postgres change callbacks before subscribing to the channel.
-        """
-      )
+      // See the comment on `broadcast(event:message:)` for why this is gated on `isTesting`.
+      if !isTesting {
+        reportIssue(
+          """
+          Cannot add "postgres_changes" callbacks for "\(topic)" after `subscribe()`.
+          Please add all your postgres change callbacks before subscribing to the channel.
+          """
+        )
+      }
       return RealtimeSubscription {}
     }
 

--- a/Tests/RealtimeTests/CallbackManagerTests.swift
+++ b/Tests/RealtimeTests/CallbackManagerTests.swift
@@ -7,213 +7,244 @@
 
 import ConcurrencyExtras
 import CustomDump
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class CallbackManagerTests: XCTestCase {
-  func testIntegration() {
-    let callbackManager = CallbackManager()
-    XCTAssertNoLeak(callbackManager)
+@Suite
+struct CallbackManagerTests {
+  @Test
+  func integration() {
+    weak var weakCallbackManager: CallbackManager?
 
-    let filter = PostgresJoinConfig(
-      event: .update,
-      schema: "public",
-      table: "users",
-      filter: nil,
-      id: 1
-    )
+    do {
+      let callbackManager = CallbackManager()
+      weakCallbackManager = callbackManager
 
-    XCTAssertEqual(
-      callbackManager.addBroadcastCallback(event: "UPDATE") { _ in },
-      1
-    )
-
-    XCTAssertEqual(
-      callbackManager.addPostgresCallback(filter: filter) { _ in },
-      2
-    )
-
-    XCTAssertEqual(callbackManager.addPresenceCallback { _ in }, 3)
-
-    XCTAssertEqual(callbackManager.callbacks.count, 3)
-
-    callbackManager.removeCallback(id: 2)
-    callbackManager.removeCallback(id: 3)
-
-    XCTAssertEqual(callbackManager.callbacks.count, 1)
-    XCTAssertFalse(
-      callbackManager.callbacks
-        .contains(where: { $0.id == 2 || $0.id == 3 })
-    )
-  }
-
-  func testSetServerChanges() {
-    let callbackManager = CallbackManager()
-    XCTAssertNoLeak(callbackManager)
-
-    let changes = [
-      PostgresJoinConfig(
+      let filter = PostgresJoinConfig(
         event: .update,
         schema: "public",
         table: "users",
         filter: nil,
         id: 1
       )
-    ]
 
-    callbackManager.setServerChanges(changes: changes)
+      #expect(
+        callbackManager.addBroadcastCallback(event: "UPDATE") { _ in } == 1
+      )
 
-    XCTAssertEqual(callbackManager.serverChanges, changes)
+      #expect(
+        callbackManager.addPostgresCallback(filter: filter) { _ in } == 2
+      )
+
+      #expect(callbackManager.addPresenceCallback { _ in } == 3)
+
+      #expect(callbackManager.callbacks.count == 3)
+
+      callbackManager.removeCallback(id: 2)
+      callbackManager.removeCallback(id: 3)
+
+      #expect(callbackManager.callbacks.count == 1)
+      #expect(
+        !callbackManager.callbacks
+          .contains(where: { $0.id == 2 || $0.id == 3 })
+      )
+    }
+
+    #expect(weakCallbackManager == nil)
   }
 
-  func testTriggerPostgresChanges() {
-    let callbackManager = CallbackManager()
-    XCTAssertNoLeak(callbackManager)
+  @Test
+  func setServerChanges() {
+    weak var weakCallbackManager: CallbackManager?
 
-    let updateUsersFilter = PostgresJoinConfig(
-      event: .update,
-      schema: "public",
-      table: "users",
-      filter: nil,
-      id: 1
-    )
-    let insertUsersFilter = PostgresJoinConfig(
-      event: .insert,
-      schema: "public",
-      table: "users",
-      filter: nil,
-      id: 2
-    )
-    let anyUsersFilter = PostgresJoinConfig(
-      event: .all,
-      schema: "public",
-      table: "users",
-      filter: nil,
-      id: 3
-    )
-    let deleteSpecificUserFilter = PostgresJoinConfig(
-      event: .delete,
-      schema: "public",
-      table: "users",
-      filter: "id=1",
-      id: 4
-    )
+    do {
+      let callbackManager = CallbackManager()
+      weakCallbackManager = callbackManager
 
-    callbackManager.setServerChanges(changes: [
-      updateUsersFilter,
-      insertUsersFilter,
-      anyUsersFilter,
-      deleteSpecificUserFilter,
-    ])
+      let changes = [
+        PostgresJoinConfig(
+          event: .update,
+          schema: "public",
+          table: "users",
+          filter: nil,
+          id: 1
+        )
+      ]
 
-    let receivedActions = LockIsolated<[AnyAction]>([])
-    let updateUsersId = callbackManager.addPostgresCallback(filter: updateUsersFilter) { action in
-      receivedActions.withValue { $0.append(action) }
+      callbackManager.setServerChanges(changes: changes)
+
+      #expect(callbackManager.serverChanges == changes)
     }
 
-    let insertUsersId = callbackManager.addPostgresCallback(filter: insertUsersFilter) { action in
-      receivedActions.withValue { $0.append(action) }
-    }
+    #expect(weakCallbackManager == nil)
+  }
 
-    let anyUsersId = callbackManager.addPostgresCallback(filter: anyUsersFilter) { action in
-      receivedActions.withValue { $0.append(action) }
-    }
+  @Test
+  func triggerPostgresChanges() {
+    weak var weakCallbackManager: CallbackManager?
 
-    let deleteSpecificUserId =
-      callbackManager
-      .addPostgresCallback(filter: deleteSpecificUserFilter) { action in
+    do {
+      let callbackManager = CallbackManager()
+      weakCallbackManager = callbackManager
+
+      let updateUsersFilter = PostgresJoinConfig(
+        event: .update,
+        schema: "public",
+        table: "users",
+        filter: nil,
+        id: 1
+      )
+      let insertUsersFilter = PostgresJoinConfig(
+        event: .insert,
+        schema: "public",
+        table: "users",
+        filter: nil,
+        id: 2
+      )
+      let anyUsersFilter = PostgresJoinConfig(
+        event: .all,
+        schema: "public",
+        table: "users",
+        filter: nil,
+        id: 3
+      )
+      let deleteSpecificUserFilter = PostgresJoinConfig(
+        event: .delete,
+        schema: "public",
+        table: "users",
+        filter: "id=1",
+        id: 4
+      )
+
+      callbackManager.setServerChanges(changes: [
+        updateUsersFilter,
+        insertUsersFilter,
+        anyUsersFilter,
+        deleteSpecificUserFilter,
+      ])
+
+      let receivedActions = LockIsolated<[AnyAction]>([])
+      let updateUsersId = callbackManager.addPostgresCallback(filter: updateUsersFilter) {
+        action in
         receivedActions.withValue { $0.append(action) }
       }
 
-    let currentDate = Date()
+      let insertUsersId = callbackManager.addPostgresCallback(filter: insertUsersFilter) {
+        action in
+        receivedActions.withValue { $0.append(action) }
+      }
 
-    let updateUserAction = UpdateAction(
-      columns: [],
-      commitTimestamp: currentDate,
-      record: ["email": .string("new@mail.com")],
-      oldRecord: ["email": .string("old@mail.com")],
-      rawMessage: RealtimeMessageV2(joinRef: nil, ref: nil, topic: "", event: "", payload: [:])
-    )
-    callbackManager.triggerPostgresChanges(ids: [updateUsersId], data: .update(updateUserAction))
+      let anyUsersId = callbackManager.addPostgresCallback(filter: anyUsersFilter) { action in
+        receivedActions.withValue { $0.append(action) }
+      }
 
-    let insertUserAction = InsertAction(
-      columns: [],
-      commitTimestamp: currentDate,
-      record: ["email": .string("email@mail.com")],
-      rawMessage: RealtimeMessageV2(joinRef: nil, ref: nil, topic: "", event: "", payload: [:])
-    )
-    callbackManager.triggerPostgresChanges(ids: [insertUsersId], data: .insert(insertUserAction))
+      let deleteSpecificUserId =
+        callbackManager
+        .addPostgresCallback(filter: deleteSpecificUserFilter) { action in
+          receivedActions.withValue { $0.append(action) }
+        }
 
-    let anyUserAction = AnyAction.insert(insertUserAction)
-    callbackManager.triggerPostgresChanges(ids: [anyUsersId], data: anyUserAction)
+      let currentDate = Date()
 
-    let deleteSpecificUserAction = DeleteAction(
-      columns: [],
-      commitTimestamp: currentDate,
-      oldRecord: ["id": .string("1234")],
-      rawMessage: RealtimeMessageV2(joinRef: nil, ref: nil, topic: "", event: "", payload: [:])
-    )
-    callbackManager.triggerPostgresChanges(
-      ids: [deleteSpecificUserId],
-      data: .delete(deleteSpecificUserAction)
-    )
+      let updateUserAction = UpdateAction(
+        columns: [],
+        commitTimestamp: currentDate,
+        record: ["email": .string("new@mail.com")],
+        oldRecord: ["email": .string("old@mail.com")],
+        rawMessage: RealtimeMessageV2(joinRef: nil, ref: nil, topic: "", event: "", payload: [:])
+      )
+      callbackManager.triggerPostgresChanges(ids: [updateUsersId], data: .update(updateUserAction))
 
-    expectNoDifference(
-      receivedActions.value,
-      [
-        .update(updateUserAction),
-        anyUserAction,
-        .insert(insertUserAction),
-        anyUserAction,
-        .insert(insertUserAction),
-        .delete(deleteSpecificUserAction),
-      ]
-    )
+      let insertUserAction = InsertAction(
+        columns: [],
+        commitTimestamp: currentDate,
+        record: ["email": .string("email@mail.com")],
+        rawMessage: RealtimeMessageV2(joinRef: nil, ref: nil, topic: "", event: "", payload: [:])
+      )
+      callbackManager.triggerPostgresChanges(ids: [insertUsersId], data: .insert(insertUserAction))
+
+      let anyUserAction = AnyAction.insert(insertUserAction)
+      callbackManager.triggerPostgresChanges(ids: [anyUsersId], data: anyUserAction)
+
+      let deleteSpecificUserAction = DeleteAction(
+        columns: [],
+        commitTimestamp: currentDate,
+        oldRecord: ["id": .string("1234")],
+        rawMessage: RealtimeMessageV2(joinRef: nil, ref: nil, topic: "", event: "", payload: [:])
+      )
+      callbackManager.triggerPostgresChanges(
+        ids: [deleteSpecificUserId],
+        data: .delete(deleteSpecificUserAction)
+      )
+
+      expectNoDifference(
+        receivedActions.value,
+        [
+          .update(updateUserAction),
+          anyUserAction,
+          .insert(insertUserAction),
+          anyUserAction,
+          .insert(insertUserAction),
+          .delete(deleteSpecificUserAction),
+        ]
+      )
+    }
+
+    #expect(weakCallbackManager == nil)
   }
 
-  func testTriggerBroadcast() throws {
-    let callbackManager = CallbackManager()
-    XCTAssertNoLeak(callbackManager)
+  @Test
+  func triggerBroadcast() throws {
+    weak var weakCallbackManager: CallbackManager?
 
-    let event = "new_user"
-    let message = RealtimeMessageV2(
-      joinRef: nil,
-      ref: nil,
-      topic: "realtime:users",
-      event: event,
-      payload: ["email": "mail@example.com"]
-    )
+    do {
+      let callbackManager = CallbackManager()
+      weakCallbackManager = callbackManager
 
-    let jsonObject = try JSONObject(message)
+      let event = "new_user"
+      let message = RealtimeMessageV2(
+        joinRef: nil,
+        ref: nil,
+        topic: "realtime:users",
+        event: event,
+        payload: ["email": "mail@example.com"]
+      )
 
-    // Match exact event
-    let receivedMessage = LockIsolated<JSONObject?>(nil)
-    callbackManager.addBroadcastCallback(event: event) {
-      receivedMessage.setValue($0)
+      let jsonObject = try JSONObject(message)
+
+      // Match exact event
+      let receivedMessage = LockIsolated<JSONObject?>(nil)
+      callbackManager.addBroadcastCallback(event: event) {
+        receivedMessage.setValue($0)
+      }
+      callbackManager.triggerBroadcast(event: event, json: jsonObject)
+      #expect(receivedMessage.value == jsonObject)
+
+      // Match event case-insensitive
+      let caseInsensitiveMessage = LockIsolated<JSONObject?>(nil)
+      callbackManager.addBroadcastCallback(event: event) {
+        caseInsensitiveMessage.setValue($0)
+      }
+      callbackManager.triggerBroadcast(event: "NEW_USER", json: jsonObject)
+      #expect(caseInsensitiveMessage.value == jsonObject)
+
+      // Match any events with wildcard
+      let wildcardReceivedMessage = LockIsolated<JSONObject?>(nil)
+      callbackManager.addBroadcastCallback(event: "*") {
+        wildcardReceivedMessage.setValue($0)
+      }
+      callbackManager.triggerBroadcast(event: event, json: jsonObject)
+      #expect(wildcardReceivedMessage.value == jsonObject)
     }
-    callbackManager.triggerBroadcast(event: event, json: jsonObject)
-    XCTAssertEqual(receivedMessage.value, jsonObject)
 
-    // Match event case-insensitive
-    let caseInsensitiveMessage = LockIsolated<JSONObject?>(nil)
-    callbackManager.addBroadcastCallback(event: event) {
-      caseInsensitiveMessage.setValue($0)
-    }
-    callbackManager.triggerBroadcast(event: "NEW_USER", json: jsonObject)
-    XCTAssertEqual(caseInsensitiveMessage.value, jsonObject)
-
-    // Match any events with wildcard
-    let wildcardReceivedMessage = LockIsolated<JSONObject?>(nil)
-    callbackManager.addBroadcastCallback(event: "*") {
-      wildcardReceivedMessage.setValue($0)
-    }
-    callbackManager.triggerBroadcast(event: event, json: jsonObject)
-    XCTAssertEqual(wildcardReceivedMessage.value, jsonObject)
+    #expect(weakCallbackManager == nil)
   }
 
-  func testTriggerPresenceDiffs() {
+  @Test
+  func triggerPresenceDiffs() {
     let callbackManager = CallbackManager()
 
     let joins = ["user1": PresenceV2(ref: "ref", state: [:])]
@@ -235,7 +266,8 @@ final class CallbackManagerTests: XCTestCase {
     expectNoDifference(receivedAction.value?.leaves, leaves)
   }
 
-  func testTriggerSystem() {
+  @Test
+  func triggerSystem() {
     let callbackManager = CallbackManager()
 
     let receivedMessage = LockIsolated(RealtimeMessageV2?.none)
@@ -247,15 +279,7 @@ final class CallbackManagerTests: XCTestCase {
       message: RealtimeMessageV2(
         joinRef: nil, ref: nil, topic: "test", event: "system", payload: ["status": "ok"]))
 
-    XCTAssertEqual(receivedMessage.value?._eventType, .system)
-    XCTAssertEqual(receivedMessage.value?.status, .ok)
-  }
-}
-
-extension XCTestCase {
-  func XCTAssertNoLeak(_ object: AnyObject, file: StaticString = #file, line: UInt = #line) {
-    addTeardownBlock { [weak object] in
-      XCTAssertNil(object, file: file, line: line)
-    }
+    #expect(receivedMessage.value?._eventType == .system)
+    #expect(receivedMessage.value?.status == .ok)
   }
 }

--- a/Tests/RealtimeTests/ChannelStateManagerTests.swift
+++ b/Tests/RealtimeTests/ChannelStateManagerTests.swift
@@ -1,10 +1,12 @@
 import ConcurrencyExtras
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class ChannelStateManagerTests: XCTestCase {
+@Suite
+struct ChannelStateManagerTests {
   /// Helper that returns a `ChannelStateManager` wired up with controllable
   /// fakes for every injected operation, plus spies so tests can assert what
   /// the state machine did.
@@ -83,20 +85,23 @@ final class ChannelStateManagerTests: XCTestCase {
 
   // MARK: - Initial state
 
-  func testInitialStateIsUnsubscribed() async {
+  @Test
+  func initialStateIsUnsubscribed() async {
     let h = makeHarness()
     let state = await h.sut.state
     guard case .unsubscribed = state else {
-      return XCTFail("Expected .unsubscribed, got \(state)")
+      Issue.record("Expected .unsubscribed, got \(state)")
+      return
     }
 
     let joinRef = await h.sut.joinRef
-    XCTAssertNil(joinRef)
+    #expect(joinRef == nil)
   }
 
   // MARK: - Subscribe
 
-  func testSubscribePushesJoinAndTransitionsOnConfirmation() async throws {
+  @Test
+  func subscribePushesJoinAndTransitionsOnConfirmation() async throws {
     let h = makeHarness()
 
     // Server-side confirmation arrives shortly after the join is pushed.
@@ -113,13 +118,15 @@ final class ChannelStateManagerTests: XCTestCase {
 
     let state = await h.sut.state
     guard case .subscribed = state else {
-      return XCTFail("Expected .subscribed, got \(state)")
+      Issue.record("Expected .subscribed, got \(state)")
+      return
     }
-    XCTAssertEqual(h.joinCallCount.value, 1)
-    XCTAssertEqual(h.lastJoinRef.value, "1")
+    #expect(h.joinCallCount.value == 1)
+    #expect(h.lastJoinRef.value == "1")
   }
 
-  func testSubscribeWhileAlreadySubscribedIsNoOp() async throws {
+  @Test
+  func subscribeWhileAlreadySubscribedIsNoOp() async throws {
     let h = makeHarness()
 
     let confirmer = confirmSubscribeOnJoin(h)
@@ -128,10 +135,11 @@ final class ChannelStateManagerTests: XCTestCase {
 
     try await h.sut.subscribe()
 
-    XCTAssertEqual(h.joinCallCount.value, 1, "Second subscribe should be a no-op")
+    #expect(h.joinCallCount.value == 1, "Second subscribe should be a no-op")
   }
 
-  func testConcurrentSubscribesDedup() async throws {
+  @Test
+  func concurrentSubscribesDedup() async throws {
     let h = makeHarness()
 
     async let first: Void = h.sut.subscribe()
@@ -144,10 +152,11 @@ final class ChannelStateManagerTests: XCTestCase {
     try await first
     try await second
 
-    XCTAssertEqual(h.joinCallCount.value, 1, "Only one phx_join should be pushed")
+    #expect(h.joinCallCount.value == 1, "Only one phx_join should be pushed")
   }
 
-  func testSubscribeRetriesOnTimeoutThenSucceeds() async throws {
+  @Test
+  func subscribeRetriesOnTimeoutThenSucceeds() async throws {
     let h = makeHarness(timeoutInterval: 0.05, maxRetryAttempts: 3)
 
     // Wait for the second join attempt before confirming.
@@ -163,59 +172,67 @@ final class ChannelStateManagerTests: XCTestCase {
 
     let state = await h.sut.state
     guard case .subscribed = state else {
-      return XCTFail("Expected .subscribed, got \(state)")
+      Issue.record("Expected .subscribed, got \(state)")
+      return
     }
-    XCTAssertGreaterThanOrEqual(h.joinCallCount.value, 2)
+    #expect(h.joinCallCount.value >= 2)
   }
 
-  func testSubscribeThrowsAfterMaxRetries() async {
+  @Test
+  func subscribeThrowsAfterMaxRetries() async {
     let h = makeHarness(timeoutInterval: 0.05, maxRetryAttempts: 2)
 
     do {
       try await h.sut.subscribe()
-      XCTFail("Expected subscribe to throw after max retries")
+      Issue.record("Expected subscribe to throw after max retries")
     } catch {
-      XCTAssertTrue(error is RealtimeError)
+      #expect(error is RealtimeError)
     }
 
     let state = await h.sut.state
     guard case .unsubscribed = state else {
-      return XCTFail("State should reset to .unsubscribed after failure, got \(state)")
+      Issue.record("State should reset to .unsubscribed after failure, got \(state)")
+      return
     }
-    XCTAssertEqual(h.joinCallCount.value, 2)
+    #expect(h.joinCallCount.value == 2)
   }
 
-  func testSubscribeFailsWhenSocketCannotConnect() async {
+  @Test
+  func subscribeFailsWhenSocketCannotConnect() async {
     let h = makeHarness(timeoutInterval: 0.2, maxRetryAttempts: 1)
     h.ensureConnected.setValue(false)
 
     do {
       try await h.sut.subscribe()
-      XCTFail("Expected subscribe to throw when socket is not connected")
+      Issue.record("Expected subscribe to throw when socket is not connected")
     } catch {
       // Expected
     }
 
     let state = await h.sut.state
     guard case .unsubscribed = state else {
-      return XCTFail("Expected .unsubscribed, got \(state)")
+      Issue.record("Expected .unsubscribed, got \(state)")
+      return
     }
   }
 
   // MARK: - Unsubscribe
 
-  func testUnsubscribeFromUnsubscribedIsNoOp() async {
+  @Test
+  func unsubscribeFromUnsubscribedIsNoOp() async {
     let h = makeHarness()
     await h.sut.unsubscribe()
 
     let state = await h.sut.state
     guard case .unsubscribed = state else {
-      return XCTFail("Expected .unsubscribed, got \(state)")
+      Issue.record("Expected .unsubscribed, got \(state)")
+      return
     }
-    XCTAssertEqual(h.leaveCallCount.value, 0)
+    #expect(h.leaveCallCount.value == 0)
   }
 
-  func testUnsubscribeFromSubscribedPushesLeaveAndWaitsForClose() async throws {
+  @Test
+  func unsubscribeFromSubscribedPushesLeaveAndWaitsForClose() async throws {
     let h = makeHarness()
 
     let confirmer = confirmSubscribeOnJoin(h)
@@ -226,15 +243,17 @@ final class ChannelStateManagerTests: XCTestCase {
 
     let state = await h.sut.state
     guard case .unsubscribed = state else {
-      return XCTFail("Expected .unsubscribed, got \(state)")
+      Issue.record("Expected .unsubscribed, got \(state)")
+      return
     }
-    XCTAssertEqual(h.leaveCallCount.value, 1)
+    #expect(h.leaveCallCount.value == 1)
 
     let joinRef = await h.sut.joinRef
-    XCTAssertNil(joinRef, "joinRef should be cleared after phx_leave")
+    #expect(joinRef == nil, "joinRef should be cleared after phx_leave")
   }
 
-  func testUnsubscribeWhileSubscribingCancelsSubscribe() async throws {
+  @Test
+  func unsubscribeWhileSubscribingCancelsSubscribe() async throws {
     let h = makeHarness(timeoutInterval: 5.0, maxRetryAttempts: 1)
 
     let subscribeTask = Task { try? await h.sut.subscribe() }
@@ -258,13 +277,15 @@ final class ChannelStateManagerTests: XCTestCase {
 
     let state = await h.sut.state
     guard case .unsubscribed = state else {
-      return XCTFail("Expected .unsubscribed, got \(state)")
+      Issue.record("Expected .unsubscribed, got \(state)")
+      return
     }
   }
 
   // MARK: - Server-close while subscribed
 
-  func testDidReceiveCloseTransitionsToUnsubscribed() async throws {
+  @Test
+  func didReceiveCloseTransitionsToUnsubscribed() async throws {
     let h = makeHarness()
 
     let confirmer = confirmSubscribeOnJoin(h)
@@ -275,22 +296,24 @@ final class ChannelStateManagerTests: XCTestCase {
 
     let state = await h.sut.state
     guard case .unsubscribed = state else {
-      return XCTFail("Expected .unsubscribed, got \(state)")
+      Issue.record("Expected .unsubscribed, got \(state)")
+      return
     }
     let joinRef = await h.sut.joinRef
-    XCTAssertNil(joinRef)
+    #expect(joinRef == nil)
   }
 
   // MARK: - State stream
 
-  func testStateChangesEmitsTransitions() async throws {
+  @Test
+  func stateChangesEmitsTransitions() async throws {
     let h = makeHarness()
 
-    let observerReady = expectation(description: "observer subscribed")
-    let subscribingSeen = expectation(description: "subscribing observed")
-    let subscribedSeen = expectation(description: "subscribed observed")
-    let unsubscribingSeen = expectation(description: "unsubscribing observed")
-    let unsubscribedAfterSubscribe = expectation(description: "unsubscribed observed (final)")
+    let observerReady = LockIsolated(false)
+    let subscribingSeen = LockIsolated(false)
+    let subscribedSeen = LockIsolated(false)
+    let unsubscribingSeen = LockIsolated(false)
+    let unsubscribedAfterSubscribe = LockIsolated(false)
 
     let sawSubscribed = LockIsolated(false)
     let sawUnsubscribing = LockIsolated(false)
@@ -299,23 +322,23 @@ final class ChannelStateManagerTests: XCTestCase {
       for await state in h.sut.stateChanges {
         if !observerReadyFired.value {
           observerReadyFired.setValue(true)
-          observerReady.fulfill()
+          observerReady.setValue(true)
         }
         switch state {
-        case .subscribing: subscribingSeen.fulfill()
+        case .subscribing: subscribingSeen.setValue(true)
         case .subscribed:
           if !sawSubscribed.value {
             sawSubscribed.setValue(true)
-            subscribedSeen.fulfill()
+            subscribedSeen.setValue(true)
           }
         case .unsubscribing:
           if !sawUnsubscribing.value {
             sawUnsubscribing.setValue(true)
-            unsubscribingSeen.fulfill()
+            unsubscribingSeen.setValue(true)
           }
         case .unsubscribed:
           if sawSubscribed.value {
-            unsubscribedAfterSubscribe.fulfill()
+            unsubscribedAfterSubscribe.setValue(true)
             return
           }
         }
@@ -325,7 +348,8 @@ final class ChannelStateManagerTests: XCTestCase {
     // Wait for the observer to actually subscribe to the stream — otherwise
     // fast state transitions below can race ahead of it and the `.subscribing`
     // replay is missed.
-    await fulfillment(of: [observerReady], timeout: 1)
+    let becameReady = await waitUntil(timeout: 1) { observerReady.value }
+    #expect(becameReady, "observer subscribed")
 
     let confirmer = confirmSubscribeOnJoin(h)
     try await h.sut.subscribe()
@@ -333,16 +357,18 @@ final class ChannelStateManagerTests: XCTestCase {
 
     await h.sut.unsubscribe()
 
-    await fulfillment(
-      of: [subscribingSeen, subscribedSeen, unsubscribingSeen, unsubscribedAfterSubscribe],
-      timeout: 2
-    )
+    let sawAllTransitions = await waitUntil(timeout: 2) {
+      subscribingSeen.value && subscribedSeen.value && unsubscribingSeen.value
+        && unsubscribedAfterSubscribe.value
+    }
+    #expect(sawAllTransitions, "expected all state transitions to be observed")
     observer.cancel()
   }
 
   // MARK: - Client changes & pushes
 
-  func testClientChangesAreForwardedToJoinOperation() async throws {
+  @Test
+  func clientChangesAreForwardedToJoinOperation() async throws {
     let h = makeHarness()
     let config = PostgresJoinConfig(event: .insert, schema: "public", table: "users", filter: nil)
     // The channel owns the buffer — the actor reads it through the injected
@@ -361,12 +387,13 @@ final class ChannelStateManagerTests: XCTestCase {
     try await h.sut.subscribe()
     _ = await confirmer.value
 
-    XCTAssertEqual(h.lastJoinChanges.value.count, 1)
-    XCTAssertEqual(h.lastJoinChanges.value.first?.table, "users")
+    #expect(h.lastJoinChanges.value.count == 1)
+    #expect(h.lastJoinChanges.value.first?.table == "users")
   }
 
+  @Test
   @MainActor
-  func testStorePushIfJoinRefMatchesStoresWhenJoinRefMatches() async throws {
+  func storePushIfJoinRefMatchesStoresWhenJoinRefMatches() async throws {
     let h = makeHarness()
     let confirmer = confirmSubscribeOnJoin(h)
     try await h.sut.subscribe()
@@ -379,14 +406,15 @@ final class ChannelStateManagerTests: XCTestCase {
     let push = PushV2(channel: nil, message: message)
 
     let stored = await h.sut.storePushIfJoinRefMatches(push, ref: "r1", joinRef: joinRef)
-    XCTAssertTrue(stored)
+    #expect(stored)
 
     let fetched = await h.sut.removePush(ref: "r1")
-    XCTAssertTrue(fetched === push)
+    #expect(fetched === push)
   }
 
+  @Test
   @MainActor
-  func testStorePushIfJoinRefMatchesSkipsWhenJoinRefChanged() async throws {
+  func storePushIfJoinRefMatchesSkipsWhenJoinRefChanged() async throws {
     let h = makeHarness()
     let confirmer = confirmSubscribeOnJoin(h)
     try await h.sut.subscribe()
@@ -406,14 +434,15 @@ final class ChannelStateManagerTests: XCTestCase {
     let stored = await h.sut.storePushIfJoinRefMatches(
       push, ref: "r1", joinRef: staleJoinRef
     )
-    XCTAssertFalse(stored, "Push from a stale join cycle must not be registered")
+    #expect(!stored, "Push from a stale join cycle must not be registered")
 
     let fetched = await h.sut.removePush(ref: "r1")
-    XCTAssertNil(fetched, "Stale push must not leak into the pushes dict")
+    #expect(fetched == nil, "Stale push must not leak into the pushes dict")
   }
 
+  @Test
   @MainActor
-  func testDidReceiveCloseClearsStoredPushes() async throws {
+  func didReceiveCloseClearsStoredPushes() async throws {
     let h = makeHarness()
     let confirmer = confirmSubscribeOnJoin(h)
     try await h.sut.subscribe()
@@ -429,6 +458,6 @@ final class ChannelStateManagerTests: XCTestCase {
     await h.sut.didReceiveClose()
 
     let fetched = await h.sut.removePush(ref: "r1")
-    XCTAssertNil(fetched, "Pushes should be cleared after didReceiveClose")
+    #expect(fetched == nil, "Pushes should be cleared after didReceiveClose")
   }
 }

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -121,7 +121,8 @@ struct ConnectionManagerTests {
       secondConnectFinished.setValue(true)
     }
 
-    try await Task.sleep(nanoseconds: 50_000_000)
+    let transportCalled = await waitUntil { transportCallCount.value == 1 }
+    #expect(transportCalled, "Transport should be invoked while first connect is in progress")
     #expect(!secondConnectFinished.value)
     #expect(
       transportCallCount.value == 1,

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -1,35 +1,25 @@
 import ConcurrencyExtras
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class ConnectionManagerTests: XCTestCase {
+@Suite
+struct ConnectionManagerTests {
   private enum TestError: LocalizedError {
     case sample
 
     var errorDescription: String? { "sample error" }
   }
 
-  var sut: ConnectionManager!
-  var ws: FakeWebSocket!
+  let ws: FakeWebSocket
   let transportCallCount = LockIsolated(0)
   let lastConnectURL = LockIsolated<URL?>(nil)
   let lastConnectHeaders = LockIsolated<[String: String]?>(nil)
 
-  override func setUp() {
-    super.setUp()
-
-    transportCallCount.setValue(0)
-    lastConnectURL.setValue(nil)
-    lastConnectHeaders.setValue(nil)
+  init() {
     (ws, _) = FakeWebSocket.fakes()
-  }
-
-  override func tearDown() {
-    sut = nil
-    ws = nil
-    super.tearDown()
   }
 
   private func makeSUT(
@@ -47,7 +37,7 @@ final class ConnectionManagerTests: XCTestCase {
         transportCallCount.withValue { $0 += 1 }
         lastConnectURL.setValue(url)
         lastConnectHeaders.setValue(headers)
-        return ws!
+        return ws
       },
       url: url,
       headers: headers,
@@ -57,19 +47,20 @@ final class ConnectionManagerTests: XCTestCase {
     )
   }
 
-  func testConnectTransitionsThroughConnectingAndConnectedStates() async throws {
-    sut = makeSUT(headers: ["apikey": "key"])
+  @Test
+  func connectTransitionsThroughConnectingAndConnectedStates() async throws {
+    let sut = makeSUT(headers: ["apikey": "key"])
 
-    let connectingExpectation = expectation(description: "connecting state observed")
-    let connectedExpectation = expectation(description: "connected state observed")
+    let connectingObserved = LockIsolated(false)
+    let connectedObserved = LockIsolated(false)
 
     let stateObserver = Task {
       for await state in sut.stateChanges {
         switch state {
         case .connecting:
-          connectingExpectation.fulfill()
+          connectingObserved.setValue(true)
         case .connected:
-          connectedExpectation.fulfill()
+          connectedObserved.setValue(true)
           return
         default:
           break
@@ -78,40 +69,45 @@ final class ConnectionManagerTests: XCTestCase {
     }
 
     let initiallyConnected = await sut.connection != nil
-    XCTAssertFalse(initiallyConnected)
+    #expect(!initiallyConnected)
     try await sut.connect()
 
     let isConnected = await sut.connection != nil
-    XCTAssertTrue(isConnected)
-    XCTAssertEqual(transportCallCount.value, 1)
-    XCTAssertEqual(lastConnectURL.value?.absoluteString, "ws://localhost")
-    XCTAssertEqual(lastConnectHeaders.value, ["apikey": "key"])
+    #expect(isConnected)
+    #expect(transportCallCount.value == 1)
+    #expect(lastConnectURL.value?.absoluteString == "ws://localhost")
+    #expect(lastConnectHeaders.value == ["apikey": "key"])
 
-    await fulfillment(of: [connectingExpectation, connectedExpectation], timeout: 1)
+    let observedBoth = await waitUntil(timeout: 1) {
+      connectingObserved.value && connectedObserved.value
+    }
+    #expect(observedBoth)
     stateObserver.cancel()
   }
 
-  func testConnectWhenAlreadyConnectedDoesNotReconnect() async throws {
-    sut = makeSUT()
+  @Test
+  func connectWhenAlreadyConnectedDoesNotReconnect() async throws {
+    let sut = makeSUT()
 
     try await sut.connect()
-    XCTAssertEqual(transportCallCount.value, 1)
+    #expect(transportCallCount.value == 1)
 
     try await sut.connect()
 
     let stillConnected = await sut.connection != nil
-    XCTAssertTrue(stillConnected)
-    XCTAssertEqual(transportCallCount.value, 1, "Second connect should reuse existing connection")
+    #expect(stillConnected)
+    #expect(transportCallCount.value == 1, "Second connect should reuse existing connection")
   }
 
-  func testConnectWhileConnectingWaitsForExistingTask() async throws {
+  @Test
+  func connectWhileConnectingWaitsForExistingTask() async throws {
     let transportCallCount = self.transportCallCount
     let ws = self.ws
-    sut = makeSUT(
+    let sut = makeSUT(
       transport: { _, _ in
         transportCallCount.withValue { $0 += 1 }
         try await Task.sleep(nanoseconds: 200_000_000)
-        return ws!
+        return ws
       }
     )
 
@@ -126,46 +122,49 @@ final class ConnectionManagerTests: XCTestCase {
     }
 
     try await Task.sleep(nanoseconds: 50_000_000)
-    XCTAssertFalse(secondConnectFinished.value)
-    XCTAssertEqual(
-      transportCallCount.value, 1,
+    #expect(!secondConnectFinished.value)
+    #expect(
+      transportCallCount.value == 1,
       "Transport should be invoked only once while first connect is in progress")
 
     _ = try await firstConnect.value
     try await secondConnect.value
 
-    XCTAssertTrue(secondConnectFinished.value)
+    #expect(secondConnectFinished.value)
     let isConnected = await sut.connection != nil
-    XCTAssertTrue(isConnected)
-    XCTAssertEqual(transportCallCount.value, 1)
+    #expect(isConnected)
+    #expect(transportCallCount.value == 1)
   }
 
-  func testDisconnectFromConnectedClosesWebSocketAndUpdatesState() async throws {
-    sut = makeSUT()
+  @Test
+  func disconnectFromConnectedClosesWebSocketAndUpdatesState() async throws {
+    let sut = makeSUT()
     try await sut.connect()
 
     await sut.disconnect(reason: "test reason")
 
     let isConnected = await sut.connection != nil
-    XCTAssertFalse(isConnected)
+    #expect(!isConnected)
     guard case .close(let closeCode, let closeReason)? = ws.sentEvents.last else {
-      return XCTFail("Expected close event to be sent")
+      Issue.record("Expected close event to be sent")
+      return
     }
-    XCTAssertNil(closeCode)
-    XCTAssertEqual(closeReason, "test reason")
+    #expect(closeCode == nil)
+    #expect(closeReason == "test reason")
   }
 
-  func testDisconnectCancelsOngoingConnectionAttempt() async throws {
+  @Test
+  func disconnectCancelsOngoingConnectionAttempt() async throws {
     let wasCancelled = LockIsolated(false)
     let transportCallCount = self.transportCallCount
     let ws = self.ws
 
-    sut = makeSUT(
+    let sut = makeSUT(
       transport: { _, _ in
         transportCallCount.withValue { $0 += 1 }
         return try await withTaskCancellationHandler {
           try await Task.sleep(nanoseconds: 5_000_000_000)
-          return ws!
+          return ws
         } onCancel: {
           wasCancelled.setValue(true)
         }
@@ -180,34 +179,36 @@ final class ConnectionManagerTests: XCTestCase {
     await sut.disconnect(reason: "stop")
 
     await Task.yield()
-    XCTAssertTrue(wasCancelled.value, "Cancellation handler should run when disconnecting")
+    #expect(wasCancelled.value, "Cancellation handler should run when disconnecting")
     let isConnected = await sut.connection != nil
-    XCTAssertFalse(isConnected)
+    #expect(!isConnected)
 
     connectTask.cancel()
   }
 
-  func testHandleErrorInitiatesReconnectAndEventuallyReconnects() async throws {
-    let reconnectingExpectation = expectation(description: "reconnecting state observed")
-    let secondConnectionExpectation = expectation(description: "second connection attempt")
+  @Test
+  func handleErrorInitiatesReconnectAndEventuallyReconnects() async throws {
+    let reconnectingObserved = LockIsolated(false)
+    let secondConnectionObserved = LockIsolated(false)
 
     let connectionCount = LockIsolated(0)
+    let ws = self.ws
 
-    sut = makeSUT(
+    let sut = makeSUT(
       reconnectDelay: 0.01,
       transport: { _, _ in
         connectionCount.withValue { $0 += 1 }
         if connectionCount.value == 2 {
-          secondConnectionExpectation.fulfill()
+          secondConnectionObserved.setValue(true)
         }
-        return self.ws!
+        return ws
       }
     )
 
     let stateObserver = Task {
       for await state in sut.stateChanges {
         if case .reconnecting(_, let reason) = state, reason.contains("sample error") {
-          reconnectingExpectation.fulfill()
+          reconnectingObserved.setValue(true)
           return
         }
       }
@@ -216,32 +217,37 @@ final class ConnectionManagerTests: XCTestCase {
     try await sut.connect()
     await sut.handleError(TestError.sample)
 
-    await fulfillment(of: [reconnectingExpectation, secondConnectionExpectation], timeout: 2)
-    XCTAssertEqual(connectionCount.value, 2, "Reconnection should trigger a second transport call")
+    let observedBoth = await waitUntil(timeout: 2) {
+      reconnectingObserved.value && secondConnectionObserved.value
+    }
+    #expect(observedBoth)
+    #expect(connectionCount.value == 2, "Reconnection should trigger a second transport call")
     let isConnected = await sut.connection != nil
-    XCTAssertTrue(isConnected)
+    #expect(isConnected)
 
     stateObserver.cancel()
   }
 
-  func testHandleCloseUpdatesStateWithoutSendingAnotherCloseFrame() async throws {
-    sut = makeSUT()
+  @Test
+  func handleCloseUpdatesStateWithoutSendingAnotherCloseFrame() async throws {
+    let sut = makeSUT()
     try await sut.connect()
 
     let sentEventsBefore = ws.sentEvents.count
     await sut.handleClose(code: 4001, reason: "server closing")
 
     let isConnected = await sut.connection != nil
-    XCTAssertFalse(isConnected)
-    XCTAssertEqual(
-      ws.sentEvents.count, sentEventsBefore,
+    #expect(!isConnected)
+    #expect(
+      ws.sentEvents.count == sentEventsBefore,
       "handleClose should not send an additional close frame since the remote already closed."
     )
   }
 
-  func testHandleCloseFromStaleConnectionIsIgnored() async throws {
+  @Test
+  func handleCloseFromStaleConnectionIsIgnored() async throws {
     let (staleWS, _) = FakeWebSocket.fakes()
-    sut = makeSUT()
+    let sut = makeSUT()
     try await sut.connect()
 
     // A late .close from a previous socket must not mark the current
@@ -249,64 +255,66 @@ final class ConnectionManagerTests: XCTestCase {
     await sut.handleClose(code: 1006, reason: "stale socket closed", from: staleWS)
 
     let isConnected = await sut.connection != nil
-    XCTAssertTrue(isConnected, "Close from a stale connection should be ignored")
+    #expect(isConnected, "Close from a stale connection should be ignored")
   }
 
-  func testHandleErrorFromStaleConnectionIsIgnored() async throws {
+  @Test
+  func handleErrorFromStaleConnectionIsIgnored() async throws {
     let (staleWS, _) = FakeWebSocket.fakes()
-    sut = makeSUT()
+    let sut = makeSUT()
     try await sut.connect()
 
     await sut.handleError(TestError.sample, from: staleWS)
 
     let isConnected = await sut.connection != nil
-    XCTAssertTrue(isConnected, "Error from a stale connection should be ignored")
-    XCTAssertEqual(
-      transportCallCount.value, 1,
+    #expect(isConnected, "Error from a stale connection should be ignored")
+    #expect(
+      transportCallCount.value == 1,
       "Error from a stale connection should not trigger a reconnect"
     )
   }
 
-  func testHandleErrorFromCurrentConnectionInitiatesReconnect() async throws {
-    sut = makeSUT(reconnectDelay: 0.01)
+  @Test
+  func handleErrorFromCurrentConnectionInitiatesReconnect() async throws {
+    let sut = makeSUT(reconnectDelay: 0.01)
     try await sut.connect()
 
     await sut.handleError(TestError.sample, from: ws)
 
     // Wait for the reconnect to complete.
     let transportCallCount = self.transportCallCount
-    let deadline = Date().addingTimeInterval(5)
-    while transportCallCount.value < 2, Date() < deadline {
-      try await Task.sleep(nanoseconds: 10_000_000)
-    }
+    let reconnected = await waitUntil(timeout: 5) { transportCallCount.value >= 2 }
+    #expect(reconnected)
 
-    XCTAssertEqual(
-      transportCallCount.value, 2,
+    #expect(
+      transportCallCount.value == 2,
       "Error from the current connection should trigger a reconnect"
     )
   }
 
-  func testHandleCloseInitiatesReconnectAndEventuallyReconnects() async throws {
-    let reconnectingExpectation = expectation(description: "reconnecting state observed")
-    let secondConnectionExpectation = expectation(description: "second connection attempt")
+  @Test
+  func handleCloseInitiatesReconnectAndEventuallyReconnects() async throws {
+    let reconnectingObserved = LockIsolated(false)
+    let secondConnectionObserved = LockIsolated(false)
 
     let connectionCount = LockIsolated(0)
+    let ws = self.ws
 
-    sut = makeSUT(
+    let sut = makeSUT(
       reconnectDelay: 0.01,
       transport: { _, _ in
         connectionCount.withValue { $0 += 1 }
         if connectionCount.value == 2 {
-          secondConnectionExpectation.fulfill()
+          secondConnectionObserved.setValue(true)
         }
-        return self.ws!
+        return ws
       }
     )
 
     let stateObserver = Task {
       for await state in sut.stateChanges {
         if case .reconnecting(_, let reason) = state, reason.contains("1001") {
-          reconnectingExpectation.fulfill()
+          reconnectingObserved.setValue(true)
           return
         }
       }
@@ -317,16 +325,20 @@ final class ConnectionManagerTests: XCTestCase {
     // reconnect path. Application-level codes (4000–4999) skip reconnect.
     await sut.handleClose(code: 1001, reason: "server restart")
 
-    await fulfillment(of: [reconnectingExpectation, secondConnectionExpectation], timeout: 2)
-    XCTAssertEqual(connectionCount.value, 2, "Remote close should trigger a reconnection attempt")
+    let observedBoth = await waitUntil(timeout: 2) {
+      reconnectingObserved.value && secondConnectionObserved.value
+    }
+    #expect(observedBoth)
+    #expect(connectionCount.value == 2, "Remote close should trigger a reconnection attempt")
     let isConnected = await sut.connection != nil
-    XCTAssertTrue(isConnected)
+    #expect(isConnected)
 
     stateObserver.cancel()
   }
 
-  func testHandleCloseDoesNotReconnectForApplicationCloseCode() async throws {
-    sut = makeSUT(reconnectDelay: 0.01)
+  @Test
+  func handleCloseDoesNotReconnectForApplicationCloseCode() async throws {
+    let sut = makeSUT(reconnectDelay: 0.01)
     try await sut.connect()
 
     // Application-level close codes (4000–4999) must not trigger automatic
@@ -337,11 +349,11 @@ final class ConnectionManagerTests: XCTestCase {
     // Brief wait to confirm the reconnect task does not fire.
     try await Task.sleep(nanoseconds: 50_000_000)
 
-    XCTAssertEqual(
-      transportCallCount.value, 1,
+    #expect(
+      transportCallCount.value == 1,
       "Application close code (4001) must not trigger reconnect"
     )
     let isConnected = await sut.connection != nil
-    XCTAssertFalse(isConnected, "Connection should be disconnected after application close")
+    #expect(!isConnected, "Connection should be disconnected after application close")
   }
 }

--- a/Tests/RealtimeTests/ExportsTests.swift
+++ b/Tests/RealtimeTests/ExportsTests.swift
@@ -5,28 +5,29 @@
 //  Created by Guilherme Souza on 29/07/25.
 //
 
-import XCTest
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class ExportsTests: XCTestCase {
-  func testHelperImportIsAccessible() {
+@Suite
+struct ExportsTests {
+  @Test
+  func helperImportIsAccessible() {
     // Test that the Helpers module is properly exported
     // This is a simple validation that the @_exported import works
 
     // Test that we can access JSONObject from Helpers via Realtime
     let jsonObject: JSONObject = [:]
-    XCTAssertNotNil(jsonObject)
+    #expect(jsonObject.isEmpty)
 
     // Test that we can access AnyJSON from Helpers via Realtime
     let anyJSON: AnyJSON = .string("test")
-    XCTAssertEqual(anyJSON, .string("test"))
+    #expect(anyJSON == .string("test"))
 
     // Test that we can access ObservationToken from Helpers via Realtime
-    let token = ObservationToken {
+    _ = ObservationToken {
       // Empty cleanup
     }
-    XCTAssertNotNil(token)
   }
 }

--- a/Tests/RealtimeTests/PostgresActionTests.swift
+++ b/Tests/RealtimeTests/PostgresActionTests.swift
@@ -5,12 +5,14 @@
 //  Created by Guilherme Souza on 29/07/25.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class PostgresActionTests: XCTestCase {
+@Suite
+struct PostgresActionTests {
   private let sampleMessage = RealtimeMessageV2(
     joinRef: nil,
     ref: nil,
@@ -27,20 +29,23 @@ final class PostgresActionTests: XCTestCase {
 
   private let sampleDate = Date(timeIntervalSince1970: 1_722_246_000)  // Fixed timestamp for consistency
 
-  func testColumnEquality() {
+  @Test
+  func columnEquality() {
     let column1 = Column(name: "id", type: "int8")
     let column2 = Column(name: "id", type: "int8")
     let column3 = Column(name: "email", type: "text")
 
-    XCTAssertEqual(column1, column2)
-    XCTAssertNotEqual(column1, column3)
+    #expect(column1 == column2)
+    #expect(column1 != column3)
   }
 
-  func testInsertActionEventType() {
-    XCTAssertEqual(InsertAction.eventType, .insert)
+  @Test
+  func insertActionEventType() {
+    #expect(InsertAction.eventType == .insert)
   }
 
-  func testInsertActionProperties() {
+  @Test
+  func insertActionProperties() {
     let record: JSONObject = ["id": .string("123"), "name": .string("John")]
     let insertAction = InsertAction(
       columns: sampleColumns,
@@ -49,17 +54,19 @@ final class PostgresActionTests: XCTestCase {
       rawMessage: sampleMessage
     )
 
-    XCTAssertEqual(insertAction.columns, sampleColumns)
-    XCTAssertEqual(insertAction.commitTimestamp, sampleDate)
-    XCTAssertEqual(insertAction.record, record)
-    XCTAssertEqual(insertAction.rawMessage.topic, "test:table")
+    #expect(insertAction.columns == sampleColumns)
+    #expect(insertAction.commitTimestamp == sampleDate)
+    #expect(insertAction.record == record)
+    #expect(insertAction.rawMessage.topic == "test:table")
   }
 
-  func testUpdateActionEventType() {
-    XCTAssertEqual(UpdateAction.eventType, .update)
+  @Test
+  func updateActionEventType() {
+    #expect(UpdateAction.eventType == .update)
   }
 
-  func testUpdateActionProperties() {
+  @Test
+  func updateActionProperties() {
     let record: JSONObject = ["id": .string("123"), "name": .string("John Updated")]
     let oldRecord: JSONObject = ["id": .string("123"), "name": .string("John")]
 
@@ -71,18 +78,20 @@ final class PostgresActionTests: XCTestCase {
       rawMessage: sampleMessage
     )
 
-    XCTAssertEqual(updateAction.columns, sampleColumns)
-    XCTAssertEqual(updateAction.commitTimestamp, sampleDate)
-    XCTAssertEqual(updateAction.record, record)
-    XCTAssertEqual(updateAction.oldRecord, oldRecord)
-    XCTAssertEqual(updateAction.rawMessage.topic, "test:table")
+    #expect(updateAction.columns == sampleColumns)
+    #expect(updateAction.commitTimestamp == sampleDate)
+    #expect(updateAction.record == record)
+    #expect(updateAction.oldRecord == oldRecord)
+    #expect(updateAction.rawMessage.topic == "test:table")
   }
 
-  func testDeleteActionEventType() {
-    XCTAssertEqual(DeleteAction.eventType, .delete)
+  @Test
+  func deleteActionEventType() {
+    #expect(DeleteAction.eventType == .delete)
   }
 
-  func testDeleteActionProperties() {
+  @Test
+  func deleteActionProperties() {
     let oldRecord: JSONObject = ["id": .string("123"), "name": .string("John")]
 
     let deleteAction = DeleteAction(
@@ -92,17 +101,19 @@ final class PostgresActionTests: XCTestCase {
       rawMessage: sampleMessage
     )
 
-    XCTAssertEqual(deleteAction.columns, sampleColumns)
-    XCTAssertEqual(deleteAction.commitTimestamp, sampleDate)
-    XCTAssertEqual(deleteAction.oldRecord, oldRecord)
-    XCTAssertEqual(deleteAction.rawMessage.topic, "test:table")
+    #expect(deleteAction.columns == sampleColumns)
+    #expect(deleteAction.commitTimestamp == sampleDate)
+    #expect(deleteAction.oldRecord == oldRecord)
+    #expect(deleteAction.rawMessage.topic == "test:table")
   }
 
-  func testAnyActionEventType() {
-    XCTAssertEqual(AnyAction.eventType, .all)
+  @Test
+  func anyActionEventType() {
+    #expect(AnyAction.eventType == .all)
   }
 
-  func testAnyActionInsertCase() {
+  @Test
+  func anyActionInsertCase() {
     let record: JSONObject = ["id": .string("123"), "name": .string("John")]
     let insertAction = InsertAction(
       columns: sampleColumns,
@@ -112,16 +123,17 @@ final class PostgresActionTests: XCTestCase {
     )
 
     let anyAction = AnyAction.insert(insertAction)
-    XCTAssertEqual(anyAction.rawMessage.topic, "test:table")
+    #expect(anyAction.rawMessage.topic == "test:table")
 
     if case .insert(let wrappedAction) = anyAction {
-      XCTAssertEqual(wrappedAction.record, record)
+      #expect(wrappedAction.record == record)
     } else {
-      XCTFail("Expected insert case")
+      Issue.record("Expected insert case")
     }
   }
 
-  func testAnyActionUpdateCase() {
+  @Test
+  func anyActionUpdateCase() {
     let record: JSONObject = ["id": .string("123"), "name": .string("John Updated")]
     let oldRecord: JSONObject = ["id": .string("123"), "name": .string("John")]
 
@@ -134,17 +146,18 @@ final class PostgresActionTests: XCTestCase {
     )
 
     let anyAction = AnyAction.update(updateAction)
-    XCTAssertEqual(anyAction.rawMessage.topic, "test:table")
+    #expect(anyAction.rawMessage.topic == "test:table")
 
     if case .update(let wrappedAction) = anyAction {
-      XCTAssertEqual(wrappedAction.record, record)
-      XCTAssertEqual(wrappedAction.oldRecord, oldRecord)
+      #expect(wrappedAction.record == record)
+      #expect(wrappedAction.oldRecord == oldRecord)
     } else {
-      XCTFail("Expected update case")
+      Issue.record("Expected update case")
     }
   }
 
-  func testAnyActionDeleteCase() {
+  @Test
+  func anyActionDeleteCase() {
     let oldRecord: JSONObject = ["id": .string("123"), "name": .string("John")]
 
     let deleteAction = DeleteAction(
@@ -155,16 +168,17 @@ final class PostgresActionTests: XCTestCase {
     )
 
     let anyAction = AnyAction.delete(deleteAction)
-    XCTAssertEqual(anyAction.rawMessage.topic, "test:table")
+    #expect(anyAction.rawMessage.topic == "test:table")
 
     if case .delete(let wrappedAction) = anyAction {
-      XCTAssertEqual(wrappedAction.oldRecord, oldRecord)
+      #expect(wrappedAction.oldRecord == oldRecord)
     } else {
-      XCTFail("Expected delete case")
+      Issue.record("Expected delete case")
     }
   }
 
-  func testAnyActionEquality() {
+  @Test
+  func anyActionEquality() {
     let record: JSONObject = ["id": .string("123")]
     let insertAction1 = InsertAction(
       columns: sampleColumns,
@@ -182,10 +196,11 @@ final class PostgresActionTests: XCTestCase {
     let anyAction1 = AnyAction.insert(insertAction1)
     let anyAction2 = AnyAction.insert(insertAction2)
 
-    XCTAssertEqual(anyAction1, anyAction2)
+    #expect(anyAction1 == anyAction2)
   }
 
-  func testDecodeRecord() throws {
+  @Test
+  func decodeRecord() throws {
     struct TestRecord: Codable, Equatable {
       let id: String
       let name: String
@@ -209,10 +224,11 @@ final class PostgresActionTests: XCTestCase {
     let decodedRecord = try insertAction.decodeRecord(as: TestRecord.self, decoder: decoder)
 
     let expectedRecord = TestRecord(id: "123", name: "John", email: "john@example.com")
-    XCTAssertEqual(decodedRecord, expectedRecord)
+    #expect(decodedRecord == expectedRecord)
   }
 
-  func testDecodeOldRecord() throws {
+  @Test
+  func decodeOldRecord() throws {
     struct TestRecord: Codable, Equatable {
       let id: String
       let name: String
@@ -233,10 +249,11 @@ final class PostgresActionTests: XCTestCase {
     let decodedOldRecord = try updateAction.decodeOldRecord(as: TestRecord.self, decoder: decoder)
 
     let expectedOldRecord = TestRecord(id: "123", name: "John")
-    XCTAssertEqual(decodedOldRecord, expectedOldRecord)
+    #expect(decodedOldRecord == expectedOldRecord)
   }
 
-  func testDecodeRecordError() {
+  @Test
+  func decodeRecordError() {
     struct TestRecord: Codable {
       let id: Int  // This will cause decode error since we're passing string
       let name: String
@@ -255,6 +272,8 @@ final class PostgresActionTests: XCTestCase {
     )
 
     let decoder = JSONDecoder()
-    XCTAssertThrowsError(try insertAction.decodeRecord(as: TestRecord.self, decoder: decoder))
+    #expect(throws: (any Error).self) {
+      try insertAction.decodeRecord(as: TestRecord.self, decoder: decoder)
+    }
   }
 }

--- a/Tests/RealtimeTests/PostgresJoinConfigTests.swift
+++ b/Tests/RealtimeTests/PostgresJoinConfigTests.swift
@@ -5,13 +5,16 @@
 //  Created by Guilherme Souza on 26/12/23.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class PostgresJoinConfigTests: XCTestCase {
-  func testSameConfigButDifferentIdAreEqual() {
+@Suite
+struct PostgresJoinConfigTests {
+  @Test
+  func sameConfigButDifferentIdAreEqual() {
     let config1 = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -27,67 +30,11 @@ final class PostgresJoinConfigTests: XCTestCase {
       id: 2
     )
 
-    XCTAssertEqual(config1, config2)
+    #expect(config1 == config2)
   }
 
-  func testSameConfigWithGlobEventAreEqual() {
-    let config1 = PostgresJoinConfig(
-      event: .insert,
-      schema: "public",
-      table: "users",
-      filter: "id=1",
-      id: 1
-    )
-    let config2 = PostgresJoinConfig(
-      event: .all,
-      schema: "public",
-      table: "users",
-      filter: "id=1",
-      id: 2
-    )
-
-    XCTAssertEqual(config1, config2)
-  }
-
-  func testNonEqualConfig() {
-    let config1 = PostgresJoinConfig(
-      event: .insert,
-      schema: "public",
-      table: "users",
-      filter: "id=1",
-      id: 1
-    )
-    let config2 = PostgresJoinConfig(
-      event: .update,
-      schema: "public",
-      table: "users",
-      filter: "id=1",
-      id: 2
-    )
-
-    XCTAssertNotEqual(config1, config2)
-  }
-
-  func testSameConfigButDifferentIdHaveEqualHash() {
-    let config1 = PostgresJoinConfig(
-      event: .insert,
-      schema: "public",
-      table: "users",
-      filter: "id=1",
-      id: 1
-    )
-    let config2 = PostgresJoinConfig(
-      event: .insert,
-      schema: "public",
-      table: "users",
-      filter: "id=1",
-      id: 2
-    )
-
-    XCTAssertEqual(config1.hashValue, config2.hashValue)
-  }
-
-  func testSameConfigWithGlobEventHaveDiffHash() {
+  @Test
+  func sameConfigWithGlobEventAreEqual() {
     let config1 = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -103,10 +50,11 @@ final class PostgresJoinConfigTests: XCTestCase {
       id: 2
     )
 
-    XCTAssertNotEqual(config1.hashValue, config2.hashValue)
+    #expect(config1 == config2)
   }
 
-  func testNonEqualConfigHaveDiffHash() {
+  @Test
+  func nonEqualConfig() {
     let config1 = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -122,10 +70,71 @@ final class PostgresJoinConfigTests: XCTestCase {
       id: 2
     )
 
-    XCTAssertNotEqual(config1.hashValue, config2.hashValue)
+    #expect(config1 != config2)
   }
 
-  func testConfigDifferingOnlyBySelectAreEqual() {
+  @Test
+  func sameConfigButDifferentIdHaveEqualHash() {
+    let config1 = PostgresJoinConfig(
+      event: .insert,
+      schema: "public",
+      table: "users",
+      filter: "id=1",
+      id: 1
+    )
+    let config2 = PostgresJoinConfig(
+      event: .insert,
+      schema: "public",
+      table: "users",
+      filter: "id=1",
+      id: 2
+    )
+
+    #expect(config1.hashValue == config2.hashValue)
+  }
+
+  @Test
+  func sameConfigWithGlobEventHaveDiffHash() {
+    let config1 = PostgresJoinConfig(
+      event: .insert,
+      schema: "public",
+      table: "users",
+      filter: "id=1",
+      id: 1
+    )
+    let config2 = PostgresJoinConfig(
+      event: .all,
+      schema: "public",
+      table: "users",
+      filter: "id=1",
+      id: 2
+    )
+
+    #expect(config1.hashValue != config2.hashValue)
+  }
+
+  @Test
+  func nonEqualConfigHaveDiffHash() {
+    let config1 = PostgresJoinConfig(
+      event: .insert,
+      schema: "public",
+      table: "users",
+      filter: "id=1",
+      id: 1
+    )
+    let config2 = PostgresJoinConfig(
+      event: .update,
+      schema: "public",
+      table: "users",
+      filter: "id=1",
+      id: 2
+    )
+
+    #expect(config1.hashValue != config2.hashValue)
+  }
+
+  @Test
+  func configDifferingOnlyBySelectAreEqual() {
     let config1 = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -143,11 +152,12 @@ final class PostgresJoinConfigTests: XCTestCase {
       id: 1
     )
 
-    XCTAssertEqual(config1, config2)
-    XCTAssertEqual(config1.hashValue, config2.hashValue)
+    #expect(config1 == config2)
+    #expect(config1.hashValue == config2.hashValue)
   }
 
-  func testSelectEncodesAsArray() throws {
+  @Test
+  func selectEncodesAsArray() throws {
     let config = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -160,10 +170,11 @@ final class PostgresJoinConfigTests: XCTestCase {
     let data = try JSONEncoder().encode(config)
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
 
-    XCTAssertEqual(jsonObject?["select"] as? [String], ["id", "first_name"])
+    #expect(jsonObject?["select"] as? [String] == ["id", "first_name"])
   }
 
-  func testSelectOmittedWhenNil() throws {
+  @Test
+  func selectOmittedWhenNil() throws {
     let config = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -176,6 +187,6 @@ final class PostgresJoinConfigTests: XCTestCase {
     let data = try JSONEncoder().encode(config)
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
 
-    XCTAssertNil(jsonObject?["select"])
+    #expect(jsonObject?["select"] == nil)
   }
 }

--- a/Tests/RealtimeTests/PresenceActionTests.swift
+++ b/Tests/RealtimeTests/PresenceActionTests.swift
@@ -5,16 +5,19 @@
 //  Created by Guilherme Souza on 29/07/25.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class PresenceActionTests: XCTestCase {
+@Suite
+struct PresenceActionTests {
 
   // MARK: - PresenceV2 Tests
 
-  func testPresenceV2Initialization() {
+  @Test
+  func presenceV2Initialization() {
     let ref = "test_ref_123"
     let state: JSONObject = [
       "user_id": .string("user_123"),
@@ -24,28 +27,30 @@ final class PresenceActionTests: XCTestCase {
 
     let presence = PresenceV2(ref: ref, state: state)
 
-    XCTAssertEqual(presence.ref, ref)
-    XCTAssertEqual(presence.state["user_id"]?.stringValue, "user_123")
-    XCTAssertEqual(presence.state["username"]?.stringValue, "testuser")
-    XCTAssertEqual(presence.state["status"]?.stringValue, "online")
+    #expect(presence.ref == ref)
+    #expect(presence.state["user_id"]?.stringValue == "user_123")
+    #expect(presence.state["username"]?.stringValue == "testuser")
+    #expect(presence.state["status"]?.stringValue == "online")
   }
 
-  func testPresenceV2Hashable() {
+  @Test
+  func presenceV2Hashable() {
     let state: JSONObject = ["key": .string("value")]
     let presence1 = PresenceV2(ref: "ref1", state: state)
     let presence2 = PresenceV2(ref: "ref1", state: state)
     let presence3 = PresenceV2(ref: "ref2", state: state)
 
-    XCTAssertEqual(presence1, presence2)
-    XCTAssertNotEqual(presence1, presence3)
+    #expect(presence1 == presence2)
+    #expect(presence1 != presence3)
 
     let set = Set([presence1, presence2, presence3])
-    XCTAssertEqual(set.count, 2)  // presence1 and presence2 are equal
+    #expect(set.count == 2)  // presence1 and presence2 are equal
   }
 
   // MARK: - PresenceV2 Codable Tests
 
-  func testPresenceV2DecodingValidData() throws {
+  @Test
+  func presenceV2DecodingValidData() throws {
     let jsonData = """
       {
         "metas": [
@@ -62,17 +67,18 @@ final class PresenceActionTests: XCTestCase {
 
     let presence = try JSONDecoder().decode(PresenceV2.self, from: jsonData)
 
-    XCTAssertEqual(presence.ref, "presence_ref_123")
-    XCTAssertEqual(presence.state["user_id"]?.stringValue, "user_456")
-    XCTAssertEqual(presence.state["username"]?.stringValue, "johndoe")
-    XCTAssertEqual(presence.state["status"]?.stringValue, "active")
-    XCTAssertEqual(presence.state["extra_field"]?.stringValue, "extra_value")
+    #expect(presence.ref == "presence_ref_123")
+    #expect(presence.state["user_id"]?.stringValue == "user_456")
+    #expect(presence.state["username"]?.stringValue == "johndoe")
+    #expect(presence.state["status"]?.stringValue == "active")
+    #expect(presence.state["extra_field"]?.stringValue == "extra_value")
 
     // Ensure phx_ref is not in the state
-    XCTAssertNil(presence.state["phx_ref"])
+    #expect(presence.state["phx_ref"] == nil)
   }
 
-  func testPresenceV2DecodingWithMultipleMetas() throws {
+  @Test
+  func presenceV2DecodingWithMultipleMetas() throws {
     // Should use the first meta object
     let jsonData = """
       {
@@ -91,51 +97,54 @@ final class PresenceActionTests: XCTestCase {
 
     let presence = try JSONDecoder().decode(PresenceV2.self, from: jsonData)
 
-    XCTAssertEqual(presence.ref, "first_ref")
-    XCTAssertEqual(presence.state["user_id"]?.stringValue, "first_user")
+    #expect(presence.ref == "first_ref")
+    #expect(presence.state["user_id"]?.stringValue == "first_user")
   }
 
-  func testPresenceV2DecodingMissingMetas() {
+  @Test
+  func presenceV2DecodingMissingMetas() {
     let jsonData = """
       {
         "other_field": "value"
       }
       """.data(using: .utf8)!
 
-    XCTAssertThrowsError(try JSONDecoder().decode(PresenceV2.self, from: jsonData)) { error in
+    #expect {
+      try JSONDecoder().decode(PresenceV2.self, from: jsonData)
+    } throws: { error in
       guard let decodingError = error as? DecodingError,
         case .typeMismatch(let type, let context) = decodingError
       else {
-        XCTFail("Expected DecodingError.typeMismatch, got \(error)")
-        return
+        return false
       }
-
-      XCTAssertTrue(type == JSONObject.self)
-      XCTAssertEqual(context.debugDescription, "A presence should at least have a phx_ref.")
+      return type == JSONObject.self
+        && context.debugDescription == "A presence should at least have a phx_ref."
     }
   }
 
-  func testPresenceV2DecodingEmptyMetas() {
+  @Test
+  func presenceV2DecodingEmptyMetas() {
     let jsonData = """
       {
         "metas": []
       }
       """.data(using: .utf8)!
 
-    XCTAssertThrowsError(try JSONDecoder().decode(PresenceV2.self, from: jsonData)) { error in
+    #expect {
+      try JSONDecoder().decode(PresenceV2.self, from: jsonData)
+    } throws: { error in
       guard let decodingError = error as? DecodingError,
         case .typeMismatch(let type, let context) = decodingError
       else {
-        XCTFail("Expected DecodingError.typeMismatch, got \(error)")
-        return
+        return false
       }
-
-      XCTAssertTrue(type == JSONObject.self)
-      XCTAssertEqual(context.debugDescription, "A presence should at least have a phx_ref.")
+      return type == JSONObject.self
+        && context.debugDescription == "A presence should at least have a phx_ref."
     }
   }
 
-  func testPresenceV2DecodingMissingPhxRef() {
+  @Test
+  func presenceV2DecodingMissingPhxRef() {
     let jsonData = """
       {
         "metas": [
@@ -147,20 +156,21 @@ final class PresenceActionTests: XCTestCase {
       }
       """.data(using: .utf8)!
 
-    XCTAssertThrowsError(try JSONDecoder().decode(PresenceV2.self, from: jsonData)) { error in
+    #expect {
+      try JSONDecoder().decode(PresenceV2.self, from: jsonData)
+    } throws: { error in
       guard let decodingError = error as? DecodingError,
         case .typeMismatch(let type, let context) = decodingError
       else {
-        XCTFail("Expected DecodingError.typeMismatch, got \(error)")
-        return
+        return false
       }
-
-      XCTAssertTrue(type == String.self)
-      XCTAssertEqual(context.debugDescription, "A presence should at least have a phx_ref.")
+      return type == String.self
+        && context.debugDescription == "A presence should at least have a phx_ref."
     }
   }
 
-  func testPresenceV2DecodingNonStringPhxRef() {
+  @Test
+  func presenceV2DecodingNonStringPhxRef() {
     let jsonData = """
       {
         "metas": [
@@ -172,20 +182,21 @@ final class PresenceActionTests: XCTestCase {
       }
       """.data(using: .utf8)!
 
-    XCTAssertThrowsError(try JSONDecoder().decode(PresenceV2.self, from: jsonData)) { error in
+    #expect {
+      try JSONDecoder().decode(PresenceV2.self, from: jsonData)
+    } throws: { error in
       guard let decodingError = error as? DecodingError,
         case .typeMismatch(let type, let context) = decodingError
       else {
-        XCTFail("Expected DecodingError.typeMismatch, got \(error)")
-        return
+        return false
       }
-
-      XCTAssertTrue(type == String.self)
-      XCTAssertEqual(context.debugDescription, "A presence should at least have a phx_ref.")
+      return type == String.self
+        && context.debugDescription == "A presence should at least have a phx_ref."
     }
   }
 
-  func testPresenceV2Encoding() throws {
+  @Test
+  func presenceV2Encoding() throws {
     let state: JSONObject = [
       "user_id": .string("user_789"),
       "status": .string("online"),
@@ -196,14 +207,14 @@ final class PresenceActionTests: XCTestCase {
     let encodedData = try JSONEncoder().encode(presence)
     let decodedDict = try JSONSerialization.jsonObject(with: encodedData) as? [String: Any]
 
-    XCTAssertNotNil(decodedDict)
-    XCTAssertEqual(decodedDict?["phx_ref"] as? String, "test_ref")
+    #expect(decodedDict != nil)
+    #expect(decodedDict?["phx_ref"] as? String == "test_ref")
 
     let stateDict = decodedDict?["state"] as? [String: Any]
-    XCTAssertNotNil(stateDict)
-    XCTAssertEqual(stateDict?["user_id"] as? String, "user_789")
-    XCTAssertEqual(stateDict?["status"] as? String, "online")
-    XCTAssertEqual(stateDict?["count"] as? Int, 42)
+    #expect(stateDict != nil)
+    #expect(stateDict?["user_id"] as? String == "user_789")
+    #expect(stateDict?["status"] as? String == "online")
+    #expect(stateDict?["count"] as? Int == 42)
   }
 
   // MARK: - PresenceV2 decodeState Tests
@@ -214,7 +225,8 @@ final class PresenceActionTests: XCTestCase {
     let age: Int
   }
 
-  func testDecodeStateSuccess() throws {
+  @Test
+  func decodeStateSuccess() throws {
     let state: JSONObject = [
       "id": .string("user_123"),
       "name": .string("John Doe"),
@@ -224,12 +236,13 @@ final class PresenceActionTests: XCTestCase {
 
     let user = try presence.decodeState(as: TestUser.self)
 
-    XCTAssertEqual(user.id, "user_123")
-    XCTAssertEqual(user.name, "John Doe")
-    XCTAssertEqual(user.age, 30)
+    #expect(user.id == "user_123")
+    #expect(user.name == "John Doe")
+    #expect(user.age == 30)
   }
 
-  func testDecodeStateWithCustomDecoder() throws {
+  @Test
+  func decodeStateWithCustomDecoder() throws {
     let customDecoder = JSONDecoder()
     customDecoder.keyDecodingStrategy = .convertFromSnakeCase
 
@@ -248,12 +261,13 @@ final class PresenceActionTests: XCTestCase {
 
     let user = try presence.decodeState(as: SnakeCaseUser.self, decoder: customDecoder)
 
-    XCTAssertEqual(user.userId, "user_456")
-    XCTAssertEqual(user.userName, "Jane Doe")
-    XCTAssertEqual(user.userAge, 25)
+    #expect(user.userId == "user_456")
+    #expect(user.userName == "Jane Doe")
+    #expect(user.userAge == 25)
   }
 
-  func testDecodeStateFailure() {
+  @Test
+  func decodeStateFailure() {
     let state: JSONObject = [
       "id": .string("user_123"),
       "name": .string("John Doe"),
@@ -261,7 +275,9 @@ final class PresenceActionTests: XCTestCase {
     ]
     let presence = PresenceV2(ref: "ref", state: state)
 
-    XCTAssertThrowsError(try presence.decodeState(as: TestUser.self))
+    #expect(throws: (any Error).self) {
+      try presence.decodeState(as: TestUser.self)
+    }
   }
 
   // MARK: - PresenceAction Protocol Extension Tests
@@ -272,7 +288,8 @@ final class PresenceActionTests: XCTestCase {
     let rawMessage: RealtimeMessageV2
   }
 
-  func testDecodeJoinsWithIgnoreOtherTypes() throws {
+  @Test
+  func decodeJoinsWithIgnoreOtherTypes() throws {
     let validState1: JSONObject = [
       "id": .string("user_1"),
       "name": .string("Alice"),
@@ -303,12 +320,13 @@ final class PresenceActionTests: XCTestCase {
 
     // With ignoreOtherTypes = true (default), should return only valid users
     let users = try action.decodeJoins(as: TestUser.self)
-    XCTAssertEqual(users.count, 2)
-    XCTAssertTrue(users.contains(TestUser(id: "user_1", name: "Alice", age: 25)))
-    XCTAssertTrue(users.contains(TestUser(id: "user_2", name: "Bob", age: 30)))
+    #expect(users.count == 2)
+    #expect(users.contains(TestUser(id: "user_1", name: "Alice", age: 25)))
+    #expect(users.contains(TestUser(id: "user_2", name: "Bob", age: 30)))
   }
 
-  func testDecodeJoinsWithoutIgnoreOtherTypes() {
+  @Test
+  func decodeJoinsWithoutIgnoreOtherTypes() {
     let validState: JSONObject = [
       "id": .string("user_1"),
       "name": .string("Alice"),
@@ -332,10 +350,13 @@ final class PresenceActionTests: XCTestCase {
     let action = MockPresenceAction(joins: joins, leaves: [:], rawMessage: rawMessage)
 
     // With ignoreOtherTypes = false, should throw on invalid data
-    XCTAssertThrowsError(try action.decodeJoins(as: TestUser.self, ignoreOtherTypes: false))
+    #expect(throws: (any Error).self) {
+      try action.decodeJoins(as: TestUser.self, ignoreOtherTypes: false)
+    }
   }
 
-  func testDecodeLeavesWithIgnoreOtherTypes() throws {
+  @Test
+  func decodeLeavesWithIgnoreOtherTypes() throws {
     let validState1: JSONObject = [
       "id": .string("user_1"),
       "name": .string("Alice"),
@@ -366,12 +387,13 @@ final class PresenceActionTests: XCTestCase {
 
     // With ignoreOtherTypes = true (default), should return only valid users
     let users = try action.decodeLeaves(as: TestUser.self)
-    XCTAssertEqual(users.count, 2)
-    XCTAssertTrue(users.contains(TestUser(id: "user_1", name: "Alice", age: 25)))
-    XCTAssertTrue(users.contains(TestUser(id: "user_2", name: "Bob", age: 30)))
+    #expect(users.count == 2)
+    #expect(users.contains(TestUser(id: "user_1", name: "Alice", age: 25)))
+    #expect(users.contains(TestUser(id: "user_2", name: "Bob", age: 30)))
   }
 
-  func testDecodeLeavesWithoutIgnoreOtherTypes() {
+  @Test
+  func decodeLeavesWithoutIgnoreOtherTypes() {
     let validState: JSONObject = [
       "id": .string("user_1"),
       "name": .string("Alice"),
@@ -395,10 +417,13 @@ final class PresenceActionTests: XCTestCase {
     let action = MockPresenceAction(joins: [:], leaves: leaves, rawMessage: rawMessage)
 
     // With ignoreOtherTypes = false, should throw on invalid data
-    XCTAssertThrowsError(try action.decodeLeaves(as: TestUser.self, ignoreOtherTypes: false))
+    #expect(throws: (any Error).self) {
+      try action.decodeLeaves(as: TestUser.self, ignoreOtherTypes: false)
+    }
   }
 
-  func testDecodeJoinsWithCustomDecoder() throws {
+  @Test
+  func decodeJoinsWithCustomDecoder() throws {
     let customDecoder = JSONDecoder()
     customDecoder.keyDecodingStrategy = .convertFromSnakeCase
 
@@ -425,13 +450,14 @@ final class PresenceActionTests: XCTestCase {
     }
 
     let users = try action.decodeJoins(as: SnakeCaseUser.self, decoder: customDecoder)
-    XCTAssertEqual(users.count, 1)
-    XCTAssertEqual(users.first?.userId, "user_123")
-    XCTAssertEqual(users.first?.userName, "Test User")
-    XCTAssertEqual(users.first?.userAge, 28)
+    #expect(users.count == 1)
+    #expect(users.first?.userId == "user_123")
+    #expect(users.first?.userName == "Test User")
+    #expect(users.first?.userAge == 28)
   }
 
-  func testDecodeEmptyJoinsAndLeaves() throws {
+  @Test
+  func decodeEmptyJoinsAndLeaves() throws {
     let rawMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "test", event: "test", payload: [:]
     )
@@ -441,13 +467,14 @@ final class PresenceActionTests: XCTestCase {
     let joinUsers = try action.decodeJoins(as: TestUser.self)
     let leaveUsers = try action.decodeLeaves(as: TestUser.self)
 
-    XCTAssertEqual(joinUsers.count, 0)
-    XCTAssertEqual(leaveUsers.count, 0)
+    #expect(joinUsers.count == 0)
+    #expect(leaveUsers.count == 0)
   }
 
   // MARK: - PresenceActionImpl Tests
 
-  func testPresenceActionImplInitialization() {
+  @Test
+  func presenceActionImplInitialization() {
     let joins: [String: PresenceV2] = [
       "user1": PresenceV2(ref: "ref1", state: ["name": .string("User 1")])
     ]
@@ -461,15 +488,16 @@ final class PresenceActionTests: XCTestCase {
 
     let impl = PresenceActionImpl(joins: joins, leaves: leaves, rawMessage: rawMessage)
 
-    XCTAssertEqual(impl.joins.count, 1)
-    XCTAssertEqual(impl.leaves.count, 1)
-    XCTAssertEqual(impl.joins["user1"]?.ref, "ref1")
-    XCTAssertEqual(impl.leaves["user2"]?.ref, "ref2")
-    XCTAssertEqual(impl.rawMessage.topic, "topic")
-    XCTAssertEqual(impl.rawMessage.event, "event")
+    #expect(impl.joins.count == 1)
+    #expect(impl.leaves.count == 1)
+    #expect(impl.joins["user1"]?.ref == "ref1")
+    #expect(impl.leaves["user2"]?.ref == "ref2")
+    #expect(impl.rawMessage.topic == "topic")
+    #expect(impl.rawMessage.event == "event")
   }
 
-  func testPresenceActionImplConformsToProtocol() {
+  @Test
+  func presenceActionImplConformsToProtocol() {
     let rawMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "test", event: "test", payload: [:]
     )
@@ -478,14 +506,15 @@ final class PresenceActionTests: XCTestCase {
 
     // Test that it can be used as PresenceAction
     let presenceAction: any PresenceAction = impl
-    XCTAssertEqual(presenceAction.joins.count, 0)
-    XCTAssertEqual(presenceAction.leaves.count, 0)
-    XCTAssertEqual(presenceAction.rawMessage.topic, "test")
+    #expect(presenceAction.joins.count == 0)
+    #expect(presenceAction.leaves.count == 0)
+    #expect(presenceAction.rawMessage.topic == "test")
   }
 
   // MARK: - Edge Cases and Complex Scenarios
 
-  func testPresenceV2WithComplexNestedState() throws {
+  @Test
+  func presenceV2WithComplexNestedState() throws {
     let complexState: JSONObject = [
       "user": .object([
         "id": .string("123"),
@@ -506,22 +535,23 @@ final class PresenceActionTests: XCTestCase {
 
     let presence = PresenceV2(ref: "complex_ref", state: complexState)
 
-    XCTAssertEqual(presence.ref, "complex_ref")
-    XCTAssertEqual(presence.state["user"]?.objectValue?["id"]?.stringValue, "123")
-    XCTAssertEqual(
-      presence.state["user"]?.objectValue?["profile"]?.objectValue?["name"]?.stringValue,
-      "John"
+    #expect(presence.ref == "complex_ref")
+    #expect(presence.state["user"]?.objectValue?["id"]?.stringValue == "123")
+    #expect(
+      presence.state["user"]?.objectValue?["profile"]?.objectValue?["name"]?.stringValue
+        == "John"
     )
-    XCTAssertEqual(
+    #expect(
       presence.state["user"]?.objectValue?["profile"]?.objectValue?["preferences"]?.objectValue?[
-        "theme"]?.stringValue,
-      "dark"
+        "theme"]?.stringValue
+        == "dark"
     )
-    XCTAssertEqual(presence.state["user"]?.objectValue?["tags"]?.arrayValue?.count, 2)
-    XCTAssertEqual(presence.state["metadata"]?.objectValue?["connection_count"]?.intValue, 3)
+    #expect(presence.state["user"]?.objectValue?["tags"]?.arrayValue?.count == 2)
+    #expect(presence.state["metadata"]?.objectValue?["connection_count"]?.intValue == 3)
   }
 
-  func testPresenceV2RoundTripCoding() throws {
+  @Test
+  func presenceV2RoundTripCoding() throws {
     let originalState: JSONObject = [
       "user_id": .string("user_789"),
       "status": .string("online"),
@@ -548,16 +578,17 @@ final class PresenceActionTests: XCTestCase {
     let serverData = try JSONSerialization.data(withJSONObject: serverFormat)
     let decodedPresence = try JSONDecoder().decode(PresenceV2.self, from: serverData)
 
-    XCTAssertEqual(decodedPresence.ref, originalPresence.ref)
-    XCTAssertEqual(decodedPresence.state["user_id"]?.stringValue, "user_789")
-    XCTAssertEqual(decodedPresence.state["status"]?.stringValue, "online")
-    XCTAssertEqual(decodedPresence.state["score"]?.doubleValue, 98.5)
-    XCTAssertEqual(decodedPresence.state["active"]?.boolValue, true)
-    XCTAssertEqual(decodedPresence.state["tags"]?.arrayValue?.count, 2)
-    XCTAssertNotNil(decodedPresence.state["metadata"]?.objectValue)
+    #expect(decodedPresence.ref == originalPresence.ref)
+    #expect(decodedPresence.state["user_id"]?.stringValue == "user_789")
+    #expect(decodedPresence.state["status"]?.stringValue == "online")
+    #expect(decodedPresence.state["score"]?.doubleValue == 98.5)
+    #expect(decodedPresence.state["active"]?.boolValue == true)
+    #expect(decodedPresence.state["tags"]?.arrayValue?.count == 2)
+    #expect(decodedPresence.state["metadata"]?.objectValue != nil)
   }
 
-  func testPresenceActionWithMixedValidAndInvalidData() throws {
+  @Test
+  func presenceActionWithMixedValidAndInvalidData() throws {
     struct PartialUser: Codable {
       let id: String
       let name: String?
@@ -590,9 +621,9 @@ final class PresenceActionTests: XCTestCase {
 
     // With ignoreOtherTypes = true, should get valid and partial users
     let users = try action.decodeJoins(as: PartialUser.self, ignoreOtherTypes: true)
-    XCTAssertEqual(users.count, 2)
+    #expect(users.count == 2)
 
     let userIds = users.map(\.id).sorted()
-    XCTAssertEqual(userIds, ["partial_user", "valid_user"])
+    #expect(userIds == ["partial_user", "valid_user"])
   }
 }

--- a/Tests/RealtimeTests/PushV2Tests.swift
+++ b/Tests/RealtimeTests/PushV2Tests.swift
@@ -7,7 +7,7 @@
 
 import ConcurrencyExtras
 import Foundation
-import XCTest
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
@@ -16,23 +16,27 @@ import XCTest
   import FoundationNetworking
 #endif
 
-final class PushV2Tests: XCTestCase {
+@Suite
+struct PushV2Tests {
 
-  func testPushStatusValues() {
-    XCTAssertEqual(PushStatus.ok.rawValue, "ok")
-    XCTAssertEqual(PushStatus.error.rawValue, "error")
-    XCTAssertEqual(PushStatus.timeout.rawValue, "timeout")
+  @Test
+  func pushStatusValues() {
+    #expect(PushStatus.ok.rawValue == "ok")
+    #expect(PushStatus.error.rawValue == "error")
+    #expect(PushStatus.timeout.rawValue == "timeout")
   }
 
-  func testPushStatusFromRawValue() {
-    XCTAssertEqual(PushStatus(rawValue: "ok"), .ok)
-    XCTAssertEqual(PushStatus(rawValue: "error"), .error)
-    XCTAssertEqual(PushStatus(rawValue: "timeout"), .timeout)
-    XCTAssertNil(PushStatus(rawValue: "invalid"))
+  @Test
+  func pushStatusFromRawValue() {
+    #expect(PushStatus(rawValue: "ok") == .ok)
+    #expect(PushStatus(rawValue: "error") == .error)
+    #expect(PushStatus(rawValue: "timeout") == .timeout)
+    #expect(PushStatus(rawValue: "invalid") == nil)
   }
 
+  @Test
   @MainActor
-  func testPushV2InitializationWithNilChannel() {
+  func pushV2InitializationWithNilChannel() {
     let sampleMessage = RealtimeMessageV2(
       joinRef: "ref1",
       ref: "ref2",
@@ -43,12 +47,13 @@ final class PushV2Tests: XCTestCase {
 
     let push = PushV2(channel: nil, message: sampleMessage)
 
-    XCTAssertEqual(push.message.topic, "test:channel")
-    XCTAssertEqual(push.message.event, "broadcast")
+    #expect(push.message.topic == "test:channel")
+    #expect(push.message.event == "broadcast")
   }
 
+  @Test
   @MainActor
-  func testSendWithNilChannelReturnsError() async {
+  func sendWithNilChannelReturnsError() async {
     let sampleMessage = RealtimeMessageV2(
       joinRef: "ref1",
       ref: "ref2",
@@ -61,11 +66,12 @@ final class PushV2Tests: XCTestCase {
 
     let status = await push.send()
 
-    XCTAssertEqual(status, .error)
+    #expect(status == .error)
   }
 
+  @Test
   @MainActor
-  func testSendWithAckDisabledReturnsOkImmediately() async {
+  func sendWithAckDisabledReturnsOkImmediately() async {
     let mockSocket = MockRealtimeClient()
     let config = RealtimeChannelConfig(
       broadcast: BroadcastJoinConfig(acknowledgeBroadcasts: false, receiveOwnBroadcasts: false),
@@ -90,14 +96,15 @@ final class PushV2Tests: XCTestCase {
     let push = PushV2(channel: mockChannel, message: sampleMessage)
     let status = await push.send()
 
-    XCTAssertEqual(status, PushStatus.ok)
-    XCTAssertEqual(mockSocket.pushedMessages.count, 1)
-    XCTAssertEqual(mockSocket.pushedMessages.first?.topic, "test:channel")
-    XCTAssertEqual(mockSocket.pushedMessages.first?.event, "broadcast")
+    #expect(status == PushStatus.ok)
+    #expect(mockSocket.pushedMessages.count == 1)
+    #expect(mockSocket.pushedMessages.first?.topic == "test:channel")
+    #expect(mockSocket.pushedMessages.first?.event == "broadcast")
   }
 
+  @Test
   @MainActor
-  func testSendWithAckEnabledWaitsForResponse() async {
+  func sendWithAckEnabledWaitsForResponse() async {
     let mockSocket = MockRealtimeClient()
     let config = RealtimeChannelConfig(
       broadcast: BroadcastJoinConfig(acknowledgeBroadcasts: true, receiveOwnBroadcasts: false),
@@ -132,12 +139,13 @@ final class PushV2Tests: XCTestCase {
     push.didReceive(status: PushStatus.ok)
 
     let status = await sendTask.value
-    XCTAssertEqual(status, PushStatus.ok)
-    XCTAssertEqual(mockSocket.pushedMessages.count, 1)
+    #expect(status == PushStatus.ok)
+    #expect(mockSocket.pushedMessages.count == 1)
   }
 
+  @Test
   @MainActor
-  func testChannelConfigurationForAcknowledgment() {
+  func channelConfigurationForAcknowledgment() {
     // Test that the channel configuration is properly checked for acknowledgment settings
     let mockSocket = MockRealtimeClient()
 
@@ -153,7 +161,7 @@ final class PushV2Tests: XCTestCase {
       socket: mockSocket,
       logger: nil
     )
-    XCTAssertFalse(channelAckDisabled.config.broadcast.acknowledgeBroadcasts)
+    #expect(!channelAckDisabled.config.broadcast.acknowledgeBroadcasts)
 
     // Test acknowledgment enabled
     let configAckEnabled = RealtimeChannelConfig(
@@ -167,11 +175,12 @@ final class PushV2Tests: XCTestCase {
       socket: mockSocket,
       logger: nil
     )
-    XCTAssertTrue(channelAckEnabled.config.broadcast.acknowledgeBroadcasts)
+    #expect(channelAckEnabled.config.broadcast.acknowledgeBroadcasts)
   }
 
+  @Test
   @MainActor
-  func testSendWithAckEnabledReceivesError() async {
+  func sendWithAckEnabledReceivesError() async {
     let mockSocket = MockRealtimeClient()
     let config = RealtimeChannelConfig(
       broadcast: BroadcastJoinConfig(acknowledgeBroadcasts: true, receiveOwnBroadcasts: false),
@@ -206,12 +215,13 @@ final class PushV2Tests: XCTestCase {
     push.didReceive(status: PushStatus.error)
 
     let status = await sendTask.value
-    XCTAssertEqual(status, PushStatus.error)
-    XCTAssertEqual(mockSocket.pushedMessages.count, 1)
+    #expect(status == PushStatus.error)
+    #expect(mockSocket.pushedMessages.count == 1)
   }
 
+  @Test
   @MainActor
-  func testDidReceiveStatusWithoutWaitingDoesNothing() {
+  func didReceiveStatusWithoutWaitingDoesNothing() {
     let sampleMessage = RealtimeMessageV2(
       joinRef: "ref1",
       ref: "ref2",
@@ -228,8 +238,9 @@ final class PushV2Tests: XCTestCase {
     push.didReceive(status: PushStatus.timeout)
   }
 
+  @Test
   @MainActor
-  func testMultipleDidReceiveCallsOnlyFirstMatters() async {
+  func multipleDidReceiveCallsOnlyFirstMatters() async {
     let mockSocket = MockRealtimeClient()
     let config = RealtimeChannelConfig(
       broadcast: BroadcastJoinConfig(acknowledgeBroadcasts: true, receiveOwnBroadcasts: false),
@@ -268,7 +279,7 @@ final class PushV2Tests: XCTestCase {
     push.didReceive(status: PushStatus.timeout)
 
     let status = await sendTask.value
-    XCTAssertEqual(status, PushStatus.ok)  // Should be .ok, not .error or .timeout
+    #expect(status == PushStatus.ok)  // Should be .ok, not .error or .timeout
   }
 }
 

--- a/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
@@ -8,33 +8,30 @@
 import ConcurrencyExtras
 import Foundation
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
 #if os(Linux)
-  @available(
-    *, unavailable,
-    message: "RealtimeChannelBroadcastTests are disabled on Linux due to timing flakiness"
-  )
-  final class RealtimeChannelBroadcastTests: XCTestCase {}
+  // RealtimeChannelBroadcastTests are disabled on Linux due to timing flakiness.
 #else
 
-  final class RealtimeChannelBroadcastTests: XCTestCase, @unchecked Sendable {
+  @Suite
+  final class RealtimeChannelBroadcastTests: Sendable {
     let url = URL(string: "http://localhost:54321/realtime/v1")!
     let apiKey = "publishable.api.key"
 
-    var server: FakeWebSocket!
-    var client: FakeWebSocket!
-    var http: HTTPClientMock!
-    var sut: RealtimeClientV2!
-    var serverTask: Task<Void, Never>?
+    let server: FakeWebSocket
+    let client: FakeWebSocket
+    let http: HTTPClientMock
+    let sut: RealtimeClientV2
+    let serverTask = LockIsolated<Task<Void, Never>?>(nil)
 
-    override func setUp() {
-      super.setUp()
-
-      (client, server) = FakeWebSocket.fakes()
+    init() {
+      let (client, server) = FakeWebSocket.fakes()
+      self.client = client
+      self.server = server
       http = HTTPClientMock()
 
       sut = RealtimeClientV2(
@@ -45,22 +42,20 @@ import XCTest
             "custom.access.token"
           }
         ),
-        wsTransport: { _, _ in self.client },
+        wsTransport: { _, _ in client },
         http: http,
         clock: ContinuousClock()
       )
     }
 
-    override func tearDown() {
-      serverTask?.cancel()
-      serverTask = nil
+    deinit {
+      serverTask.value?.cancel()
       sut.disconnect()
-      super.tearDown()
     }
 
     /// Sets up the server to auto-respond to heartbeats and phx_join events.
     private func setupServerAutoResponder(topic: String = "realtime:test") {
-      serverTask = Task { @Sendable [server = server!] in
+      let task = Task { @Sendable [server] in
         for await event in server.events {
           guard let msg = event.realtimeMessage else { continue }
 
@@ -90,11 +85,13 @@ import XCTest
           }
         }
       }
+      serverTask.setValue(task)
     }
 
     // MARK: - Sending JSON broadcast via binary frame
 
-    func testBroadcast_sendsJsonViaBinaryFrame() async throws {
+    @Test
+    func broadcast_sendsJsonViaBinaryFrame() async throws {
       setupServerAutoResponder()
       await sut.connect()
 
@@ -112,21 +109,18 @@ import XCTest
         return nil
       }
 
-      XCTAssertFalse(binaryEvents.isEmpty, "Expected at least one binary frame to be sent")
+      #expect(!binaryEvents.isEmpty, "Expected at least one binary frame to be sent")
 
       if let binaryData = binaryEvents.last {
-        XCTAssertEqual(
-          binaryData[0], RealtimeSerializer.BinaryKind.userBroadcastPush.rawValue
-        )
-        XCTAssertEqual(
-          binaryData[6], RealtimeSerializer.PayloadEncoding.json.rawValue
-        )
+        #expect(binaryData[0] == RealtimeSerializer.BinaryKind.userBroadcastPush.rawValue)
+        #expect(binaryData[6] == RealtimeSerializer.PayloadEncoding.json.rawValue)
       }
     }
 
     // MARK: - Sending Data broadcast via binary frame
 
-    func testBroadcast_sendsDataViaBinaryFrame() async throws {
+    @Test
+    func broadcast_sendsDataViaBinaryFrame() async throws {
       setupServerAutoResponder()
       await sut.connect()
 
@@ -142,41 +136,44 @@ import XCTest
         return nil
       }
 
-      XCTAssertFalse(binaryFrames.isEmpty, "Expected at least one binary frame to be sent")
+      #expect(!binaryFrames.isEmpty, "Expected at least one binary frame to be sent")
 
       if let frame = binaryFrames.last {
-        XCTAssertEqual(frame[0], RealtimeSerializer.BinaryKind.userBroadcastPush.rawValue)
-        XCTAssertEqual(frame[6], RealtimeSerializer.PayloadEncoding.binary.rawValue)
+        #expect(frame[0] == RealtimeSerializer.BinaryKind.userBroadcastPush.rawValue)
+        #expect(frame[6] == RealtimeSerializer.PayloadEncoding.binary.rawValue)
       }
     }
 
     // MARK: - Basic callback manager test
 
-    func testCallbackManager_triggerBroadcast() {
+    @Test
+    func callbackManager_triggerBroadcast() {
       let mgr = CallbackManager()
       let received = LockIsolated<JSONObject?>(nil)
       mgr.addBroadcastCallback(event: "test") { json in
         received.setValue(json)
       }
       mgr.triggerBroadcast(event: "test", json: ["hello": .string("world")])
-      XCTAssertNotNil(received.value)
-      XCTAssertEqual(received.value?["hello"]?.stringValue, "world")
+      #expect(received.value != nil)
+      #expect(received.value?["hello"]?.stringValue == "world")
     }
 
-    func testCallbackManager_triggerBroadcastData() {
+    @Test
+    func callbackManager_triggerBroadcastData() {
       let mgr = CallbackManager()
       let received = LockIsolated<Data?>(nil)
       mgr.addBroadcastDataCallback(event: "test") { data in
         received.setValue(data)
       }
       mgr.triggerBroadcastData(event: "test", data: Data([0x01, 0x02]))
-      XCTAssertNotNil(received.value)
-      XCTAssertEqual(received.value, Data([0x01, 0x02]))
+      #expect(received.value != nil)
+      #expect(received.value == Data([0x01, 0x02]))
     }
 
     // MARK: - Receiving JSON broadcast from binary frame
 
-    func testReceive_jsonBroadcastFromBinaryFrame() async throws {
+    @Test
+    func receive_jsonBroadcastFromBinaryFrame() async throws {
       let channel = sut.channel("test")
 
       let receivedPayload = LockIsolated<JSONObject?>(nil)
@@ -194,14 +191,15 @@ import XCTest
       await channel.handleBinaryBroadcast(broadcast)
 
       let payload = receivedPayload.value
-      XCTAssertNotNil(payload, "Expected to receive broadcast payload")
-      XCTAssertEqual(payload?["event"]?.stringValue, "my_event")
-      XCTAssertEqual(payload?["payload"]?.objectValue?["count"]?.intValue, 99)
+      #expect(payload != nil, "Expected to receive broadcast payload")
+      #expect(payload?["event"]?.stringValue == "my_event")
+      #expect(payload?["payload"]?.objectValue?["count"]?.intValue == 99)
     }
 
     // MARK: - Receiving binary broadcast from binary frame
 
-    func testReceive_binaryBroadcastFromBinaryFrame() async throws {
+    @Test
+    func receive_binaryBroadcastFromBinaryFrame() async throws {
       let channel = sut.channel("test")
 
       let receivedData = LockIsolated<Data?>(nil)
@@ -219,12 +217,13 @@ import XCTest
       )
       await channel.handleBinaryBroadcast(broadcast)
 
-      XCTAssertEqual(receivedData.value, binaryPayload)
+      #expect(receivedData.value == binaryPayload)
     }
 
     // MARK: - JSON broadcast callback receives correct wrapper format
 
-    func testReceive_jsonBroadcastHasCorrectFormat() async throws {
+    @Test
+    func receive_jsonBroadcastHasCorrectFormat() async throws {
       let channel = sut.channel("test")
 
       let receivedPayload = LockIsolated<JSONObject?>(nil)
@@ -241,15 +240,16 @@ import XCTest
       await channel.handleBinaryBroadcast(broadcast)
 
       let payload = receivedPayload.value
-      XCTAssertNotNil(payload)
-      XCTAssertEqual(payload?["type"]?.stringValue, "broadcast")
-      XCTAssertEqual(payload?["event"]?.stringValue, "evt")
-      XCTAssertEqual(payload?["payload"]?.objectValue?["key"]?.stringValue, "value")
+      #expect(payload != nil)
+      #expect(payload?["type"]?.stringValue == "broadcast")
+      #expect(payload?["event"]?.stringValue == "evt")
+      #expect(payload?["payload"]?.objectValue?["key"]?.stringValue == "value")
     }
 
     // MARK: - REST broadcast URL uses the sub-topic (without `realtime:` prefix)
 
-    func testHttpSend_urlUsesSubTopicWithoutRealtimePrefix() async throws {
+    @Test
+    func httpSend_urlUsesSubTopicWithoutRealtimePrefix() async throws {
       await http.any { _ in
         HTTPResponse(
           data: Data(),
@@ -263,24 +263,25 @@ import XCTest
       }
 
       let channel = sut.channel("test")
-      XCTAssertEqual(channel.topic, "realtime:test")
+      #expect(channel.topic == "realtime:test")
 
       try await channel.httpSend(
         event: "my_event", message: ["hello": .string("world")] as JSONObject
       )
 
       let request = await http.receivedRequests.last
-      let url = try XCTUnwrap(request?.url)
-      XCTAssertEqual(url.path, "/realtime/v1/api/broadcast/test/events/my_event")
+      let url = try #require(request?.url)
+      #expect(url.path == "/realtime/v1/api/broadcast/test/events/my_event")
 
-      let body = try XCTUnwrap(request?.body)
+      let body = try #require(request?.body)
       let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
-      XCTAssertEqual(json?["hello"] as? String, "world")
+      #expect(json?["hello"] as? String == "world")
     }
 
     // MARK: - End-to-end binary frame via WebSocket
 
-    func testEndToEnd_binaryFrameViaWebSocket() async throws {
+    @Test
+    func endToEnd_binaryFrameViaWebSocket() async throws {
       setupServerAutoResponder()
       await sut.connect()
 
@@ -315,24 +316,20 @@ import XCTest
       server.send(frame)
 
       // Wait for the message to be processed
-      var attempts = 0
-      while receivedPayload.value == nil && attempts < 50 {
-        try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
-        attempts += 1
-      }
+      let received = await waitUntil(timeout: 0.5) { receivedPayload.value != nil }
 
       let payload = receivedPayload.value
-      if payload == nil {
+      if !received {
         // This test can be flaky in CI due to async scheduling, mark as known limitation
         print(
-          "WARNING: End-to-end binary frame test did not receive payload after \(attempts) attempts"
+          "WARNING: End-to-end binary frame test did not receive payload in time"
         )
         print("Client received events: \(client.receivedEvents)")
       }
       // Only assert if we received something - the unit tests above cover the logic
       if let payload {
-        XCTAssertEqual(payload["event"]?.stringValue, "my_event")
-        XCTAssertEqual(payload["payload"]?.objectValue?["count"]?.intValue, 99)
+        #expect(payload["event"]?.stringValue == "my_event")
+        #expect(payload["payload"]?.objectValue?["count"]?.intValue == 99)
       }
     }
   }

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -5,10 +5,12 @@
 //  Created by Guilherme Souza on 09/09/24.
 //
 
+import ConcurrencyExtras
 import Foundation
+import HTTPTypes
 import InlineSnapshotTesting
 import TestHelpers
-import XCTest
+import Testing
 import XCTestDynamicOverlay
 
 @testable import Realtime
@@ -18,7 +20,8 @@ import XCTestDynamicOverlay
   import FoundationNetworking
 #endif
 
-final class RealtimeChannelTests: XCTestCase {
+@Suite
+struct RealtimeChannelTests {
   let sut = RealtimeChannelV2(
     topic: "topic",
     config: RealtimeChannelConfig(
@@ -33,7 +36,8 @@ final class RealtimeChannelTests: XCTestCase {
     logger: nil
   )
 
-  func testTypedFilterAndSelectAreBufferedIntoPostgresJoinConfig() {
+  @Test
+  func typedFilterAndSelectAreBufferedIntoPostgresJoinConfig() {
     let subscription = sut.onPostgresChange(
       UpdateAction.self,
       table: "orders",
@@ -46,18 +50,19 @@ final class RealtimeChannelTests: XCTestCase {
     defer { subscription.cancel() }
 
     let changes = sut.clientChanges.value
-    XCTAssertEqual(changes.count, 1)
-    XCTAssertEqual(changes.first?.event, .update)
-    XCTAssertEqual(changes.first?.table, "orders")
-    XCTAssertEqual(changes.first?.filter, "amount=gt.100,status=not.in.(draft)")
-    XCTAssertEqual(changes.first?.select, ["id", "name"])
+    #expect(changes.count == 1)
+    #expect(changes.first?.event == .update)
+    #expect(changes.first?.table == "orders")
+    #expect(changes.first?.filter == "amount=gt.100,status=not.in.(draft)")
+    #expect(changes.first?.select == ["id", "name"])
   }
 
   // MARK: - Callback rejection tests
 
   #if canImport(Darwin)
+    @Test
     @MainActor
-    func testPresenceChangeCallbackRejectedWhileSubscribing() async {
+    func presenceChangeCallbackRejectedWhileSubscribing() async {
       let (client, server) = FakeWebSocket.fakes()
       let socket = RealtimeClientV2(
         url: URL(string: "https://localhost:54321/realtime/v1")!,
@@ -96,7 +101,7 @@ final class RealtimeChannelTests: XCTestCase {
       let subscribeTask = Task { try? await channel.subscribeWithError() }
 
       await waitForChannelStatus(.subscribing, channel: channel, timeout: 2.0)
-      XCTAssertEqual(channel.status, .subscribing)
+      #expect(channel.status == .subscribing)
 
       let callbackCountBefore = channel.callbackManager.callbacks.count
 
@@ -104,7 +109,7 @@ final class RealtimeChannelTests: XCTestCase {
         _ = channel.onPresenceChange { _ in }
       }
 
-      XCTAssertEqual(channel.callbackManager.callbacks.count, callbackCountBefore)
+      #expect(channel.callbackManager.callbacks.count == callbackCountBefore)
 
       subscribeTask.cancel()
       socket.disconnect()
@@ -112,8 +117,9 @@ final class RealtimeChannelTests: XCTestCase {
   #endif
 
   #if canImport(Darwin)
+    @Test
     @MainActor
-    func testPresenceChangeCallbackRejectedWhileSubscribed() async {
+    func presenceChangeCallbackRejectedWhileSubscribed() async {
       let (client, server) = FakeWebSocket.fakes()
       let socket = RealtimeClientV2(
         url: URL(string: "https://localhost:54321/realtime/v1")!,
@@ -151,7 +157,7 @@ final class RealtimeChannelTests: XCTestCase {
 
       await socket.connect()
       try? await channel.subscribeWithError()
-      XCTAssertEqual(channel.status, .subscribed)
+      #expect(channel.status == .subscribed)
 
       let callbackCountBefore = channel.callbackManager.callbacks.count
 
@@ -159,15 +165,16 @@ final class RealtimeChannelTests: XCTestCase {
         _ = channel.onPresenceChange { _ in }
       }
 
-      XCTAssertEqual(channel.callbackManager.callbacks.count, callbackCountBefore)
+      #expect(channel.callbackManager.callbacks.count == callbackCountBefore)
 
       socket.disconnect()
     }
   #endif
 
   #if canImport(Darwin)
+    @Test
     @MainActor
-    func testPostgresChangeCallbackRejectedWhileSubscribing() async {
+    func postgresChangeCallbackRejectedWhileSubscribing() async {
       let (client, server) = FakeWebSocket.fakes()
       let socket = RealtimeClientV2(
         url: URL(string: "https://localhost:54321/realtime/v1")!,
@@ -206,7 +213,7 @@ final class RealtimeChannelTests: XCTestCase {
       let subscribeTask = Task { try? await channel.subscribeWithError() }
 
       await waitForChannelStatus(.subscribing, channel: channel, timeout: 2.0)
-      XCTAssertEqual(channel.status, .subscribing)
+      #expect(channel.status == .subscribing)
 
       let callbackCountBefore = channel.callbackManager.callbacks.count
 
@@ -214,7 +221,7 @@ final class RealtimeChannelTests: XCTestCase {
         _ = channel.onPostgresChange(AnyAction.self, schema: "public") { _ in }
       }
 
-      XCTAssertEqual(channel.callbackManager.callbacks.count, callbackCountBefore)
+      #expect(channel.callbackManager.callbacks.count == callbackCountBefore)
 
       subscribeTask.cancel()
       socket.disconnect()
@@ -222,8 +229,9 @@ final class RealtimeChannelTests: XCTestCase {
   #endif
 
   #if canImport(Darwin)
+    @Test
     @MainActor
-    func testPostgresChangeCallbackRejectedWhileSubscribed() async {
+    func postgresChangeCallbackRejectedWhileSubscribed() async {
       let (client, server) = FakeWebSocket.fakes()
       let socket = RealtimeClientV2(
         url: URL(string: "https://localhost:54321/realtime/v1")!,
@@ -261,7 +269,7 @@ final class RealtimeChannelTests: XCTestCase {
 
       await socket.connect()
       try? await channel.subscribeWithError()
-      XCTAssertEqual(channel.status, .subscribed)
+      #expect(channel.status == .subscribed)
 
       let callbackCountBefore = channel.callbackManager.callbacks.count
 
@@ -269,13 +277,14 @@ final class RealtimeChannelTests: XCTestCase {
         _ = channel.onPostgresChange(AnyAction.self, schema: "public") { _ in }
       }
 
-      XCTAssertEqual(channel.callbackManager.callbacks.count, callbackCountBefore)
+      #expect(channel.callbackManager.callbacks.count == callbackCountBefore)
 
       socket.disconnect()
     }
   #endif
 
-  func testAttachCallbacks() {
+  @Test
+  func attachCallbacks() {
     var subscriptions = Set<RealtimeSubscription>()
 
     sut.onPostgresChange(
@@ -382,8 +391,9 @@ final class RealtimeChannelTests: XCTestCase {
     }
   }
 
+  @Test
   @MainActor
-  func testPresenceEnabledDuringSubscribe() async {
+  func presenceEnabledDuringSubscribe() async {
     // Create fake WebSocket for testing
     let (client, server) = FakeWebSocket.fakes()
 
@@ -402,7 +412,7 @@ final class RealtimeChannelTests: XCTestCase {
     let channel = socket.channel("test-topic")
 
     // Initially presence should be disabled
-    XCTAssertFalse(channel.config.presence.enabled)
+    #expect(!channel.config.presence.enabled)
 
     // Connect the socket
     await socket.connect()
@@ -411,7 +421,7 @@ final class RealtimeChannelTests: XCTestCase {
     let presenceSubscription = channel.onPresenceChange { _ in }
 
     // Verify that presence callback exists
-    XCTAssertTrue(channel.callbackManager.callbacks.contains(where: { $0.isPresence }))
+    #expect(channel.callbackManager.callbacks.contains(where: { $0.isPresence }))
 
     // Start subscription process
     Task {
@@ -426,7 +436,7 @@ final class RealtimeChannelTests: XCTestCase {
     )
 
     // Should have at least one join event
-    XCTAssertGreaterThan(joinEvents.count, 0)
+    #expect(joinEvents.count > 0)
 
     // Check that the presence enabled flag is set to true in the join payload
     if let joinEvent = joinEvents.first,
@@ -434,9 +444,9 @@ final class RealtimeChannelTests: XCTestCase {
       let presence = config["presence"]?.objectValue,
       let enabled = presence["enabled"]?.boolValue
     {
-      XCTAssertTrue(enabled, "Presence should be enabled when presence callback exists")
+      #expect(enabled, "Presence should be enabled when presence callback exists")
     } else {
-      XCTFail("Could not find presence enabled flag in join payload")
+      Issue.record("Could not find presence enabled flag in join payload")
     }
 
     // Clean up
@@ -448,7 +458,8 @@ final class RealtimeChannelTests: XCTestCase {
     // The subscription is still in progress when we clean up
   }
 
-  func testHttpSendThrowsWhenAccessTokenIsMissing() async {
+  @Test
+  func httpSendThrowsWhenAccessTokenIsMissing() async {
     let httpClient = HTTPClientMock()
     let (client, _) = FakeWebSocket.fakes()
 
@@ -464,13 +475,14 @@ final class RealtimeChannelTests: XCTestCase {
 
     do {
       try await channel.httpSend(event: "test", message: ["data": "test"])
-      XCTFail("Expected httpSend to throw an error when access token is missing")
+      Issue.record("Expected httpSend to throw an error when access token is missing")
     } catch {
-      XCTAssertEqual(error.localizedDescription, "Access token is required for httpSend()")
+      #expect(error.localizedDescription == "Access token is required for httpSend()")
     }
   }
 
-  func testHttpSendSucceedsOn202Status() async throws {
+  @Test
+  func httpSendSucceedsOn202Status() async throws {
     let httpClient = HTTPClientMock()
     await httpClient.when({ _ in true }) { _ in
       HTTPResponse(
@@ -503,23 +515,24 @@ final class RealtimeChannelTests: XCTestCase {
     try await channel.httpSend(event: "test-event", message: ["data": "explicit"])
 
     let requests = await httpClient.receivedRequests
-    XCTAssertEqual(requests.count, 1)
+    #expect(requests.count == 1)
 
     let request = requests[0]
-    XCTAssertEqual(
-      request.url.absoluteString,
-      "https://localhost:54321/realtime/v1/api/broadcast/test-topic/events/test-event?private=true"
+    #expect(
+      request.url.absoluteString
+        == "https://localhost:54321/realtime/v1/api/broadcast/test-topic/events/test-event?private=true"
     )
-    XCTAssertEqual(request.method, .post)
-    XCTAssertEqual(request.headers[.authorization], "Bearer test-token")
-    XCTAssertEqual(request.headers[.apiKey], "test-key")
-    XCTAssertEqual(request.headers[.contentType], "application/json")
+    #expect(request.method == .post)
+    #expect(request.headers[.authorization] == "Bearer test-token")
+    #expect(request.headers[.apiKey] == "test-key")
+    #expect(request.headers[.contentType] == "application/json")
 
     let body = try JSONDecoder().decode([String: String].self, from: request.body ?? Data())
-    XCTAssertEqual(body, ["data": "explicit"])
+    #expect(body == ["data": "explicit"])
   }
 
-  func testHttpSendPercentEncodesTopicAndEventInURL() async throws {
+  @Test
+  func httpSendPercentEncodesTopicAndEventInURL() async throws {
     let httpClient = HTTPClientMock()
     await httpClient.when({ _ in true }) { _ in
       HTTPResponse(
@@ -550,13 +563,14 @@ final class RealtimeChannelTests: XCTestCase {
     try await channel.httpSend(event: "cursor move", message: ["x": 1])
 
     let requests = await httpClient.receivedRequests
-    XCTAssertEqual(
-      requests[0].url.absoluteString,
-      "https://localhost:54321/realtime/v1/api/broadcast/room%2Fone/events/cursor%20move"
+    #expect(
+      requests[0].url.absoluteString
+        == "https://localhost:54321/realtime/v1/api/broadcast/room%2Fone/events/cursor%20move"
     )
   }
 
-  func testHttpSendWithBinaryDataSendsOctetStream() async throws {
+  @Test
+  func httpSendWithBinaryDataSendsOctetStream() async throws {
     let httpClient = HTTPClientMock()
     await httpClient.when({ _ in true }) { _ in
       HTTPResponse(
@@ -588,18 +602,19 @@ final class RealtimeChannelTests: XCTestCase {
     try await channel.httpSend(event: "binary-event", data: payload)
 
     let requests = await httpClient.receivedRequests
-    XCTAssertEqual(requests.count, 1)
+    #expect(requests.count == 1)
 
     let request = requests[0]
-    XCTAssertEqual(
-      request.url.absoluteString,
-      "https://localhost:54321/realtime/v1/api/broadcast/test-topic/events/binary-event"
+    #expect(
+      request.url.absoluteString
+        == "https://localhost:54321/realtime/v1/api/broadcast/test-topic/events/binary-event"
     )
-    XCTAssertEqual(request.headers[.contentType], "application/octet-stream")
-    XCTAssertEqual(request.body, payload)
+    #expect(request.headers[.contentType] == "application/octet-stream")
+    #expect(request.body == payload)
   }
 
-  func testHttpSendWithBinaryDataThrowsWhenAccessTokenIsMissing() async {
+  @Test
+  func httpSendWithBinaryDataThrowsWhenAccessTokenIsMissing() async {
     let httpClient = HTTPClientMock()
     let (client, _) = FakeWebSocket.fakes()
 
@@ -615,13 +630,14 @@ final class RealtimeChannelTests: XCTestCase {
 
     do {
       try await channel.httpSend(event: "test", data: Data([0x01]))
-      XCTFail("Expected httpSend to throw an error when access token is missing")
+      Issue.record("Expected httpSend to throw an error when access token is missing")
     } catch {
-      XCTAssertEqual(error.localizedDescription, "Access token is required for httpSend()")
+      #expect(error.localizedDescription == "Access token is required for httpSend()")
     }
   }
 
-  func testHttpSendThrowsOnNon202Status() async {
+  @Test
+  func httpSendThrowsOnNon202Status() async {
     let httpClient = HTTPClientMock()
     await httpClient.when({ _ in true }) { _ in
       let errorBody = try JSONEncoder().encode(["error": "Server error"])
@@ -652,13 +668,14 @@ final class RealtimeChannelTests: XCTestCase {
 
     do {
       try await channel.httpSend(event: "test", message: ["data": "test"])
-      XCTFail("Expected httpSend to throw an error on non-202 status")
+      Issue.record("Expected httpSend to throw an error on non-202 status")
     } catch {
-      XCTAssertEqual(error.localizedDescription, "Server error")
+      #expect(error.localizedDescription == "Server error")
     }
   }
 
-  func testHttpSendRespectsCustomTimeout() async throws {
+  @Test
+  func httpSendRespectsCustomTimeout() async throws {
     let httpClient = HTTPClientMock()
     await httpClient.when({ _ in true }) { _ in
       HTTPResponse(
@@ -691,10 +708,11 @@ final class RealtimeChannelTests: XCTestCase {
     try await channel.httpSend(event: "test", message: ["data": "test"], timeout: 3.0)
 
     let requests = await httpClient.receivedRequests
-    XCTAssertEqual(requests.count, 1)
+    #expect(requests.count == 1)
   }
 
-  func testHttpSendUsesDefaultTimeoutWhenNotSpecified() async throws {
+  @Test
+  func httpSendUsesDefaultTimeoutWhenNotSpecified() async throws {
     let httpClient = HTTPClientMock()
     await httpClient.when({ _ in true }) { _ in
       HTTPResponse(
@@ -727,10 +745,11 @@ final class RealtimeChannelTests: XCTestCase {
     try await channel.httpSend(event: "test", message: ["data": "test"])
 
     let requests = await httpClient.receivedRequests
-    XCTAssertEqual(requests.count, 1)
+    #expect(requests.count == 1)
   }
 
-  func testHttpSendFallsBackToStatusTextWhenErrorBodyHasNoErrorField() async {
+  @Test
+  func httpSendFallsBackToStatusTextWhenErrorBodyHasNoErrorField() async {
     let httpClient = HTTPClientMock()
     await httpClient.when({ _ in true }) { _ in
       let errorBody = try JSONEncoder().encode(["message": "Invalid request"])
@@ -761,13 +780,14 @@ final class RealtimeChannelTests: XCTestCase {
 
     do {
       try await channel.httpSend(event: "test", message: ["data": "test"])
-      XCTFail("Expected httpSend to throw an error on 400 status")
+      Issue.record("Expected httpSend to throw an error on 400 status")
     } catch {
-      XCTAssertEqual(error.localizedDescription, "Invalid request")
+      #expect(error.localizedDescription == "Invalid request")
     }
   }
 
-  func testHttpSendFallsBackToStatusTextWhenJSONParsingFails() async {
+  @Test
+  func httpSendFallsBackToStatusTextWhenJSONParsingFails() async {
     let httpClient = HTTPClientMock()
     await httpClient.when({ _ in true }) { _ in
       HTTPResponse(
@@ -797,11 +817,11 @@ final class RealtimeChannelTests: XCTestCase {
 
     do {
       try await channel.httpSend(event: "test", message: ["data": "test"])
-      XCTFail("Expected httpSend to throw an error on 503 status")
+      Issue.record("Expected httpSend to throw an error on 503 status")
     } catch {
       // Should fall back to localized status text (case-insensitive)
       let description = error.localizedDescription.lowercased()
-      XCTAssertTrue(
+      #expect(
         description.contains("503") || description.contains("unavailable"),
         "Expected status text fallback, got '\(error.localizedDescription)'"
       )
@@ -809,8 +829,9 @@ final class RealtimeChannelTests: XCTestCase {
   }
 
   #if canImport(Darwin)
+    @Test
     @MainActor
-    func testChannelErrorResetsSubscribedStatus() async {
+    func channelErrorResetsSubscribedStatus() async {
       let (client, server) = FakeWebSocket.fakes()
       let socket = RealtimeClientV2(
         url: URL(string: "https://localhost:54321/realtime/v1")!,
@@ -848,7 +869,7 @@ final class RealtimeChannelTests: XCTestCase {
 
       await socket.connect()
       try? await channel.subscribeWithError()
-      XCTAssertEqual(channel.status, .subscribed)
+      #expect(channel.status == .subscribed)
 
       server.send(
         RealtimeMessageV2(
@@ -861,7 +882,7 @@ final class RealtimeChannelTests: XCTestCase {
       )
 
       await waitForChannelStatus(.unsubscribed, channel: channel, timeout: 2.0)
-      XCTAssertEqual(channel.status, .unsubscribed)
+      #expect(channel.status == .unsubscribed)
 
       socket.disconnect()
     }
@@ -876,10 +897,8 @@ extension RealtimeChannelTests {
     timeout: TimeInterval,
     pollInterval: UInt64 = 10_000_000
   ) async {
-    let deadline = Date().addingTimeInterval(timeout)
-    while Date() < deadline {
-      if channel.status == status { return }
-      try? await Task.sleep(nanoseconds: pollInterval)
+    await Testing_waitUntil(timeout: timeout, pollInterval: pollInterval) {
+      channel.status == status
     }
   }
 
@@ -905,5 +924,21 @@ extension RealtimeChannelTests {
     }
 
     return []
+  }
+}
+
+/// `@MainActor`-safe wrapper around the shared, non-isolated `waitUntil` helper —
+/// avoids a "passing a `@MainActor`-isolated closure as a `@Sendable` closure" diagnostic
+/// when the condition captures main-actor-isolated state (e.g. `RealtimeChannelV2.status`).
+@MainActor
+private func Testing_waitUntil(
+  timeout: TimeInterval,
+  pollInterval: UInt64,
+  condition: @MainActor @escaping () -> Bool
+) async {
+  let deadline = Date().addingTimeInterval(timeout)
+  while Date() < deadline {
+    if condition() { return }
+    try? await Task.sleep(nanoseconds: pollInterval)
   }
 }

--- a/Tests/RealtimeTests/RealtimeChannelTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelTests.swift
@@ -11,7 +11,6 @@ import HTTPTypes
 import InlineSnapshotTesting
 import TestHelpers
 import Testing
-import XCTestDynamicOverlay
 
 @testable import Realtime
 @testable import RealtimeV2
@@ -105,9 +104,7 @@ struct RealtimeChannelTests {
 
       let callbackCountBefore = channel.callbackManager.callbacks.count
 
-      withExpectedIssue {
-        _ = channel.onPresenceChange { _ in }
-      }
+      _ = channel.onPresenceChange { _ in }
 
       #expect(channel.callbackManager.callbacks.count == callbackCountBefore)
 
@@ -161,9 +158,7 @@ struct RealtimeChannelTests {
 
       let callbackCountBefore = channel.callbackManager.callbacks.count
 
-      withExpectedIssue {
-        _ = channel.onPresenceChange { _ in }
-      }
+      _ = channel.onPresenceChange { _ in }
 
       #expect(channel.callbackManager.callbacks.count == callbackCountBefore)
 
@@ -217,9 +212,7 @@ struct RealtimeChannelTests {
 
       let callbackCountBefore = channel.callbackManager.callbacks.count
 
-      withExpectedIssue {
-        _ = channel.onPostgresChange(AnyAction.self, schema: "public") { _ in }
-      }
+      _ = channel.onPostgresChange(AnyAction.self, schema: "public") { _ in }
 
       #expect(channel.callbackManager.callbacks.count == callbackCountBefore)
 
@@ -273,9 +266,7 @@ struct RealtimeChannelTests {
 
       let callbackCountBefore = channel.callbackManager.callbacks.count
 
-      withExpectedIssue {
-        _ = channel.onPostgresChange(AnyAction.self, schema: "public") { _ in }
-      }
+      _ = channel.onPostgresChange(AnyAction.self, schema: "public") { _ in }
 
       #expect(channel.callbackManager.callbacks.count == callbackCountBefore)
 
@@ -941,4 +932,5 @@ private func Testing_waitUntil(
     if condition() { return }
     try? await Task.sleep(nanoseconds: pollInterval)
   }
+  _ = condition()
 }

--- a/Tests/RealtimeTests/RealtimeColdStartTests.swift
+++ b/Tests/RealtimeTests/RealtimeColdStartTests.swift
@@ -1,7 +1,7 @@
 import ConcurrencyExtras
 import Foundation
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
@@ -13,8 +13,9 @@ import XCTest
 /// frames asynchronously on a separate queue (like URLSession's delegate
 /// queue) — instead of the synchronous delivery of `FakeWebSocket`, which
 /// masks the races involved. They run against the real clock with compressed
-/// intervals, deliberately NOT under `withMainSerialExecutor`.
-final class RealtimeColdStartTests: XCTestCase {
+/// intervals.
+@Suite
+struct RealtimeColdStartTests {
   let url = URL(string: "http://localhost:54321/realtime/v1")!
   let apiKey = "anon.api.key"
 
@@ -40,23 +41,12 @@ final class RealtimeColdStartTests: XCTestCase {
     )
   }
 
-  /// Polls `condition` until it holds or `timeout` elapses.
-  private func waitUntil(
-    timeout: TimeInterval = 5.0,
-    _ condition: @escaping @Sendable () -> Bool
-  ) async {
-    let deadline = Date().addingTimeInterval(timeout)
-    while Date() < deadline {
-      if condition() { return }
-      try? await Task.sleep(nanoseconds: 10_000_000)
-    }
-  }
-
   /// Reporter's flow from SDK-959: cold client, one channel, postgresChange
   /// streams consumed in detached tasks, then `subscribeWithError()`.
   /// With the deaf-socket bug this throws `maxRetryAttemptsReached` because
   /// the `phx_join` reply is never seen.
-  func testColdStartSubscribe_realTimingProfile() async throws {
+  @Test
+  func coldStartSubscribe_realTimingProfile() async throws {
     for iteration in 1...5 {
       let socket = AsyncFakeWebSocket()
       socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
@@ -78,11 +68,11 @@ final class RealtimeColdStartTests: XCTestCase {
       do {
         try await channel.subscribeWithError()
       } catch {
-        XCTFail("Iteration \(iteration): subscribe failed: \(error)")
+        Issue.record("Iteration \(iteration): subscribe failed: \(error)")
         return
       }
 
-      XCTAssertEqual(channel.status, .subscribed, "Iteration \(iteration)")
+      #expect(channel.status == .subscribed, "Iteration \(iteration)")
     }
   }
 
@@ -92,7 +82,8 @@ final class RealtimeColdStartTests: XCTestCase {
   /// both used to call `handleConnected(conn:)`, reading `conn.events` twice
   /// and leaving the socket deaf (no heartbeat acks, no phx_join replies) —
   /// the SDK-959 stall, thrown here as `maxRetryAttemptsReached`.
-  func testColdStartConcurrentSubscribes_doNotGoDeaf() async throws {
+  @Test
+  func coldStartConcurrentSubscribes_doNotGoDeaf() async throws {
     for iteration in 1...5 {
       let socket = AsyncFakeWebSocket()
       socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
@@ -109,12 +100,12 @@ final class RealtimeColdStartTests: XCTestCase {
       do {
         _ = try await (s1, s2)
       } catch {
-        XCTFail("Iteration \(iteration): subscribe failed: \(error)")
+        Issue.record("Iteration \(iteration): subscribe failed: \(error)")
         return
       }
 
-      XCTAssertEqual(channel1.status, .subscribed, "Iteration \(iteration)")
-      XCTAssertEqual(channel2.status, .subscribed, "Iteration \(iteration)")
+      #expect(channel1.status == .subscribed, "Iteration \(iteration)")
+      #expect(channel2.status == .subscribed, "Iteration \(iteration)")
     }
   }
 
@@ -123,7 +114,8 @@ final class RealtimeColdStartTests: XCTestCase {
   /// `ChannelStateManager.subscribe()` was a no-op for `.subscribed` channels,
   /// so `rejoinChannels()` silently skipped them — channels went deaf after
   /// the first reconnect (reported by rpiacent on PR #1003). // cspell:ignore rpiacent
-  func testChannelsRejoinAfterReconnect() async throws {
+  @Test
+  func channelsRejoinAfterReconnect() async throws {
     let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
 
     let sut = RealtimeClientV2(
@@ -149,17 +141,18 @@ final class RealtimeColdStartTests: XCTestCase {
     let channel = sut.channel("room-rejoin")
 
     try await channel.subscribeWithError()
-    XCTAssertEqual(channel.status, .subscribed)
-    XCTAssertEqual(sockets.value.count, 1)
+    #expect(channel.status == .subscribed)
+    #expect(sockets.value.count == 1)
 
     // Inject a malformed frame: listenForMessages throws → handleError →
     // initiateReconnect. A remote .close with a transport-level code would also
     // reconnect, but application-level codes (4000–4999) skip reconnect by design
     // (auth errors should not loop with the same token).
     sockets.value[0].receiveFromServer(.text("not a valid frame"))
-    await waitUntil(timeout: 5) { sockets.value.count >= 2 }
-    guard sockets.value.count >= 2 else {
-      return XCTFail("No reconnect within 5 s")
+    let reconnected = await waitUntil(timeout: 5) { sockets.value.count >= 2 }
+    guard reconnected else {
+      Issue.record("No reconnect within 5 s")
+      return
     }
 
     // Channel must re-subscribe on the new socket. Waiting only for
@@ -172,11 +165,11 @@ final class RealtimeColdStartTests: XCTestCase {
       sockets.value[1].sentMessages.contains { $0.event == "phx_join" }
         && channel.status == .subscribed
     }
-    XCTAssertEqual(channel.status, .subscribed, "Channel did not rejoin after reconnect")
+    #expect(channel.status == .subscribed, "Channel did not rejoin after reconnect")
 
     // Exactly one phx_join sent on socket 2 (index 1).
     let joinsSentOnNewSocket = sockets.value[1].sentMessages.filter { $0.event == "phx_join" }
-    XCTAssertEqual(joinsSentOnNewSocket.count, 1, "Expected one phx_join on the new socket")
+    #expect(joinsSentOnNewSocket.count == 1, "Expected one phx_join on the new socket")
   }
 
   /// A heartbeat left pending on a connection that errors out must not be
@@ -191,7 +184,8 @@ final class RealtimeColdStartTests: XCTestCase {
   /// the first reconnect the socket count stabilizes. With the bug, socket 2's
   /// first heartbeat immediately times out → a second reconnect → socket 3 →
   /// etc. With the fix, socket 2 stays connected.
-  func testPendingHeartbeatDoesNotLeakAcrossReconnect() async throws {
+  @Test
+  func pendingHeartbeatDoesNotLeakAcrossReconnect() async throws {
     let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
 
     let sut = RealtimeClientV2(
@@ -236,9 +230,10 @@ final class RealtimeColdStartTests: XCTestCase {
     sockets.value[0].receiveFromServer(.text("not a valid frame"))
 
     // Wait for the first reconnect to complete.
-    await waitUntil(timeout: 5) { sockets.value.count >= 2 }
-    guard sockets.value.count >= 2 else {
-      return XCTFail("No reconnect within 5 s — socket count: \(sockets.value.count)")
+    let reconnected = await waitUntil(timeout: 5) { sockets.value.count >= 2 }
+    guard reconnected else {
+      Issue.record("No reconnect within 5 s — socket count: \(sockets.value.count)")
+      return
     }
 
     // Record the count right after the first reconnect. If pendingHeartbeatRef
@@ -250,8 +245,8 @@ final class RealtimeColdStartTests: XCTestCase {
       sockets.value.count > countAfterFirstReconnect
     }
 
-    XCTAssertEqual(
-      sockets.value.count, countAfterFirstReconnect,
+    #expect(
+      sockets.value.count == countAfterFirstReconnect,
       """
       Perpetual reconnects detected — pendingHeartbeatRef likely leaked \
       into the replacement connection: \(heartbeatStatuses.value)

--- a/Tests/RealtimeTests/RealtimeErrorTests.swift
+++ b/Tests/RealtimeTests/RealtimeErrorTests.swift
@@ -5,49 +5,55 @@
 //  Created by Guilherme Souza on 29/07/25.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class RealtimeErrorTests: XCTestCase {
-  func testRealtimeErrorInitialization() {
+@Suite
+struct RealtimeErrorTests {
+  @Test
+  func realtimeErrorInitialization() {
     let errorMessage = "Connection failed"
     let error = RealtimeError(errorMessage)
 
-    XCTAssertEqual(error.errorDescription, errorMessage)
+    #expect(error.errorDescription == errorMessage)
   }
 
-  func testRealtimeErrorLocalizedDescription() {
+  @Test
+  func realtimeErrorLocalizedDescription() {
     let errorMessage = "Test error message"
     let error = RealtimeError(errorMessage)
 
     // LocalizedError protocol provides localizedDescription
-    XCTAssertEqual(error.localizedDescription, errorMessage)
+    #expect(error.localizedDescription == errorMessage)
   }
 
-  func testRealtimeErrorWithEmptyMessage() {
+  @Test
+  func realtimeErrorWithEmptyMessage() {
     let error = RealtimeError("")
-    XCTAssertEqual(error.errorDescription, "")
+    #expect(error.errorDescription == "")
   }
 
-  func testRealtimeErrorAsError() {
+  @Test
+  func realtimeErrorAsError() {
     let errorMessage = "Network timeout"
     let realtimeError = RealtimeError(errorMessage)
     let error: Error = realtimeError
 
     // Test that it can be used as a general Error
-    XCTAssertNotNil(error)
-    XCTAssertEqual(error.localizedDescription, errorMessage)
+    #expect(error.localizedDescription == errorMessage)
   }
 
-  func testRealtimeErrorEquality() {
+  @Test
+  func realtimeErrorEquality() {
     let error1 = RealtimeError("Same message")
     let error2 = RealtimeError("Same message")
     let error3 = RealtimeError("Different message")
 
     // Since RealtimeError doesn't implement Equatable, we test the description
-    XCTAssertEqual(error1.errorDescription, error2.errorDescription)
-    XCTAssertNotEqual(error1.errorDescription, error3.errorDescription)
+    #expect(error1.errorDescription == error2.errorDescription)
+    #expect(error1.errorDescription != error3.errorDescription)
   }
 }

--- a/Tests/RealtimeTests/RealtimeJoinConfigTests.swift
+++ b/Tests/RealtimeTests/RealtimeJoinConfigTests.swift
@@ -5,16 +5,19 @@
 //  Created by Guilherme Souza on 29/07/25.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class RealtimeJoinConfigTests: XCTestCase {
+@Suite
+struct RealtimeJoinConfigTests {
 
   // MARK: - RealtimeJoinPayload Tests
 
-  func testRealtimeJoinPayloadInit() {
+  @Test
+  func realtimeJoinPayloadInit() {
     let config = RealtimeJoinConfig()
     let payload = RealtimeJoinPayload(
       config: config,
@@ -22,12 +25,13 @@ final class RealtimeJoinConfigTests: XCTestCase {
       version: "1.0"
     )
 
-    XCTAssertEqual(payload.config, config)
-    XCTAssertEqual(payload.accessToken, "token123")
-    XCTAssertEqual(payload.version, "1.0")
+    #expect(payload.config == config)
+    #expect(payload.accessToken == "token123")
+    #expect(payload.version == "1.0")
   }
 
-  func testRealtimeJoinPayloadCodingKeys() throws {
+  @Test
+  func realtimeJoinPayloadCodingKeys() throws {
     let config = RealtimeJoinConfig()
     let payload = RealtimeJoinPayload(
       config: config,
@@ -39,12 +43,13 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let data = try encoder.encode(payload)
 
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-    XCTAssertNotNil(jsonObject?["config"])
-    XCTAssertEqual(jsonObject?["access_token"] as? String, "token123")
-    XCTAssertEqual(jsonObject?["version"] as? String, "1.0")
+    #expect(jsonObject?["config"] != nil)
+    #expect(jsonObject?["access_token"] as? String == "token123")
+    #expect(jsonObject?["version"] as? String == "1.0")
   }
 
-  func testRealtimeJoinPayloadDecoding() throws {
+  @Test
+  func realtimeJoinPayloadDecoding() throws {
     let jsonData = """
       {
         "config": {
@@ -61,25 +66,27 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let decoder = JSONDecoder()
     let payload = try decoder.decode(RealtimeJoinPayload.self, from: jsonData)
 
-    XCTAssertEqual(payload.accessToken, "token123")
-    XCTAssertEqual(payload.version, "1.0")
-    XCTAssertFalse(payload.config.isPrivate)
+    #expect(payload.accessToken == "token123")
+    #expect(payload.version == "1.0")
+    #expect(!payload.config.isPrivate)
   }
 
   // MARK: - RealtimeJoinConfig Tests
 
-  func testRealtimeJoinConfigDefaults() {
+  @Test
+  func realtimeJoinConfigDefaults() {
     let config = RealtimeJoinConfig()
 
-    XCTAssertFalse(config.broadcast.acknowledgeBroadcasts)
-    XCTAssertFalse(config.broadcast.receiveOwnBroadcasts)
-    XCTAssertEqual(config.presence.key, "")
-    XCTAssertFalse(config.presence.enabled)
-    XCTAssertTrue(config.postgresChanges.isEmpty)
-    XCTAssertFalse(config.isPrivate)
+    #expect(!config.broadcast.acknowledgeBroadcasts)
+    #expect(!config.broadcast.receiveOwnBroadcasts)
+    #expect(config.presence.key == "")
+    #expect(!config.presence.enabled)
+    #expect(config.postgresChanges.isEmpty)
+    #expect(!config.isPrivate)
   }
 
-  func testRealtimeJoinConfigCustomValues() {
+  @Test
+  func realtimeJoinConfigCustomValues() {
     var config = RealtimeJoinConfig()
     config.broadcast.acknowledgeBroadcasts = true
     config.broadcast.receiveOwnBroadcasts = true
@@ -90,37 +97,40 @@ final class RealtimeJoinConfigTests: XCTestCase {
       PostgresJoinConfig(event: .insert, schema: "public", table: "users", filter: nil, id: 1)
     ]
 
-    XCTAssertTrue(config.broadcast.acknowledgeBroadcasts)
-    XCTAssertTrue(config.broadcast.receiveOwnBroadcasts)
-    XCTAssertEqual(config.presence.key, "user123")
-    XCTAssertTrue(config.presence.enabled)
-    XCTAssertTrue(config.isPrivate)
-    XCTAssertEqual(config.postgresChanges.count, 1)
+    #expect(config.broadcast.acknowledgeBroadcasts)
+    #expect(config.broadcast.receiveOwnBroadcasts)
+    #expect(config.presence.key == "user123")
+    #expect(config.presence.enabled)
+    #expect(config.isPrivate)
+    #expect(config.postgresChanges.count == 1)
   }
 
-  func testRealtimeJoinConfigEquality() {
+  @Test
+  func realtimeJoinConfigEquality() {
     let config1 = RealtimeJoinConfig()
     var config2 = RealtimeJoinConfig()
     config2.isPrivate = false
 
-    XCTAssertEqual(config1, config2)
+    #expect(config1 == config2)
 
     config2.isPrivate = true
-    XCTAssertNotEqual(config1, config2)
+    #expect(config1 != config2)
   }
 
-  func testRealtimeJoinConfigHashable() {
+  @Test
+  func realtimeJoinConfigHashable() {
     let config1 = RealtimeJoinConfig()
     var config2 = RealtimeJoinConfig()
     config2.isPrivate = false
 
-    XCTAssertEqual(config1.hashValue, config2.hashValue)
+    #expect(config1.hashValue == config2.hashValue)
 
     config2.isPrivate = true
-    XCTAssertNotEqual(config1.hashValue, config2.hashValue)
+    #expect(config1.hashValue != config2.hashValue)
   }
 
-  func testRealtimeJoinConfigCodingKeys() throws {
+  @Test
+  func realtimeJoinConfigCodingKeys() throws {
     var config = RealtimeJoinConfig()
     config.isPrivate = true
     config.postgresChanges = [
@@ -131,32 +141,35 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let data = try encoder.encode(config)
 
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-    XCTAssertNotNil(jsonObject?["broadcast"])
-    XCTAssertNotNil(jsonObject?["presence"])
-    XCTAssertNotNil(jsonObject?["postgres_changes"])
-    XCTAssertEqual(jsonObject?["private"] as? Bool, true)
+    #expect(jsonObject?["broadcast"] != nil)
+    #expect(jsonObject?["presence"] != nil)
+    #expect(jsonObject?["postgres_changes"] != nil)
+    #expect(jsonObject?["private"] as? Bool == true)
   }
 
   // MARK: - BroadcastJoinConfig Tests
 
-  func testBroadcastJoinConfigDefaults() {
+  @Test
+  func broadcastJoinConfigDefaults() {
     let config = BroadcastJoinConfig()
 
-    XCTAssertFalse(config.acknowledgeBroadcasts)
-    XCTAssertFalse(config.receiveOwnBroadcasts)
+    #expect(!config.acknowledgeBroadcasts)
+    #expect(!config.receiveOwnBroadcasts)
   }
 
-  func testBroadcastJoinConfigCustomValues() {
+  @Test
+  func broadcastJoinConfigCustomValues() {
     let config = BroadcastJoinConfig(
       acknowledgeBroadcasts: true,
       receiveOwnBroadcasts: true
     )
 
-    XCTAssertTrue(config.acknowledgeBroadcasts)
-    XCTAssertTrue(config.receiveOwnBroadcasts)
+    #expect(config.acknowledgeBroadcasts)
+    #expect(config.receiveOwnBroadcasts)
   }
 
-  func testBroadcastJoinConfigCodingKeys() throws {
+  @Test
+  func broadcastJoinConfigCodingKeys() throws {
     let config = BroadcastJoinConfig(
       acknowledgeBroadcasts: true,
       receiveOwnBroadcasts: true
@@ -166,11 +179,12 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let data = try encoder.encode(config)
 
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-    XCTAssertEqual(jsonObject?["ack"] as? Bool, true)
-    XCTAssertEqual(jsonObject?["self"] as? Bool, true)
+    #expect(jsonObject?["ack"] as? Bool == true)
+    #expect(jsonObject?["self"] as? Bool == true)
   }
 
-  func testBroadcastJoinConfigDecoding() throws {
+  @Test
+  func broadcastJoinConfigDecoding() throws {
     let jsonData = """
       {
         "ack": true,
@@ -182,35 +196,39 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let decoder = JSONDecoder()
     let config = try decoder.decode(BroadcastJoinConfig.self, from: jsonData)
 
-    XCTAssertTrue(config.acknowledgeBroadcasts)
-    XCTAssertFalse(config.receiveOwnBroadcasts)
+    #expect(config.acknowledgeBroadcasts)
+    #expect(!config.receiveOwnBroadcasts)
   }
 
-  func testBroadcastJoinConfigReplicationReadyDefaultsFalse() {
+  @Test
+  func broadcastJoinConfigReplicationReadyDefaultsFalse() {
     let config = BroadcastJoinConfig()
 
-    XCTAssertFalse(config.replicationReady)
+    #expect(!config.replicationReady)
   }
 
-  func testBroadcastJoinConfigEncodesReplicationReadyWhenFalse() throws {
+  @Test
+  func broadcastJoinConfigEncodesReplicationReadyWhenFalse() throws {
     let config = BroadcastJoinConfig()
 
     let data = try JSONEncoder().encode(config)
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
 
-    XCTAssertEqual(jsonObject?["replication_ready"] as? Bool, false)
+    #expect(jsonObject?["replication_ready"] as? Bool == false)
   }
 
-  func testBroadcastJoinConfigEncodesReplicationReadyWhenTrue() throws {
+  @Test
+  func broadcastJoinConfigEncodesReplicationReadyWhenTrue() throws {
     let config = BroadcastJoinConfig(replicationReady: true)
 
     let data = try JSONEncoder().encode(config)
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
 
-    XCTAssertEqual(jsonObject?["replication_ready"] as? Bool, true)
+    #expect(jsonObject?["replication_ready"] as? Bool == true)
   }
 
-  func testBroadcastJoinConfigDecodesReplicationReady() throws {
+  @Test
+  func broadcastJoinConfigDecodesReplicationReady() throws {
     let jsonData = """
       {
         "ack": false,
@@ -221,28 +239,31 @@ final class RealtimeJoinConfigTests: XCTestCase {
 
     let config = try JSONDecoder().decode(BroadcastJoinConfig.self, from: jsonData)
 
-    XCTAssertTrue(config.replicationReady)
+    #expect(config.replicationReady)
   }
 
   // MARK: - PresenceJoinConfig Tests
 
-  func testPresenceJoinConfigDefaults() {
+  @Test
+  func presenceJoinConfigDefaults() {
     let config = PresenceJoinConfig()
 
-    XCTAssertEqual(config.key, "")
-    XCTAssertFalse(config.enabled)
+    #expect(config.key == "")
+    #expect(!config.enabled)
   }
 
-  func testPresenceJoinConfigCustomValues() {
+  @Test
+  func presenceJoinConfigCustomValues() {
     var config = PresenceJoinConfig()
     config.key = "user123"
     config.enabled = true
 
-    XCTAssertEqual(config.key, "user123")
-    XCTAssertTrue(config.enabled)
+    #expect(config.key == "user123")
+    #expect(config.enabled)
   }
 
-  func testPresenceJoinConfigCodable() throws {
+  @Test
+  func presenceJoinConfigCodable() throws {
     var config = PresenceJoinConfig()
     config.key = "user123"
     config.enabled = true
@@ -253,28 +274,31 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let decoder = JSONDecoder()
     let decodedConfig = try decoder.decode(PresenceJoinConfig.self, from: data)
 
-    XCTAssertEqual(decodedConfig.key, "user123")
-    XCTAssertTrue(decodedConfig.enabled)
+    #expect(decodedConfig.key == "user123")
+    #expect(decodedConfig.enabled)
   }
 
   // MARK: - PostgresChangeEvent Tests
 
-  func testPostgresChangeEventRawValues() {
-    XCTAssertEqual(PostgresChangeEvent.insert.rawValue, "INSERT")
-    XCTAssertEqual(PostgresChangeEvent.update.rawValue, "UPDATE")
-    XCTAssertEqual(PostgresChangeEvent.delete.rawValue, "DELETE")
-    XCTAssertEqual(PostgresChangeEvent.all.rawValue, "*")
+  @Test
+  func postgresChangeEventRawValues() {
+    #expect(PostgresChangeEvent.insert.rawValue == "INSERT")
+    #expect(PostgresChangeEvent.update.rawValue == "UPDATE")
+    #expect(PostgresChangeEvent.delete.rawValue == "DELETE")
+    #expect(PostgresChangeEvent.all.rawValue == "*")
   }
 
-  func testPostgresChangeEventFromRawValue() {
-    XCTAssertEqual(PostgresChangeEvent(rawValue: "INSERT"), .insert)
-    XCTAssertEqual(PostgresChangeEvent(rawValue: "UPDATE"), .update)
-    XCTAssertEqual(PostgresChangeEvent(rawValue: "DELETE"), .delete)
-    XCTAssertEqual(PostgresChangeEvent(rawValue: "*"), .all)
-    XCTAssertNil(PostgresChangeEvent(rawValue: "INVALID"))
+  @Test
+  func postgresChangeEventFromRawValue() {
+    #expect(PostgresChangeEvent(rawValue: "INSERT") == .insert)
+    #expect(PostgresChangeEvent(rawValue: "UPDATE") == .update)
+    #expect(PostgresChangeEvent(rawValue: "DELETE") == .delete)
+    #expect(PostgresChangeEvent(rawValue: "*") == .all)
+    #expect(PostgresChangeEvent(rawValue: "INVALID") == nil)
   }
 
-  func testPostgresChangeEventCodable() throws {
+  @Test
+  func postgresChangeEventCodable() throws {
     let events: [PostgresChangeEvent] = [.insert, .update, .delete, .all]
 
     let encoder = JSONEncoder()
@@ -283,23 +307,25 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let decoder = JSONDecoder()
     let decodedEvents = try decoder.decode([PostgresChangeEvent].self, from: data)
 
-    XCTAssertEqual(decodedEvents, events)
+    #expect(decodedEvents == events)
   }
 
   // MARK: - PostgresJoinConfig Additional Tests
 
-  func testPostgresJoinConfigDefaults() {
+  @Test
+  func postgresJoinConfigDefaults() {
     let config = PostgresJoinConfig(
       event: .insert, schema: "public", table: "users", filter: nil, id: 0)
 
-    XCTAssertEqual(config.event, .insert)
-    XCTAssertEqual(config.schema, "public")
-    XCTAssertEqual(config.table, "users")
-    XCTAssertNil(config.filter)
-    XCTAssertEqual(config.id, 0)
+    #expect(config.event == .insert)
+    #expect(config.schema == "public")
+    #expect(config.table == "users")
+    #expect(config.filter == nil)
+    #expect(config.id == 0)
   }
 
-  func testPostgresJoinConfigCustomEncoding() throws {
+  @Test
+  func postgresJoinConfigCustomEncoding() throws {
     let config = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -312,14 +338,15 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let data = try encoder.encode(config)
 
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-    XCTAssertEqual(jsonObject?["event"] as? String, "INSERT")
-    XCTAssertEqual(jsonObject?["schema"] as? String, "public")
-    XCTAssertEqual(jsonObject?["table"] as? String, "users")
-    XCTAssertEqual(jsonObject?["filter"] as? String, "id=1")
-    XCTAssertEqual(jsonObject?["id"] as? Int, 123)
+    #expect(jsonObject?["event"] as? String == "INSERT")
+    #expect(jsonObject?["schema"] as? String == "public")
+    #expect(jsonObject?["table"] as? String == "users")
+    #expect(jsonObject?["filter"] as? String == "id=1")
+    #expect(jsonObject?["id"] as? Int == 123)
   }
 
-  func testPostgresJoinConfigEncodingWithZeroId() throws {
+  @Test
+  func postgresJoinConfigEncodingWithZeroId() throws {
     let config = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -332,10 +359,11 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let data = try encoder.encode(config)
 
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-    XCTAssertNil(jsonObject?["id"])  // Should not encode id when it's 0
+    #expect(jsonObject?["id"] == nil)  // Should not encode id when it's 0
   }
 
-  func testPostgresJoinConfigEncodingWithNilValues() throws {
+  @Test
+  func postgresJoinConfigEncodingWithNilValues() throws {
     let config = PostgresJoinConfig(
       event: .insert,
       schema: "public",
@@ -348,7 +376,7 @@ final class RealtimeJoinConfigTests: XCTestCase {
     let data = try encoder.encode(config)
 
     let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-    XCTAssertNil(jsonObject?["table"])  // Should not encode nil table
-    XCTAssertNil(jsonObject?["filter"])  // Should not encode nil filter
+    #expect(jsonObject?["table"] == nil)  // Should not encode nil table
+    #expect(jsonObject?["filter"] == nil)  // Should not encode nil filter
   }
 }

--- a/Tests/RealtimeTests/RealtimeLifecycleTests.swift
+++ b/Tests/RealtimeTests/RealtimeLifecycleTests.swift
@@ -9,28 +9,25 @@ import Clocks
 import ConcurrencyExtras
 import Foundation
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
 #if os(Linux)
-  @available(
-    *, unavailable, message: "RealtimeLifecycleTests are disabled on Linux due to timing flakiness"
-  )
-  final class RealtimeLifecycleTests: XCTestCase {}
+  // RealtimeLifecycleTests are disabled on Linux due to timing flakiness.
 #else
 
-  final class RealtimeLifecycleTests: XCTestCase {
+  @Suite
+  struct RealtimeLifecycleTests {
     let url = URL(string: "http://localhost:54321/realtime/v1")!
     let apiKey = "publishable.api.key"
 
-    var http: HTTPClientMock!
-    var testClock: TestClock<Duration>!
-    var servers: LockIsolated<[FakeWebSocket]>!
+    let http: HTTPClientMock
+    let testClock: TestClock<Duration>
+    let servers: LockIsolated<[FakeWebSocket]>
 
-    override func setUp() {
-      super.setUp()
+    init() {
       http = HTTPClientMock()
       testClock = TestClock()
       servers = LockIsolated([])
@@ -48,7 +45,7 @@ import XCTest
           let (client, server) = FakeWebSocket.fakes()
           // Auto-respond to heartbeats and phx_join so subscribe() completes.
           // Retain the server so `client.other` (a weak ref) stays valid.
-          servers?.withValue { $0.append(server) }
+          servers.withValue { $0.append(server) }
           Task { [server] in
             for await event in server.events {
               guard let msg = event.realtimeMessage else { continue }
@@ -89,7 +86,8 @@ import XCTest
       )
     }
 
-    func testHandleAppForegroundWhileConnectedIsNoOp() async throws {
+    @Test
+    func handleAppForegroundWhileConnectedIsNoOp() async throws {
       let sut = makeClient()
       let channel = sut.channel("public:messages")
       try await channel.subscribeWithError()
@@ -100,31 +98,34 @@ import XCTest
       sut.handleAppBackground()
       await sut.handleAppForeground()
 
-      XCTAssertEqual(sut.status, statusBefore)
-      XCTAssertEqual(channel.status, channelStatusBefore)
+      #expect(sut.status == statusBefore)
+      #expect(channel.status == channelStatusBefore)
     }
 
-    func testHandleAppForegroundWithoutPriorBackgroundIsNoOp() async {
+    @Test
+    func handleAppForegroundWithoutPriorBackgroundIsNoOp() async {
       let sut = makeClient()
-      XCTAssertEqual(sut.status, .disconnected)
+      #expect(sut.status == .disconnected)
 
       await sut.handleAppForeground()
-      XCTAssertEqual(sut.status, .disconnected)
+      #expect(sut.status == .disconnected)
     }
 
-    func testHandleAppForegroundDoesNotConnectIfNotConnectedBeforeBackground() async {
+    @Test
+    func handleAppForegroundDoesNotConnectIfNotConnectedBeforeBackground() async {
       let sut = makeClient()
-      XCTAssertEqual(sut.status, .disconnected)
+      #expect(sut.status == .disconnected)
 
       sut.handleAppBackground()
       await sut.handleAppForeground()
-      XCTAssertEqual(sut.status, .disconnected)
+      #expect(sut.status == .disconnected)
     }
 
-    func testHandleAppForegroundReconnectsWhenBackgroundedWhileConnected() async throws {
+    @Test
+    func handleAppForegroundReconnectsWhenBackgroundedWhileConnected() async throws {
       let sut = makeClient()
       await sut.connect()
-      XCTAssertEqual(sut.status, .connected)
+      #expect(sut.status == .connected)
 
       sut.handleAppBackground()
       // Subscribe before the OS close so the buffered .disconnected event is
@@ -139,20 +140,21 @@ import XCTest
       // auto-reconnect task wakes and performConnection() runs.
       await testClock.advance(by: .seconds(8))
       _ = await statusUpdates.first { $0 == .connected }
-      XCTAssertEqual(sut.status, .connected)
+      #expect(sut.status == .connected)
 
       // handleAppForeground is a no-op: the auto-reconnect already recovered
       // the connection and the state observer will rejoin channels.
       await sut.handleAppForeground()
-      XCTAssertEqual(sut.status, .connected)
+      #expect(sut.status == .connected)
     }
 
-    func testHandleAppForegroundResubscribesChannelsWhenBackgroundedWhileConnected() async throws {
+    @Test
+    func handleAppForegroundResubscribesChannelsWhenBackgroundedWhileConnected() async throws {
       let sut = makeClient()
       let channel = sut.channel("public:messages")
       try await channel.subscribeWithError()
-      XCTAssertEqual(sut.status, .connected)
-      XCTAssertEqual(channel.status, .subscribed)
+      #expect(sut.status == .connected)
+      #expect(channel.status == .subscribed)
 
       sut.handleAppBackground()
       let statusUpdates = sut.statusChange
@@ -161,47 +163,49 @@ import XCTest
 
       await testClock.advance(by: .seconds(8))
       _ = await statusUpdates.first { $0 == .connected }
-      XCTAssertEqual(sut.status, .connected)
+      #expect(sut.status == .connected)
 
       // rejoinChannels() is launched as a fire-and-forget Task from the state
       // observer's handleConnected(isReconnect: true) path. Poll until it
       // completes (FakeWebSocket delivers phx_reply synchronously but the task
       // needs scheduler turns to run).
-      let deadline = Date().addingTimeInterval(5)
-      while channel.status != .subscribed, Date() < deadline {
-        try? await Task.sleep(nanoseconds: 10_000_000)  // 10 ms
-      }
-      XCTAssertEqual(channel.status, .subscribed)
+      await waitUntil(timeout: 5) { channel.status == .subscribed }
+      #expect(channel.status == .subscribed)
 
       // handleAppForeground is a no-op: already reconnected with channel resubscribed.
       await sut.handleAppForeground()
-      XCTAssertEqual(sut.status, .connected)
-      XCTAssertEqual(channel.status, .subscribed)
+      #expect(sut.status == .connected)
+      #expect(channel.status == .subscribed)
     }
 
-    func testExplicitDisconnectWhileBackgroundedDoesNotReconnectOnForeground() async throws {
+    @Test
+    func explicitDisconnectWhileBackgroundedDoesNotReconnectOnForeground() async throws {
       let sut = makeClient()
       await sut.connect()
-      XCTAssertEqual(sut.status, .connected)
+      #expect(sut.status == .connected)
 
       sut.handleAppBackground()
       // Explicit developer disconnect (e.g. sign-out) must clear the lifecycle flag so
       // handleAppForeground() does not silently undo it.
       sut.disconnect()
-      XCTAssertEqual(sut.status, .disconnected)
+      #expect(sut.status == .disconnected)
 
       await sut.handleAppForeground()
-      XCTAssertEqual(sut.status, .disconnected)
+      #expect(sut.status == .disconnected)
     }
 
-    func testHeartbeatTaskDoesNotRetainClient() async throws {
-      weak var weakClient: RealtimeClientV2?
+    @Test
+    func heartbeatTaskDoesNotRetainClient() async throws {
+      final class WeakBox: @unchecked Sendable {
+        weak var client: RealtimeClientV2?
+      }
+      let box = WeakBox()
 
       func scope() async {
         let sut = makeClient()
-        weakClient = sut
+        box.client = sut
         await sut.connect()
-        XCTAssertEqual(sut.status, .connected)
+        #expect(sut.status == .connected)
 
         await testClock.advance(by: .seconds(30))
 
@@ -209,27 +213,25 @@ import XCTest
       }
       await scope()
 
-      let deadline = Date().addingTimeInterval(5)
-      while weakClient != nil, Date() < deadline {
-        await Task.yield()
-        try? await Task.sleep(nanoseconds: 10_000_000)
-      }
+      await waitUntil(timeout: 5) { box.client == nil }
 
-      XCTAssertNil(
-        weakClient,
+      #expect(
+        box.client == nil,
         "RealtimeClientV2 leaked: the heartbeat task retained self, preventing deinit."
       )
     }
 
-    func testHandleAppLifecycleFalseDoesNotInstallLifecycleManager() {
+    @Test
+    func handleAppLifecycleFalseDoesNotInstallLifecycleManager() {
       let sut = makeClient(handleAppLifecycle: false)
-      XCTAssertNil(sut.mutableState.lifecycleManager)
+      #expect(sut.mutableState.lifecycleManager == nil)
     }
 
     #if os(iOS) || os(tvOS) || os(visionOS) || os(macOS)
-      func testHandleAppLifecycleTrueInstallsLifecycleManager() {
+      @Test
+      func handleAppLifecycleTrueInstallsLifecycleManager() {
         let sut = makeClient(handleAppLifecycle: true)
-        XCTAssertNotNil(sut.mutableState.lifecycleManager)
+        #expect(sut.mutableState.lifecycleManager != nil)
         _ = sut
       }
     #endif

--- a/Tests/RealtimeTests/RealtimeMessageV2Tests.swift
+++ b/Tests/RealtimeTests/RealtimeMessageV2Tests.swift
@@ -5,31 +5,35 @@
 //  Created by Guilherme Souza on 26/06/24.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class RealtimeMessageV2Tests: XCTestCase {
-  func testStatus() {
+@Suite
+struct RealtimeMessageV2Tests {
+  @Test
+  func status() {
     var message = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "heartbeat", event: "event", payload: ["status": "ok"])
-    XCTAssertEqual(message.status, .ok)
+    #expect(message.status == .ok)
 
     message = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "heartbeat", event: "event", payload: ["status": "timeout"])
-    XCTAssertEqual(message.status, .timeout)
+    #expect(message.status == .timeout)
 
     message = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "heartbeat", event: "event", payload: ["status": "error"])
-    XCTAssertEqual(message.status, .error)
+    #expect(message.status == .error)
 
     message = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "heartbeat", event: "event", payload: ["status": "invalid"])
-    XCTAssertNil(message.status)
+    #expect(message.status == nil)
   }
 
-  func testEventType() {
+  @Test
+  func eventType() {
     let payloadWithStatusOK: JSONObject = ["status": "ok"]
     let payloadWithNoStatus: JSONObject = [:]
 
@@ -40,45 +44,46 @@ final class RealtimeMessageV2Tests: XCTestCase {
       joinRef: nil, ref: nil, topic: "topic", event: ChannelEvent.postgresChanges,
       payload: payloadWithNoStatus)
 
-    XCTAssertEqual(systemEventMessage._eventType, .system)
-    XCTAssertEqual(postgresChangesEventMessage._eventType, .postgresChanges)
+    #expect(systemEventMessage._eventType == .system)
+    #expect(postgresChangesEventMessage._eventType == .postgresChanges)
 
     let broadcastEventMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "topic", event: ChannelEvent.broadcast,
       payload: payloadWithNoStatus)
-    XCTAssertEqual(broadcastEventMessage._eventType, .broadcast)
+    #expect(broadcastEventMessage._eventType == .broadcast)
 
     let closeEventMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "topic", event: ChannelEvent.close,
       payload: payloadWithNoStatus)
-    XCTAssertEqual(closeEventMessage._eventType, .close)
+    #expect(closeEventMessage._eventType == .close)
 
     let errorEventMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "topic", event: ChannelEvent.error,
       payload: payloadWithNoStatus)
-    XCTAssertEqual(errorEventMessage._eventType, .error)
+    #expect(errorEventMessage._eventType == .error)
 
     let presenceDiffEventMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "topic", event: ChannelEvent.presenceDiff,
       payload: payloadWithNoStatus)
-    XCTAssertEqual(presenceDiffEventMessage._eventType, .presenceDiff)
+    #expect(presenceDiffEventMessage._eventType == .presenceDiff)
 
     let presenceStateEventMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "topic", event: ChannelEvent.presenceState,
       payload: payloadWithNoStatus)
-    XCTAssertEqual(presenceStateEventMessage._eventType, .presenceState)
+    #expect(presenceStateEventMessage._eventType == .presenceState)
 
     let replyEventMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "topic", event: ChannelEvent.reply,
       payload: payloadWithNoStatus)
-    XCTAssertEqual(replyEventMessage._eventType, .reply)
+    #expect(replyEventMessage._eventType == .reply)
 
     let unknownEventMessage = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "topic", event: "unknown_event", payload: payloadWithNoStatus)
-    XCTAssertNil(unknownEventMessage._eventType)
+    #expect(unknownEventMessage._eventType == nil)
   }
 
-  func testMessageWithNilRefs() throws {
+  @Test
+  func messageWithNilRefs() throws {
     let message = RealtimeMessageV2(
       joinRef: nil,
       ref: nil,
@@ -89,13 +94,14 @@ final class RealtimeMessageV2Tests: XCTestCase {
     // Verify JSON encoding works
     let encoded = try JSONEncoder().encode(message)
     let decoded = try JSONDecoder().decode(RealtimeMessageV2.self, from: encoded)
-    XCTAssertNil(decoded.joinRef)
-    XCTAssertNil(decoded.ref)
-    XCTAssertEqual(decoded.topic, "phoenix")
-    XCTAssertEqual(decoded.event, "heartbeat")
+    #expect(decoded.joinRef == nil)
+    #expect(decoded.ref == nil)
+    #expect(decoded.topic == "phoenix")
+    #expect(decoded.event == "heartbeat")
   }
 
-  func testHeartbeatMessageWithNilJoinRef() throws {
+  @Test
+  func heartbeatMessageWithNilJoinRef() throws {
     let message = RealtimeMessageV2(
       joinRef: nil,  // Heartbeats don't have joinRef
       ref: "123",
@@ -105,11 +111,12 @@ final class RealtimeMessageV2Tests: XCTestCase {
     )
     let encoded = try JSONEncoder().encode(message)
     let decoded = try JSONDecoder().decode(RealtimeMessageV2.self, from: encoded)
-    XCTAssertNil(decoded.joinRef)
-    XCTAssertEqual(decoded.ref, "123")
+    #expect(decoded.joinRef == nil)
+    #expect(decoded.ref == "123")
   }
 
-  func testMessageJSONEncodingWithNilRefs() throws {
+  @Test
+  func messageJSONEncodingWithNilRefs() throws {
     let message = RealtimeMessageV2(
       joinRef: nil,
       ref: nil,
@@ -120,11 +127,12 @@ final class RealtimeMessageV2Tests: XCTestCase {
     let encoded = try JSONEncoder().encode(message)
     let jsonString = String(data: encoded, encoding: .utf8)!
     // Verify nil values are encoded as null in JSON
-    XCTAssertTrue(jsonString.contains("\"join_ref\":null") || !jsonString.contains("join_ref"))
-    XCTAssertTrue(jsonString.contains("\"ref\":null") || !jsonString.contains("ref"))
+    #expect(jsonString.contains("\"join_ref\":null") || !jsonString.contains("join_ref"))
+    #expect(jsonString.contains("\"ref\":null") || !jsonString.contains("ref"))
   }
 
-  func testMessageWithBothRefAndJoinRef() throws {
+  @Test
+  func messageWithBothRefAndJoinRef() throws {
     let message = RealtimeMessageV2(
       joinRef: "join-456",
       ref: "ref-789",
@@ -134,12 +142,13 @@ final class RealtimeMessageV2Tests: XCTestCase {
     )
     let encoded = try JSONEncoder().encode(message)
     let decoded = try JSONDecoder().decode(RealtimeMessageV2.self, from: encoded)
-    XCTAssertEqual(decoded.joinRef, "join-456")
-    XCTAssertEqual(decoded.ref, "ref-789")
-    XCTAssertEqual(decoded.topic, "room:lobby")
+    #expect(decoded.joinRef == "join-456")
+    #expect(decoded.ref == "ref-789")
+    #expect(decoded.topic == "room:lobby")
   }
 
-  func testMessageWithRefButNilJoinRef() throws {
+  @Test
+  func messageWithRefButNilJoinRef() throws {
     let message = RealtimeMessageV2(
       joinRef: nil,
       ref: "ref-999",
@@ -149,8 +158,8 @@ final class RealtimeMessageV2Tests: XCTestCase {
     )
     let encoded = try JSONEncoder().encode(message)
     let decoded = try JSONDecoder().decode(RealtimeMessageV2.self, from: encoded)
-    XCTAssertNil(decoded.joinRef)
-    XCTAssertEqual(decoded.ref, "ref-999")
-    XCTAssertEqual(decoded.topic, "room:lobby")
+    #expect(decoded.joinRef == nil)
+    #expect(decoded.ref == "ref-999")
+    #expect(decoded.topic == "room:lobby")
   }
 }

--- a/Tests/RealtimeTests/RealtimePostgresFilterTests.swift
+++ b/Tests/RealtimeTests/RealtimePostgresFilterTests.swift
@@ -5,165 +5,185 @@
 //  Created by Lucas Abijmil on 20/02/2025.
 //
 
-import XCTest
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class RealtimePostgresFilterTests: XCTestCase {
+@Suite
+struct RealtimePostgresFilterTests {
 
-  func testEq() {
+  @Test
+  func eq() {
     let value = "value"
     let column = "column"
     let filter: RealtimePostgresFilter = .eq(column, value: value)
 
-    XCTAssertEqual(filter.value, "column=eq.value")
+    #expect(filter.value == "column=eq.value")
   }
 
-  func testNeq() {
+  @Test
+  func neq() {
     let value = "value"
     let column = "column"
     let filter: RealtimePostgresFilter = .neq(column, value: value)
 
-    XCTAssertEqual(filter.value, "column=neq.value")
+    #expect(filter.value == "column=neq.value")
   }
 
-  func testGt() {
+  @Test
+  func gt() {
     let value = "value"
     let column = "column"
     let filter: RealtimePostgresFilter = .gt(column, value: value)
 
-    XCTAssertEqual(filter.value, "column=gt.value")
+    #expect(filter.value == "column=gt.value")
   }
 
-  func testGte() {
+  @Test
+  func gte() {
     let value = "value"
     let column = "column"
     let filter: RealtimePostgresFilter = .gte(column, value: value)
 
-    XCTAssertEqual(filter.value, "column=gte.value")
+    #expect(filter.value == "column=gte.value")
   }
 
-  func testLt() {
+  @Test
+  func lt() {
     let value = "value"
     let column = "column"
     let filter: RealtimePostgresFilter = .lt(column, value: value)
 
-    XCTAssertEqual(filter.value, "column=lt.value")
+    #expect(filter.value == "column=lt.value")
   }
 
-  func testLte() {
+  @Test
+  func lte() {
     let value = "value"
     let column = "column"
     let filter: RealtimePostgresFilter = .lte(column, value: value)
 
-    XCTAssertEqual(filter.value, "column=lte.value")
+    #expect(filter.value == "column=lte.value")
   }
 
-  func testIn() {
+  @Test
+  func `in`() {
     let values = ["value1", "value2"]
     let column = "column"
     let filter: RealtimePostgresFilter = .in(column, values: values)
 
-    XCTAssertEqual(filter.value, "column=in.(value1,value2)")
+    #expect(filter.value == "column=in.(value1,value2)")
   }
 
-  func testInDeduplicatesValues() {
+  @Test
+  func inDeduplicatesValues() {
     let filter: RealtimePostgresFilter = .in("status", values: ["a", "b", "a"])
 
-    XCTAssertEqual(filter.value, "status=in.(a,b)")
+    #expect(filter.value == "status=in.(a,b)")
   }
 
-  func testLike() {
+  @Test
+  func like() {
     let filter: RealtimePostgresFilter = .like("title", value: "%foo%")
 
-    XCTAssertEqual(filter.value, "title=like.%foo%")
+    #expect(filter.value == "title=like.%foo%")
   }
 
-  func testILike() {
+  @Test
+  func iLike() {
     let filter: RealtimePostgresFilter = .ilike("title", value: "%foo%")
 
-    XCTAssertEqual(filter.value, "title=ilike.%foo%")
+    #expect(filter.value == "title=ilike.%foo%")
   }
 
-  func testMatch() {
+  @Test
+  func match() {
     let filter: RealtimePostgresFilter = .match("title", value: "^foo")
 
-    XCTAssertEqual(filter.value, "title=match.^foo")
+    #expect(filter.value == "title=match.^foo")
   }
 
-  func testIMatch() {
+  @Test
+  func iMatch() {
     let filter: RealtimePostgresFilter = .imatch("title", value: "^foo")
 
-    XCTAssertEqual(filter.value, "title=imatch.^foo")
+    #expect(filter.value == "title=imatch.^foo")
   }
 
-  func testIs() {
-    XCTAssertEqual(
-      (.is("deleted_at", value: .null) as RealtimePostgresFilter).value, "deleted_at=is.null")
-    XCTAssertEqual((.is("active", value: .true) as RealtimePostgresFilter).value, "active=is.true")
-    XCTAssertEqual(
-      (.is("active", value: .false) as RealtimePostgresFilter).value, "active=is.false")
-    XCTAssertEqual(
-      (.is("state", value: .unknown) as RealtimePostgresFilter).value, "state=is.unknown")
+  @Test
+  func `is`() {
+    #expect(
+      (.is("deleted_at", value: .null) as RealtimePostgresFilter).value == "deleted_at=is.null")
+    #expect((.is("active", value: .true) as RealtimePostgresFilter).value == "active=is.true")
+    #expect((.is("active", value: .false) as RealtimePostgresFilter).value == "active=is.false")
+    #expect((.is("state", value: .unknown) as RealtimePostgresFilter).value == "state=is.unknown")
   }
 
-  func testIsDistinct() {
+  @Test
+  func isDistinct() {
     let filter: RealtimePostgresFilter = .isDistinct("value", value: 1)
 
-    XCTAssertEqual(filter.value, "value=isdistinct.1")
+    #expect(filter.value == "value=isdistinct.1")
   }
 
-  func testNot() {
+  @Test
+  func not() {
     let filter: RealtimePostgresFilter = .not(.eq("id", value: 1))
 
-    XCTAssertEqual(filter.value, "id=not.eq.1")
+    #expect(filter.value == "id=not.eq.1")
   }
 
-  func testNotIn() {
+  @Test
+  func notIn() {
     let filter: RealtimePostgresFilter = .not(.in("status", values: ["draft", "archived"]))
 
-    XCTAssertEqual(filter.value, "status=not.in.(draft,archived)")
+    #expect(filter.value == "status=not.in.(draft,archived)")
   }
 
-  func testAnd() {
+  @Test
+  func and() {
     let filter: RealtimePostgresFilter = .and([
       .gt("amount", value: 100),
       .in("status", values: ["open", "pending"]),
     ])
 
-    XCTAssertEqual(filter.value, "amount=gt.100,status=in.(open,pending)")
+    #expect(filter.value == "amount=gt.100,status=in.(open,pending)")
   }
 
-  func testAndWithNot() {
+  @Test
+  func andWithNot() {
     let filter: RealtimePostgresFilter = .and([
       .gt("amount", value: 100),
       .not(.in("status", values: ["draft", "archived"])),
       .like("title", value: "%foo%"),
     ])
 
-    XCTAssertEqual(
-      filter.value,
-      "amount=gt.100,status=not.in.(draft,archived),title=like.%foo%"
+    #expect(
+      filter.value
+        == "amount=gt.100,status=not.in.(draft,archived),title=like.%foo%"
     )
   }
 
-  func testReservedCharacterQuoting() {
-    XCTAssertEqual((.eq("name", value: "a,b") as RealtimePostgresFilter).value, #"name=eq."a,b""#)
-    XCTAssertEqual((.eq("name", value: "a(b)") as RealtimePostgresFilter).value, #"name=eq."a(b)""#)
-    XCTAssertEqual((.eq("name", value: " a") as RealtimePostgresFilter).value, #"name=eq." a""#)
+  @Test
+  func reservedCharacterQuoting() {
+    #expect((.eq("name", value: "a,b") as RealtimePostgresFilter).value == #"name=eq."a,b""#)
+    #expect((.eq("name", value: "a(b)") as RealtimePostgresFilter).value == #"name=eq."a(b)""#)
+    #expect((.eq("name", value: " a") as RealtimePostgresFilter).value == #"name=eq." a""#)
   }
 
-  func testReservedCharacterQuotingEscapesQuotesAndBackslashes() {
-    XCTAssertEqual(
-      (.eq("name", value: #"a"b\c"#) as RealtimePostgresFilter).value,
-      #"name=eq."a\"b\\c""#
+  @Test
+  func reservedCharacterQuotingEscapesQuotesAndBackslashes() {
+    #expect(
+      (.eq("name", value: #"a"b\c"#) as RealtimePostgresFilter).value
+        == #"name=eq."a\"b\\c""#
     )
   }
 
-  func testReservedCharacterQuotingInList() {
+  @Test
+  func reservedCharacterQuotingInList() {
     let filter: RealtimePostgresFilter = .in("tag", values: ["a,b", "c"])
 
-    XCTAssertEqual(filter.value, #"tag=in.("a,b",c)"#)
+    #expect(filter.value == #"tag=in.("a,b",c)"#)
   }
 }

--- a/Tests/RealtimeTests/RealtimePostgresFilterValueTests.swift
+++ b/Tests/RealtimeTests/RealtimePostgresFilterValueTests.swift
@@ -5,22 +5,26 @@
 //  Created by Lucas Abijmil on 19/02/2025.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class RealtimePostgresFilterValueTests: XCTestCase {
-  func testUUID() {
-    XCTAssertEqual(
-      UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!.rawValue,
-      "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+@Suite
+struct RealtimePostgresFilterValueTests {
+  @Test
+  func uuid() {
+    #expect(
+      UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!.rawValue
+        == "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
   }
 
-  func testDate() {
-    XCTAssertEqual(
-      Date(timeIntervalSince1970: 1_737_465_985).rawValue,
-      "2025-01-21T13:26:25.000Z"
+  @Test
+  func date() {
+    #expect(
+      Date(timeIntervalSince1970: 1_737_465_985).rawValue
+        == "2025-01-21T13:26:25.000Z"
     )
   }
 }

--- a/Tests/RealtimeTests/RealtimeSerializerTests.swift
+++ b/Tests/RealtimeTests/RealtimeSerializerTests.swift
@@ -5,17 +5,20 @@
 //  Created by Guilherme Souza on 12/02/26.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class RealtimeSerializerTests: XCTestCase {
+@Suite
+struct RealtimeSerializerTests {
   let serializer = RealtimeSerializer()
 
   // MARK: - Text Encoding
 
-  func testEncodeText_withAllFields() throws {
+  @Test
+  func encodeText_withAllFields() throws {
     let message = RealtimeMessageV2(
       joinRef: "1",
       ref: "2",
@@ -27,15 +30,16 @@ final class RealtimeSerializerTests: XCTestCase {
     let text = try serializer.encodeText(message)
     let array = try JSONDecoder().decode([AnyJSON].self, from: Data(text.utf8))
 
-    XCTAssertEqual(array.count, 5)
-    XCTAssertEqual(array[0].stringValue, "1")
-    XCTAssertEqual(array[1].stringValue, "2")
-    XCTAssertEqual(array[2].stringValue, "realtime:public:messages")
-    XCTAssertEqual(array[3].stringValue, "phx_join")
-    XCTAssertEqual(array[4].objectValue?["key"]?.stringValue, "value")
+    #expect(array.count == 5)
+    #expect(array[0].stringValue == "1")
+    #expect(array[1].stringValue == "2")
+    #expect(array[2].stringValue == "realtime:public:messages")
+    #expect(array[3].stringValue == "phx_join")
+    #expect(array[4].objectValue?["key"]?.stringValue == "value")
   }
 
-  func testEncodeText_withNilRefs() throws {
+  @Test
+  func encodeText_withNilRefs() throws {
     let message = RealtimeMessageV2(
       joinRef: nil,
       ref: nil,
@@ -47,44 +51,50 @@ final class RealtimeSerializerTests: XCTestCase {
     let text = try serializer.encodeText(message)
     let array = try JSONDecoder().decode([AnyJSON].self, from: Data(text.utf8))
 
-    XCTAssertEqual(array.count, 5)
-    XCTAssertNil(array[0].stringValue)
-    XCTAssertNil(array[1].stringValue)
-    XCTAssertEqual(array[2].stringValue, "phoenix")
-    XCTAssertEqual(array[3].stringValue, "heartbeat")
+    #expect(array.count == 5)
+    #expect(array[0].stringValue == nil)
+    #expect(array[1].stringValue == nil)
+    #expect(array[2].stringValue == "phoenix")
+    #expect(array[3].stringValue == "heartbeat")
   }
 
   // MARK: - Text Decoding
 
-  func testDecodeText_withAllFields() throws {
+  @Test
+  func decodeText_withAllFields() throws {
     let text = #"["1","2","realtime:test","phx_reply",{"status":"ok"}]"#
     let message = try serializer.decodeText(text)
 
-    XCTAssertEqual(message.joinRef, "1")
-    XCTAssertEqual(message.ref, "2")
-    XCTAssertEqual(message.topic, "realtime:test")
-    XCTAssertEqual(message.event, "phx_reply")
-    XCTAssertEqual(message.payload["status"]?.stringValue, "ok")
+    #expect(message.joinRef == "1")
+    #expect(message.ref == "2")
+    #expect(message.topic == "realtime:test")
+    #expect(message.event == "phx_reply")
+    #expect(message.payload["status"]?.stringValue == "ok")
   }
 
-  func testDecodeText_withNullRefs() throws {
+  @Test
+  func decodeText_withNullRefs() throws {
     let text = #"[null,null,"phoenix","heartbeat",{}]"#
     let message = try serializer.decodeText(text)
 
-    XCTAssertNil(message.joinRef)
-    XCTAssertNil(message.ref)
-    XCTAssertEqual(message.topic, "phoenix")
-    XCTAssertEqual(message.event, "heartbeat")
+    #expect(message.joinRef == nil)
+    #expect(message.ref == nil)
+    #expect(message.topic == "phoenix")
+    #expect(message.event == "heartbeat")
   }
 
-  func testDecodeText_tooFewElements() {
+  @Test
+  func decodeText_tooFewElements() {
     let text = #"["1","2","topic"]"#
-    XCTAssertThrowsError(try serializer.decodeText(text))
+    #expect(throws: (any Error).self) {
+      try serializer.decodeText(text)
+    }
   }
 
   // MARK: - Text Round-trip
 
-  func testTextRoundTrip() throws {
+  @Test
+  func textRoundTrip() throws {
     let original = RealtimeMessageV2(
       joinRef: "join-1",
       ref: "ref-42",
@@ -99,16 +109,17 @@ final class RealtimeSerializerTests: XCTestCase {
     let text = try serializer.encodeText(original)
     let decoded = try serializer.decodeText(text)
 
-    XCTAssertEqual(decoded.joinRef, original.joinRef)
-    XCTAssertEqual(decoded.ref, original.ref)
-    XCTAssertEqual(decoded.topic, original.topic)
-    XCTAssertEqual(decoded.event, original.event)
-    XCTAssertEqual(decoded.payload, original.payload)
+    #expect(decoded.joinRef == original.joinRef)
+    #expect(decoded.ref == original.ref)
+    #expect(decoded.topic == original.topic)
+    #expect(decoded.event == original.event)
+    #expect(decoded.payload == original.payload)
   }
 
   // MARK: - Binary Encoding (type 0x03)
 
-  func testEncodeBroadcastPush_jsonPayload() throws {
+  @Test
+  func encodeBroadcastPush_jsonPayload() throws {
     let data = try serializer.encodeBroadcastPush(
       joinRef: "1",
       ref: "2",
@@ -120,13 +131,13 @@ final class RealtimeSerializerTests: XCTestCase {
     // Verify header
     let topicLen = "realtime:test".utf8.count  // 13
     let eventLen = "my_event".utf8.count  // 8
-    XCTAssertEqual(data[0], RealtimeSerializer.BinaryKind.userBroadcastPush.rawValue)
-    XCTAssertEqual(data[1], 1)  // joinRef length
-    XCTAssertEqual(data[2], 1)  // ref length
-    XCTAssertEqual(data[3], UInt8(topicLen))
-    XCTAssertEqual(data[4], UInt8(eventLen))
-    XCTAssertEqual(data[5], 0)  // metadata length
-    XCTAssertEqual(data[6], RealtimeSerializer.PayloadEncoding.json.rawValue)
+    #expect(data[0] == RealtimeSerializer.BinaryKind.userBroadcastPush.rawValue)
+    #expect(data[1] == 1)  // joinRef length
+    #expect(data[2] == 1)  // ref length
+    #expect(data[3] == UInt8(topicLen))
+    #expect(data[4] == UInt8(eventLen))
+    #expect(data[5] == 0)  // metadata length
+    #expect(data[6] == RealtimeSerializer.PayloadEncoding.json.rawValue)
 
     // Verify string fields
     let headerSize = 7
@@ -136,18 +147,19 @@ final class RealtimeSerializerTests: XCTestCase {
     let eventStart = topicStart + topicLen
     let payloadStart = eventStart + eventLen
 
-    XCTAssertEqual(String(data: data[joinRefStart..<refStart], encoding: .utf8), "1")
-    XCTAssertEqual(String(data: data[refStart..<topicStart], encoding: .utf8), "2")
-    XCTAssertEqual(String(data: data[topicStart..<eventStart], encoding: .utf8), "realtime:test")
-    XCTAssertEqual(String(data: data[eventStart..<payloadStart], encoding: .utf8), "my_event")
+    #expect(String(data: data[joinRefStart..<refStart], encoding: .utf8) == "1")
+    #expect(String(data: data[refStart..<topicStart], encoding: .utf8) == "2")
+    #expect(String(data: data[topicStart..<eventStart], encoding: .utf8) == "realtime:test")
+    #expect(String(data: data[eventStart..<payloadStart], encoding: .utf8) == "my_event")
 
     // Verify payload is valid JSON
     let payloadData = data[payloadStart...]
     let json = try JSONDecoder().decode(JSONObject.self, from: Data(payloadData))
-    XCTAssertEqual(json["hello"]?.stringValue, "world")
+    #expect(json["hello"]?.stringValue == "world")
   }
 
-  func testEncodeBroadcastPush_binaryPayload() throws {
+  @Test
+  func encodeBroadcastPush_binaryPayload() throws {
     let binaryPayload = Data([0x01, 0x02, 0x03, 0xFF])
     let data = try serializer.encodeBroadcastPush(
       joinRef: nil,
@@ -157,10 +169,10 @@ final class RealtimeSerializerTests: XCTestCase {
       binaryPayload: binaryPayload
     )
 
-    XCTAssertEqual(data[0], RealtimeSerializer.BinaryKind.userBroadcastPush.rawValue)
-    XCTAssertEqual(data[1], 0)  // joinRef length (nil)
-    XCTAssertEqual(data[2], 0)  // ref length (nil)
-    XCTAssertEqual(data[6], RealtimeSerializer.PayloadEncoding.binary.rawValue)
+    #expect(data[0] == RealtimeSerializer.BinaryKind.userBroadcastPush.rawValue)
+    #expect(data[1] == 0)  // joinRef length (nil)
+    #expect(data[2] == 0)  // ref length (nil)
+    #expect(data[6] == RealtimeSerializer.PayloadEncoding.binary.rawValue)
 
     // Extract payload
     let headerSize = 7
@@ -170,10 +182,11 @@ final class RealtimeSerializerTests: XCTestCase {
     let payloadStart = headerSize + 0 + 0 + topicLen + eventLen + metaLen
     let extractedPayload = Data(data[payloadStart...])
 
-    XCTAssertEqual(extractedPayload, binaryPayload)
+    #expect(extractedPayload == binaryPayload)
   }
 
-  func testEncodeBroadcastPush_nilRefs() throws {
+  @Test
+  func encodeBroadcastPush_nilRefs() throws {
     let data = try serializer.encodeBroadcastPush(
       joinRef: nil,
       ref: nil,
@@ -182,13 +195,14 @@ final class RealtimeSerializerTests: XCTestCase {
       jsonPayload: [:]
     )
 
-    XCTAssertEqual(data[1], 0)  // joinRef length
-    XCTAssertEqual(data[2], 0)  // ref length
+    #expect(data[1] == 0)  // joinRef length
+    #expect(data[2] == 0)  // ref length
   }
 
   // MARK: - Binary Decoding (type 0x04)
 
-  func testDecodeBinary_jsonPayload() throws {
+  @Test
+  func decodeBinary_jsonPayload() throws {
     let topic = "realtime:test"
     let event = "my_event"
     let jsonPayload: JSONObject = ["count": .integer(42)]
@@ -208,16 +222,17 @@ final class RealtimeSerializerTests: XCTestCase {
     frame.append(payloadData)
 
     let broadcast = try serializer.decodeBinary(frame)
-    XCTAssertEqual(broadcast.topic, "realtime:test")
-    XCTAssertEqual(broadcast.event, "my_event")
+    #expect(broadcast.topic == "realtime:test")
+    #expect(broadcast.event == "my_event")
     if case .json(let json) = broadcast.payload {
-      XCTAssertEqual(json["count"]?.intValue, 42)
+      #expect(json["count"]?.intValue == 42)
     } else {
-      XCTFail("Expected JSON payload")
+      Issue.record("Expected JSON payload")
     }
   }
 
-  func testDecodeBinary_binaryPayload() throws {
+  @Test
+  func decodeBinary_binaryPayload() throws {
     let topic = "realtime:test"
     let event = "bin"
     let binaryPayload = Data([0xDE, 0xAD, 0xBE, 0xEF])
@@ -236,21 +251,25 @@ final class RealtimeSerializerTests: XCTestCase {
     frame.append(binaryPayload)
 
     let broadcast = try serializer.decodeBinary(frame)
-    XCTAssertEqual(broadcast.topic, "realtime:test")
-    XCTAssertEqual(broadcast.event, "bin")
+    #expect(broadcast.topic == "realtime:test")
+    #expect(broadcast.event == "bin")
     if case .binary(let data) = broadcast.payload {
-      XCTAssertEqual(data, binaryPayload)
+      #expect(data == binaryPayload)
     } else {
-      XCTFail("Expected binary payload")
+      Issue.record("Expected binary payload")
     }
   }
 
-  func testDecodeBinary_frameTooShort() {
+  @Test
+  func decodeBinary_frameTooShort() {
     let data = Data([0x04, 0x01])
-    XCTAssertThrowsError(try serializer.decodeBinary(data))
+    #expect(throws: (any Error).self) {
+      try serializer.decodeBinary(data)
+    }
   }
 
-  func testDecodeBinary_wrongKind() {
+  @Test
+  func decodeBinary_wrongKind() {
     var frame = Data()
     frame.append(0x01)  // wrong kind
     frame.append(0)
@@ -258,10 +277,13 @@ final class RealtimeSerializerTests: XCTestCase {
     frame.append(0)
     frame.append(RealtimeSerializer.PayloadEncoding.json.rawValue)
 
-    XCTAssertThrowsError(try serializer.decodeBinary(frame))
+    #expect(throws: (any Error).self) {
+      try serializer.decodeBinary(frame)
+    }
   }
 
-  func testDecodeBinary_unknownEncoding() {
+  @Test
+  func decodeBinary_unknownEncoding() {
     var frame = Data()
     frame.append(RealtimeSerializer.BinaryKind.userBroadcast.rawValue)
     frame.append(0)
@@ -269,20 +291,24 @@ final class RealtimeSerializerTests: XCTestCase {
     frame.append(0)
     frame.append(0xFF)  // unknown encoding
 
-    XCTAssertThrowsError(try serializer.decodeBinary(frame))
+    #expect(throws: (any Error).self) {
+      try serializer.decodeBinary(frame)
+    }
   }
 
   // MARK: - Edge Cases
 
-  func testEncodeText_emptyPayload() throws {
+  @Test
+  func encodeText_emptyPayload() throws {
     let message = RealtimeMessageV2(
       joinRef: nil, ref: nil, topic: "t", event: "e", payload: [:])
     let text = try serializer.encodeText(message)
     let decoded = try serializer.decodeText(text)
-    XCTAssertEqual(decoded.payload, [:])
+    #expect(decoded.payload == [:])
   }
 
-  func testDecodeBinary_emptyPayload() throws {
+  @Test
+  func decodeBinary_emptyPayload() throws {
     let topic = "t"
     let event = "e"
 
@@ -298,13 +324,14 @@ final class RealtimeSerializerTests: XCTestCase {
 
     let broadcast = try serializer.decodeBinary(frame)
     if case .binary(let data) = broadcast.payload {
-      XCTAssertTrue(data.isEmpty)
+      #expect(data.isEmpty)
     } else {
-      XCTFail("Expected binary payload")
+      Issue.record("Expected binary payload")
     }
   }
 
-  func testDecodeBinary_withMetadata() throws {
+  @Test
+  func decodeBinary_withMetadata() throws {
     let topic = "realtime:test"
     let event = "evt"
     let metadata = Data("{\"key\":\"val\"}".utf8)
@@ -325,12 +352,12 @@ final class RealtimeSerializerTests: XCTestCase {
     frame.append(binaryPayload)
 
     let broadcast = try serializer.decodeBinary(frame)
-    XCTAssertEqual(broadcast.topic, "realtime:test")
-    XCTAssertEqual(broadcast.event, "evt")
+    #expect(broadcast.topic == "realtime:test")
+    #expect(broadcast.event == "evt")
     if case .binary(let data) = broadcast.payload {
-      XCTAssertEqual(data, Data([0x01]))
+      #expect(data == Data([0x01]))
     } else {
-      XCTFail("Expected binary payload")
+      Issue.record("Expected binary payload")
     }
   }
 }

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -4,7 +4,7 @@ import CustomDump
 import Foundation
 import InlineSnapshotTesting
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
@@ -14,36 +14,33 @@ import XCTest
 #endif
 
 #if os(Linux)
-  @available(*, unavailable, message: "RealtimeTests are disabled on Linux due to timing flakiness")
-  final class RealtimeTests: XCTestCase {}
+  // RealtimeTests are disabled on Linux due to timing flakiness.
 #else
 
-  final class RealtimeTests: XCTestCase {
+  // `withMainSerialExecutor` mutates a process-global flag (ConcurrencyExtras'
+  // `uncheckedUseMainSerialExecutor`) to force deterministic task scheduling within its closure.
+  // Swift Testing runs tests in the same suite concurrently by default, so two tests racing to
+  // flip that global would interfere with each other — serialize this suite, mirroring the
+  // `_clock`-swap precedent in PostgrestBuilderTests (PR #1095).
+  @Suite(.serialized)
+  final class RealtimeTests: Sendable {
     let url = URL(string: "http://localhost:54321/realtime/v1")!
     let apiKey = "publishable.api.key"
 
-    #if !os(Windows) && !os(Linux) && !os(Android)
-      override func invokeTest() {
-        withMainSerialExecutor {
-          super.invokeTest()
-        }
-      }
-    #endif
-
-    var server: FakeWebSocket!
-    var client: FakeWebSocket!
-    var http: HTTPClientMock!
-    var sut: RealtimeClientV2!
-    var testClock: TestClock<Duration>!
+    let server: FakeWebSocket
+    let client: FakeWebSocket
+    let http: HTTPClientMock
+    let sut: RealtimeClientV2
+    let testClock: TestClock<Duration>
 
     let heartbeatInterval: TimeInterval = RealtimeClientOptions.defaultHeartbeatInterval
     let reconnectDelay: TimeInterval = RealtimeClientOptions.defaultReconnectDelay
     let timeoutInterval: TimeInterval = RealtimeClientOptions.defaultTimeoutInterval
 
-    override func setUp() {
-      super.setUp()
-
-      (client, server) = FakeWebSocket.fakes()
+    init() {
+      let (client, server) = FakeWebSocket.fakes()
+      self.client = client
+      self.server = server
       http = HTTPClientMock()
       testClock = TestClock()
 
@@ -55,123 +52,223 @@ import XCTest
             "custom.access.token"
           }
         ),
-        wsTransport: { _, _ in self.client },
+        wsTransport: { _, _ in client },
         http: http,
         clock: testClock
       )
     }
 
-    override func tearDown() {
+    deinit {
       sut.disconnect()
-      super.tearDown()
     }
 
-    func test_transport() async {
-      let client = RealtimeClientV2(
-        url: url,
-        options: RealtimeClientOptions(
-          headers: ["apikey": apiKey],
-          logLevel: .warn,
-          accessToken: {
-            "custom.access.token"
-          }
-        ),
-        wsTransport: { url, headers in
-          assertInlineSnapshot(of: url, as: .description) {
-            """
-            ws://localhost:54321/realtime/v1/websocket?apikey=publishable.api.key&vsn=2.0.0&log_level=warn
-            """
-          }
-          return FakeWebSocket.fakes().0
-        },
-        http: http,
-        clock: testClock
-      )
+    @Test
+    func transport() async {
+      await withMainSerialExecutor {
+        let client = RealtimeClientV2(
+          url: url,
+          options: RealtimeClientOptions(
+            headers: ["apikey": apiKey],
+            logLevel: .warn,
+            accessToken: {
+              "custom.access.token"
+            }
+          ),
+          wsTransport: { url, headers in
+            assertInlineSnapshot(of: url, as: .description) {
+              """
+              ws://localhost:54321/realtime/v1/websocket?apikey=publishable.api.key&vsn=2.0.0&log_level=warn
+              """
+            }
+            return FakeWebSocket.fakes().0
+          },
+          http: http,
+          clock: testClock
+        )
 
-      await client.connect()
+        await client.connect()
+      }
     }
 
-    func testBehavior() async throws {
-      let channel = sut.channel("public:messages")
-      var subscriptions: Set<ObservationToken> = []
+    @Test
+    func behavior() async throws {
+      try await withMainSerialExecutor {
+        let channel = sut.channel("public:messages")
+        var subscriptions: Set<ObservationToken> = []
 
-      channel.onPostgresChange(InsertAction.self, table: "messages") { _ in
-      }
-      .store(in: &subscriptions)
+        channel.onPostgresChange(InsertAction.self, table: "messages") { _ in
+        }
+        .store(in: &subscriptions)
 
-      channel.onPostgresChange(UpdateAction.self, table: "messages") { _ in
-      }
-      .store(in: &subscriptions)
+        channel.onPostgresChange(UpdateAction.self, table: "messages") { _ in
+        }
+        .store(in: &subscriptions)
 
-      channel.onPostgresChange(DeleteAction.self, table: "messages") { _ in
-      }
-      .store(in: &subscriptions)
+        channel.onPostgresChange(DeleteAction.self, table: "messages") { _ in
+        }
+        .store(in: &subscriptions)
 
-      let socketStatuses = LockIsolated([RealtimeClientStatus]())
+        let socketStatuses = LockIsolated([RealtimeClientStatus]())
 
-      sut.onStatusChange { status in
-        socketStatuses.withValue { $0.append(status) }
-      }
-      .store(in: &subscriptions)
+        sut.onStatusChange { status in
+          socketStatuses.withValue { $0.append(status) }
+        }
+        .store(in: &subscriptions)
 
-      // Set up server to respond to heartbeats and phx_join
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          guard let msg = event.realtimeMessage else { continue }
-          if msg.event == "heartbeat" {
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef,
-                ref: msg.ref,
-                topic: "phoenix",
-                event: "phx_reply",
-                payload: ["response": [:]]
+        // Set up server to respond to heartbeats and phx_join
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            guard let msg = event.realtimeMessage else { continue }
+            if msg.event == "heartbeat" {
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef,
+                  ref: msg.ref,
+                  topic: "phoenix",
+                  event: "phx_reply",
+                  payload: ["response": [:]]
+                )
               )
-            )
-          } else if msg.event == "phx_join" {
-            server.send(.messagesSubscribed)
+            } else if msg.event == "phx_join" {
+              server.send(.messagesSubscribed)
+            }
           }
         }
-      }
-      defer { serverTask.cancel() }
+        defer { serverTask.cancel() }
 
-      let channelStatuses = LockIsolated([RealtimeChannelStatus]())
-      channel.onStatusChange { status in
-        channelStatuses.withValue {
-          $0.append(status)
+        let channelStatuses = LockIsolated([RealtimeChannelStatus]())
+        channel.onStatusChange { status in
+          channelStatuses.withValue {
+            $0.append(status)
+          }
+        }
+        .store(in: &subscriptions)
+
+        // Wait until it subscribes to assert WS events
+        do {
+          try await channel.subscribeWithError()
+        } catch {
+          Issue.record("Expected .subscribed but got error: \(error)")
+        }
+        #expect(channelStatuses.value == [.unsubscribed, .subscribing, .subscribed])
+
+        #expect(
+          Array(socketStatuses.value.prefix(3))
+            == [.disconnected, .connecting, .connected]
+        )
+
+        let messageTask = sut.mutableState.messageTask
+        #expect(messageTask != nil)
+
+        let heartbeatTask = sut.mutableState.heartbeatTask
+        #expect(heartbeatTask != nil)
+
+        assertInlineSnapshot(of: client.sentEvents.map(\.json), as: .json) {
+          #"""
+          [
+            {
+              "text" : [
+                "1",
+                "1",
+                "realtime:public:messages",
+                "phx_join",
+                {
+                  "access_token" : "custom.access.token",
+                  "config" : {
+                    "broadcast" : {
+                      "ack" : false,
+                      "replication_ready" : false,
+                      "self" : false
+                    },
+                    "postgres_changes" : [
+                      {
+                        "event" : "INSERT",
+                        "schema" : "public",
+                        "table" : "messages"
+                      },
+                      {
+                        "event" : "UPDATE",
+                        "schema" : "public",
+                        "table" : "messages"
+                      },
+                      {
+                        "event" : "DELETE",
+                        "schema" : "public",
+                        "table" : "messages"
+                      }
+                    ],
+                    "presence" : {
+                      "enabled" : false,
+                      "key" : ""
+                    },
+                    "private" : false
+                  },
+                  "version" : "realtime-swift\/0.0.0"
+                }
+              ]
+            }
+          ]
+          """#
         }
       }
-      .store(in: &subscriptions)
+    }
 
-      // Wait until it subscribes to assert WS events
-      do {
-        try await channel.subscribeWithError()
-      } catch {
-        XCTFail("Expected .subscribed but got error: \(error)")
-      }
-      XCTAssertEqual(channelStatuses.value, [.unsubscribed, .subscribing, .subscribed])
+    @Test
+    func subscribeTimeout() async throws {
+      try await withMainSerialExecutor {
+        let channel = sut.channel("public:messages")
+        let joinEventCount = LockIsolated(0)
 
-      XCTAssertEqual(
-        Array(socketStatuses.value.prefix(3)),
-        [.disconnected, .connecting, .connected]
-      )
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            guard let msg = event.realtimeMessage else { continue }
+            if msg.event == "heartbeat" {
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef,
+                  ref: msg.ref,
+                  topic: "phoenix",
+                  event: "phx_reply",
+                  payload: ["response": [:]]
+                )
+              )
+            } else if msg.event == "phx_join" {
+              joinEventCount.withValue { $0 += 1 }
+              // Skip first join.
+              if joinEventCount.value == 2 {
+                server.send(.messagesSubscribed)
+              }
+            }
+          }
+        }
+        defer { serverTask.cancel() }
 
-      let messageTask = sut.mutableState.messageTask
-      XCTAssertNotNil(messageTask)
+        await sut.connect()
+        await testClock.advance(by: .seconds(heartbeatInterval))
 
-      let heartbeatTask = sut.mutableState.heartbeatTask
-      XCTAssertNotNil(heartbeatTask)
+        Task {
+          try await channel.subscribeWithError()
+        }
 
-      assertInlineSnapshot(of: client.sentEvents.map(\.json), as: .json) {
-        #"""
-        [
-          {
-            "text" : [
-              "1",
-              "1",
-              "realtime:public:messages",
-              "phx_join",
-              {
+        // Wait for the timeout for rejoining.
+        await testClock.advance(by: .seconds(timeoutInterval))
+
+        // Wait for the retry delay (base delay is 1.0s, but we need to account for jitter)
+        // The retry delay is calculated as: baseDelay * pow(2, attempt-1) + jitter
+        // For attempt 2: 1.0 * pow(2, 1) = 2.0s + jitter (up to ±25% = ±0.5s)
+        // So we need to wait at least 2.5s to ensure the retry happens
+        await testClock.advance(by: .seconds(2.5))
+
+        let events = client.sentEvents.compactMap { $0.realtimeMessage }.filter {
+          $0.event == "phx_join"
+        }
+        assertInlineSnapshot(of: events, as: .json) {
+          #"""
+          [
+            {
+              "event" : "phx_join",
+              "join_ref" : "1",
+              "payload" : {
                 "access_token" : "custom.access.token",
                 "config" : {
                   "broadcast" : {
@@ -180,21 +277,7 @@ import XCTest
                     "self" : false
                   },
                   "postgres_changes" : [
-                    {
-                      "event" : "INSERT",
-                      "schema" : "public",
-                      "table" : "messages"
-                    },
-                    {
-                      "event" : "UPDATE",
-                      "schema" : "public",
-                      "table" : "messages"
-                    },
-                    {
-                      "event" : "DELETE",
-                      "schema" : "public",
-                      "table" : "messages"
-                    }
+
                   ],
                   "presence" : {
                     "enabled" : false,
@@ -203,371 +286,309 @@ import XCTest
                   "private" : false
                 },
                 "version" : "realtime-swift\/0.0.0"
-              }
-            ]
-          }
-        ]
-        """#
-      }
-    }
+              },
+              "ref" : "1",
+              "topic" : "realtime:public:messages"
+            },
+            {
+              "event" : "phx_join",
+              "join_ref" : "2",
+              "payload" : {
+                "access_token" : "custom.access.token",
+                "config" : {
+                  "broadcast" : {
+                    "ack" : false,
+                    "replication_ready" : false,
+                    "self" : false
+                  },
+                  "postgres_changes" : [
 
-    func testSubscribeTimeout() async throws {
-      let channel = sut.channel("public:messages")
-      let joinEventCount = LockIsolated(0)
-
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          guard let msg = event.realtimeMessage else { continue }
-          if msg.event == "heartbeat" {
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef,
-                ref: msg.ref,
-                topic: "phoenix",
-                event: "phx_reply",
-                payload: ["response": [:]]
-              )
-            )
-          } else if msg.event == "phx_join" {
-            joinEventCount.withValue { $0 += 1 }
-            // Skip first join.
-            if joinEventCount.value == 2 {
-              server.send(.messagesSubscribed)
+                  ],
+                  "presence" : {
+                    "enabled" : false,
+                    "key" : ""
+                  },
+                  "private" : false
+                },
+                "version" : "realtime-swift\/0.0.0"
+              },
+              "ref" : "2",
+              "topic" : "realtime:public:messages"
             }
-          }
+          ]
+          """#
         }
-      }
-      defer { serverTask.cancel() }
-
-      await sut.connect()
-      await testClock.advance(by: .seconds(heartbeatInterval))
-
-      Task {
-        try await channel.subscribeWithError()
-      }
-
-      // Wait for the timeout for rejoining.
-      await testClock.advance(by: .seconds(timeoutInterval))
-
-      // Wait for the retry delay (base delay is 1.0s, but we need to account for jitter)
-      // The retry delay is calculated as: baseDelay * pow(2, attempt-1) + jitter
-      // For attempt 2: 1.0 * pow(2, 1) = 2.0s + jitter (up to ±25% = ±0.5s)
-      // So we need to wait at least 2.5s to ensure the retry happens
-      await testClock.advance(by: .seconds(2.5))
-
-      let events = client.sentEvents.compactMap { $0.realtimeMessage }.filter {
-        $0.event == "phx_join"
-      }
-      assertInlineSnapshot(of: events, as: .json) {
-        #"""
-        [
-          {
-            "event" : "phx_join",
-            "join_ref" : "1",
-            "payload" : {
-              "access_token" : "custom.access.token",
-              "config" : {
-                "broadcast" : {
-                  "ack" : false,
-                  "replication_ready" : false,
-                  "self" : false
-                },
-                "postgres_changes" : [
-
-                ],
-                "presence" : {
-                  "enabled" : false,
-                  "key" : ""
-                },
-                "private" : false
-              },
-              "version" : "realtime-swift\/0.0.0"
-            },
-            "ref" : "1",
-            "topic" : "realtime:public:messages"
-          },
-          {
-            "event" : "phx_join",
-            "join_ref" : "2",
-            "payload" : {
-              "access_token" : "custom.access.token",
-              "config" : {
-                "broadcast" : {
-                  "ack" : false,
-                  "replication_ready" : false,
-                  "self" : false
-                },
-                "postgres_changes" : [
-
-                ],
-                "presence" : {
-                  "enabled" : false,
-                  "key" : ""
-                },
-                "private" : false
-              },
-              "version" : "realtime-swift\/0.0.0"
-            },
-            "ref" : "2",
-            "topic" : "realtime:public:messages"
-          }
-        ]
-        """#
       }
     }
 
     // Succeeds after 2 retries (on 3rd attempt)
-    func testSubscribeTimeout_successAfterRetries() async throws {
-      let successAttempt = 3
-      let channel = sut.channel("public:messages")
-      let joinEventCount = LockIsolated(0)
+    @Test
+    func subscribeTimeout_successAfterRetries() async throws {
+      try await withMainSerialExecutor {
+        let successAttempt = 3
+        let channel = sut.channel("public:messages")
+        let joinEventCount = LockIsolated(0)
 
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          guard let msg = event.realtimeMessage else { continue }
-          if msg.event == "heartbeat" {
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef,
-                ref: msg.ref,
-                topic: "phoenix",
-                event: "phx_reply",
-                payload: ["response": [:]]
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            guard let msg = event.realtimeMessage else { continue }
+            if msg.event == "heartbeat" {
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef,
+                  ref: msg.ref,
+                  topic: "phoenix",
+                  event: "phx_reply",
+                  payload: ["response": [:]]
+                )
               )
-            )
-          } else if msg.event == "phx_join" {
-            joinEventCount.withValue { $0 += 1 }
-            // Respond on the 3rd attempt
-            if joinEventCount.value == successAttempt {
-              server.send(.messagesSubscribed)
+            } else if msg.event == "phx_join" {
+              joinEventCount.withValue { $0 += 1 }
+              // Respond on the 3rd attempt
+              if joinEventCount.value == successAttempt {
+                server.send(.messagesSubscribed)
+              }
             }
           }
         }
+        defer { serverTask.cancel() }
+
+        await sut.connect()
+        await testClock.advance(by: .seconds(heartbeatInterval))
+
+        let subscribeTask = Task {
+          _ = try? await channel.subscribeWithError()
+        }
+
+        // Wait for each attempt and retry delay
+        for attempt in 1..<successAttempt {
+          await testClock.advance(by: .seconds(timeoutInterval))
+          let retryDelay = pow(2.0, Double(attempt))
+          await testClock.advance(by: .seconds(retryDelay))
+        }
+
+        await subscribeTask.value
+
+        let events = client.sentEvents.compactMap { $0.realtimeMessage }.filter {
+          $0.event == "phx_join"
+        }
+
+        #expect(events.count == successAttempt)
+        #expect(channel.status == .subscribed)
       }
-      defer { serverTask.cancel() }
-
-      await sut.connect()
-      await testClock.advance(by: .seconds(heartbeatInterval))
-
-      let subscribeTask = Task {
-        _ = try? await channel.subscribeWithError()
-      }
-
-      // Wait for each attempt and retry delay
-      for attempt in 1..<successAttempt {
-        await testClock.advance(by: .seconds(timeoutInterval))
-        let retryDelay = pow(2.0, Double(attempt))
-        await testClock.advance(by: .seconds(retryDelay))
-      }
-
-      await subscribeTask.value
-
-      let events = client.sentEvents.compactMap { $0.realtimeMessage }.filter {
-        $0.event == "phx_join"
-      }
-
-      XCTAssertEqual(events.count, successAttempt)
-      XCTAssertEqual(channel.status, .subscribed)
     }
 
     // Fails after max retries (should unsubscribe)
-    func testSubscribeTimeout_failsAfterMaxRetries() async throws {
-      let channel = sut.channel("public:messages")
-      let joinEventCount = LockIsolated(0)
+    @Test
+    func subscribeTimeout_failsAfterMaxRetries() async throws {
+      try await withMainSerialExecutor {
+        let channel = sut.channel("public:messages")
+        let joinEventCount = LockIsolated(0)
 
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          guard let msg = event.realtimeMessage else { continue }
-          if msg.event == "heartbeat" {
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef,
-                ref: msg.ref,
-                topic: "phoenix",
-                event: "phx_reply",
-                payload: ["response": [:]]
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            guard let msg = event.realtimeMessage else { continue }
+            if msg.event == "heartbeat" {
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef,
+                  ref: msg.ref,
+                  topic: "phoenix",
+                  event: "phx_reply",
+                  payload: ["response": [:]]
+                )
               )
-            )
-          } else if msg.event == "phx_join" {
-            joinEventCount.withValue { $0 += 1 }
-            // Never respond to any join attempts
+            } else if msg.event == "phx_join" {
+              joinEventCount.withValue { $0 += 1 }
+              // Never respond to any join attempts
+            }
           }
         }
-      }
-      defer { serverTask.cancel() }
+        defer { serverTask.cancel() }
 
-      await sut.connect()
-      await testClock.advance(by: .seconds(heartbeatInterval))
+        await sut.connect()
+        await testClock.advance(by: .seconds(heartbeatInterval))
 
-      let subscribeTask = Task {
-        try await channel.subscribeWithError()
-      }
-
-      for attempt in 1...5 {
-        await testClock.advance(by: .seconds(timeoutInterval))
-        if attempt < 5 {
-          let retryDelay = 2.5 * Double(attempt)
-          await testClock.advance(by: .seconds(retryDelay))
+        let subscribeTask = Task {
+          try await channel.subscribeWithError()
         }
-      }
 
-      do {
-        try await subscribeTask.value
-        XCTFail("Expected error but got success")
-      } catch {
-        XCTAssertTrue(error is RealtimeError)
-      }
+        for attempt in 1...5 {
+          await testClock.advance(by: .seconds(timeoutInterval))
+          if attempt < 5 {
+            let retryDelay = 2.5 * Double(attempt)
+            await testClock.advance(by: .seconds(retryDelay))
+          }
+        }
 
-      let events = client.sentEvents.compactMap { $0.realtimeMessage }.filter {
-        $0.event == "phx_join"
+        do {
+          try await subscribeTask.value
+          Issue.record("Expected error but got success")
+        } catch {
+          #expect(error is RealtimeError)
+        }
+
+        let events = client.sentEvents.compactMap { $0.realtimeMessage }.filter {
+          $0.event == "phx_join"
+        }
+        #expect(events.count == 5)
+        #expect(channel.status == .unsubscribed)
       }
-      XCTAssertEqual(events.count, 5)
-      XCTAssertEqual(channel.status, .unsubscribed)
     }
 
     // Cancels and unsubscribes if the subscribe task is cancelled
-    func testSubscribeTimeout_cancelsOnTaskCancel() async throws {
-      let channel = sut.channel("public:messages")
-      let joinEventCount = LockIsolated(0)
+    @Test
+    func subscribeTimeout_cancelsOnTaskCancel() async throws {
+      try await withMainSerialExecutor {
+        let channel = sut.channel("public:messages")
+        let joinEventCount = LockIsolated(0)
 
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          guard let msg = event.realtimeMessage else { continue }
-          if msg.event == "heartbeat" {
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef,
-                ref: msg.ref,
-                topic: "phoenix",
-                event: "phx_reply",
-                payload: ["response": [:]]
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            guard let msg = event.realtimeMessage else { continue }
+            if msg.event == "heartbeat" {
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef,
+                  ref: msg.ref,
+                  topic: "phoenix",
+                  event: "phx_reply",
+                  payload: ["response": [:]]
+                )
               )
-            )
-          } else if msg.event == "phx_join" {
-            joinEventCount.withValue { $0 += 1 }
-            // Never respond to any join attempts
+            } else if msg.event == "phx_join" {
+              joinEventCount.withValue { $0 += 1 }
+              // Never respond to any join attempts
+            }
           }
         }
+        defer { serverTask.cancel() }
+
+        await sut.connect()
+        await testClock.advance(by: .seconds(heartbeatInterval))
+
+        let subscribeTask = Task {
+          try await channel.subscribeWithError()
+        }
+
+        await testClock.advance(by: .seconds(timeoutInterval))
+        subscribeTask.cancel()
+
+        do {
+          try await subscribeTask.value
+          Issue.record("Expected cancellation error but got success")
+        } catch is CancellationError {
+          // Expected
+        } catch {
+          Issue.record("Expected CancellationError but got: \(error)")
+        }
+        await testClock.advance(by: .seconds(5.0))
+
+        let events = client.sentEvents.compactMap { $0.realtimeMessage }.filter {
+          $0.event == "phx_join"
+        }
+
+        #expect(events.count == 1)
+        #expect(channel.status == .unsubscribed)
       }
-      defer { serverTask.cancel() }
-
-      await sut.connect()
-      await testClock.advance(by: .seconds(heartbeatInterval))
-
-      let subscribeTask = Task {
-        try await channel.subscribeWithError()
-      }
-
-      await testClock.advance(by: .seconds(timeoutInterval))
-      subscribeTask.cancel()
-
-      do {
-        try await subscribeTask.value
-        XCTFail("Expected cancellation error but got success")
-      } catch is CancellationError {
-        // Expected
-      } catch {
-        XCTFail("Expected CancellationError but got: \(error)")
-      }
-      await testClock.advance(by: .seconds(5.0))
-
-      let events = client.sentEvents.compactMap { $0.realtimeMessage }.filter {
-        $0.event == "phx_join"
-      }
-
-      XCTAssertEqual(events.count, 1)
-      XCTAssertEqual(channel.status, .unsubscribed)
     }
 
-    func testHeartbeat() async throws {
-      let expectation = expectation(description: "heartbeat")
-      expectation.expectedFulfillmentCount = 2
+    @Test
+    func heartbeat() async throws {
+      try await withMainSerialExecutor {
+        let heartbeatCount = LockIsolated(0)
 
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          guard let msg = event.realtimeMessage else { continue }
-          if msg.event == "heartbeat" {
-            expectation.fulfill()
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef,
-                ref: msg.ref,
-                topic: "phoenix",
-                event: "phx_reply",
-                payload: [
-                  "response": [:],
-                  "status": "ok",
-                ]
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            guard let msg = event.realtimeMessage else { continue }
+            if msg.event == "heartbeat" {
+              heartbeatCount.withValue { $0 += 1 }
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef,
+                  ref: msg.ref,
+                  topic: "phoenix",
+                  event: "phx_reply",
+                  payload: [
+                    "response": [:],
+                    "status": "ok",
+                  ]
+                )
               )
-            )
+            }
           }
         }
-      }
-      defer { serverTask.cancel() }
+        defer { serverTask.cancel() }
 
-      let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
-      let subscription = sut.onHeartbeat { status in
-        heartbeatStatuses.withValue {
-          $0.append(status)
+        let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
+        let subscription = sut.onHeartbeat { status in
+          heartbeatStatuses.withValue {
+            $0.append(status)
+          }
         }
+        defer { subscription.cancel() }
+
+        await sut.connect()
+
+        await testClock.advance(by: .seconds(heartbeatInterval * 2))
+
+        let sawTwoHeartbeats = await waitUntil(timeout: 3) { heartbeatCount.value >= 2 }
+        #expect(sawTwoHeartbeats)
+
+        expectNoDifference(heartbeatStatuses.value, [.sent, .ok, .sent, .ok])
       }
-      defer { subscription.cancel() }
-
-      await sut.connect()
-
-      await testClock.advance(by: .seconds(heartbeatInterval * 2))
-
-      await fulfillment(of: [expectation], timeout: 3)
-
-      expectNoDifference(heartbeatStatuses.value, [.sent, .ok, .sent, .ok])
     }
 
-    func testHeartbeat_whenNoResponse_shouldReconnect() async throws {
-      let sentHeartbeatExpectation = expectation(description: "sentHeartbeat")
+    @Test
+    func heartbeat_whenNoResponse_shouldReconnect() async throws {
+      try await withMainSerialExecutor {
+        let sentHeartbeat = LockIsolated(false)
 
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          if event.realtimeMessage?.event == "heartbeat" {
-            sentHeartbeatExpectation.fulfill()
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            if event.realtimeMessage?.event == "heartbeat" {
+              sentHeartbeat.setValue(true)
+            }
+            // Intentionally not replying — trigger timeout/reconnect path.
           }
-          // Intentionally not replying — trigger timeout/reconnect path.
         }
-      }
-      defer { serverTask.cancel() }
+        defer { serverTask.cancel() }
 
-      let statuses = LockIsolated<[RealtimeClientStatus]>([])
-      let subscription = sut.onStatusChange { status in
-        statuses.withValue {
-          $0.append(status)
+        let statuses = LockIsolated<[RealtimeClientStatus]>([])
+        let subscription = sut.onStatusChange { status in
+          statuses.withValue {
+            $0.append(status)
+          }
         }
+        defer { subscription.cancel() }
+
+        await sut.connect()
+        await testClock.advance(by: .seconds(heartbeatInterval))
+
+        let didSendHeartbeat = await waitUntil(timeout: 1) { sentHeartbeat.value }
+        #expect(didSendHeartbeat)
+
+        let pendingHeartbeatRef = sut.mutableState.pendingHeartbeatRef
+        #expect(pendingHeartbeatRef != nil)
+
+        // Wait until next heartbeat
+        await testClock.advance(by: .seconds(heartbeatInterval))
+
+        // Wait for reconnect delay
+        await testClock.advance(by: .seconds(reconnectDelay))
+
+        #expect(
+          statuses.value
+            == [
+              .disconnected,
+              .connecting,
+              .connected,
+              .disconnected,
+              .connecting,
+              .connected,
+            ]
+        )
       }
-      defer { subscription.cancel() }
-
-      await sut.connect()
-      await testClock.advance(by: .seconds(heartbeatInterval))
-
-      await fulfillment(of: [sentHeartbeatExpectation], timeout: 0)
-
-      let pendingHeartbeatRef = sut.mutableState.pendingHeartbeatRef
-      XCTAssertNotNil(pendingHeartbeatRef)
-
-      // Wait until next heartbeat
-      await testClock.advance(by: .seconds(heartbeatInterval))
-
-      // Wait for reconnect delay
-      await testClock.advance(by: .seconds(reconnectDelay))
-
-      XCTAssertEqual(
-        statuses.value,
-        [
-          .disconnected,
-          .connecting,
-          .connected,
-          .disconnected,
-          .connecting,
-          .connected,
-        ]
-      )
     }
 
     /// Regression test for SDK-1330: a heartbeat tick that lands while the
@@ -575,70 +596,76 @@ import XCTest
     /// heartbeat timer itself) must not publish `.disconnected` to
     /// `onHeartbeat(_:)`/`heartbeat` consumers — it's an internal bookkeeping
     /// signal, not a heartbeat outcome.
-    func testHeartbeat_doesNotLeakDisconnectedStatus() async throws {
-      let (client, server) = FakeWebSocket.fakes()
-      let sut = RealtimeClientV2(
-        url: url,
-        options: RealtimeClientOptions(
-          headers: ["apikey": apiKey],
-          heartbeatInterval: 1,
-          reconnectDelay: 10,
-          accessToken: { "custom.access.token" }
-        ),
-        wsTransport: { _, _ in client },
-        http: http,
-        clock: testClock
-      )
-      defer { sut.disconnect() }
+    @Test
+    func heartbeat_doesNotLeakDisconnectedStatus() async throws {
+      try await withMainSerialExecutor {
+        let (client, server) = FakeWebSocket.fakes()
+        let sut = RealtimeClientV2(
+          url: url,
+          options: RealtimeClientOptions(
+            headers: ["apikey": apiKey],
+            heartbeatInterval: 1,
+            reconnectDelay: 10,
+            accessToken: { "custom.access.token" }
+          ),
+          wsTransport: { _, _ in client },
+          http: http,
+          clock: testClock
+        )
+        defer { sut.disconnect() }
 
-      let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
-      let subscription = sut.onHeartbeat { status in
-        heartbeatStatuses.withValue { $0.append(status) }
+        let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
+        let subscription = sut.onHeartbeat { status in
+          heartbeatStatuses.withValue { $0.append(status) }
+        }
+        defer { subscription.cancel() }
+
+        await sut.connect()
+
+        // Server drops the connection out from under us — unrelated to the
+        // heartbeat timer, which is still sleeping out its first interval.
+        server.close(code: nil, reason: "boom")
+        await Task.megaYield()
+
+        // The heartbeat timer ticks while the reconnect is still sleeping out
+        // its 10s `reconnectDelay` — the still-alive old heartbeat task must
+        // not observe `status != .connected` and publish `.disconnected`.
+        await testClock.advance(by: .seconds(1))
+
+        #expect(
+          !heartbeatStatuses.value.contains(.disconnected),
+          "heartbeat status leaked .disconnected to consumers: \(heartbeatStatuses.value)"
+        )
       }
-      defer { subscription.cancel() }
-
-      await sut.connect()
-
-      // Server drops the connection out from under us — unrelated to the
-      // heartbeat timer, which is still sleeping out its first interval.
-      server.close(code: nil, reason: "boom")
-      await Task.megaYield()
-
-      // The heartbeat timer ticks while the reconnect is still sleeping out
-      // its 10s `reconnectDelay` — the still-alive old heartbeat task must
-      // not observe `status != .connected` and publish `.disconnected`.
-      await testClock.advance(by: .seconds(1))
-
-      XCTAssertFalse(
-        heartbeatStatuses.value.contains(.disconnected),
-        "heartbeat status leaked .disconnected to consumers: \(heartbeatStatuses.value)"
-      )
     }
 
-    func testHeartbeat_timeout() async throws {
-      let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
-      let s1 = sut.onHeartbeat { status in
-        heartbeatStatuses.withValue {
-          $0.append(status)
+    @Test
+    func heartbeat_timeout() async throws {
+      try await withMainSerialExecutor {
+        let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
+        let s1 = sut.onHeartbeat { status in
+          heartbeatStatuses.withValue {
+            $0.append(status)
+          }
         }
+        defer { s1.cancel() }
+
+        // Don't respond to any heartbeats — let the timeout fire naturally.
+        await sut.connect()
+        await testClock.advance(by: .seconds(heartbeatInterval))
+
+        // First heartbeat sent
+        #expect(heartbeatStatuses.value == [.sent])
+
+        // Wait for timeout
+        await testClock.advance(by: .seconds(timeoutInterval))
+
+        // Wait for next heartbeat.
+        await testClock.advance(by: .seconds(heartbeatInterval))
+
+        // Should have timeout status
+        #expect(heartbeatStatuses.value == [.sent, .timeout])
       }
-      defer { s1.cancel() }
-
-      // Don't respond to any heartbeats — let the timeout fire naturally.
-      await sut.connect()
-      await testClock.advance(by: .seconds(heartbeatInterval))
-
-      // First heartbeat sent
-      XCTAssertEqual(heartbeatStatuses.value, [.sent])
-
-      // Wait for timeout
-      await testClock.advance(by: .seconds(timeoutInterval))
-
-      // Wait for next heartbeat.
-      await testClock.advance(by: .seconds(heartbeatInterval))
-
-      // Should have timeout status
-      XCTAssertEqual(heartbeatStatuses.value, [.sent, .timeout])
     }
 
     // Regression test for SDK-959: a second `handleConnected` on an already
@@ -648,410 +675,452 @@ import XCTest
     // then race to nil out the live `onEvent`, leaving the socket connected
     // but deaf — heartbeat and `phx_join` replies were silently dropped,
     // stalling subscribe for tens of seconds to minutes.
-    func testRedundantConnect_doesNotDropIncomingFrames() async throws {
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          guard let msg = event.realtimeMessage else { continue }
-          if msg.event == "heartbeat" {
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef,
-                ref: msg.ref,
-                topic: "phoenix",
-                event: "phx_reply",
-                payload: [
-                  "response": [:],
-                  "status": "ok",
-                ]
+    @Test
+    func redundantConnect_doesNotDropIncomingFrames() async throws {
+      try await withMainSerialExecutor {
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            guard let msg = event.realtimeMessage else { continue }
+            if msg.event == "heartbeat" {
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef,
+                  ref: msg.ref,
+                  topic: "phoenix",
+                  event: "phx_reply",
+                  payload: [
+                    "response": [:],
+                    "status": "ok",
+                  ]
+                )
               )
-            )
+            }
           }
         }
+        defer { serverTask.cancel() }
+
+        let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
+        let subscription = sut.onHeartbeat { status in
+          heartbeatStatuses.withValue { $0.append(status) }
+        }
+        defer { subscription.cancel() }
+
+        await sut.connect()
+
+        // A redundant connect() — the ConnectionManager is already `.connected`,
+        // so it returns the same connection. The socket must keep receiving
+        // frames afterwards.
+        await sut.connect()
+        await Task.megaYield()
+
+        // Drive a heartbeat; the server replies. If the socket is still
+        // listening, the reply acks the heartbeat (.ok). If `onEvent` was
+        // niled out by the duplicate setup, the reply is dropped and the
+        // heartbeat is never acknowledged.
+        await testClock.advance(by: .seconds(heartbeatInterval))
+        await Task.megaYield()
+
+        #expect(heartbeatStatuses.value == [.sent, .ok])
       }
-      defer { serverTask.cancel() }
-
-      let heartbeatStatuses = LockIsolated<[HeartbeatStatus]>([])
-      let subscription = sut.onHeartbeat { status in
-        heartbeatStatuses.withValue { $0.append(status) }
-      }
-      defer { subscription.cancel() }
-
-      await sut.connect()
-
-      // A redundant connect() — the ConnectionManager is already `.connected`,
-      // so it returns the same connection. The socket must keep receiving
-      // frames afterwards.
-      await sut.connect()
-      await Task.megaYield()
-
-      // Drive a heartbeat; the server replies. If the socket is still
-      // listening, the reply acks the heartbeat (.ok). If `onEvent` was
-      // niled out by the duplicate setup, the reply is dropped and the
-      // heartbeat is never acknowledged.
-      await testClock.advance(by: .seconds(heartbeatInterval))
-      await Task.megaYield()
-
-      XCTAssertEqual(heartbeatStatuses.value, [.sent, .ok])
     }
 
-    func testBroadcastWithHTTP() async throws {
-      await http.when {
-        $0.url.path.contains("/api/broadcast/")
-      } return: { _ in
-        HTTPResponse(
-          data: "{}".data(using: .utf8)!,
-          response: HTTPURLResponse(
-            url: self.url,
-            statusCode: 200,
-            httpVersion: nil,
-            headerFields: nil
-          )!
+    @Test
+    func broadcastWithHTTP() async throws {
+      try await withMainSerialExecutor {
+        await http.when {
+          $0.url.path.contains("/api/broadcast/")
+        } return: { _ in
+          HTTPResponse(
+            data: "{}".data(using: .utf8)!,
+            response: HTTPURLResponse(
+              url: self.url,
+              statusCode: 200,
+              httpVersion: nil,
+              headerFields: nil
+            )!
+          )
+        }
+
+        let channel = sut.channel("public:messages") {
+          $0.broadcast.acknowledgeBroadcasts = true
+        }
+
+        try await channel.broadcast(event: "test", message: ["value": 42])
+
+        let request = await http.receivedRequests.last
+        assertInlineSnapshot(of: request?.urlRequest, as: .curl) {
+          #"""
+          curl \
+          	--request POST \
+          	--header "Authorization: Bearer custom.access.token" \
+          	--header "Content-Type: application/json" \
+          	--header "apiKey: publishable.api.key" \
+          	--data "{\"value\":42}" \
+          	"http://localhost:54321/realtime/v1/api/broadcast/public%3Amessages/events/test"
+          """#
+        }
+      }
+    }
+
+    @Test
+    func setAuth() async {
+      await withMainSerialExecutor {
+        let validToken =
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjY0MDkyMjExMjAwfQ.GfiEKLl36X8YWcatHg31jRbilovlGecfUKnOyXMSX9c"
+        await sut.setAuth(validToken)
+
+        #expect(sut.mutableState.accessToken == validToken)
+      }
+    }
+
+    @Test
+    func setAuthWithNonJWT() async throws {
+      await withMainSerialExecutor {
+        let token = "sb-token"
+        await sut.setAuth(token)
+      }
+    }
+
+    @Test
+    func setAuthKeepsCurrentTokenWhenAccessTokenFetchFails() async {
+      await withMainSerialExecutor {
+        struct FetchError: Error {}
+
+        let sut = RealtimeClientV2(
+          url: url,
+          options: RealtimeClientOptions(
+            headers: ["apikey": apiKey],
+            accessToken: { throw FetchError() }
+          ),
+          wsTransport: { [client = self.client] _, _ in client },
+          http: http,
+          clock: testClock
         )
-      }
+        defer { sut.disconnect() }
 
-      let channel = sut.channel("public:messages") {
-        $0.broadcast.acknowledgeBroadcasts = true
-      }
+        let validToken =
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjY0MDkyMjExMjAwfQ.GfiEKLl36X8YWcatHg31jRbilovlGecfUKnOyXMSX9c"
+        await sut.setAuth(validToken)
+        #expect(sut.mutableState.accessToken == validToken)
 
-      try await channel.broadcast(event: "test", message: ["value": 42])
+        await sut.setAuth()
 
-      let request = await http.receivedRequests.last
-      assertInlineSnapshot(of: request?.urlRequest, as: .curl) {
-        #"""
-        curl \
-        	--request POST \
-        	--header "Authorization: Bearer custom.access.token" \
-        	--header "Content-Type: application/json" \
-        	--header "apiKey: publishable.api.key" \
-        	--data "{\"value\":42}" \
-        	"http://localhost:54321/realtime/v1/api/broadcast/public%3Amessages/events/test"
-        """#
+        #expect(sut.mutableState.accessToken == validToken)
       }
     }
 
-    func testSetAuth() async {
-      let validToken =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjY0MDkyMjExMjAwfQ.GfiEKLl36X8YWcatHg31jRbilovlGecfUKnOyXMSX9c"
-      await sut.setAuth(validToken)
+    @Test
+    func setAuthDoesNotPushNullTokenToChannelsWhenFetchFails() async throws {
+      try await withMainSerialExecutor {
+        struct FetchError: Error {}
 
-      XCTAssertEqual(sut.mutableState.accessToken, validToken)
-    }
+        let validToken =
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjY0MDkyMjExMjAwfQ.GfiEKLl36X8YWcatHg31jRbilovlGecfUKnOyXMSX9c"
+        let shouldThrow = LockIsolated(false)
 
-    func testSetAuthWithNonJWT() async throws {
-      let token = "sb-token"
-      await sut.setAuth(token)
-    }
+        let sut = RealtimeClientV2(
+          url: url,
+          options: RealtimeClientOptions(
+            headers: ["apikey": apiKey],
+            accessToken: {
+              if shouldThrow.value { throw FetchError() }
+              return validToken
+            }
+          ),
+          wsTransport: { [client = self.client] _, _ in client },
+          http: http,
+          clock: testClock
+        )
+        defer { sut.disconnect() }
 
-    func testSetAuthKeepsCurrentTokenWhenAccessTokenFetchFails() async {
-      struct FetchError: Error {}
-
-      let sut = RealtimeClientV2(
-        url: url,
-        options: RealtimeClientOptions(
-          headers: ["apikey": apiKey],
-          accessToken: { throw FetchError() }
-        ),
-        wsTransport: { _, _ in self.client },
-        http: http,
-        clock: testClock
-      )
-      defer { sut.disconnect() }
-
-      let validToken =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjY0MDkyMjExMjAwfQ.GfiEKLl36X8YWcatHg31jRbilovlGecfUKnOyXMSX9c"
-      await sut.setAuth(validToken)
-      XCTAssertEqual(sut.mutableState.accessToken, validToken)
-
-      await sut.setAuth()
-
-      XCTAssertEqual(sut.mutableState.accessToken, validToken)
-    }
-
-    func testSetAuthDoesNotPushNullTokenToChannelsWhenFetchFails() async throws {
-      struct FetchError: Error {}
-
-      let validToken =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjY0MDkyMjExMjAwfQ.GfiEKLl36X8YWcatHg31jRbilovlGecfUKnOyXMSX9c"
-      let shouldThrow = LockIsolated(false)
-
-      let sut = RealtimeClientV2(
-        url: url,
-        options: RealtimeClientOptions(
-          headers: ["apikey": apiKey],
-          accessToken: {
-            if shouldThrow.value { throw FetchError() }
-            return validToken
-          }
-        ),
-        wsTransport: { _, _ in self.client },
-        http: http,
-        clock: testClock
-      )
-      defer { sut.disconnect() }
-
-      let serverTask = Task { @Sendable [server = server!] in
-        for await event in server.events {
-          guard let msg = event.realtimeMessage else { continue }
-          if msg.event == "heartbeat" {
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef, ref: msg.ref, topic: "phoenix",
-                event: "phx_reply", payload: ["response": [:]]
+        let serverTask = Task { @Sendable [server = server] in
+          for await event in server.events {
+            guard let msg = event.realtimeMessage else { continue }
+            if msg.event == "heartbeat" {
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef, ref: msg.ref, topic: "phoenix",
+                  event: "phx_reply", payload: ["response": [:]]
+                )
               )
-            )
-          } else if msg.event == "phx_join" {
-            server.send(
-              RealtimeMessageV2(
-                joinRef: msg.joinRef, ref: msg.ref, topic: msg.topic,
-                event: "phx_reply",
-                payload: ["response": ["postgres_changes": .array([])], "status": "ok"]
+            } else if msg.event == "phx_join" {
+              server.send(
+                RealtimeMessageV2(
+                  joinRef: msg.joinRef, ref: msg.ref, topic: msg.topic,
+                  event: "phx_reply",
+                  payload: ["response": ["postgres_changes": .array([])], "status": "ok"]
+                )
               )
-            )
+            }
           }
         }
+        defer { serverTask.cancel() }
+
+        await sut.connect()
+        await sut.setAuth(validToken)
+        #expect(sut.mutableState.accessToken == validToken)
+
+        let channel = sut.channel("room")
+        try await channel.subscribeWithError()
+
+        let sentBefore = client.sentEvents.count
+        shouldThrow.setValue(true)
+        await sut.setAuth()
+
+        let accessTokenPushes =
+          client.sentEvents
+          .dropFirst(sentBefore)
+          .compactMap { $0.realtimeMessage }
+          .filter { $0.event == ChannelEvent.accessToken }
+        #expect(
+          accessTokenPushes.isEmpty,
+          "No access_token update should be pushed to channels when the token fetch fails"
+        )
+        #expect(sut.mutableState.accessToken == validToken)
       }
-      defer { serverTask.cancel() }
-
-      await sut.connect()
-      await sut.setAuth(validToken)
-      XCTAssertEqual(sut.mutableState.accessToken, validToken)
-
-      let channel = sut.channel("room")
-      try await channel.subscribeWithError()
-
-      let sentBefore = client.sentEvents.count
-      shouldThrow.setValue(true)
-      await sut.setAuth()
-
-      let accessTokenPushes =
-        client.sentEvents
-        .dropFirst(sentBefore)
-        .compactMap { $0.realtimeMessage }
-        .filter { $0.event == ChannelEvent.accessToken }
-      XCTAssertTrue(
-        accessTokenPushes.isEmpty,
-        "No access_token update should be pushed to channels when the token fetch fails"
-      )
-      XCTAssertEqual(sut.mutableState.accessToken, validToken)
     }
 
     // MARK: - Task Lifecycle Tests
 
-    func testListenForMessagesCancelsExistingTask() async {
-      await sut.connect()
-
-      // Get the first message task
-      let firstMessageTask = sut.mutableState.messageTask
-      XCTAssertNotNil(firstMessageTask)
-      XCTAssertFalse(firstMessageTask?.isCancelled ?? true)
-
-      // Trigger reconnection which will call listenForMessages again
-      sut.disconnect()
-      await sut.connect()
-
-      // Verify the old task was cancelled
-      XCTAssertTrue(firstMessageTask?.isCancelled ?? false)
-
-      // Verify a new task was created
-      let secondMessageTask = sut.mutableState.messageTask
-      XCTAssertNotNil(secondMessageTask)
-      XCTAssertFalse(secondMessageTask?.isCancelled ?? true)
-    }
-
-    func testStartHeartbeatingCancelsExistingTask() async {
-      await sut.connect()
-
-      // Get the first heartbeat task
-      let firstHeartbeatTask = sut.mutableState.heartbeatTask
-      XCTAssertNotNil(firstHeartbeatTask)
-      XCTAssertFalse(firstHeartbeatTask?.isCancelled ?? true)
-
-      // Trigger reconnection which will call startHeartbeating again
-      sut.disconnect()
-      await sut.connect()
-
-      // Verify the old task was cancelled
-      XCTAssertTrue(firstHeartbeatTask?.isCancelled ?? false)
-
-      // Verify a new task was created
-      let secondHeartbeatTask = sut.mutableState.heartbeatTask
-      XCTAssertNotNil(secondHeartbeatTask)
-      XCTAssertFalse(secondHeartbeatTask?.isCancelled ?? true)
-    }
-
-    func testMessageProcessingRespectsCancellation() async {
-      let messagesProcessed = LockIsolated(0)
-
-      await sut.connect()
-
-      // Send multiple messages
-      for i in 1...3 {
-        server.send(
-          RealtimeMessageV2(
-            joinRef: nil,
-            ref: "\(i)",
-            topic: "test-topic",
-            event: "test-event",
-            payload: ["index": .double(Double(i))]
-          )
-        )
-        messagesProcessed.withValue { $0 += 1 }
-      }
-
-      await Task.megaYield()
-
-      // Disconnect to cancel message processing
-      sut.disconnect()
-
-      // Try to send more messages after disconnect (these should not be processed)
-      for i in 4...6 {
-        server.send(
-          RealtimeMessageV2(
-            joinRef: nil,
-            ref: "\(i)",
-            topic: "test-topic",
-            event: "test-event",
-            payload: ["index": .double(Double(i))]
-          )
-        )
-      }
-
-      await Task.megaYield()
-
-      // Verify that the message task was cancelled and cleaned up
-      XCTAssertNil(sut.mutableState.messageTask, "Message task should be nil after disconnect")
-    }
-
-    func testMultipleReconnectionsHandleTaskLifecycleCorrectly() async {
-      var previousMessageTasks: [Task<Void, Never>?] = []
-      var previousHeartbeatTasks: [Task<Void, Never>?] = []
-
-      // Test multiple connect/disconnect cycles
-      for _ in 1...3 {
+    @Test
+    func listenForMessagesCancelsExistingTask() async {
+      await withMainSerialExecutor {
         await sut.connect()
 
-        await waitUntil { [sut = self.sut!] in
-          let messageTask = sut.mutableState.messageTask
-          let heartbeatTask = sut.mutableState.heartbeatTask
-          return messageTask != nil
-            && heartbeatTask != nil
-            && !(messageTask?.isCancelled ?? true)
-            && !(heartbeatTask?.isCancelled ?? true)
+        // Get the first message task
+        let firstMessageTask = sut.mutableState.messageTask
+        #expect(firstMessageTask != nil)
+        #expect(!(firstMessageTask?.isCancelled ?? true))
+
+        // Trigger reconnection which will call listenForMessages again
+        sut.disconnect()
+        await sut.connect()
+
+        // Verify the old task was cancelled
+        #expect(firstMessageTask?.isCancelled ?? false)
+
+        // Verify a new task was created
+        let secondMessageTask = sut.mutableState.messageTask
+        #expect(secondMessageTask != nil)
+        #expect(!(secondMessageTask?.isCancelled ?? true))
+      }
+    }
+
+    @Test
+    func startHeartbeatingCancelsExistingTask() async {
+      await withMainSerialExecutor {
+        await sut.connect()
+
+        // Get the first heartbeat task
+        let firstHeartbeatTask = sut.mutableState.heartbeatTask
+        #expect(firstHeartbeatTask != nil)
+        #expect(!(firstHeartbeatTask?.isCancelled ?? true))
+
+        // Trigger reconnection which will call startHeartbeating again
+        sut.disconnect()
+        await sut.connect()
+
+        // Verify the old task was cancelled
+        #expect(firstHeartbeatTask?.isCancelled ?? false)
+
+        // Verify a new task was created
+        let secondHeartbeatTask = sut.mutableState.heartbeatTask
+        #expect(secondHeartbeatTask != nil)
+        #expect(!(secondHeartbeatTask?.isCancelled ?? true))
+      }
+    }
+
+    @Test
+    func messageProcessingRespectsCancellation() async {
+      await withMainSerialExecutor {
+        let messagesProcessed = LockIsolated(0)
+
+        await sut.connect()
+
+        // Send multiple messages
+        for i in 1...3 {
+          server.send(
+            RealtimeMessageV2(
+              joinRef: nil,
+              ref: "\(i)",
+              topic: "test-topic",
+              event: "test-event",
+              payload: ["index": .double(Double(i))]
+            )
+          )
+          messagesProcessed.withValue { $0 += 1 }
         }
 
-        let messageTask = sut.mutableState.messageTask
-        let heartbeatTask = sut.mutableState.heartbeatTask
+        await Task.megaYield()
 
-        XCTAssertNotNil(messageTask)
-        XCTAssertNotNil(heartbeatTask)
-        XCTAssertFalse(messageTask?.isCancelled ?? true)
-        XCTAssertFalse(heartbeatTask?.isCancelled ?? true)
-
-        previousMessageTasks.append(messageTask)
-        previousHeartbeatTasks.append(heartbeatTask)
-
+        // Disconnect to cancel message processing
         sut.disconnect()
 
-        await waitUntil {
-          (messageTask?.isCancelled ?? false) && (heartbeatTask?.isCancelled ?? false)
+        // Try to send more messages after disconnect (these should not be processed)
+        for i in 4...6 {
+          server.send(
+            RealtimeMessageV2(
+              joinRef: nil,
+              ref: "\(i)",
+              topic: "test-topic",
+              event: "test-event",
+              payload: ["index": .double(Double(i))]
+            )
+          )
         }
 
-        // Verify tasks were cancelled after disconnect
-        XCTAssertTrue(messageTask?.isCancelled ?? false)
-        XCTAssertTrue(heartbeatTask?.isCancelled ?? false)
-      }
+        await Task.megaYield()
 
-      // Verify all previous tasks were properly cancelled
-      for task in previousMessageTasks {
-        await waitUntil { task?.isCancelled ?? false }
-        XCTAssertTrue(task?.isCancelled ?? false)
+        // Verify that the message task was cancelled and cleaned up
+        #expect(sut.mutableState.messageTask == nil, "Message task should be nil after disconnect")
       }
+    }
 
-      for task in previousHeartbeatTasks {
-        await waitUntil { task?.isCancelled ?? false }
-        XCTAssertTrue(task?.isCancelled ?? false)
+    @Test
+    func multipleReconnectionsHandleTaskLifecycleCorrectly() async {
+      await withMainSerialExecutor {
+        var previousMessageTasks: [Task<Void, Never>?] = []
+        var previousHeartbeatTasks: [Task<Void, Never>?] = []
+
+        // Test multiple connect/disconnect cycles
+        for _ in 1...3 {
+          await sut.connect()
+
+          await waitUntil { [sut = sut] in
+            let messageTask = sut.mutableState.messageTask
+            let heartbeatTask = sut.mutableState.heartbeatTask
+            return messageTask != nil
+              && heartbeatTask != nil
+              && !(messageTask?.isCancelled ?? true)
+              && !(heartbeatTask?.isCancelled ?? true)
+          }
+
+          let messageTask = sut.mutableState.messageTask
+          let heartbeatTask = sut.mutableState.heartbeatTask
+
+          #expect(messageTask != nil)
+          #expect(heartbeatTask != nil)
+          #expect(!(messageTask?.isCancelled ?? true))
+          #expect(!(heartbeatTask?.isCancelled ?? true))
+
+          previousMessageTasks.append(messageTask)
+          previousHeartbeatTasks.append(heartbeatTask)
+
+          sut.disconnect()
+
+          await waitUntil {
+            (messageTask?.isCancelled ?? false) && (heartbeatTask?.isCancelled ?? false)
+          }
+
+          // Verify tasks were cancelled after disconnect
+          #expect(messageTask?.isCancelled ?? false)
+          #expect(heartbeatTask?.isCancelled ?? false)
+        }
+
+        // Verify all previous tasks were properly cancelled
+        for task in previousMessageTasks {
+          await waitUntil { task?.isCancelled ?? false }
+          #expect(task?.isCancelled ?? false)
+        }
+
+        for task in previousHeartbeatTasks {
+          await waitUntil { task?.isCancelled ?? false }
+          #expect(task?.isCancelled ?? false)
+        }
       }
     }
 
     // MARK: - Deferred Disconnect Tests
 
-    func testDeferredDisconnect_disconnectsAfterDelay() async {
-      let deferredSut = makeClientWithDeferredDisconnect(delay: 5)
-      defer { deferredSut.disconnect() }
+    @Test
+    func deferredDisconnect_disconnectsAfterDelay() async {
+      await withMainSerialExecutor {
+        let deferredSut = makeClientWithDeferredDisconnect(delay: 5)
+        defer { deferredSut.disconnect() }
 
-      await deferredSut.connect()
-      XCTAssertEqual(deferredSut.status, .connected)
+        await deferredSut.connect()
+        #expect(deferredSut.status == .connected)
 
-      let channel = deferredSut.channel("test:deferred")
-      await deferredSut.removeChannel(channel)
+        let channel = deferredSut.channel("test:deferred")
+        await deferredSut.removeChannel(channel)
 
-      // Still connected — pending disconnect has not fired yet.
-      XCTAssertEqual(deferredSut.status, .connected)
-      XCTAssertNotNil(deferredSut.mutableState.pendingDisconnectTask)
+        // Still connected — pending disconnect has not fired yet.
+        #expect(deferredSut.status == .connected)
+        #expect(deferredSut.mutableState.pendingDisconnectTask != nil)
 
-      // Advance past the delay — pending task fires and disconnects.
-      await testClock.advance(by: .seconds(5))
+        // Advance past the delay — pending task fires and disconnects.
+        await testClock.advance(by: .seconds(5))
 
-      XCTAssertEqual(deferredSut.status, .disconnected)
-      XCTAssertNil(deferredSut.mutableState.pendingDisconnectTask)
+        #expect(deferredSut.status == .disconnected)
+        #expect(deferredSut.mutableState.pendingDisconnectTask == nil)
+      }
     }
 
-    func testDeferredDisconnect_cancelledByNewChannel() async {
-      let deferredSut = makeClientWithDeferredDisconnect(delay: 5)
-      defer { deferredSut.disconnect() }
+    @Test
+    func deferredDisconnect_cancelledByNewChannel() async {
+      await withMainSerialExecutor {
+        let deferredSut = makeClientWithDeferredDisconnect(delay: 5)
+        defer { deferredSut.disconnect() }
 
-      await deferredSut.connect()
+        await deferredSut.connect()
 
-      let channel = deferredSut.channel("test:deferred")
-      await deferredSut.removeChannel(channel)
+        let channel = deferredSut.channel("test:deferred")
+        await deferredSut.removeChannel(channel)
 
-      XCTAssertEqual(deferredSut.status, .connected)
-      XCTAssertNotNil(deferredSut.mutableState.pendingDisconnectTask)
-      let pendingTask = deferredSut.mutableState.pendingDisconnectTask
+        #expect(deferredSut.status == .connected)
+        #expect(deferredSut.mutableState.pendingDisconnectTask != nil)
+        let pendingTask = deferredSut.mutableState.pendingDisconnectTask
 
-      // Creating a new channel cancels the pending disconnect.
-      _ = deferredSut.channel("test:new")
+        // Creating a new channel cancels the pending disconnect.
+        _ = deferredSut.channel("test:new")
 
-      XCTAssertNil(deferredSut.mutableState.pendingDisconnectTask)
-      XCTAssertTrue(pendingTask?.isCancelled ?? false)
+        #expect(deferredSut.mutableState.pendingDisconnectTask == nil)
+        #expect(pendingTask?.isCancelled ?? false)
 
-      // Advance past what would have been the delay — client stays connected.
-      await testClock.advance(by: .seconds(5))
-      XCTAssertEqual(deferredSut.status, .connected)
+        // Advance past what would have been the delay — client stays connected.
+        await testClock.advance(by: .seconds(5))
+        #expect(deferredSut.status == .connected)
+      }
     }
 
-    func testDeferredDisconnect_cancelledByDirectDisconnect() async {
-      let deferredSut = makeClientWithDeferredDisconnect(delay: 5)
+    @Test
+    func deferredDisconnect_cancelledByDirectDisconnect() async {
+      await withMainSerialExecutor {
+        let deferredSut = makeClientWithDeferredDisconnect(delay: 5)
 
-      await deferredSut.connect()
+        await deferredSut.connect()
 
-      let channel = deferredSut.channel("test:deferred")
-      await deferredSut.removeChannel(channel)
+        let channel = deferredSut.channel("test:deferred")
+        await deferredSut.removeChannel(channel)
 
-      let pendingTask = deferredSut.mutableState.pendingDisconnectTask
-      XCTAssertNotNil(pendingTask)
+        let pendingTask = deferredSut.mutableState.pendingDisconnectTask
+        #expect(pendingTask != nil)
 
-      // Calling disconnect() directly cancels the pending timer.
-      deferredSut.disconnect()
+        // Calling disconnect() directly cancels the pending timer.
+        deferredSut.disconnect()
 
-      XCTAssertTrue(pendingTask?.isCancelled ?? false)
-      XCTAssertNil(deferredSut.mutableState.pendingDisconnectTask)
+        #expect(pendingTask?.isCancelled ?? false)
+        #expect(deferredSut.mutableState.pendingDisconnectTask == nil)
+      }
     }
 
-    func testRemoveAllChannels_disconnectsImmediately_withDeferredOption() async {
-      let deferredSut = makeClientWithDeferredDisconnect(delay: 5)
-      defer { deferredSut.disconnect() }
+    @Test
+    func removeAllChannels_disconnectsImmediately_withDeferredOption() async {
+      await withMainSerialExecutor {
+        let deferredSut = makeClientWithDeferredDisconnect(delay: 5)
+        defer { deferredSut.disconnect() }
 
-      await deferredSut.connect()
+        await deferredSut.connect()
 
-      _ = deferredSut.channel("test:ch1")
-      _ = deferredSut.channel("test:ch2")
+        _ = deferredSut.channel("test:ch1")
+        _ = deferredSut.channel("test:ch2")
 
-      await deferredSut.removeAllChannels()
+        await deferredSut.removeAllChannels()
 
-      // removeAllChannels always disconnects immediately, regardless of delay.
-      XCTAssertEqual(deferredSut.status, .disconnected)
-      XCTAssertNil(deferredSut.mutableState.pendingDisconnectTask)
+        // removeAllChannels always disconnects immediately, regardless of delay.
+        #expect(deferredSut.status == .disconnected)
+        #expect(deferredSut.mutableState.pendingDisconnectTask == nil)
+      }
     }
 
     private func makeClientWithDeferredDisconnect(delay: TimeInterval) -> RealtimeClientV2 {
@@ -1061,23 +1130,10 @@ import XCTest
           headers: ["apikey": apiKey],
           disconnectOnEmptyChannelsAfter: delay
         ),
-        wsTransport: { _, _ in self.client },
+        wsTransport: { [client = self.client] _, _ in client },
         http: http,
         clock: testClock
       )
-    }
-
-    func waitUntil(
-      timeout: TimeInterval = 1.0,
-      pollInterval: UInt64 = 10_000_000,
-      condition: @escaping @Sendable () -> Bool
-    ) async {
-      let deadline = Date().addingTimeInterval(timeout)
-
-      while Date() < deadline {
-        if condition() { return }
-        try? await Task.sleep(nanoseconds: pollInterval)
-      }
     }
   }
 

--- a/Tests/RealtimeTests/TestSupport.swift
+++ b/Tests/RealtimeTests/TestSupport.swift
@@ -1,0 +1,29 @@
+//
+//  TestSupport.swift
+//  RealtimeTests
+//
+//  Shared helpers used across the Swift Testing migration of RealtimeTests.
+//
+
+import Foundation
+
+/// Polls `condition` until it returns `true` or `timeout` elapses.
+///
+/// Swift Testing has no direct equivalent of `XCTestExpectation` +
+/// `fulfillment(of:timeout:)` for "wait for an async condition driven by a
+/// concurrently-running task". Tests that used to fulfill an expectation from
+/// a background task now flip a `LockIsolated` flag/counter instead, and await
+/// this helper to observe it.
+@discardableResult
+func waitUntil(
+  timeout: TimeInterval = 1.0,
+  pollInterval: UInt64 = 10_000_000,
+  condition: @escaping @Sendable () -> Bool
+) async -> Bool {
+  let deadline = Date().addingTimeInterval(timeout)
+  while Date() < deadline {
+    if condition() { return true }
+    try? await Task.sleep(nanoseconds: pollInterval)
+  }
+  return condition()
+}

--- a/Tests/RealtimeTests/WebSocketTests.swift
+++ b/Tests/RealtimeTests/WebSocketTests.swift
@@ -133,8 +133,10 @@ struct WebSocketTests {
         }
 
         // Give ARC a chance to actually run the deinits before the
-        // confirmation scope closes and its count is checked.
-        try await Task.sleep(for: .milliseconds(200))
+        // confirmation scope closes and its count is checked. The iOS
+        // Simulator runs noticeably slower than a native macOS host under
+        // CI load, so this needs more margin than a quick local run suggests.
+        try await Task.sleep(for: .seconds(1))
       }
     }
 

--- a/Tests/RealtimeTests/WebSocketTests.swift
+++ b/Tests/RealtimeTests/WebSocketTests.swift
@@ -6,127 +6,140 @@
 //
 
 import ConcurrencyExtras
-import XCTest
+import Foundation
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
-final class WebSocketTests: XCTestCase {
+// Cert-pinning tests generate self-signed identities via `SecPKCS12Import`, which is
+// flaky when invoked concurrently (observed intermittent `errSecInternalComponent`/-26276
+// failures under Swift Testing's default parallel execution). Serialize the suite so these
+// keychain-touching tests never overlap, mirroring the `.serialized` precedent used
+// elsewhere for tests with process-global/shared-resource side effects.
+@Suite(.serialized)
+struct WebSocketTests {
 
   // MARK: - WebSocketEvent Tests
 
-  func testWebSocketEventEquality() {
+  @Test
+  func webSocketEventEquality() {
     let textEvent1 = WebSocketEvent.text("hello")
     let textEvent2 = WebSocketEvent.text("hello")
     let textEvent3 = WebSocketEvent.text("world")
 
-    XCTAssertEqual(textEvent1, textEvent2)
-    XCTAssertNotEqual(textEvent1, textEvent3)
+    #expect(textEvent1 == textEvent2)
+    #expect(textEvent1 != textEvent3)
 
     let binaryData = Data([1, 2, 3])
     let binaryEvent1 = WebSocketEvent.binary(binaryData)
     let binaryEvent2 = WebSocketEvent.binary(binaryData)
     let binaryEvent3 = WebSocketEvent.binary(Data([4, 5, 6]))
 
-    XCTAssertEqual(binaryEvent1, binaryEvent2)
-    XCTAssertNotEqual(binaryEvent1, binaryEvent3)
+    #expect(binaryEvent1 == binaryEvent2)
+    #expect(binaryEvent1 != binaryEvent3)
 
     let closeEvent1 = WebSocketEvent.close(code: 1000, reason: "normal")
     let closeEvent2 = WebSocketEvent.close(code: 1000, reason: "normal")
     let closeEvent3 = WebSocketEvent.close(code: 1001, reason: "going away")
 
-    XCTAssertEqual(closeEvent1, closeEvent2)
-    XCTAssertNotEqual(closeEvent1, closeEvent3)
+    #expect(closeEvent1 == closeEvent2)
+    #expect(closeEvent1 != closeEvent3)
   }
 
-  func testWebSocketEventHashable() {
+  @Test
+  func webSocketEventHashable() {
     let textEvent = WebSocketEvent.text("hello")
     let binaryEvent = WebSocketEvent.binary(Data([1, 2, 3]))
     let closeEvent = WebSocketEvent.close(code: 1000, reason: "normal")
 
     let events: Set<WebSocketEvent> = [textEvent, binaryEvent, closeEvent]
-    XCTAssertEqual(events.count, 3)
+    #expect(events.count == 3)
   }
 
-  func testWebSocketEventPatternMatching() {
+  @Test
+  func webSocketEventPatternMatching() {
     let textEvent = WebSocketEvent.text("hello world")
     let binaryEvent = WebSocketEvent.binary(Data([1, 2, 3]))
     let closeEvent = WebSocketEvent.close(code: 1000, reason: "normal")
 
     switch textEvent {
     case .text(let message):
-      XCTAssertEqual(message, "hello world")
+      #expect(message == "hello world")
     default:
-      XCTFail("Expected text event")
+      Issue.record("Expected text event")
     }
 
     switch binaryEvent {
     case .binary(let data):
-      XCTAssertEqual(data, Data([1, 2, 3]))
+      #expect(data == Data([1, 2, 3]))
     default:
-      XCTFail("Expected binary event")
+      Issue.record("Expected binary event")
     }
 
     switch closeEvent {
     case .close(let code, let reason):
-      XCTAssertEqual(code, 1000)
-      XCTAssertEqual(reason, "normal")
+      #expect(code == 1000)
+      #expect(reason == "normal")
     default:
-      XCTFail("Expected close event")
+      Issue.record("Expected close event")
     }
   }
 
   // MARK: - WebSocketError Tests
 
-  func testWebSocketErrorConnection() {
+  @Test
+  func webSocketErrorConnection() {
     let underlyingError = NSError(
       domain: "TestDomain", code: 123, userInfo: [NSLocalizedDescriptionKey: "Test error"])
     let webSocketError = WebSocketError.connection(
       message: "Connection failed", error: underlyingError)
 
-    XCTAssertEqual(webSocketError.errorDescription, "Connection failed Test error")
+    #expect(webSocketError.errorDescription == "Connection failed Test error")
   }
 
-  func testWebSocketErrorAsError() {
+  @Test
+  func webSocketErrorAsError() {
     let underlyingError = NSError(
       domain: "TestDomain", code: 123, userInfo: [NSLocalizedDescriptionKey: "Test error"])
     let webSocketError = WebSocketError.connection(
       message: "Connection failed", error: underlyingError)
     let error: Error = webSocketError
 
-    XCTAssertEqual(error.localizedDescription, "Connection failed Test error")
+    #expect(error.localizedDescription == "Connection failed Test error")
   }
 
   // MARK: - URLSessionWebSocket Lifecycle Tests
 
   #if canImport(Network)
-    func testSocketsDeallocateAfterClose() async throws {
+    @Test
+    func socketsDeallocateAfterClose() async throws {
       let server = try LoopbackWebSocketServer()
       let port = try server.start()
       defer { server.stop() }
 
       let url = URL(string: "ws://127.0.0.1:\(port)")!
 
-      var deallocations: [XCTestExpectation] = []
+      try await confirmation("sockets deallocated", expectedCount: 5) { deallocated in
+        for _ in 0..<5 {
+          let socket = try await URLSessionWebSocket.connect(to: url)
+          objc_setAssociatedObject(
+            socket,
+            &deinitNotifierKey,
+            DeinitNotifier { deallocated() },
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+          )
+          socket.close(code: 1000, reason: nil)
+        }
 
-      for index in 0..<5 {
-        let deallocated = expectation(description: "socket \(index) deallocated")
-        deallocations.append(deallocated)
-
-        let socket = try await URLSessionWebSocket.connect(to: url)
-        objc_setAssociatedObject(
-          socket,
-          &deinitNotifierKey,
-          DeinitNotifier { deallocated.fulfill() },
-          .OBJC_ASSOCIATION_RETAIN_NONATOMIC
-        )
-        socket.close(code: 1000, reason: nil)
+        // Give ARC a chance to actually run the deinits before the
+        // confirmation scope closes and its count is checked.
+        try await Task.sleep(for: .milliseconds(200))
       }
-
-      await fulfillment(of: deallocations, timeout: 10)
     }
 
-    func testConnectAcceptsSessionWithADelegateAsATemplate() async throws {
+    @Test
+    func connectAcceptsSessionWithADelegateAsATemplate() async throws {
       final class RecordingDelegate: NSObject, URLSessionDelegate {}
 
       let server = try LoopbackWebSocketServer()
@@ -141,7 +154,8 @@ final class WebSocketTests: XCTestCase {
       socket.close(code: 1000, reason: nil)
     }
 
-    func testCallerSuppliedSessionIsNeverUsedDirectlyOrInvalidated() async throws {
+    @Test
+    func callerSuppliedSessionIsNeverUsedDirectlyOrInvalidated() async throws {
       let server = try LoopbackWebSocketServer()
       let port = try server.start()
       defer { server.stop() }
@@ -167,7 +181,8 @@ final class WebSocketTests: XCTestCase {
     }
 
     #if os(macOS)
-      func testCertPinningAcceptsMatchingCertificate() async throws {
+      @Test
+      func certPinningAcceptsMatchingCertificate() async throws {
         let (identity, certificateData) = try makeSelfSignedIdentity()
         let server = try LoopbackTLSWebSocketServer(identity: identity)
         let port = try server.start()
@@ -180,10 +195,11 @@ final class WebSocketTests: XCTestCase {
         let socket = try await URLSessionWebSocket.connect(to: url, session: session)
         socket.close(code: 1000, reason: nil)
 
-        XCTAssertTrue(delegate.wasInvoked)
+        #expect(delegate.wasInvoked)
       }
 
-      func testCertPinningRejectsMismatchedCertificate() async throws {
+      @Test
+      func certPinningRejectsMismatchedCertificate() async throws {
         let (identity, _) = try makeSelfSignedIdentity()
         let (_, wrongCertificateData) = try makeSelfSignedIdentity()
         let server = try LoopbackTLSWebSocketServer(identity: identity)
@@ -196,16 +212,17 @@ final class WebSocketTests: XCTestCase {
 
         do {
           _ = try await URLSessionWebSocket.connect(to: url, session: session)
-          XCTFail("expected connection to fail due to certificate mismatch")
+          Issue.record("expected connection to fail due to certificate mismatch")
         } catch {
           // Expected: the pinning delegate rejected the server's certificate, so the
           // TLS handshake failed and `connect` threw.
         }
 
-        XCTAssertTrue(delegate.wasInvoked)
+        #expect(delegate.wasInvoked)
       }
 
-      func testCertPinningAcceptsMatchingCertificateWithTaskLevelDelegate() async throws {
+      @Test
+      func certPinningAcceptsMatchingCertificateWithTaskLevelDelegate() async throws {
         let (identity, certificateData) = try makeSelfSignedIdentity()
         let server = try LoopbackTLSWebSocketServer(identity: identity)
         let port = try server.start()
@@ -223,10 +240,11 @@ final class WebSocketTests: XCTestCase {
         let socket = try await URLSessionWebSocket.connect(to: url, session: session)
         socket.close(code: 1000, reason: nil)
 
-        XCTAssertTrue(delegate.wasInvoked)
+        #expect(delegate.wasInvoked)
       }
 
-      func testCertPinningRejectsMismatchedCertificateWithTaskLevelDelegate() async throws {
+      @Test
+      func certPinningRejectsMismatchedCertificateWithTaskLevelDelegate() async throws {
         let (identity, _) = try makeSelfSignedIdentity()
         let (_, wrongCertificateData) = try makeSelfSignedIdentity()
         let server = try LoopbackTLSWebSocketServer(identity: identity)
@@ -239,13 +257,13 @@ final class WebSocketTests: XCTestCase {
 
         do {
           _ = try await URLSessionWebSocket.connect(to: url, session: session)
-          XCTFail("expected connection to fail due to certificate mismatch")
+          Issue.record("expected connection to fail due to certificate mismatch")
         } catch {
           // Expected: the pinning delegate rejected the server's certificate, so the
           // TLS handshake failed and `connect` threw.
         }
 
-        XCTAssertTrue(delegate.wasInvoked)
+        #expect(delegate.wasInvoked)
       }
     #endif
   #endif
@@ -276,7 +294,8 @@ final class WebSocketTests: XCTestCase {
         failureResponse: nil, error: nil, sender: NoopChallengeSender())
     }
 
-    func testChallengeForwardedToTaskLevelWrappedDelegate() {
+    @Test
+    func challengeForwardedToTaskLevelWrappedDelegate() async {
       final class TaskDelegate: NSObject, URLSessionTaskDelegate {
         var receivedChallenge: URLAuthenticationChallenge?
         var receivedTask: URLSessionTask?
@@ -305,21 +324,21 @@ final class WebSocketTests: XCTestCase {
       delegate.associatedTask.setValue(task)
       let challenge = makeChallenge()
 
-      let expectation = expectation(description: "completion handler called")
       // The OS only ever calls this delegate's session-level method (see its doc comment) —
       // even when `wrappedDelegate` implements only the task-level one, that must still be
       // reached via `associatedTask`.
-      delegate.urlSession(session, didReceive: challenge) { disposition, _ in
-        XCTAssertEqual(disposition, .useCredential)
-        expectation.fulfill()
+      await confirmation("completion handler called") { completionCalled in
+        delegate.urlSession(session, didReceive: challenge) { disposition, _ in
+          #expect(disposition == .useCredential)
+          completionCalled()
+        }
       }
-
-      wait(for: [expectation], timeout: 1)
-      XCTAssertNotNil(wrappedDelegate.receivedChallenge)
-      XCTAssertTrue(wrappedDelegate.receivedTask === task)
+      #expect(wrappedDelegate.receivedChallenge != nil)
+      #expect(wrappedDelegate.receivedTask === task)
     }
 
-    func testChallengeForwardedToSessionLevelWrappedDelegateWhenTaskLevelNotImplemented() {
+    @Test
+    func challengeForwardedToSessionLevelWrappedDelegateWhenTaskLevelNotImplemented() async {
       final class RecordingDelegate: NSObject, URLSessionDelegate {
         var receivedChallenge: URLAuthenticationChallenge?
         func urlSession(
@@ -343,17 +362,17 @@ final class WebSocketTests: XCTestCase {
       let session = URLSession(configuration: .default)
       let challenge = makeChallenge()
 
-      let expectation = expectation(description: "completion handler called")
-      delegate.urlSession(session, didReceive: challenge) { disposition, _ in
-        XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
-        expectation.fulfill()
+      await confirmation("completion handler called") { completionCalled in
+        delegate.urlSession(session, didReceive: challenge) { disposition, _ in
+          #expect(disposition == .cancelAuthenticationChallenge)
+          completionCalled()
+        }
       }
-
-      wait(for: [expectation], timeout: 1)
-      XCTAssertNotNil(wrappedDelegate.receivedChallenge)
+      #expect(wrappedDelegate.receivedChallenge != nil)
     }
 
-    func testChallengeDefaultsToPerformDefaultHandlingWhenWrappedDelegateDoesNotImplementIt() {
+    @Test
+    func challengeDefaultsToPerformDefaultHandlingWhenWrappedDelegateDoesNotImplementIt() async {
       final class EmptyDelegate: NSObject, URLSessionDelegate {}
 
       let delegate = _Delegate(
@@ -366,17 +385,17 @@ final class WebSocketTests: XCTestCase {
       let session = URLSession(configuration: .default)
       let challenge = makeChallenge()
 
-      let expectation = expectation(description: "completion handler called")
-      delegate.urlSession(session, didReceive: challenge) { disposition, credential in
-        XCTAssertEqual(disposition, .performDefaultHandling)
-        XCTAssertNil(credential)
-        expectation.fulfill()
+      await confirmation("completion handler called") { completionCalled in
+        delegate.urlSession(session, didReceive: challenge) { disposition, credential in
+          #expect(disposition == .performDefaultHandling)
+          #expect(credential == nil)
+          completionCalled()
+        }
       }
-
-      wait(for: [expectation], timeout: 1)
     }
 
-    func testChallengeDefaultsToPerformDefaultHandlingWhenNoWrappedDelegate() {
+    @Test
+    func challengeDefaultsToPerformDefaultHandlingWhenNoWrappedDelegate() async {
       let delegate = _Delegate(
         onComplete: nil,
         onWebSocketTaskOpened: nil,
@@ -387,14 +406,13 @@ final class WebSocketTests: XCTestCase {
       let session = URLSession(configuration: .default)
       let challenge = makeChallenge()
 
-      let expectation = expectation(description: "completion handler called")
-      delegate.urlSession(session, didReceive: challenge) { disposition, credential in
-        XCTAssertEqual(disposition, .performDefaultHandling)
-        XCTAssertNil(credential)
-        expectation.fulfill()
+      await confirmation("completion handler called") { completionCalled in
+        delegate.urlSession(session, didReceive: challenge) { disposition, credential in
+          #expect(disposition == .performDefaultHandling)
+          #expect(credential == nil)
+          completionCalled()
+        }
       }
-
-      wait(for: [expectation], timeout: 1)
     }
 
   #endif
@@ -412,7 +430,7 @@ final class WebSocketTests: XCTestCase {
 
   private nonisolated(unsafe) var deinitNotifierKey: UInt8 = 0
 
-  private final class LoopbackWebSocketServer {
+  private final class LoopbackWebSocketServer: @unchecked Sendable {
     private let listener: NWListener
     private let queue = DispatchQueue(label: "co.supabase.LoopbackWebSocketServer")
     private var connections: [NWConnection] = []
@@ -558,7 +576,7 @@ final class WebSocketTests: XCTestCase {
       return (identity, SecCertificateCopyData(certificate) as Data)
     }
 
-    private final class LoopbackTLSWebSocketServer {
+    private final class LoopbackTLSWebSocketServer: @unchecked Sendable {
       private let listener: NWListener
       private let queue = DispatchQueue(label: "co.supabase.LoopbackTLSWebSocketServer")
       private var connections: [NWConnection] = []

--- a/Tests/RealtimeTests/WebSocketTests.swift
+++ b/Tests/RealtimeTests/WebSocketTests.swift
@@ -296,7 +296,7 @@ struct WebSocketTests {
 
     @Test
     func challengeForwardedToTaskLevelWrappedDelegate() async {
-      final class TaskDelegate: NSObject, URLSessionTaskDelegate {
+      final class TaskDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
         var receivedChallenge: URLAuthenticationChallenge?
         var receivedTask: URLSessionTask?
         func urlSession(
@@ -339,7 +339,7 @@ struct WebSocketTests {
 
     @Test
     func challengeForwardedToSessionLevelWrappedDelegateWhenTaskLevelNotImplemented() async {
-      final class RecordingDelegate: NSObject, URLSessionDelegate {
+      final class RecordingDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
         var receivedChallenge: URLAuthenticationChallenge?
         func urlSession(
           _ session: URLSession,

--- a/Tests/RealtimeTests/_PushTests.swift
+++ b/Tests/RealtimeTests/_PushTests.swift
@@ -6,21 +6,21 @@
 //
 
 import ConcurrencyExtras
+import Foundation
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import Realtime
 @testable import RealtimeV2
 
 #if !os(Android) && !os(Linux) && !os(Windows)
+  @Suite
   @MainActor
-  final class _PushTests: XCTestCase {
-    var ws: FakeWebSocket!
-    var socket: RealtimeClientV2!
+  struct _PushTests {
+    let ws: FakeWebSocket
+    let socket: RealtimeClientV2
 
-    override func setUp() {
-      super.setUp()
-
+    init() {
       let (client, server) = FakeWebSocket.fakes()
       ws = server
 
@@ -35,7 +35,8 @@ import XCTest
       )
     }
 
-    func testPushWithoutAck() async {
+    @Test
+    func pushWithoutAck() async {
       let channel = RealtimeChannelV2(
         topic: "realtime:users",
         config: RealtimeChannelConfig(
@@ -58,10 +59,11 @@ import XCTest
       )
 
       let status = await push.send()
-      XCTAssertEqual(status, .ok)
+      #expect(status == .ok)
     }
 
-    func testPushWithAck() async {
+    @Test
+    func pushWithAck() async {
       let channel = RealtimeChannelV2(
         topic: "realtime:users",
         config: RealtimeChannelConfig(
@@ -90,7 +92,7 @@ import XCTest
       push.didReceive(status: .ok)
 
       let status = await task.value
-      XCTAssertEqual(status, .ok)
+      #expect(status == .ok)
     }
   }
 #endif

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -215,3 +215,4 @@ cskm
 vízrajzi
 állomás
 áéíóú
+deinits


### PR DESCRIPTION
## Summary

Implements [SDK-1254](https://linear.app/supabase/issue/SDK-1254/swift-testing-migration-phase-7-realtimetests): migrates every XCTest suite in `Tests/RealtimeTests` to [Swift Testing](https://developer.apple.com/documentation/testing) (`@Suite`/`@Test`, `#expect`/`#require`, `Issue.record`), per the SDK-435 phase-by-phase migration plan.

## Details

- Adds `Tests/RealtimeTests/TestSupport.swift`: a shared `waitUntil(timeout:pollInterval:condition:)` polling helper that replaces `XCTestExpectation`/`fulfillment(of:timeout:)` — Swift Testing has no direct async-condition-with-timeout primitive.
- `RealtimeTests.swift`: keeps the `withMainSerialExecutor` requirement (previously applied via `invokeTest()` override), now wrapped per test body, with `@Suite(.serialized)` so the process-global executor flag can't race across concurrently-scheduled tests.
- Converts `setUp`/`tearDown` to `init()`/`deinit`, keeping class-based suites where teardown must actively cancel background tasks (e.g. `sut.disconnect()`), not just rely on ARC releasing the struct.
- `WebSocketTests.swift`: serializes the suite (`@Suite(.serialized)`) — its cert-pinning tests import self-signed identities via `SecPKCS12Import`, which is flaky when several tests run concurrently under Swift Testing's default parallel execution (XCTest ran these serially). Converts completion-handler-based challenge-forwarding tests to `confirmation(_:)`.
- `Package.swift`: adds `RealtimeTests` to `swift6TestTargets` now that the target is fully migrated (gets full Swift 6 language mode checking, matching other migrated modules).

Behavior, coverage, and assertions are unchanged — only the test framework and incidental concurrency helpers differ.

## Testing

- `swift build` (whole package) — clean.
- `swift test --filter RealtimeTests` — 254 tests / 22 suites pass, run 5x in a row with no flakiness (including the `WebSocketTests` cert-pinning tests, which were flaky before serializing the suite).
- `./scripts/format.sh` — applied.