### PR TITLE
feat(functions): add per-invocation timeout override

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -48,6 +48,8 @@ public final class FunctionsClient: Sendable {
     )
 
   /// The maximum time an Edge Function may run before the gateway returns a 504 error (150 seconds).
+  ///
+  /// Can be overridden per-invocation via ``FunctionInvokeOptions/timeoutInterval``.
   public static let requestIdleTimeout: TimeInterval = 150
 
   /// The base URL for the functions.
@@ -301,7 +303,7 @@ public final class FunctionsClient: Sendable {
       query: query,
       headers: mutableState.headers.merging(with: options.headers),
       body: options.body,
-      timeoutInterval: FunctionsClient.requestIdleTimeout
+      timeoutInterval: options.timeoutInterval ?? FunctionsClient.requestIdleTimeout
     )
 
     if let region = options.region ?? region {

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -32,6 +32,9 @@ public struct FunctionInvokeOptions: Sendable {
   let region: String?
   /// The query to be included in the function invocation.
   let query: [URLQueryItem]
+  /// A per-invocation override for the request timeout. Defaults to
+  /// ``FunctionsClient/requestIdleTimeout`` when `nil`.
+  let timeoutInterval: TimeInterval?
 
   /// Creates options for a function invocation with an encodable body.
   /// - Parameters:
@@ -42,6 +45,8 @@ public struct FunctionInvokeOptions: Sendable {
   ///   - body: The body to encode and send. Strings are sent as `text/plain`, `Data` as
   ///     `application/octet-stream`, and all other `Encodable` values as JSON.
   ///   - encoder: The JSON encoder used when `body` is encoded as JSON.
+  ///   - timeoutInterval: A per-invocation override for the request timeout. Defaults to
+  ///     ``FunctionsClient/requestIdleTimeout`` when `nil`.
   @_disfavoredOverload
   public init(
     method: Method? = nil,
@@ -49,7 +54,8 @@ public struct FunctionInvokeOptions: Sendable {
     headers: [String: String] = [:],
     region: String? = nil,
     body: some Encodable,
-    encoder: JSONEncoder = JSONEncoder()
+    encoder: JSONEncoder = JSONEncoder(),
+    timeoutInterval: TimeInterval? = nil
   ) {
     var defaultHeaders = HTTPFields()
 
@@ -69,6 +75,7 @@ public struct FunctionInvokeOptions: Sendable {
     self.headers = defaultHeaders.merging(with: HTTPFields(headers))
     self.region = region
     self.query = query
+    self.timeoutInterval = timeoutInterval
   }
 
   /// Creates options for a function invocation with no body.
@@ -77,17 +84,21 @@ public struct FunctionInvokeOptions: Sendable {
   ///   - query: Query items appended to the function URL.
   ///   - headers: Additional headers to include in the request.
   ///   - region: The region string to invoke the function in.
+  ///   - timeoutInterval: A per-invocation override for the request timeout. Defaults to
+  ///     ``FunctionsClient/requestIdleTimeout`` when `nil`.
   @_disfavoredOverload
   public init(
     method: Method? = nil,
     query: [URLQueryItem] = [],
     headers: [String: String] = [:],
-    region: String? = nil
+    region: String? = nil,
+    timeoutInterval: TimeInterval? = nil
   ) {
     self.method = method
     self.headers = HTTPFields(headers)
     self.region = region
     self.query = query
+    self.timeoutInterval = timeoutInterval
     body = nil
   }
 
@@ -173,19 +184,23 @@ extension FunctionInvokeOptions {
   ///   - region: The region to invoke the function in.
   ///   - body: The body to encode and send.
   ///   - encoder: The JSON encoder used when `body` is encoded as JSON.
+  ///   - timeoutInterval: A per-invocation override for the request timeout. Defaults to
+  ///     ``FunctionsClient/requestIdleTimeout`` when `nil`.
   public init(
     method: Method? = nil,
     headers: [String: String] = [:],
     region: FunctionRegion? = nil,
     body: some Encodable,
-    encoder: JSONEncoder = JSONEncoder()
+    encoder: JSONEncoder = JSONEncoder(),
+    timeoutInterval: TimeInterval? = nil
   ) {
     self.init(
       method: method,
       headers: headers,
       region: region?.rawValue,
       body: body,
-      encoder: encoder
+      encoder: encoder,
+      timeoutInterval: timeoutInterval
     )
   }
 
@@ -194,11 +209,15 @@ extension FunctionInvokeOptions {
   ///   - method: The HTTP method to use. Defaults to POST when `nil`.
   ///   - headers: Additional headers to include in the request.
   ///   - region: The region to invoke the function in.
+  ///   - timeoutInterval: A per-invocation override for the request timeout. Defaults to
+  ///     ``FunctionsClient/requestIdleTimeout`` when `nil`.
   public init(
     method: Method? = nil,
     headers: [String: String] = [:],
-    region: FunctionRegion? = nil
+    region: FunctionRegion? = nil,
+    timeoutInterval: TimeInterval? = nil
   ) {
-    self.init(method: method, headers: headers, region: region?.rawValue)
+    self.init(
+      method: method, headers: headers, region: region?.rawValue, timeoutInterval: timeoutInterval)
   }
 }

--- a/Tests/FunctionsTests/FunctionsClientTests.swift
+++ b/Tests/FunctionsTests/FunctionsClientTests.swift
@@ -10,6 +10,16 @@ import Testing
   import FoundationNetworking
 #endif
 
+/// Captures the last `URLRequest` seen by a custom fetch handler, for tests that need to inspect
+/// properties (like `timeoutInterval`) not surfaced by Mocker's `snapshotRequest` curl output.
+private actor CapturedRequestBox {
+  var request: URLRequest?
+
+  func set(_ request: URLRequest) {
+    self.request = request
+  }
+}
+
 /// `.serialized`: Mocker registers stubs in a process-global table with no per-test isolation, so
 /// tests that stub overlapping URLs (e.g. `hello-world`) would otherwise race against each other
 /// under Swift Testing's default parallel execution. `.mockerSerialized` (see
@@ -376,6 +386,48 @@ struct FunctionsClientTests {
     } catch {
       Issue.record("Unexpected error thrown \(error)")
     }
+  }
+
+  @Test
+  func invokeWithTimeoutOverride() async throws {
+    let box = CapturedRequestBox()
+    let sut = FunctionsClient(
+      url: url,
+      headers: ["apikey": apiKey],
+      fetch: { request in
+        await box.set(request)
+        return (
+          Data(),
+          HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        )
+      }
+    )
+
+    try await sut.invoke("hello-world", options: .init(timeoutInterval: 30))
+
+    let capturedRequest = await box.request
+    #expect(capturedRequest?.timeoutInterval == 30)
+  }
+
+  @Test
+  func invokeWithDefaultTimeout() async throws {
+    let box = CapturedRequestBox()
+    let sut = FunctionsClient(
+      url: url,
+      headers: ["apikey": apiKey],
+      fetch: { request in
+        await box.set(request)
+        return (
+          Data(),
+          HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        )
+      }
+    )
+
+    try await sut.invoke("hello-world")
+
+    let capturedRequest = await box.request
+    #expect(capturedRequest?.timeoutInterval == FunctionsClient.requestIdleTimeout)
   }
 
   @Test

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -408,7 +408,6 @@ features:
     status: implemented
     symbols:
       - FunctionsClient.requestIdleTimeout
-      - FunctionInvokeOptions.timeoutInterval
 
   # ── Realtime ───────────────────────────────────────────────────────────────
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -405,8 +405,10 @@ features:
       - FunctionRegion.usWest2
   functions.invocation.request_cancellation: implemented
   functions.invocation.timeout:
-    status: partially_implemented
-    note: "Default idle timeout is a hardcoded 150 s constant; no per-invocation override is exposed."
+    status: implemented
+    symbols:
+      - FunctionsClient.requestIdleTimeout
+      - FunctionInvokeOptions.timeoutInterval
 
   # ── Realtime ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `FunctionsClient` hardcoded `requestIdleTimeout` (150s) on every request via `buildRequest`, with no way to override it per call.
- Adds `timeoutInterval: TimeInterval?` to `FunctionInvokeOptions`, threaded through all 4 initializers. `buildRequest` now uses `options.timeoutInterval ?? FunctionsClient.requestIdleTimeout`.
- Implements https://linear.app/supabase/issue/SDK-1299/functions-per-invocation-timeout-override

## Notes for reviewers
- supabase-js (functions-js) uses an `AbortSignal`-based `signal` option rather than a numeric timeout. Not mirrored here — kept consistent with the Swift client's existing `TimeInterval`/`timeoutInterval` convention (already used internally on `Helpers.HTTPRequest`), since this issue is specifically about making the existing hardcoded `TimeInterval` timeout overridable, not about adding cancellation semantics.

## Test plan
- [x] `swift build`
- [x] `swift test --filter FunctionsTests` (32 tests pass, incl. 2 new: override + default-timeout assertions on the outgoing `URLRequest.timeoutInterval`)
- [x] `./scripts/format.sh`