### PR TITLE
feat(auth): add admin generateLink and signOut

### DIFF
--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -24,6 +24,8 @@ import HTTPTypes
 /// - ``inviteUserByEmail(_:data:redirectTo:)``
 /// - ``deleteUser(id:shouldSoftDelete:)``
 /// - ``listUsers(params:)``
+/// - ``generateLink(params:)``
+/// - ``signOut(jwt:scope:)``
 ///
 /// ### OAuth 2.1 clients
 /// - ``oauth``
@@ -148,6 +150,27 @@ public struct AuthAdmin: Sendable {
     )
   }
 
+  /// Signs out a user's session(s) using their access token.
+  ///
+  /// Unlike ``AuthClient/signOut(scope:)``, which signs out the *current* client's session, this
+  /// lets a server holding another user's access token force that session (or all/other sessions
+  /// for that user) to be revoked.
+  ///
+  /// - Parameters:
+  ///   - jwt: The access token of the session(s) to sign out.
+  ///   - scope: Specifies which sessions should be logged out.
+  /// - Warning: Never expose your `secret` key on the client.
+  public func signOut(jwt: String, scope: SignOutScope = .global) async throws {
+    _ = try await api.execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("logout"),
+        method: .post,
+        query: [URLQueryItem(name: "scope", value: scope.rawValue)],
+        headers: [.authorization: "Bearer \(jwt)"]
+      )
+    )
+  }
+
   /// Get a list of users.
   ///
   /// This function should only be called on a server.
@@ -198,10 +221,6 @@ public struct AuthAdmin: Sendable {
     return pagination
   }
 
