### PR TITLE
feat(examples): update SlackClone to use typed PostgREST API

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		79D884D22B3C18840009EA4A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 79D884D12B3C18840009EA4A /* Preview Assets.xcassets */; };
 		79D884D72B3C18DB0009EA4A /* Supabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D884D62B3C18DB0009EA4A /* Supabase.swift */; };
 		79D884D92B3C18E90009EA4A /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 79D884D82B3C18E90009EA4A /* Supabase */; };
-		79D884E02B3C19500009EA4A /* SupabaseSwiftMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 79D884E12B3C19500009EA4A /* SupabaseSwiftMacros */; };
+		79D884E02B3C19500009EA4A /* PostgrestMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 79D884E12B3C19500009EA4A /* PostgrestMacros */; };
 		79D884DB2B3C191F0009EA4A /* ChannelListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D884DA2B3C191F0009EA4A /* ChannelListView.swift */; };
 		79D884DD2B3C19320009EA4A /* MessagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D884DC2B3C19320009EA4A /* MessagesView.swift */; };
 		79E2B5582B97890F0042CD21 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 79E2B5572B97890F0042CD21 /* GoogleSignIn */; };
@@ -235,7 +235,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				79D884D92B3C18E90009EA4A /* Supabase in Frameworks */,
-				79D884E02B3C19500009EA4A /* SupabaseSwiftMacros in Frameworks */,
+				79D884E02B3C19500009EA4A /* PostgrestMacros in Frameworks */,
 				79B8F4242B5FED7C0000E839 /* IdentifiedCollections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -430,7 +430,7 @@
 			name = SlackClone;
 			packageProductDependencies = (
 				79D884D82B3C18E90009EA4A /* Supabase */,
-				79D884E12B3C19500009EA4A /* SupabaseSwiftMacros */,
+				79D884E12B3C19500009EA4A /* PostgrestMacros */,
 				79B8F4232B5FED7C0000E839 /* IdentifiedCollections */,
 			);
 			productName = SlackClone;
@@ -1118,10 +1118,10 @@
 			package = 79AABBCC2B3C20000009EA4A /* XCLocalSwiftPackageReference ".." */;
 			productName = Supabase;
 		};
-		79D884E12B3C19500009EA4A /* SupabaseSwiftMacros */ = {
+		79D884E12B3C19500009EA4A /* PostgrestMacros */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 79AABBCC2B3C20000009EA4A /* XCLocalSwiftPackageReference ".." */;
-			productName = SupabaseSwiftMacros;
+			productName = PostgrestMacros;
 		};
 		79E2B5572B97890F0042CD21 /* GoogleSignIn */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		79D884D22B3C18840009EA4A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 79D884D12B3C18840009EA4A /* Preview Assets.xcassets */; };
 		79D884D72B3C18DB0009EA4A /* Supabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D884D62B3C18DB0009EA4A /* Supabase.swift */; };
 		79D884D92B3C18E90009EA4A /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 79D884D82B3C18E90009EA4A /* Supabase */; };
+		79D884E02B3C19500009EA4A /* SupabaseSwiftMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 79D884E12B3C19500009EA4A /* SupabaseSwiftMacros */; };
 		79D884DB2B3C191F0009EA4A /* ChannelListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D884DA2B3C191F0009EA4A /* ChannelListView.swift */; };
 		79D884DD2B3C19320009EA4A /* MessagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D884DC2B3C19320009EA4A /* MessagesView.swift */; };
 		79E2B5582B97890F0042CD21 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 79E2B5572B97890F0042CD21 /* GoogleSignIn */; };
@@ -234,6 +235,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				79D884D92B3C18E90009EA4A /* Supabase in Frameworks */,
+				79D884E02B3C19500009EA4A /* SupabaseSwiftMacros in Frameworks */,
 				79B8F4242B5FED7C0000E839 /* IdentifiedCollections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -428,6 +430,7 @@
 			name = SlackClone;
 			packageProductDependencies = (
 				79D884D82B3C18E90009EA4A /* Supabase */,
