### PR TITLE
test: swift testing migration cleanup and enforce (Phase 8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,19 +135,19 @@ Use standard file headers with copyright:
 
 ### Testing Conventions
 
-The test suite is migrating from XCTest to the [Swift Testing](https://developer.apple.com/documentation/testing) framework, module by module (tracked in [SDK-435](https://linear.app/supabase/issue/SDK-435)). New test files use Swift Testing; existing files keep working under XCTest until their module's migration phase lands — both coexist fine in the same target.
+This project uses the [Swift Testing](https://developer.apple.com/documentation/testing) framework, and only Swift Testing — do not use XCTest or `XCTestCase`.
 
 - Test files should mirror source file structure (`Foo.swift` → `FooTests.swift`)
 - Suite naming: the type name matches the file name (`FooTests.swift` → `struct FooTests`), with an explicit `@Suite` attribute even when no custom name/tags are needed
-- Test function names drop the `test` prefix (the `@Test` attribute already conveys that) — `testFooBehavior()` becomes `fooBehavior()`
+- Test function names drop the `test` prefix (the `@Test` attribute already conveys that) — write `fooBehavior()`, not `testFooBehavior()`
 - Use `@testable import` for internal access
-- Prefer `#expect`/`#require` over `XCTAssert*` family; `#expect(x != nil, "message")` reads the same as the old `XCTAssertNotNil(x, "message")`
-- `expectNoDifference` (CustomDump) and `withExpectedIssue`/`reportIssue` (IssueReporting) work under both frameworks unchanged — no conversion needed at call sites
-- Use snapshot testing for complex data structures (via swift-snapshot-testing); `assertSnapshot`/`assertInlineSnapshot` work inside `@Test` functions the same as `XCTestCase`
-- For HTTP mocking: modules already migrated to Swift Testing use [Replay](https://github.com/mattt/Replay) (`@Test(.replay(...))`, HAR fixtures or inline `.replay(stubs:)`) instead of Mocker — see SDK-435 phase issues for the migration order. Un-migrated modules keep using Mocker for URLSession mocking until their phase lands
+- Prefer `#expect`/`#require` for assertions; `#expect(x != nil, "message")` reads the same as `XCTAssertNotNil(x, "message")` did
+- `expectNoDifference` (CustomDump) and `withExpectedIssue`/`reportIssue` (IssueReporting) work unchanged at call sites
+- Use snapshot testing for complex data structures (via swift-snapshot-testing); `assertSnapshot`/`assertInlineSnapshot` work inside `@Test` functions
+- Use Mocker for URLSession mocking
 - Use CustomDump for test assertions with better output
 - Keep integration tests separate in `IntegrationTests` directory
-- Test targets get full Swift 6 language mode checking (matching production targets) once migrated — see the `swift6TestTargets` set in `Package.swift`
+- Test targets get full Swift 6 language mode checking, matching production targets
 
 Example test structure (Swift Testing):
 

--- a/Package.swift
+++ b/Package.swift
@@ -242,23 +242,7 @@ let package = Package(
   ]
 )
 
-// Test targets migrated to Swift Testing get full Swift 6 checking, same as
-// production targets. Everything else stays pinned to v5 until its migration
-// phase lands (see SDK-435).
-let swift6TestTargets: Set<String> = [
-  "SupabaseTests", "HelpersTests", "StorageTests", "PostgRESTTests", "AuthTests", "FunctionsTests",
-  "IntegrationTests", "RealtimeTests",
-]
-
 for target in package.targets {
-  // Test targets never opted into `ExistentialAny` below, so bumping swift-tools-version
-  // to 6.1 must not silently switch their *default* language mode to Swift 6 either —
-  // pin the rest to v5 to preserve their pre-6.1 compilation behavior exactly.
-  if target.isTest, !swift6TestTargets.contains(target.name) {
-    target.swiftSettings = [.swiftLanguageMode(.v5)]
-    continue
-  }
-
   var swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ImmutableWeakCaptures"),

--- a/Tests/IntegrationTests/AuthOAuthServerIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthOAuthServerIntegrationTests.swift
@@ -5,7 +5,8 @@
 //  Created by Guilherme Souza on 10/07/26.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import Auth
 
@@ -13,17 +14,9 @@ import XCTest
   import FoundationNetworking
 #endif
 
-final class AuthOAuthServerIntegrationTests: XCTestCase {
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+struct AuthOAuthServerIntegrationTests {
   let authClient = AuthClientIntegrationTests.makeClient()
-
-  override func setUp() async throws {
-    try await super.setUp()
-
-    try XCTSkipUnless(
-      ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil,
-      "INTEGRATION_TESTS not defined."
-    )
-  }
 
   /// Performs a raw GET to `/oauth/authorize` with PKCE params, capturing the
   /// `authorization_id` from the 302 redirect's `Location` header — the
@@ -66,14 +59,15 @@ final class AuthOAuthServerIntegrationTests: XCTestCase {
         $0.name == "authorization_id"
       })?.value
     else {
-      XCTFail("Expected a redirect with an authorization_id query param, got \(response)")
+      Issue.record("Expected a redirect with an authorization_id query param, got \(response)")
       throw AuthError.sessionMissing
     }
 
     return authorizationId
   }
 
-  func testApproveAuthorizationFlow() async throws {
+  @Test
+  func approveAuthorizationFlow() async throws {
     let email = mockEmail()
     let password = mockPassword()
     try await signUpIfNeededOrSignIn(email: email, password: password)
@@ -100,28 +94,29 @@ final class AuthOAuthServerIntegrationTests: XCTestCase {
     )
 
     guard case .details(let details) = detailsResponse else {
-      XCTFail("Expected pending .details, got \(detailsResponse)")
+      Issue.record("Expected pending .details, got \(detailsResponse)")
       return
     }
-    XCTAssertEqual(details.client.id, oauthClient.clientId)
-    XCTAssertEqual(details.scope, "email")
+    #expect(details.client.id == oauthClient.clientId)
+    #expect(details.scope == "email")
 
     let approveRedirect = try await authClient.oauthServer.approveAuthorization(
       authorizationId: authorizationId
     )
-    XCTAssertEqual(approveRedirect.redirectURL.query?.contains("code="), true)
+    #expect(approveRedirect.redirectURL.query?.contains("code=") == true)
     let grants = try await authClient.oauthServer.listGrants()
-    XCTAssertTrue(grants.contains { $0.client.id == oauthClient.clientId })
+    #expect(grants.contains { $0.client.id == oauthClient.clientId })
 
     try await authClient.oauthServer.revokeGrant(clientId: oauthClient.clientId)
 
     let grantsAfterRevoke = try await authClient.oauthServer.listGrants()
-    XCTAssertFalse(grantsAfterRevoke.contains { $0.client.id == oauthClient.clientId })
+    #expect(!grantsAfterRevoke.contains { $0.client.id == oauthClient.clientId })
 
     try await serviceRoleClient.admin.oauth.deleteClient(clientId: oauthClient.clientId)
   }
 
-  func testDenyAuthorizationFlow() async throws {
+  @Test
+  func denyAuthorizationFlow() async throws {
     let email = mockEmail()
     let password = mockPassword()
     try await signUpIfNeededOrSignIn(email: email, password: password)
@@ -154,7 +149,7 @@ final class AuthOAuthServerIntegrationTests: XCTestCase {
     let denyRedirect = try await authClient.oauthServer.denyAuthorization(
       authorizationId: authorizationId
     )
-    XCTAssertEqual(denyRedirect.redirectURL.query?.contains("error=access_denied"), true)
+    #expect(denyRedirect.redirectURL.query?.contains("error=access_denied") == true)
 
     try await serviceRoleClient.admin.oauth.deleteClient(clientId: oauthClient.clientId)
   }


### PR DESCRIPTION
## Summary

Final cleanup pass for [SDK-1255](https://linear.app/supabase/issue/SDK-1255), the last phase of the Swift Testing migration tracked in SDK-435.

- Migrated the last `XCTestCase` holdout — [`AuthOAuthServerIntegrationTests.swift`](Tests/IntegrationTests/AuthOAuthServerIntegrationTests.swift) — to Swift Testing (`@Suite`/`@Test`/`#expect`/`Issue.record`), mirroring `AuthClientIntegrationTests.swift`'s pattern.
- Removed the now-dead `swift6TestTargets` / per-target v5-pin branch in `Package.swift` — every test target had already opted into Swift 6 mode via the prior migration phases, so all targets (production and test) now share one `swiftSettings` loop.
- Rewrote AGENTS.md's Testing Conventions section to describe Swift Testing as the sole convention (no XCTest, no migration-in-progress language, Mocker only — no Replay, since no module currently uses it).

## Verification

- `grep -r "import XCTest" Tests/` → 0 real hits (2 remaining matches are `XCTestDynamicOverlay`, an unrelated package, substring-matched by the grep).
- `swift build`, `swift build --build-tests`, `swift test --parallel` — all pass (1004 tests, 90 suites).
- Ran the real coverage pipeline (`xcodebuild test` on iOS simulator + `./scripts/generate-coverage.sh`) end-to-end — confirms `lcov.info` generation still works against Swift Testing's XCTest-bridge output.
- Evaluated CI's `--parallel` flag: Swift Testing parallelizes internally by default regardless of SwiftPM's `--parallel`, and the full local run above showed no timing regression, so no CI change is needed.
- `./scripts/format.sh` and `./scripts/spell-check.sh` clean.

## Test plan

- [x] CI green across all platforms/Xcode versions
- [x] Coverage job still uploads to Coveralls successfully