### PR TITLE
fix(realtime): make subscribe converge after a failed auto-reconnect

### DIFF
--- a/Sources/RealtimeV2/ChannelStateManager.swift
+++ b/Sources/RealtimeV2/ChannelStateManager.swift
@@ -263,7 +263,25 @@ actor ChannelStateManager {
 
   /// Called when the server closes the channel (phx_close or system error
   /// that should drop the channel).
-  func didReceiveClose() {
+  ///
+  /// When `expectedJoinRef` is provided (Phoenix tags `phx_close` with the
+  /// `join_ref` of the join it closes), the close is only applied if it still
+  /// matches the current ``joinRef`` — checked here, on the actor, so a
+  /// concurrent subscribe attempt can't swap `joinRef` between the caller's
+  /// check and the close (issue #1145, defect 3). Closes without a `join_ref`
+  /// are applied unconditionally.
+  ///
+  /// Returns `true` if the close was applied; `false` if it belonged to a
+  /// stale join and was ignored.
+  @discardableResult
+  func didReceiveClose(joinRef expectedJoinRef: String? = nil) -> Bool {
+    if let expectedJoinRef, expectedJoinRef != joinRef {
+      logger?.debug(
+        "Ignoring close for stale join_ref \(expectedJoinRef) on '\(topic)' "
+          + "(current: \(joinRef ?? "<none>"))"
+      )
+      return false
+    }
     logger?.debug("Server closed channel '\(topic)'")
     joinRef = nil
     pushes = [:]
@@ -275,6 +293,7 @@ actor ChannelStateManager {
       task.cancel()
     }
     updateState(.unsubscribed)
+    return true
   }
 
   // MARK: - Private
@@ -309,10 +328,14 @@ actor ChannelStateManager {
         updateState(.unsubscribed)
       }
 
-      // The task was cancelled by `didReceiveClose()`, not by the caller —
-      // translate to a typed error so it isn't mistaken for a caller-side
-      // cancellation.
-      if closedByServer, error is CancellationError {
+      // The subscribe was aborted by `didReceiveClose()`, not by the caller.
+      // Depending on how the cancellation is observed, the task can exit with
+      // `CancellationError`, `SubscribeFailure.channelClosed`, or — when the
+      // close lands on the final retry attempt — `maxRetryAttemptsReached`.
+      // All of them are consequences of the server close, so translate
+      // unconditionally; a genuine caller-side cancellation never sets the
+      // flag and still propagates as `CancellationError`.
+      if closedByServer {
         throw RealtimeError.channelClosedByServer
       }
       throw error

--- a/Sources/RealtimeV2/ChannelStateManager.swift
+++ b/Sources/RealtimeV2/ChannelStateManager.swift
@@ -32,8 +32,24 @@ actor ChannelStateManager {
     }
   }
 
+  /// Typed failure for a single subscribe attempt. These are lifecycle
+  /// failures — not task cancellations — so the retry ladder treats them
+  /// like timeouts and callers never see a spurious `CancellationError`
+  /// (issue #1145, defect 2).
+  enum SubscribeFailure: Error {
+    /// The socket could not be connected (or reconnected) for this attempt.
+    case socketNotConnected
+    /// The channel transitioned to `.unsubscribed` while waiting for the
+    /// join confirmation.
+    case channelClosed
+  }
+
   typealias MakeRef = @Sendable () -> String
   typealias EnsureSocketConnected = @Sendable () async -> Bool
+  /// Synchronous socket-status probe. Unlike ``EnsureSocketConnected`` it
+  /// never attempts to connect — used to decide whether `phx_leave` can be
+  /// delivered at all.
+  typealias IsSocketConnected = @Sendable () -> Bool
   typealias GetClientChanges = @Sendable () -> [PostgresJoinConfig]
   typealias JoinOperation =
     @Sendable (_ joinRef: String, _ clientChanges: [PostgresJoinConfig])
@@ -71,10 +87,16 @@ actor ChannelStateManager {
 
   private let makeRef: MakeRef
   private let ensureSocketConnected: EnsureSocketConnected
+  private let isSocketConnected: IsSocketConnected
   private let getClientChanges: GetClientChanges
   private let joinOperation: JoinOperation
   private let leaveOperation: LeaveOperation
   private let retryDelay: RetryDelay
+
+  /// Set by ``didReceiveClose()`` when the server closes the channel while a
+  /// subscribe is in flight, so ``beginSubscribe()`` can surface a typed
+  /// error instead of the bare `CancellationError` from the cancelled task.
+  private var closedByServerWhileSubscribing = false
 
   init(
     topic: String,
@@ -84,6 +106,7 @@ actor ChannelStateManager {
     clock: any Clock<Duration>,
     makeRef: @escaping MakeRef,
     ensureSocketConnected: @escaping EnsureSocketConnected,
+    isSocketConnected: @escaping IsSocketConnected = { true },
     getClientChanges: @escaping GetClientChanges,
     joinOperation: @escaping JoinOperation,
     leaveOperation: @escaping LeaveOperation,
@@ -97,6 +120,7 @@ actor ChannelStateManager {
     self.clock = clock
     self.makeRef = makeRef
     self.ensureSocketConnected = ensureSocketConnected
+    self.isSocketConnected = isSocketConnected
     self.getClientChanges = getClientChanges
     self.joinOperation = joinOperation
     self.leaveOperation = leaveOperation
@@ -181,12 +205,18 @@ actor ChannelStateManager {
       task.cancel()
       // Subscribe hadn't completed yet, so the server may not recognize the
       // channel and will likely never send `phx_close`. Don't wait for it.
-      await beginUnsubscribe(waitForServerClose: false)
+      await beginUnsubscribe(waitForServerClose: false, sendLeave: isSocketConnected())
 
     case .subscribed:
       // We had a live subscription; wait (bounded) for the server's
       // `phx_close` to arrive so observers see the full status trail.
-      await beginUnsubscribe(waitForServerClose: true)
+      //
+      // Unless the socket is dead: the server-side channel died with the
+      // connection, `phx_leave` would only be buffered into the *next*
+      // connection as a stale frame, and `phx_close` can never arrive —
+      // waiting would stall for the full timeout (issue #1145, hazard 4).
+      let socketConnected = isSocketConnected()
+      await beginUnsubscribe(waitForServerClose: socketConnected, sendLeave: socketConnected)
     }
   }
 
@@ -238,6 +268,10 @@ actor ChannelStateManager {
     joinRef = nil
     pushes = [:]
     if case .subscribing(let task) = state {
+      // Record why the task is being cancelled so `beginSubscribe` can
+      // rethrow a typed error — the caller must be able to tell a server
+      // close apart from its own task cancellation (issue #1145, defect 2).
+      closedByServerWhileSubscribing = true
       task.cancel()
     }
     updateState(.unsubscribed)
@@ -247,6 +281,7 @@ actor ChannelStateManager {
 
   private func beginSubscribe() async throws {
     logger?.debug("Beginning subscribe flow for channel '\(topic)'")
+    closedByServerWhileSubscribing = false
     let task = Task<Void, any Error> { [weak self] in
       guard let self else { return }
       try await self.runSubscribeAttempts()
@@ -263,12 +298,22 @@ actor ChannelStateManager {
         task.cancel()
       }
     } catch {
+      let closedByServer = closedByServerWhileSubscribing
+      closedByServerWhileSubscribing = false
+
       // If the subscribe attempt didn't transition us to .subscribed, make
       // sure external observers see .unsubscribed.
       if case .subscribing = state {
         joinRef = nil
         pushes = [:]
         updateState(.unsubscribed)
+      }
+
+      // The task was cancelled by `didReceiveClose()`, not by the caller —
+      // translate to a typed error so it isn't mistaken for a caller-side
+      // cancellation.
+      if closedByServer, error is CancellationError {
+        throw RealtimeError.channelClosedByServer
       }
       throw error
     }
@@ -291,9 +336,10 @@ actor ChannelStateManager {
 
         logger?.debug("Subscribe succeeded for channel '\(topic)'")
         return
-      } catch is TimeoutError {
+      } catch let error where error is TimeoutError || error is SubscribeFailure {
         logger?.debug(
-          "Subscribe timed out for channel '\(topic)' (attempt \(attempts)/\(maxRetryAttempts))"
+          "Subscribe attempt failed for channel '\(topic)' "
+            + "(attempt \(attempts)/\(maxRetryAttempts)): \(error)"
         )
 
         guard attempts < maxRetryAttempts else {
@@ -308,15 +354,10 @@ actor ChannelStateManager {
           "Retrying subscribe for '\(topic)' in \(String(format: "%.2f", delay))s"
         )
 
-        do {
-          try await clock.sleep(for: .seconds(delay))
-          if !(await ensureSocketConnected()) {
-            logger?.debug("Socket disconnected during retry delay for '\(topic)'")
-            throw CancellationError()
-          }
-        } catch {
-          throw CancellationError()
-        }
+        // A genuine cancellation of this task propagates out of `sleep` as
+        // `CancellationError`; the next attempt re-checks the socket itself,
+        // so no extra connectivity probe is needed here.
+        try await clock.sleep(for: .seconds(delay))
       }
     }
 
@@ -325,7 +366,7 @@ actor ChannelStateManager {
 
   private func runOneSubscribeAttempt() async throws {
     guard await ensureSocketConnected() else {
-      throw CancellationError()
+      throw SubscribeFailure.socketNotConnected
     }
 
     let ref = makeRef()
@@ -346,31 +387,34 @@ actor ChannelStateManager {
         // Channel was closed (by server or unsubscribe) while we were
         // waiting. Abort this attempt; the outer flow decides whether to
         // retry or propagate.
-        throw CancellationError()
+        throw SubscribeFailure.channelClosed
       case .subscribing, .unsubscribing:
         continue
       }
     }
-    throw CancellationError()
+    throw SubscribeFailure.channelClosed
   }
 
-  private func beginUnsubscribe(waitForServerClose: Bool) async {
+  private func beginUnsubscribe(waitForServerClose: Bool, sendLeave: Bool) async {
     logger?.debug("Beginning unsubscribe flow for channel '\(topic)'")
     let task = Task<Void, Never> { [weak self] in
       guard let self else { return }
-      await self.runUnsubscribe(waitForServerClose: waitForServerClose)
+      await self.runUnsubscribe(waitForServerClose: waitForServerClose, sendLeave: sendLeave)
     }
     updateState(.unsubscribing(task))
     await task.value
   }
 
-  private func runUnsubscribe(waitForServerClose: Bool) async {
-    // Send `phx_leave`. When `waitForServerClose` is true, wait (bounded by
-    // `timeoutInterval`) for the server's `phx_close` to transition us to
-    // `.unsubscribed` via `didReceiveClose()`. Otherwise transition
-    // immediately — this is the fire-and-forget path used when we abort an
-    // in-flight subscribe.
-    await leaveOperation()
+  private func runUnsubscribe(waitForServerClose: Bool, sendLeave: Bool) async {
+    // Send `phx_leave` (skipped when the socket is dead — it could never be
+    // delivered, only buffered into the next connection as a stale frame).
+    // When `waitForServerClose` is true, wait (bounded by `timeoutInterval`)
+    // for the server's `phx_close` to transition us to `.unsubscribed` via
+    // `didReceiveClose()`. Otherwise transition immediately — this is the
+    // fire-and-forget path used when we abort an in-flight subscribe.
+    if sendLeave {
+      await leaveOperation()
+    }
 
     if waitForServerClose {
       let stateSubject = self.stateSubject

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -714,20 +714,13 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
         // Phoenix tags `phx_close` with the `join_ref` of the join it closes.
         // A close for a previous incarnation of this topic (e.g. a join
         // abandoned during a reconnect) must not tear down the current
-        // subscription (issue #1145, defect 3). Closes without a `join_ref`
-        // are processed unconditionally.
-        if let closeJoinRef = message.joinRef {
-          let currentJoinRef = await stateManager.joinRef
-          guard closeJoinRef == currentJoinRef else {
-            logger?.debug(
-              "Ignoring phx_close for stale join_ref \(closeJoinRef) on '\(topic)' "
-                + "(current: \(currentJoinRef ?? "<none>"))"
-            )
-            return
-          }
+        // subscription (issue #1145, defect 3). The join_ref check runs on
+        // the state-manager actor, atomically with the close, so a concurrent
+        // subscribe attempt can't swap `joinRef` in between.
+        guard await stateManager.didReceiveClose(joinRef: message.joinRef) else {
+          return
         }
         socket._remove(self)
-        await stateManager.didReceiveClose()
 
       case .error:
         logger?.error(

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -200,6 +200,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
         await socket.connect()
         return socket.status == .connected
       },
+      isSocketConnected: { [weak socket] in socket?.status == .connected },
       getClientChanges: { clientChanges.value },
       joinOperation: { [weakSelfRef] ref, changes in
         guard let channel = weakSelfRef.value else { return }
@@ -710,6 +711,21 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
         callbackManager.triggerBroadcast(event: event, json: payload)
 
       case .close:
+        // Phoenix tags `phx_close` with the `join_ref` of the join it closes.
+        // A close for a previous incarnation of this topic (e.g. a join
+        // abandoned during a reconnect) must not tear down the current
+        // subscription (issue #1145, defect 3). Closes without a `join_ref`
+        // are processed unconditionally.
+        if let closeJoinRef = message.joinRef {
+          let currentJoinRef = await stateManager.joinRef
+          guard closeJoinRef == currentJoinRef else {
+            logger?.debug(
+              "Ignoring phx_close for stale join_ref \(closeJoinRef) on '\(topic)' "
+                + "(current: \(currentJoinRef ?? "<none>"))"
+            )
+            return
+          }
+        }
         socket._remove(self)
         await stateManager.didReceiveClose()
 

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -726,7 +726,12 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
         logger?.error(
           "Received an error in channel \(message.topic). That could be as a result of an invalid access token"
         )
-        await stateManager.didReceiveClose()
+        // Like `phx_close`, `phx_error` is tagged with the `join_ref` of the
+        // join it belongs to — an error from a stale join must not tear down
+        // the current subscription (#1148). Errors without a `join_ref`
+        // (e.g. auth errors before a join completes) are applied
+        // unconditionally.
+        await stateManager.didReceiveClose(joinRef: message.joinRef)
 
       case .presenceDiff:
         let joins = try message.payload["joins"]?.decode(as: [String: PresenceV2].self) ?? [:]

--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -294,6 +294,12 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
             Self.yieldStatusIfChanged(statusSubject, .connected)
           }
         case .disconnected:
+          // A failed auto-reconnect lands here (.reconnecting → .connecting →
+          // .disconnected). Clear the latch so a later successful `connect()`
+          // (e.g. from `connectOnSubscribe`) isn't misclassified as a
+          // reconnect completion — `rejoinChannels()` would reset every
+          // channel and cancel the very join that connect was performing.
+          sawReconnecting = false
           Self.yieldStatusIfChanged(statusSubject, .disconnected)
         case .connecting:
           // Skip — `connect()` yields .connecting/.connected synchronously

--- a/Sources/RealtimeV2/RealtimeError.swift
+++ b/Sources/RealtimeV2/RealtimeError.swift
@@ -20,4 +20,9 @@ extension RealtimeError {
   static var maxRetryAttemptsReached: Self {
     Self("Maximum retry attempts reached.")
   }
+
+  /// The server closed the channel while a subscribe was in flight.
+  static var channelClosedByServer: Self {
+    Self("Channel was closed by the server while subscribing.")
+  }
 }

--- a/Tests/RealtimeTests/ChannelStateManagerTests.swift
+++ b/Tests/RealtimeTests/ChannelStateManagerTests.swift
@@ -327,6 +327,66 @@ struct ChannelStateManagerTests {
 
   // MARK: - Server-close while subscribed
 
+  /// A server close that aborts an in-flight subscribe must surface as
+  /// `RealtimeError.channelClosedByServer` — never as `CancellationError`
+  /// (which callers must be able to attribute to their own task) and never
+  /// as `maxRetryAttemptsReached` (which can otherwise mask a close landing
+  /// on the final retry attempt).
+  @Test
+  func serverCloseDuringSubscribeSurfacesTypedError() async {
+    let h = makeHarness(timeoutInterval: 5.0, maxRetryAttempts: 1)
+
+    let subscribeTask = Task { try await h.sut.subscribe() }
+
+    // Wait until the join is in flight, then the server closes the channel.
+    while h.joinCallCount.value == 0 {
+      try? await Task.sleep(nanoseconds: 5_000_000)
+    }
+    await h.sut.didReceiveClose()
+
+    do {
+      try await subscribeTask.value
+      Issue.record("Expected subscribe to throw after server close")
+    } catch {
+      #expect(!(error is CancellationError), "Server close surfaced as CancellationError")
+      #expect(
+        (error as? RealtimeError)?.errorDescription
+          == RealtimeError.channelClosedByServer.errorDescription,
+        "Expected channelClosedByServer, got \(error)"
+      )
+    }
+  }
+
+  /// A close carrying a `join_ref` that doesn't match the current join must
+  /// be ignored — the check runs on the actor, atomically with the close.
+  @Test
+  func didReceiveCloseIgnoresStaleJoinRef() async throws {
+    let h = makeHarness()
+
+    let confirmer = confirmSubscribeOnJoin(h)
+    try await h.sut.subscribe()
+    _ = await confirmer.value
+
+    let applied = await h.sut.didReceiveClose(joinRef: "stale-join-ref")
+    #expect(!applied, "Close for a stale join_ref must be ignored")
+
+    let state = await h.sut.state
+    guard case .subscribed = state else {
+      Issue.record("Stale close changed state to \(state)")
+      return
+    }
+
+    let currentJoinRef = await h.sut.joinRef
+    let appliedCurrent = await h.sut.didReceiveClose(joinRef: currentJoinRef)
+    #expect(appliedCurrent, "Close for the current join_ref must be applied")
+
+    let finalState = await h.sut.state
+    guard case .unsubscribed = finalState else {
+      Issue.record("Expected .unsubscribed after matching close, got \(finalState)")
+      return
+    }
+  }
+
   @Test
   func didReceiveCloseTransitionsToUnsubscribed() async throws {
     let h = makeHarness()

--- a/Tests/RealtimeTests/ChannelStateManagerTests.swift
+++ b/Tests/RealtimeTests/ChannelStateManagerTests.swift
@@ -216,6 +216,49 @@ struct ChannelStateManagerTests {
     }
   }
 
+  /// Issue #1145 (defect 2): a socket connect failure aborted the whole
+  /// subscribe on attempt 1 — only timeouts entered the retry ladder. A
+  /// transient connect failure must be retried like a timeout.
+  @Test
+  func subscribeRetriesWhenSocketConnectFailsTransiently() async throws {
+    let h = makeHarness(timeoutInterval: 1.0, maxRetryAttempts: 3, retryDelay: { _ in 0.05 })
+    h.ensureConnected.setValue(false)
+
+    // The "network" comes back shortly after the first failed attempt.
+    let recovery = Task { [h] in
+      try? await Task.sleep(nanoseconds: 20_000_000)
+      h.ensureConnected.setValue(true)
+    }
+    let confirmer = confirmSubscribeOnJoin(h)
+
+    try await h.sut.subscribe()
+    _ = await recovery.value
+    _ = await confirmer.value
+
+    let state = await h.sut.state
+    guard case .subscribed = state else {
+      Issue.record("Expected .subscribed after transient connect failure, got \(state)")
+      return
+    }
+  }
+
+  /// Issue #1145 (defect 2): connect failures were manufactured as
+  /// `Swift.CancellationError`, indistinguishable from the caller's own task
+  /// cancellation. They must surface as a typed error instead.
+  @Test
+  func connectFailureDoesNotSurfaceAsCancellationError() async {
+    let h = makeHarness(timeoutInterval: 0.2, maxRetryAttempts: 2, retryDelay: { _ in 0.01 })
+    h.ensureConnected.setValue(false)
+
+    do {
+      try await h.sut.subscribe()
+      Issue.record("Expected subscribe to throw when socket is not connected")
+    } catch {
+      #expect(!(error is CancellationError), "Connect failure surfaced as CancellationError")
+      #expect(error is RealtimeError)
+    }
+  }
+
   // MARK: - Unsubscribe
 
   @Test

--- a/Tests/RealtimeTests/RealtimeReconnectRecoveryTests.swift
+++ b/Tests/RealtimeTests/RealtimeReconnectRecoveryTests.swift
@@ -148,6 +148,60 @@ struct RealtimeReconnectRecoveryTests {
     #expect(channel.status == .unsubscribed)
   }
 
+  /// Issue #1148 (follow-up to #1145 defect 3): `phx_error` was routed by
+  /// topic only, like `phx_close`. An error belonging to a stale join must
+  /// not kill the current subscription; a ref-less error still must.
+  @Test
+  func stalePhxErrorDoesNotKillCurrentSubscription() async throws {
+    let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
+
+    let sut = RealtimeClientV2(
+      url: url,
+      options: makeOptions(),
+      wsTransport: { _, _ in
+        let socket = AsyncFakeWebSocket()
+        socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
+        sockets.withValue { $0.append(socket) }
+        return socket
+      },
+      http: HTTPClientMock(),
+      clock: ContinuousClock()
+    )
+    defer { sut.disconnect() }
+
+    let channel = sut.channel("room-error")
+    try await channel.subscribeWithError()
+    #expect(channel.status == .subscribed)
+
+    // A phx_error for a *different* join_ref (a stale incarnation) arrives.
+    let socket = sockets.value[0]
+    socket.reply(
+      RealtimeMessageV2(
+        joinRef: "stale-join-ref",
+        ref: nil,
+        topic: channel.topic,
+        event: "phx_error",
+        payload: [:]
+      )
+    )
+
+    try? await Task.sleep(nanoseconds: 300_000_000)
+    #expect(channel.status == .subscribed, "Stale phx_error killed the current subscription")
+
+    // A phx_error without a join_ref (e.g. an auth error) still applies.
+    socket.reply(
+      RealtimeMessageV2(
+        joinRef: nil,
+        ref: nil,
+        topic: channel.topic,
+        event: "phx_error",
+        payload: [:]
+      )
+    )
+    await waitUntil(timeout: 2) { channel.status == .unsubscribed }
+    #expect(channel.status == .unsubscribed)
+  }
+
   /// Hazard 4 in #1145: `unsubscribe()` on a dead socket pushed `phx_leave`
   /// into the send buffer (flushed verbatim into the next connection) and
   /// waited the full timeout for a `phx_close` that could never arrive.

--- a/Tests/RealtimeTests/RealtimeReconnectRecoveryTests.swift
+++ b/Tests/RealtimeTests/RealtimeReconnectRecoveryTests.swift
@@ -1,0 +1,202 @@
+import ConcurrencyExtras
+import Foundation
+import TestHelpers
+import Testing
+
+@testable import Realtime
+@testable import RealtimeV2
+
+/// Regression tests for issue #1145: after a failed auto-reconnect a client
+/// could reach a state where no subscribe ever converged again.
+///
+/// Uses the same real-timing profile as `RealtimeColdStartTests`
+/// (`AsyncFakeWebSocket` + real clock with compressed intervals) because the
+/// defects are lifecycle races.
+@Suite
+struct RealtimeReconnectRecoveryTests {
+  let url = URL(string: "http://localhost:54321/realtime/v1")!
+  let apiKey = "anon.api.key"
+
+  private func makeOptions(timeoutInterval: TimeInterval = 3) -> RealtimeClientOptions {
+    RealtimeClientOptions(
+      headers: ["apikey": apiKey],
+      // Long heartbeat so heartbeat machinery can't interfere.
+      heartbeatInterval: 10,
+      reconnectDelay: 0.05,
+      timeoutInterval: timeoutInterval,
+      accessToken: { "token" }
+    )
+  }
+
+  /// Defect 1 in #1145: `sawReconnecting` was cleared only on `.connected`.
+  /// When the single auto-reconnect attempt failed (network still down), the
+  /// latch stayed armed, and the next successful `connect()` — e.g. from a
+  /// channel's `connectOnSubscribe` — was misclassified as a reconnect
+  /// completion. The resulting `rejoinChannels()` reset cancelled the very
+  /// join that connect was performing, surfacing as `CancellationError`.
+  @Test
+  func subscribeConvergesAfterFailedAutoReconnect() async throws {
+    let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
+    let connectAttempts = LockIsolated(0)
+
+    let sut = RealtimeClientV2(
+      url: url,
+      options: makeOptions(),
+      wsTransport: { _, _ in
+        let attempt = connectAttempts.withValue { count -> Int in
+          count += 1
+          return count
+        }
+        // Attempt 2 is the automatic reconnect — the network is still down.
+        if attempt == 2 {
+          throw RealtimeError("network down")
+        }
+        let socket = AsyncFakeWebSocket()
+        socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
+        sockets.withValue { $0.append(socket) }
+        return socket
+      },
+      http: HTTPClientMock(),
+      clock: ContinuousClock()
+    )
+    defer { sut.disconnect() }
+
+    let channel = sut.channel("room-1")
+    try await channel.subscribeWithError()
+    #expect(channel.status == .subscribed)
+
+    // Outage: the socket errors out, the single auto-reconnect attempt fails.
+    sockets.value[0].receiveFromServer(.text("not a valid frame"))
+    let parkedDisconnected = await waitUntil(timeout: 5) {
+      connectAttempts.value >= 2 && sut.status == .disconnected
+    }
+    guard parkedDisconnected else {
+      Issue.record("Client did not settle in .disconnected after failed reconnect")
+      return
+    }
+
+    // Network is back. A supervisor rebuilds with a fresh channel;
+    // `connectOnSubscribe` brings the socket up. Before the fix, the stale
+    // latch fired `rejoinChannels()`, whose reset cancelled this in-flight
+    // join (`CancellationError`).
+    let channel2 = sut.channel("room-2")
+    do {
+      try await channel2.subscribeWithError()
+    } catch {
+      Issue.record("Subscribe after failed auto-reconnect threw: \(error)")
+      return
+    }
+    #expect(channel2.status == .subscribed)
+  }
+
+  /// Defect 3 in #1145: `phx_close` was routed by topic only. A close
+  /// belonging to a previous incarnation's join killed the current
+  /// subscription on the same topic.
+  @Test
+  func stalePhxCloseDoesNotKillCurrentSubscription() async throws {
+    let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
+
+    let sut = RealtimeClientV2(
+      url: url,
+      options: makeOptions(),
+      wsTransport: { _, _ in
+        let socket = AsyncFakeWebSocket()
+        socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
+        sockets.withValue { $0.append(socket) }
+        return socket
+      },
+      http: HTTPClientMock(),
+      clock: ContinuousClock()
+    )
+    defer { sut.disconnect() }
+
+    let channel = sut.channel("room-close")
+    try await channel.subscribeWithError()
+    #expect(channel.status == .subscribed)
+
+    let socket = sockets.value[0]
+    let joinRef = socket.sentMessages.first { $0.event == "phx_join" }?.ref
+    #expect(joinRef != nil)
+
+    // A phx_close for a *different* join_ref (a stale incarnation) arrives.
+    socket.reply(
+      RealtimeMessageV2(
+        joinRef: "stale-join-ref",
+        ref: nil,
+        topic: channel.topic,
+        event: "phx_close",
+        payload: [:]
+      )
+    )
+
+    // Give the frame time to route; the channel must survive it.
+    try? await Task.sleep(nanoseconds: 300_000_000)
+    #expect(channel.status == .subscribed, "Stale phx_close killed the current subscription")
+    #expect(sut.channels[channel.topic] != nil, "Stale phx_close removed the channel")
+
+    // A phx_close for the *current* join_ref still tears the channel down.
+    socket.reply(
+      RealtimeMessageV2(
+        joinRef: joinRef,
+        ref: nil,
+        topic: channel.topic,
+        event: "phx_close",
+        payload: [:]
+      )
+    )
+    await waitUntil(timeout: 2) { channel.status == .unsubscribed }
+    #expect(channel.status == .unsubscribed)
+  }
+
+  /// Hazard 4 in #1145: `unsubscribe()` on a dead socket pushed `phx_leave`
+  /// into the send buffer (flushed verbatim into the next connection) and
+  /// waited the full timeout for a `phx_close` that could never arrive.
+  @Test
+  func unsubscribeOnDeadSocketSkipsLeaveAndDoesNotStall() async throws {
+    let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
+
+    let sut = RealtimeClientV2(
+      url: url,
+      options: makeOptions(timeoutInterval: 3),
+      wsTransport: { _, _ in
+        let socket = AsyncFakeWebSocket()
+        socket.serverResponder = AsyncFakeWebSocket.realtimeServerResponder()
+        sockets.withValue { $0.append(socket) }
+        return socket
+      },
+      http: HTTPClientMock(),
+      clock: ContinuousClock()
+    )
+    defer { sut.disconnect() }
+
+    let channel = sut.channel("room-leave")
+    try await channel.subscribeWithError()
+    #expect(channel.status == .subscribed)
+
+    // Server closes with an application-level code (4000–4999): no reconnect
+    // is attempted, the client parks in .disconnected, and the channel is
+    // left stale-`.subscribed`.
+    sockets.value[0].receiveFromServer(.close(code: 4001, reason: "auth"))
+    await waitUntil(timeout: 2) { sut.status == .disconnected }
+    #expect(sut.status == .disconnected)
+    #expect(channel.status == .subscribed)
+
+    let start = ContinuousClock.now
+    await sut.removeChannel(channel)
+    let elapsed = ContinuousClock.now - start
+    #expect(
+      elapsed < .seconds(1.5),
+      "removeChannel on a dead socket stalled waiting for phx_close (\(elapsed))"
+    )
+    #expect(channel.status == .unsubscribed)
+
+    // Reconnect: the new connection must not receive a stale phx_leave from
+    // the send buffer.
+    await sut.connect()
+    #expect(sut.status == .connected)
+    try? await Task.sleep(nanoseconds: 200_000_000)
+
+    let leaves = sockets.value[1].sentMessages.filter { $0.event == "phx_leave" }
+    #expect(leaves.isEmpty, "Stale phx_leave was flushed into the new connection")
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for supabase/supabase-swift#1145 — after a network outage in which the single-shot auto-reconnect failed, a long-lived `RealtimeClientV2` could reach a state where no subscribe ever converged again until process restart.

All four defects reported in the issue were reproduced with failing tests first, then fixed:

### Defect 1 — stale `sawReconnecting` latch

The latch was cleared only in the `.connected` branch of the state observer. A *failed* reconnect (`.reconnecting → .connecting → .disconnected`) left it armed, so the next successful `connect()` — e.g. from a channel's `connectOnSubscribe` — was misclassified as reconnect-completion: `rejoinChannels()` reset every channel and cancelled the very join that connect was performing, surfacing as `CancellationError` \~0.5 s in.<br>**Fix:** clear the latch on `.disconnected` (`RealtimeClientV2` state observer).

### Defect 2 — `CancellationError` conflation + retry policy

`ChannelStateManager` manufactured `Swift.CancellationError` for socket connect failure, socket death during a retry delay, and channel-close mid-join, while the retry ladder re-entered only on `TimeoutError` — so any lifecycle race aborted the whole subscribe on attempt 1, indistinguishable from the caller's own task cancellation.<br>**Fix:** typed internal `SubscribeFailure` (`socketNotConnected`, `channelClosed`) now participates in the retry ladder alongside timeouts; exhaustion still surfaces as `RealtimeError.maxRetryAttemptsReached`. A server close that cancels an in-flight subscribe is translated to `RealtimeError.channelClosedByServer`. Genuine task cancellation still propagates as `CancellationError`.

### Defect 3 — topic-keyed `phx_close` routing

`phx_close` was applied to whichever channel currently owned the topic, so a close for a previous incarnation's abandoned join killed the new incarnation's in-flight join.<br>**Fix:** `phx_close` carrying a `join_ref` that doesn't match the channel's current `joinRef` is ignored (mirrors phoenix.js `isMember` filtering). Closes without a `join_ref` behave as before.

### Hazard 4 — `unsubscribe()` on a dead socket

With the socket down and a channel stale-`.subscribed`, `unsubscribe()` buffered an undeliverable `phx_leave` (flushed verbatim into the *next* connection, which the server answers with a close — feeding defect 3) and stalled the full timeout waiting for a `phx_close` that could never arrive.<br>**Fix:** skip the leave and the wait when the socket is not connected — the server-side channel died with the connection.

## Tests

New `RealtimeReconnectRecoveryTests` reproduce the issue's field scenario end-to-end (failed auto-reconnect → supervisor rebuild → subscribe must converge; stale `phx_close`; dead-socket unsubscribe), plus two new `ChannelStateManagerTests` for the retry/typed-error policy. All were red before the fixes with exactly the failure modes described in the issue (`CancellationError` on rebuild, killed subscription, 3 s stall + stale `phx_leave` flushed).

Full suite: 1012 tests in 91 suites pass. `./scripts/format.sh` and spell-check clean.

Also fixes #1148, found during review: `phx_error` is now `join_ref`-discriminated like `phx_close`.

Fixes #1145
Fixes #1148