+				79D884E12B3C19500009EA4A /* SupabaseSwiftMacros */,
 				79B8F4232B5FED7C0000E839 /* IdentifiedCollections */,
 			);
 			productName = SlackClone;
@@ -485,6 +488,7 @@
 			);
 			mainGroup = 793895BD2954ABFF0044F2B8;
 			packageReferences = (
+				79AABBCC2B3C20000009EA4A /* XCLocalSwiftPackageReference ".." */,
 				7956406B2955B3500088A06F /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
 				7956406E2955B5190088A06F /* XCRemoteSwiftPackageReference "swift-identified-collections" */,
 				7962989B2AEBC6F9000AA957 /* XCRemoteSwiftPackageReference "SVGView" */,
@@ -814,6 +818,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SlackClone/Info.plist;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = "";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -856,6 +861,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SlackClone/Info.plist;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = "";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -1005,6 +1011,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		79AABBCC2B3C20000009EA4A /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "..";
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		6C93F238922618E376616E2E /* XCRemoteSwiftPackageReference "metamask-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1087,6 +1100,7 @@
 		};
 		79719ECD2ADF26C400737804 /* Supabase */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 79AABBCC2B3C20000009EA4A /* XCLocalSwiftPackageReference ".." */;
 			productName = Supabase;
 		};
 		79B8F4232B5FED7C0000E839 /* IdentifiedCollections */ = {
@@ -1101,7 +1115,13 @@
 		};
 		79D884D82B3C18E90009EA4A /* Supabase */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 79AABBCC2B3C20000009EA4A /* XCLocalSwiftPackageReference ".." */;
 			productName = Supabase;