-  /*
-   Generate link is commented out temporarily due issues with they Auth's decoding is configured.
-   Will revisit it later.
-
   /// Generates email links and OTPs to be sent via a custom email provider.
   ///
   /// - Parameter params: The parameters for the link generation.
@@ -210,22 +229,20 @@ public struct AuthAdmin: Sendable {
   public func generateLink(params: GenerateLinkParams) async throws -> GenerateLinkResponse {
     try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("admin/generate_link").appendingQueryItems(
-          [
-            (params.redirectTo ?? configuration.redirectToURL).map {
-              URLQueryItem(
-                name: "redirect_to",
-                value: $0.absoluteString
-              )
-            }
-          ].compactMap { $0 }
-        ),
+        url: configuration.url.appendingPathComponent("admin/generate_link"),
         method: .post,
+        query: [
+          (params.redirectTo ?? configuration.redirectToURL).map {
+            URLQueryItem(
+              name: "redirect_to",
+              value: $0.absoluteString
+            )
+          }
+        ].compactMap { $0 },
         body: encoder.encode(params.body)
       )
     ).decoded(decoder: configuration.decoder)
   }
-   */
 }
 
 extension HTTPField.Name {

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1335,126 +1335,170 @@ public struct ListUsersPaginatedResponse: Hashable, Sendable {
   public var total: Int
 }
 
-//public struct GenerateLinkParams: Sendable {
-//  struct Body: Encodable {
-//    var type: GenerateLinkType
-//    var email: String
-//    var password: String?
-//    var newEmail: String?
-//    var data: [String: AnyJSON]?
-//  }
-//  var body: Body
-//  var redirectTo: URL?
-//
-//  /// Generates a signup link.
-//  public static func signUp(
-//    email: String,
-//    password: String,
-//    data: [String: AnyJSON]? = nil,
-//    redirectTo: URL? = nil
-//  ) -> GenerateLinkParams {
-//    GenerateLinkParams(
-//      body: .init(
-//        type: .signup,
-//        email: email,
-//        password: password,
-//        data: data
-//      ),
-//      redirectTo: redirectTo
-//    )
-//  }
-//
-//  /// Generates an invite link.
-//  public static func invite(
-//    email: String,
-//    data: [String: AnyJSON]? = nil,
-//    redirectTo: URL? = nil
-//  ) -> GenerateLinkParams {
-//    GenerateLinkParams(
-//      body: .init(
-//        type: .invite,
-//        email: email,
-//        data: data
-//      ),
-//      redirectTo: redirectTo
-//    )
-//  }
-//
-//  /// Generates a magic link.
-//  public static func magicLink(
-//    email: String,
-//    data: [String: AnyJSON]? = nil,
-//    redirectTo: URL? = nil
-//  ) -> GenerateLinkParams {
-//    GenerateLinkParams(
-//      body: .init(
-//        type: .magiclink,
-//        email: email,
-//        data: data
-//      ),
-//      redirectTo: redirectTo
-//    )
-//  }
-//
-//  /// Generates a recovery link.
-//  public static func recovery(
-//    email: String,
-//    redirectTo: URL? = nil
-//  ) -> GenerateLinkParams {
-//    GenerateLinkParams(
-//      body: .init(
-//        type: .recovery,
-//        email: email
-//      ),
-//      redirectTo: redirectTo
-//    )
-//  }
-//
-//}
-//
-///// The response from the ``AuthAdmin/generateLink(params:)`` function.
-//public struct GenerateLinkResponse: Hashable, Sendable, Decodable {
-//  /// The properties related to the email link generated.
-//  public let properties: GenerateLinkProperties
-//  /// The user that the email link is associated to.
-//  public let user: User
-//
-//  public init(from decoder: any Decoder) throws {
-//    self.properties = try GenerateLinkProperties(from: decoder)
-//    self.user = try User(from: decoder)
-//  }
-//}
-//
-///// The properties related to the email link generated.
-//public struct GenerateLinkProperties: Decodable, Hashable, Sendable {
-//  /// The email link to send to the users.
-//  /// The action link follows the following format: auth/v1/verify?type={verification_type}&token={hashed_token}&redirect_to={redirect_to}
-//  public let actionLink: URL
-//  /// The raw email OTP.
-//  /// You should send this in the email if you want your users to verify using an OTP instead of the action link.
-//  public let emailOTP: String
-//  /// The hashed token appended to the action link.
-//  public let hashedToken: String
-//  /// The URL appended to the action link.
-//  public let redirectTo: URL
-//  /// The verification type that the emaillink is associated to.
-//  public let verificationType: GenerateLinkType
-//}
-//
-//public struct GenerateLinkType: RawRepresentable, Codable, Hashable, Sendable {
-//  public let rawValue: String
-//
-//  public init(rawValue: String) {
-//    self.rawValue = rawValue
-//  }
-//
-//  public static let signup = GenerateLinkType(rawValue: "signup")
-//  public static let invite = GenerateLinkType(rawValue: "invite")
-//  public static let magiclink = GenerateLinkType(rawValue: "magiclink")
-//  public static let recovery = GenerateLinkType(rawValue: "recovery")
-//  public static let emailChangeCurrent = GenerateLinkType(rawValue: "email_change_current")
-//  public static let emailChangeNew = GenerateLinkType(rawValue: "email_change_new")
-//}
+/// The parameters for ``AuthAdmin/generateLink(params:)``.
+public struct GenerateLinkParams: Sendable {
+  struct Body: Encodable {
+    var type: GenerateLinkType
+    var email: String
+    var password: String?
+    var newEmail: String?
+    var data: [String: AnyJSON]?
+  }
+  var body: Body
+  var redirectTo: URL?
+
+  /// Generates a signup link.
+  public static func signUp(
+    email: String,
+    password: String,
+    data: [String: AnyJSON]? = nil,
+    redirectTo: URL? = nil
+  ) -> GenerateLinkParams {
+    GenerateLinkParams(
+      body: .init(
+        type: .signup,
+        email: email,
+        password: password,
+        data: data
+      ),
+      redirectTo: redirectTo
+    )
+  }
+
+  /// Generates an invite link.
+  public static func invite(
+    email: String,
+    data: [String: AnyJSON]? = nil,
+    redirectTo: URL? = nil
+  ) -> GenerateLinkParams {
+    GenerateLinkParams(
+      body: .init(
+        type: .invite,
+        email: email,
+        data: data
+      ),
+      redirectTo: redirectTo
+    )
+  }
+
+  /// Generates a magic link.
+  public static func magicLink(
+    email: String,
+    data: [String: AnyJSON]? = nil,
+    redirectTo: URL? = nil
+  ) -> GenerateLinkParams {
+    GenerateLinkParams(
+      body: .init(
+        type: .magiclink,
+        email: email,
+        data: data
+      ),
+      redirectTo: redirectTo
+    )
+  }
+
+  /// Generates a recovery link.
+  public static func recovery(
+    email: String,
+    redirectTo: URL? = nil
+  ) -> GenerateLinkParams {
+    GenerateLinkParams(
+      body: .init(
+        type: .recovery,
+        email: email
+      ),
+      redirectTo: redirectTo
+    )
+  }
+
+  /// Generates a link to change the current email address of a user.
+  public static func emailChangeCurrent(
+    email: String,
+    newEmail: String,
+    redirectTo: URL? = nil
+  ) -> GenerateLinkParams {
+    GenerateLinkParams(
+      body: .init(
+        type: .emailChangeCurrent,
+        email: email,
+        newEmail: newEmail
+      ),
+      redirectTo: redirectTo
+    )
+  }
+
+  /// Generates a link to change the email address of a user to a new one.
+  public static func emailChangeNew(
+    email: String,
+    newEmail: String,
+    redirectTo: URL? = nil
+  ) -> GenerateLinkParams {
+    GenerateLinkParams(
+      body: .init(
+        type: .emailChangeNew,
+        email: email,
+        newEmail: newEmail
+      ),
+      redirectTo: redirectTo
+    )
+  }
+}
+
+/// The response from the ``AuthAdmin/generateLink(params:)`` function.
+public struct GenerateLinkResponse: Hashable, Sendable, Decodable {
+  /// The properties related to the email link generated.
+  public let properties: GenerateLinkProperties
+  /// The user that the email link is associated to.
+  public let user: User
+
+  public init(from decoder: any Decoder) throws {
+    self.properties = try GenerateLinkProperties(from: decoder)
+    self.user = try User(from: decoder)
+  }
+}
+
+/// The properties related to the email link generated.
+public struct GenerateLinkProperties: Decodable, Hashable, Sendable {
+  /// The email link to send to the users.
+  /// The action link follows the following format: auth/v1/verify?type={verification_type}&token={hashed_token}&redirect_to={redirect_to}
+  public let actionLink: URL
+  /// The raw email OTP.
+  /// You should send this in the email if you want your users to verify using an OTP instead of the action link.
+  public let emailOTP: String
+  /// The hashed token appended to the action link.
+  public let hashedToken: String
+  /// The URL appended to the action link.
+  public let redirectTo: URL
+  /// The verification type that the emaillink is associated to.
+  public let verificationType: GenerateLinkType
+
+  private enum CodingKeys: String, CodingKey {
+    case actionLink
+    // The decoder's `.convertFromSnakeCase` strategy converts the JSON key
+    // "email_otp" to "emailOtp" (not "emailOTP") before matching against this
+    // raw value, since it doesn't know to capitalize the "OTP" acronym.
+    case emailOTP = "emailOtp"
+    case hashedToken
+    case redirectTo
+    case verificationType
+  }
+}
+
+/// The type of link generated by ``AuthAdmin/generateLink(params:)``.
+public struct GenerateLinkType: RawRepresentable, Codable, Hashable, Sendable {
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public static let signup = GenerateLinkType(rawValue: "signup")
+  public static let invite = GenerateLinkType(rawValue: "invite")
+  public static let magiclink = GenerateLinkType(rawValue: "magiclink")
+  public static let recovery = GenerateLinkType(rawValue: "recovery")
+  public static let emailChangeCurrent = GenerateLinkType(rawValue: "email_change_current")
+  public static let emailChangeNew = GenerateLinkType(rawValue: "email_change_new")
+}
 
 // MARK: - OAuth Client Types
 

--- a/Tests/AuthTests/AuthAdminGenerateLinkTests.swift
+++ b/Tests/AuthTests/AuthAdminGenerateLinkTests.swift
@@ -1,0 +1,170 @@
+//
+//  AuthAdminGenerateLinkTests.swift
+//
+//
+
+import ConcurrencyExtras
+import CustomDump
+import Foundation
+import InlineSnapshotTesting
+import Mocker
+import TestHelpers
+import Testing
+
+@testable import Auth
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension AuthMockerTests {
+  @Suite(.mockerSerialized)
+  struct AuthAdminGenerateLinkTests {
+    let storage = InMemoryLocalStorage()
+
+    private func makeSUT() -> AuthClient {
+      let sessionConfiguration = URLSessionConfiguration.default
+      sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
+      let session = URLSession(configuration: sessionConfiguration)
+
+      let encoder = AuthClient.Configuration.jsonEncoder
+      encoder.outputFormatting = [.sortedKeys]
+
+      let configuration = AuthClient.Configuration(
+        url: clientURL,
+        headers: [
+          "apikey": "supabase.publishable.key",
+          "Authorization": "Bearer supabase.secret.key",
+        ],
+        localStorage: storage,
+        logger: nil,
+        encoder: encoder,
+        fetch: { request in
+          try await session.data(for: request)
+        }
+      )
+
+      return AuthClient(configuration: configuration)
+    }
+
+    /// Builds a flat JSON object mirroring what the `/admin/generate_link` endpoint returns:
+    /// the user's own fields merged with the generate-link-specific properties.
+    private func responseData(verificationType: String) throws -> Data {
+      let user = User(fromMockNamed: "user")
+      let encoder = AuthClient.Configuration.jsonEncoder
+      let userData = try encoder.encode(user)
+      var json = try JSONSerialization.jsonObject(with: userData, options: []) as! [String: Any]
+
+      json["action_link"] =
+        "https://example.com/auth/v1/verify?type=\(verificationType)&token=hashed_token&redirect_to=https://example.com"
+      json["email_otp"] = "123456"
+      json["hashed_token"] = "hashed_token"
+      json["redirect_to"] = "https://example.com"
+      json["verification_type"] = verificationType
+
+      return try JSONSerialization.data(withJSONObject: json)
+    }
+
+    @Test
+    func generateLinkSignUp() async throws {
+      Mock(
+        url: clientURL.appendingPathComponent("admin/generate_link"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [.post: try responseData(verificationType: "signup")]
+      )
+      .register()
+
+      let sut = makeSUT()
+
+      let link = try await sut.admin.generateLink(
+        params: .signUp(
+          email: "test@example.com",
+          password: "password",
+          data: ["full_name": "John Doe"]
+        )
+      )
+
+      expectNoDifference(link.properties.verificationType, .signup)
+      expectNoDifference(link.properties.hashedToken, "hashed_token")
+      expectNoDifference(link.properties.redirectTo, URL(string: "https://example.com")!)
+      expectNoDifference(link.user.email, "guilherme@grds.dev")
+    }
+
+    @Test
+    func generateLinkMagicLink() async throws {
+      Mock(
+        url: clientURL.appendingPathComponent("admin/generate_link"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [.post: try responseData(verificationType: "magiclink")]
+      )
+      .register()
+
+      let sut = makeSUT()
+
+      let link = try await sut.admin.generateLink(
+        params: .magicLink(email: "test@example.com")
+      )
+
+      expectNoDifference(link.properties.verificationType, .magiclink)
+    }
+
+    @Test
+    func generateLinkRecovery() async throws {
+      Mock(
+        url: clientURL.appendingPathComponent("admin/generate_link"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [.post: try responseData(verificationType: "recovery")]
+      )
+      .register()
+
+      let sut = makeSUT()
+
+      let link = try await sut.admin.generateLink(
+        params: .recovery(email: "test@example.com")
+      )
+
+      expectNoDifference(link.properties.verificationType, .recovery)
+    }
+
+    @Test
+    func generateLinkInvite() async throws {
+      Mock(
+        url: clientURL.appendingPathComponent("admin/generate_link"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [.post: try responseData(verificationType: "invite")]
+      )
+      .register()
+
+      let sut = makeSUT()
+
+      let link = try await sut.admin.generateLink(
+        params: .invite(email: "test@example.com")
+      )
+
+      expectNoDifference(link.properties.verificationType, .invite)
+    }
+
+    @Test
+    func generateLinkEmailChangeNew() async throws {
+      Mock(
+        url: clientURL.appendingPathComponent("admin/generate_link"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [.post: try responseData(verificationType: "email_change_new")]
+      )
+      .register()
+
+      let sut = makeSUT()
+
+      let link = try await sut.admin.generateLink(
+        params: .emailChangeNew(email: "test@example.com", newEmail: "new@example.com")
+      )
+
+      expectNoDifference(link.properties.verificationType, .emailChangeNew)
+    }
+  }
+}

--- a/Tests/AuthTests/AuthAdminSignOutTests.swift
+++ b/Tests/AuthTests/AuthAdminSignOutTests.swift
@@ -1,0 +1,158 @@
+//
+//  AuthAdminSignOutTests.swift
+//
+//
+
+import ConcurrencyExtras
+import CustomDump
+import Foundation
+import InlineSnapshotTesting
+import Mocker
+import TestHelpers
+import Testing
+
+@testable import Auth
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension AuthMockerTests {
+  @Suite(.mockerSerialized)
+  struct AuthAdminSignOutTests {
+    let storage = InMemoryLocalStorage()
+
+    private func makeSUT() -> AuthClient {
+      let sessionConfiguration = URLSessionConfiguration.default
+      sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
+      let session = URLSession(configuration: sessionConfiguration)
+
+      let encoder = AuthClient.Configuration.jsonEncoder
+      encoder.outputFormatting = [.sortedKeys]
+
+      let configuration = AuthClient.Configuration(
+        url: clientURL,
+        headers: [
+          "apikey": "supabase.publishable.key",
+          "Authorization": "Bearer supabase.secret.key",
+        ],
+        localStorage: storage,
+        logger: nil,
+        encoder: encoder,
+        fetch: { request in
+          try await session.data(for: request)
+        }
+      )
+
+      return AuthClient(configuration: configuration)
+    }
+
+    @Test
+    func signOutDefaultScope() async throws {
+      Mock(
+        url: clientURL.appendingPathComponent("logout"),
+        ignoreQuery: true,
+        statusCode: 204,
+        data: [.post: Data()]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Authorization: Bearer users.access.token" \
+        	--header "X-Client-Info: auth-swift/0.0.0" \
+        	--header "X-Supabase-Api-Version: 2024-01-01" \
+        	--header "apikey: supabase.publishable.key" \
+        	"http://localhost:54321/auth/v1/logout?scope=global"
+        """#
+      }
+      .register()
+
+      let sut = makeSUT()
+
+      try await sut.admin.signOut(jwt: "users.access.token")
+    }
+
+    @Test
+    func signOutLocalScope() async throws {
+      Mock(
+        url: clientURL.appendingPathComponent("logout"),
+        ignoreQuery: true,
+        statusCode: 204,
+        data: [.post: Data()]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Authorization: Bearer users.access.token" \
+        	--header "X-Client-Info: auth-swift/0.0.0" \
+        	--header "X-Supabase-Api-Version: 2024-01-01" \
+        	--header "apikey: supabase.publishable.key" \
+        	"http://localhost:54321/auth/v1/logout?scope=local"
+        """#
+      }
+      .register()
+
+      let sut = makeSUT()
+
+      try await sut.admin.signOut(jwt: "users.access.token", scope: .local)
+    }
+
+    @Test
+    func signOutOthersScope() async throws {
+      Mock(
+        url: clientURL.appendingPathComponent("logout"),
+        ignoreQuery: true,
+        statusCode: 204,
+        data: [.post: Data()]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Authorization: Bearer users.access.token" \
+        	--header "X-Client-Info: auth-swift/0.0.0" \
+        	--header "X-Supabase-Api-Version: 2024-01-01" \
+        	--header "apikey: supabase.publishable.key" \
+        	"http://localhost:54321/auth/v1/logout?scope=others"
+        """#
+      }
+      .register()
+
+      let sut = makeSUT()
+
+      try await sut.admin.signOut(jwt: "users.access.token", scope: .others)
+    }
+
+    @Test
+    func signOutPropagatesError() async throws {
+      let errorData = """
+        {
+          "error": "invalid_token",
+          "error_description": "The access token is invalid"
+        }
+        """.data(using: .utf8)!
+
+      Mock(
+        url: clientURL.appendingPathComponent("logout"),
+        ignoreQuery: true,
+        statusCode: 401,
+        data: [.post: errorData]
+      )
+      .register()
+
+      let sut = makeSUT()
+
+      do {
+        try await sut.admin.signOut(jwt: "invalid.access.token")
+        Issue.record("Expected signOut to throw")
+      } catch let error as AuthError {
+        guard case .api = error else {
+          Issue.record("Expected AuthError.api, got \(error)")
+          return
+        }
+      }
+    }
+  }
+}

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -2815,47 +2815,6 @@ extension AuthMockerTests {
       _ = try await sut.admin.createUser(attributes: attributes)
     }
 
-    //  func testGenerateLink_signUp() async throws {
-    //    let sut = makeSUT()
-    //
-    //    let user = User(fromMockNamed: "user")
-    //    let encoder = JSONEncoder.supabase()
-    //    encoder.keyEncodingStrategy = .convertToSnakeCase
-    //
-    //    let userData = try encoder.encode(user)
-    //    var json = try JSONSerialization.jsonObject(with: userData, options: []) as! [String: Any]
-    //
-    //    json["action_link"] = "https://example.com/auth/v1/verify?type=signup&token={hashed_token}&redirect_to=https://example.com"
-    //    json["email_otp"] = "123456"
-    //    json["hashed_token"] = "hashed_token"
-    //    json["redirect_to"] = "https://example.com"
-    //    json["verification_type"] = "signup"
-    //
-    //    let responseData = try JSONSerialization.data(withJSONObject: json)
-    //
-    //    Mock(
-    //      url: clientURL.appendingPathComponent("admin/generate_link"),
-    //      statusCode: 200,
-    //      data: [
-    //        .post: responseData
-    //      ]
-    //    )
-    //    .register()
-    //
-    //    let link = try await sut.admin.generateLink(
-    //      params: .signUp(
-    //        email: "test@example.com",
-    //        password: "password",
-    //        data: ["full_name": "John Doe"]
-    //      )
-    //    )
-    //
-    //    expectNoDifference(
-    //      link.properties.actionLink.absoluteString,
-    //      "https://example.com/auth/v1/verify?type=signup&token={hashed_token}&redirect_to=https://example.com".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-    //    )
-    //  }
-
     @Test
     func inviteUserByEmail() async throws {
       let sut = makeSUT()

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -399,60 +399,77 @@ struct AuthClientIntegrationTests {
     }
   }
 
-  //  func testGenerateLink_signUp() async throws {
-  //    let client = Self.makeClient(serviceRole: true)
-  //    let email = mockEmail()
-  //    let password = mockPassword()
-  //
-  //    let link = try await client.admin.generateLink(
-  //      params: .signUp(
-  //        email: email,
-  //        password: password,
-  //        data: ["full_name": "John Doe"]
-  //      )
-  //    )
-  //
-  //    expectNoDifference(link.properties.actionLink.path, "/auth/v1/verify")
-  //    expectNoDifference(link.properties.verificationType, .signup)
-  //    expectNoDifference(link.user.email, email)
-  //  }
-  //
-  //  func testGenerateLink_magicLink() async throws {
-  //    let client = Self.makeClient(serviceRole: true)
-  //    let email = mockEmail()
-  //    let password = mockPassword()
-  //
-  //    // first create a user
-  //    try await client.admin.createUser(
-  //      attributes: AdminUserAttributes(email: email, password: password)
-  //    )
-  //
-  //    // generate a magic link for the created user
-  //    let link = try await client.admin.generateLink(params: .magicLink(email: email))
-  //
-  //    expectNoDifference(link.properties.verificationType, .magiclink)
-  //  }
+  @Test
+  func generateLinkSignUp() async throws {
+    let client = Self.makeClient(serviceRole: true)
+    let email = mockEmail()
+    let password = mockPassword()
 
-  // func testGenerateLink_recovery() async throws {
-  //   let client = Self.makeClient(serviceRole: true)
-  //   let email = mockEmail()
-  //   let password = mockPassword()
+    let link = try await client.admin.generateLink(
+      params: .signUp(
+        email: email,
+        password: password,
+        data: ["full_name": "John Doe"]
+      )
+    )
 
-  //   _ = try await client.signUp(email: email, password: password)
+    expectNoDifference(link.properties.actionLink.path, "/auth/v1/verify")
+    expectNoDifference(link.properties.verificationType, .signup)
+    expectNoDifference(link.user.email, email)
+  }
 
-  //   let link = try await client.admin.generateLink(params: .recovery(email: email))
+  @Test
+  func generateLinkMagicLink() async throws {
+    let client = Self.makeClient(serviceRole: true)
+    let email = mockEmail()
+    let password = mockPassword()
 
-  //   expectNoDifference(link.properties.verificationType, .recovery)
-  // }
+    // first create a user
+    try await client.admin.createUser(
+      attributes: AdminUserAttributes(email: email, password: password)
+    )
 
-  //  func testGenerateLink_invite() async throws {
-  //    let client = Self.makeClient(serviceRole: true)
-  //    let email = mockEmail()
-  //
-  //    let link = try await client.admin.generateLink(params: .invite(email: email))
-  //
-  //    expectNoDifference(link.properties.verificationType, .invite)
-  //  }
+    // generate a magic link for the created user
+    let link = try await client.admin.generateLink(params: .magicLink(email: email))
+
+    expectNoDifference(link.properties.verificationType, .magiclink)
+  }
+
+  @Test
+  func generateLinkRecovery() async throws {
+    let client = Self.makeClient(serviceRole: true)
+    let email = mockEmail()
+    let password = mockPassword()
+
+    _ = try await client.signUp(email: email, password: password)
+
+    let link = try await client.admin.generateLink(params: .recovery(email: email))
+
+    expectNoDifference(link.properties.verificationType, .recovery)
+  }
+
+  @Test
+  func generateLinkInvite() async throws {
+    let client = Self.makeClient(serviceRole: true)
+    let email = mockEmail()
+
+    let link = try await client.admin.generateLink(params: .invite(email: email))
+
+    expectNoDifference(link.properties.verificationType, .invite)
+  }
+
+  @Test
+  func adminSignOut() async throws {
+    let email = mockEmail()
+    let password = mockPassword()
+
+    let session = try await signUpIfNeededOrSignIn(email: email, password: password).session
+    let accessToken = try #require(session?.accessToken)
+
+    // Should complete without throwing: the admin client is authenticating with
+    // the target user's access token, not its own secret key.
+    try await Self.makeClient(serviceRole: true).admin.signOut(jwt: accessToken)
+  }
 
   @discardableResult
   private func signUpIfNeededOrSignIn(

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -185,8 +185,40 @@ features:
     status: implemented
     symbols:
       - AuthAdmin.inviteUserByEmail
-  auth.admin.sign_out: not_implemented
-  auth.admin.generate_link: not_implemented
+  auth.admin.sign_out:
+    status: implemented
+    symbols:
+      - AuthAdmin.signOut
+  auth.admin.generate_link:
+    status: implemented
+    symbols:
+      - AuthAdmin.generateLink
+      - GenerateLinkParams
+      - GenerateLinkParams.signUp
+      - GenerateLinkParams.invite
+      - GenerateLinkParams.magicLink
+      - GenerateLinkParams.recovery
+      - GenerateLinkParams.emailChangeCurrent
+      - GenerateLinkParams.emailChangeNew
+      - GenerateLinkResponse
+      - GenerateLinkResponse.properties
+      - GenerateLinkResponse.user
+      - GenerateLinkResponse.init
+      - GenerateLinkProperties
+      - GenerateLinkProperties.actionLink
+      - GenerateLinkProperties.emailOTP
+      - GenerateLinkProperties.hashedToken
+      - GenerateLinkProperties.redirectTo
+      - GenerateLinkProperties.verificationType
+      - GenerateLinkType
+      - GenerateLinkType.rawValue
+      - GenerateLinkType.init
+      - GenerateLinkType.signup
+      - GenerateLinkType.invite
+      - GenerateLinkType.magiclink
+      - GenerateLinkType.recovery
+      - GenerateLinkType.emailChangeCurrent
+      - GenerateLinkType.emailChangeNew
   auth.admin.list_mfa_factors: not_implemented
   auth.admin.delete_mfa_factor: not_implemented
   auth.admin.create_provider: not_implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -205,6 +205,7 @@ features:
       - GenerateLinkResponse.user
       - GenerateLinkResponse.init
       - GenerateLinkProperties
+      - GenerateLinkProperties.init
       - GenerateLinkProperties.actionLink
       - GenerateLinkProperties.emailOTP
       - GenerateLinkProperties.hashedToken


### PR DESCRIPTION
## Summary

Implements two `not_implemented` capabilities from the SDK compliance matrix (SDK-1294):

- **`auth.admin.generate_link`** — `AuthAdmin.generateLink(params:)`. This existed as commented-out dead code; revived it and fixed a real decode bug (`.convertFromSnakeCase` turns `email_otp` into `emailOtp`, not `emailOTP` — needed explicit `CodingKeys`). Added `.emailChangeCurrent`/`.emailChangeNew` factories for full parity with `auth-js`'s `GenerateLinkParams`.
- **`auth.admin.sign_out`** — new `AuthAdmin.signOut(jwt:scope:)`. Verified against `auth-js` and the `supabase/auth` Go backend: despite the feature being colloquially "sign out a user's sessions", the actual `/logout` endpoint only ever operates on the session embedded in the bearer token — there's no user-id-keyed admin logout route. So this takes the target user's access token (which a server already holds on their behalf), not a user id, matching `auth-js`'s `GoTrueAdminApi.signOut(jwt, scope)` exactly.

## Test plan

- [x] TDD: new unit tests written first, watched fail (RED — compile error against not-yet-existing API), then implemented, then green.
- [x] `Tests/AuthTests/AuthAdminGenerateLinkTests.swift` — 5 tests (signUp/magicLink/recovery/invite/emailChangeNew), Mocker-backed.
- [x] `Tests/AuthTests/AuthAdminSignOutTests.swift` — 4 tests (default/local/others scope + error propagation), asserts via snapshot that the per-call `Authorization: Bearer <jwt>` overrides the admin client's own secret-key header.
- [x] Full `AuthTests` suite: 232/232 pass, no regressions.
- [x] Integration tests: 4 `generateLink` tests uncommented + migrated to Swift Testing, new `adminSignOut()` test added under `Tests/IntegrationTests/AuthClientIntegrationTests.swift`. Confirmed to compile.
- [ ] Live integration run — attempted against a local `supabase start` instance, but hit a pre-existing SIGSEGV in the test process unrelated to this change (reproduces on an untouched pre-existing test too, `swift_task_dealloc` inside `RetryRequestInterceptor`'s async retry path). Filed separately for investigation; not a regression from this PR.
- [x] `sdk-compliance.yaml` updated: both capabilities marked `implemented` with symbol lists.