+		};
+		79D884E12B3C19500009EA4A /* SupabaseSwiftMacros */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 79AABBCC2B3C20000009EA4A /* XCLocalSwiftPackageReference ".." */;
+			productName = SupabaseSwiftMacros;
 		};
 		79E2B5572B97890F0042CD21 /* GoogleSignIn */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1115,6 +1135,7 @@
 		};
 		79FEFFBB2B07874000D36347 /* Supabase */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 79AABBCC2B3C20000009EA4A /* XCLocalSwiftPackageReference ".." */;
 			productName = Supabase;
 		};
 		82A0B5B97246DF189941A2A7 /* metamask-ios-sdk */ = {

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,222 @@
+{
+  "originHash" : "a339c6e0a12a80408b8a7f1ac5ae3b181c081c3fdaabab063e056fce37d22f7a",
+  "pins" : [
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
+        "version" : "1.7.6"
+      }
+    },
+    {
+      "identity" : "clerk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/clerk/clerk-ios",
+      "state" : {
+        "revision" : "8d16727fbe58609e18759e3020488b840201c83d",
+        "version" : "0.71.4"
+      }
+    },
+    {
+      "identity" : "facebook-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/facebook-ios-sdk",
+      "state" : {
+        "revision" : "c19607d535864533523d1f437c84035e5fb101cf",
+        "version" : "14.1.0"
+      }
+    },
+    {
+      "identity" : "factory",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hmlongco/Factory",
+      "state" : {
+        "revision" : "ccc898f21992ebc130bc04cc197460a5ae230bcf",
+        "version" : "2.5.3"
+      }
+    },
+    {
+      "identity" : "get",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Get",
+      "state" : {
+        "revision" : "31249885da1052872e0ac91a2943f62567c0d96d",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "a7965d134c5d3567026c523e0a8a583f73b62b0d",
+        "version" : "7.1.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "ac632bd26a1c00f139ff62fd01806f21cf67325e",
+        "version" : "8.10.0"
+      }
+    },
+    {
+      "identity" : "phonenumberkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/marmelroy/PhoneNumberKit",
+      "state" : {
+        "revision" : "169ab10234347fb19b37441f2867ace896a284b0",
+        "version" : "4.3.0"
+      }
+    },
+    {
+      "identity" : "simplekeychain",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/auth0/SimpleKeychain",
+      "state" : {
+        "revision" : "776c4a6db74d5c6c143974be91c383680d468630",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "svgview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/SVGView",
+      "state" : {
+        "revision" : "6465962facdd25cb96eaebc35603afa2f15d2c0d",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "1197e80bc7e4b177051b6869ef93d8ac3ad677da",
+        "version" : "1.8.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "a8cd6c976f335ed361dcecddb0dc39ebda51bc3e",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections.git",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swiftui-navigation.git",
+      "state" : {
+        "revision" : "e628806aeaa9efe25c1abcd97931a7c498fab281",
+        "version" : "1.5.5"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "401bf70d95bfe8db2a1dc619f9e175a85c089321",
+        "version" : "1.10.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Examples/SlackClone/ChannelStore.swift
+++ b/Examples/SlackClone/ChannelStore.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
+import PostgrestMacros
 import Supabase
-import SupabaseSwiftMacros
 
 @MainActor
 @Observable

--- a/Examples/SlackClone/ChannelStore.swift
+++ b/Examples/SlackClone/ChannelStore.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Supabase
+import SupabaseSwiftMacros
 
 @MainActor
 @Observable
@@ -46,11 +47,7 @@ final class ChannelStore {
   func addChannel(_ name: String) async {
     do {
       let userId = try await supabase.auth.session.user.id
-      let channel = AddChannel(slug: name, createdBy: userId)
-      try await supabase
-        .from("channels")
-        .insert(channel)
-        .execute()
+      try await supabase.addChannel(slug: name, createdBy: userId)
     } catch {
       dump(error)
       toast = .init(status: .error, title: "Error", description: error.localizedDescription)
@@ -62,13 +59,7 @@ final class ChannelStore {
       return channel
     }
 
-    let channel: Channel =
-      try await supabase
-      .from("channels")
-      .select()
-      .eq("id", value: id)
-      .execute()
-      .value
+    let channel = try await supabase.fetchChannel(id: id)
     channels.append(channel)
     return channel
   }
@@ -91,7 +82,7 @@ final class ChannelStore {
 
   private func fetchChannels() async -> [Channel] {
     do {
-      return try await supabase.from("channels").select().execute().value
+      return try await supabase.fetchChannels()
     } catch {
       dump(error)
       toast = .init(status: .error, title: "Error", description: error.localizedDescription)

--- a/Examples/SlackClone/Dependencies.swift
+++ b/Examples/SlackClone/Dependencies.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
+import PostgrestMacros
 import Supabase
-import SupabaseSwiftMacros
 
 @MainActor
 class Dependencies {
@@ -62,7 +62,7 @@ struct UserPresence: Codable, Hashable {
 extension SupabaseClient {
   // MARK: Messages
   func fetchMessages(channelId: Channel.ID) async throws -> [MessageWithDetails] {
-    try await from(Message.self)
+    try await database.from(Message.self)
       .select(MessageWithDetails.self)
       .eq(\.channelId, value: channelId)
       .order(\.insertedAt, ascending: true)
@@ -71,14 +71,14 @@ extension SupabaseClient {
   }
 
   func sendMessage(_ text: String, userId: UUID, channelId: Channel.ID) async throws {
-    try await from(Message.self)
+    try await database.from(Message.self)
       .insert(Message.Insert(message: text, userId: userId, channelId: channelId))
       .execute()
   }
 
   // MARK: Users
   func fetchUser(id: User.ID) async throws -> User {
-    try await from(User.self)
+    try await database.from(User.self)
       .select()
       .eq(\.id, value: id)
       .single()
@@ -88,14 +88,14 @@ extension SupabaseClient {
 
   // MARK: Channels
   func fetchChannels() async throws -> [Channel] {
-    try await from(Channel.self)
+    try await database.from(Channel.self)
       .select()
       .execute()
       .value
   }
 
   func fetchChannel(id: Channel.ID) async throws -> Channel {
-    try await from(Channel.self)
+    try await database.from(Channel.self)
       .select()
       .eq(\.id, value: id)
       .single()
@@ -104,7 +104,7 @@ extension SupabaseClient {
   }
 
   func addChannel(slug: String, createdBy: UUID) async throws {
-    try await from(Channel.self)
+    try await database.from(Channel.self)
       .insert(Channel.Insert(slug: slug, createdBy: createdBy))
       .execute()
   }

--- a/Examples/SlackClone/Dependencies.swift
+++ b/Examples/SlackClone/Dependencies.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Supabase
+import SupabaseSwiftMacros
 
 @MainActor
 class Dependencies {
@@ -17,37 +18,94 @@ class Dependencies {
   let messages = MessageStore.shared
 }
 
-struct User: Codable, Identifiable, Hashable {
-  var id: UUID
+@Table("users", readOnly: true)
+struct User: Codable, Identifiable, Hashable, ReadOnlyTableRepresentable {
+  @PrimaryKey var id: UUID
   var username: String
 }
 
-struct AddChannel: Encodable {
+@Table("channels")
+struct Channel: Codable, Identifiable, Hashable, TableRepresentable {
+  @PrimaryKey var id: Int
+  @Default var insertedAt: Date
   var slug: String
   var createdBy: UUID
 }
 
-struct Channel: Identifiable, Codable, Hashable {
-  var id: Int
-  var slug: String
-  var insertedAt: Date
-}
-
-struct Message: Identifiable, Codable, Hashable {
-  var id: Int
-  var insertedAt: Date
-  var message: String
-  var user: User
-  var channel: Channel
-}
-
-struct NewMessage: Codable {
+@Table("messages")
+struct Message: Codable, Identifiable, Hashable, TableRepresentable {
+  @PrimaryKey var id: Int
+  @Default var insertedAt: Date
   var message: String
   var userId: UUID
-  let channelId: Int
+  var channelId: Int
+}
+
+@SelectionOf(Message.self)
+struct MessageWithDetails: Codable, Identifiable, Hashable {
+  var id: Int
+  var insertedAt: Date
+  var message: String
+  @Relationship(\Message.userId) var user: User
+  @Relationship(\Message.channelId) var channel: Channel
 }
 
 struct UserPresence: Codable, Hashable {
   var userId: UUID
   var onlineAt: Date
+}
+
+// MARK: - Typed query helpers
+// Defined here so macro-generated TableRepresentable/SelectionRepresentable conformances
+// are always resolved in the same compilation unit, avoiding Swift batch-compilation
+// visibility issues with attached-macro-generated conformances.
+extension SupabaseClient {
+  // MARK: Messages
+  func fetchMessages(channelId: Channel.ID) async throws -> [MessageWithDetails] {
+    try await from(Message.self)
+      .select(MessageWithDetails.self)
+      .eq(\.channelId, value: channelId)
+      .order(\.insertedAt, ascending: true)
+      .execute()
+      .value
+  }
+
+  func sendMessage(_ text: String, userId: UUID, channelId: Channel.ID) async throws {
+    try await from(Message.self)
+      .insert(Message.Insert(message: text, userId: userId, channelId: channelId))
+      .execute()
+  }
+
+  // MARK: Users
+  func fetchUser(id: User.ID) async throws -> User {
+    try await from(User.self)
+      .select()
+      .eq(\.id, value: id)
+      .single()
+      .execute()
+      .value
+  }
+
+  // MARK: Channels
+  func fetchChannels() async throws -> [Channel] {
+    try await from(Channel.self)
+      .select()
+      .execute()
+      .value
+  }
+
+  func fetchChannel(id: Channel.ID) async throws -> Channel {
+    try await from(Channel.self)
+      .select()
+      .eq(\.id, value: id)
+      .single()
+      .execute()
+      .value
+  }
+
+  func addChannel(slug: String, createdBy: UUID) async throws {
+    try await from(Channel.self)
+      .insert(Channel.Insert(slug: slug, createdBy: createdBy))
+      .execute()
+  }
 }

--- a/Examples/SlackClone/MessageStore.swift
+++ b/Examples/SlackClone/MessageStore.swift
@@ -8,6 +8,7 @@
 import Foundation
 import IdentifiedCollections
 import Supabase
+import SupabaseSwiftMacros
 
 struct Messages {
   private(set) var sections: [Section]
@@ -16,7 +17,7 @@ struct Messages {
     var id: AnyHashable { self }
 
     var author: User
-    var messages: IdentifiedArrayOf<Message>
+    var messages: IdentifiedArrayOf<MessageWithDetails>
   }
 
   init(sections: [Section]) {
@@ -29,9 +30,9 @@ struct Messages {
     }
   }
 
-  private var messageToSectionLookupTable: [Message.ID: Int] = [:]
+  private var messageToSectionLookupTable: [MessageWithDetails.ID: Int] = [:]
 
-  mutating func appendOrUpdate(_ message: Message) {
+  mutating func appendOrUpdate(_ message: MessageWithDetails) {
     if let sectionIndex = messageToSectionLookupTable[message.id],
       let messageIndex = sections[sectionIndex].messages
         .firstIndex(where: { $0.id == message.id })
@@ -42,7 +43,7 @@ struct Messages {
     }
   }
 
-  mutating func remove(id: Message.ID) {
+  mutating func remove(id: MessageWithDetails.ID) {
     if let index = messageToSectionLookupTable[id] {
       sections[index].messages.remove(id: id)
       messageToSectionLookupTable[id] = nil
@@ -53,7 +54,7 @@ struct Messages {
     }
   }
 
-  private mutating func append(_ message: Message) {
+  private mutating func append(_ message: MessageWithDetails) {
     if var section = sections.last, section.author.id == message.user.id {
       section.messages.append(message)
       sections[sections.endIndex - 1] = section
@@ -77,7 +78,7 @@ struct Messages {
 }
 
 extension Messages {
-  init(_ messages: [Message]) {
+  init(_ messages: [MessageWithDetails]) {
     self.init(sections: [])
 
     for message in messages {
@@ -95,7 +96,7 @@ final class MessageStore {
 
   struct Section {
     var author: User
-    var messages: [Message]
+    var messages: [MessageWithDetails]
   }
 
   var users: UserStore { Dependencies.shared.users }
@@ -146,18 +147,20 @@ final class MessageStore {
 
   private func handleInsertedOrUpdatedMessage(_ action: HasRecord) async {
     do {
-      let decodedMessage = try action.decodeRecord(decoder: decoder) as MessagePayload
-      let message = try await Message(
-        id: decodedMessage.id,
-        insertedAt: decodedMessage.insertedAt,
-        message: decodedMessage.message,
-        user: users.fetchUser(id: decodedMessage.userId),
-        channel: channel.fetchChannel(id: decodedMessage.channelId)
+      let payload = try action.decodeRecord(decoder: decoder) as Message
+      let user = try await users.fetchUser(id: payload.userId)
+      let channel = try await self.channel.fetchChannel(id: payload.channelId)
+      let message = MessageWithDetails(
+        id: payload.id,
+        insertedAt: payload.insertedAt,
+        message: payload.message,
+        user: user,
+        channel: channel
       )
 
-      var channelMessages = messages[decodedMessage.channelId] ?? Messages(sections: [])
+      var channelMessages = messages[payload.channelId] ?? Messages(sections: [])
       channelMessages.appendOrUpdate(message)
-      messages[decodedMessage.channelId] = channelMessages
+      messages[payload.channelId] = channelMessages
     } catch {
       dump(error)
     }
@@ -174,22 +177,8 @@ final class MessageStore {
     }
   }
 
-  /// Fetch all messages and their authors.
-  private func fetchMessages(_ channelId: Channel.ID) async throws -> [Message] {
-    try await supabase
-      .from("messages")
-      .select("*,user:user_id(*),channel:channel_id(*)")
-      .eq("channel_id", value: channelId)
-      .order("inserted_at", ascending: true)
-      .execute()
-      .value
+  /// Fetch all messages joined with their author and channel.
+  private func fetchMessages(_ channelId: Channel.ID) async throws -> [MessageWithDetails] {
+    try await supabase.fetchMessages(channelId: channelId)
   }
-}
-
-private struct MessagePayload: Decodable {
-  let id: Int
-  let message: String
-  let insertedAt: Date
-  let userId: UUID
-  let channelId: Int
 }

--- a/Examples/SlackClone/MessageStore.swift
+++ b/Examples/SlackClone/MessageStore.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 import IdentifiedCollections
+import PostgrestMacros
 import Supabase
-import SupabaseSwiftMacros
 
 struct Messages {
   private(set) var sections: [Section]

--- a/Examples/SlackClone/MessagesView.swift
+++ b/Examples/SlackClone/MessagesView.swift
@@ -7,6 +7,7 @@
 
 import Realtime
 import Supabase
+import SupabaseSwiftMacros
 import SwiftUI
 
 struct MessagesView: View {
@@ -69,13 +70,8 @@ struct MessagesView: View {
     guard !newMessage.isEmpty else { return }
 
     do {
-      let message = try await NewMessage(
-        message: newMessage,
-        userId: supabase.auth.session.user.id,
-        channelId: channel.id
-      )
-
-      try await supabase.from("messages").insert(message).execute()
+      let userId = try await supabase.auth.session.user.id
+      try await supabase.sendMessage(newMessage, userId: userId, channelId: channel.id)
       newMessage = ""
     } catch {
       dump(error)

--- a/Examples/SlackClone/MessagesView.swift
+++ b/Examples/SlackClone/MessagesView.swift
@@ -5,9 +5,9 @@
 //  Created by Guilherme Souza on 27/12/23.
 //
 
+import PostgrestMacros
 import Realtime
 import Supabase
-import SupabaseSwiftMacros
 import SwiftUI
 
 struct MessagesView: View {

--- a/Examples/SlackClone/Supabase.swift
+++ b/Examples/SlackClone/Supabase.swift
@@ -8,17 +8,11 @@
 import Foundation
 import Supabase
 
-let encoder: JSONEncoder = {
-  let encoder = PostgrestClient.Configuration.jsonEncoder
-  encoder.keyEncodingStrategy = .convertToSnakeCase
-  return encoder
-}()
+// @Table-annotated types carry explicit snake_case CodingKeys, so no key
+// conversion strategies are needed — the encoder/decoder can work as plain JSON.
+let encoder: JSONEncoder = PostgrestClient.Configuration.jsonEncoder
 
-let decoder: JSONDecoder = {
-  let decoder = PostgrestClient.Configuration.jsonDecoder
-  decoder.keyDecodingStrategy = .convertFromSnakeCase
-  return decoder
-}()
+let decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder
 
 let supabase = SupabaseClient(
   supabaseURL: URL(string: "http://127.0.0.1:54321")!,

--- a/Examples/SlackClone/UserStore.swift
+++ b/Examples/SlackClone/UserStore.swift
@@ -8,6 +8,7 @@
 import Foundation
 import OSLog
 import Supabase
+import SupabaseSwiftMacros
 
 @MainActor
 @Observable
@@ -64,14 +65,7 @@ final class UserStore {
       return user
     }
 
-    let user: User =
-      try await supabase
-      .from("users")
-      .select()
-      .eq("id", value: id)
-      .single()
-      .execute()
-      .value
+    let user = try await supabase.fetchUser(id: id)
     users[user.id] = user
     return user
   }

--- a/Examples/SlackClone/UserStore.swift
+++ b/Examples/SlackClone/UserStore.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 import OSLog
+import PostgrestMacros
 import Supabase
-import SupabaseSwiftMacros
 
 @MainActor
 @Observable


### PR DESCRIPTION
## Summary

Stacked on #1036 — adopts the typed PostgREST API (`@Table`, `@SelectionOf`, `@Relationship`, typed builders) in the SlackClone example.

- Annotate `User`, `Channel`, `Message` with `@Table` macros
- Add `MessageWithDetails` `@SelectionOf` for the join query with `@Relationship`
- Replace raw string queries with type-safe `from(T.self)`, `eq(\.keyPath)`, `order(\.keyPath)`
- Replace `AddChannel`/`NewMessage` with generated `Insert` nested types
- Remove `MessagePayload` in favour of `Message` (the `@Table` type)
- Remove `convertToSnakeCase`/`convertFromSnakeCase` encoder/decoder strategies (`@Table` `CodingKeys` carry explicit snake_case strings)
- Wire `SupabaseSwiftMacros` into the SlackClone Xcode target (local package reference + framework link)

Depends on #1036 merging first.

## Test plan

- [x] SlackClone example target builds