### PR TITLE
fix(storage): derive content type for signed URL uploads

### DIFF
--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -955,7 +955,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     file: FileUpload,
     options: FileOptions?
   ) async throws -> SignedURLUploadResponse {
-    let options = options ?? defaultFileOptions
+    let options = options ?? FileOptions()
     var headers = options.headers.map { HTTPFields($0) } ?? HTTPFields()
 
     headers[.xUpsert] = "\(options.upsert)"

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -45,6 +45,37 @@ extension StorageMockerTests {
       )
     }
 
+    /// A client whose transport records the request body, for asserting the emitted multipart
+    /// headers.
+    private func makeBodyCapturingSUT(body: LockIsolated<Data>) -> SupabaseStorageClient {
+      let respond: @Sendable (URLRequest) -> (Data, URLResponse) = { request in
+        (
+          Data(#"{"Key":"bucket/\#(request.url!.lastPathComponent)"}"#.utf8),
+          HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+          )!
+        )
+      }
+
+      return SupabaseStorageClient(
+        configuration: StorageClientConfiguration(
+          url: url,
+          headers: [:],
+          session: StorageHTTPSession(
+            fetch: { request in
+              body.setValue(request.httpBody ?? Data())
+              return respond(request)
+            },
+            upload: { request, data in
+              body.setValue(data)
+              return respond(request)
+            }
+          ),
+          logger: nil
+        )
+      )
+    }
+
     @Test
     func listFiles() async throws {
       let storage = makeSUT()
@@ -1438,39 +1469,6 @@ extension StorageMockerTests {
       #expect(response.fullPath == "bucket/file.txt")
     }
 
-    /// Captures the request body directly instead of using `snapshotRequest`, so the assertion
-    /// actually fails when the emitted `Content-Type` is wrong.
-    private func makeBodyCapturingSUT(
-      body: LockIsolated<Data>
-    ) -> SupabaseStorageClient {
-      let respond: @Sendable (URLRequest) -> (Data, URLResponse) = { request in
-        (
-          Data(#"{"Key":"bucket/cat.png"}"#.utf8),
-          HTTPURLResponse(
-            url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
-          )!
-        )
-      }
-
-      return SupabaseStorageClient(
-        configuration: StorageClientConfiguration(
-          url: url,
-          headers: [:],
-          session: StorageHTTPSession(
-            fetch: { request in
-              body.setValue(request.httpBody ?? Data())
-              return respond(request)
-            },
-            upload: { request, data in
-              body.setValue(data)
-              return respond(request)
-            }
-          ),
-          logger: nil
-        )
-      )
-    }
-
     @Test
     func uploadToSignedURLDerivesContentTypeFromPathExtensionWhenOptionsOmitted() async throws {
       let body = LockIsolated(Data())
@@ -1670,8 +1668,7 @@ extension StorageMockerTests {
 }
 
 extension Data {
-  /// Searches the raw bytes for `string`, so bodies containing non-UTF-8 file content
-  /// (e.g. a real JPEG) can still be asserted on.
+  /// Whether the raw bytes contain `string`, for bodies that are not valid UTF-8 as a whole.
   fileprivate func containsBytes(of string: String) -> Bool {
     range(of: Data(string.utf8)) != nil
   }

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -1390,7 +1390,7 @@ extension StorageMockerTests {
         curl \
         	--request PUT \
         	--header "Cache-Control: max-age=3600" \
-        	--header "Content-Length: 297" \
+        	--header "Content-Length: 283" \
         	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
         	--header "X-Client-Info: storage-swift/0.0.0" \
         	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
@@ -1401,7 +1401,7 @@ extension StorageMockerTests {
         3600\#r
         --alamofire.boundary.e56f43407f772505\#r
         Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
-        Content-Type: text/plain;charset=UTF-8\#r
+        Content-Type: text/plain\#r
         \#r
         hello world\#r
         --alamofire.boundary.e56f43407f772505--\#r
@@ -1481,7 +1481,11 @@ extension StorageMockerTests {
           data: Data("not-really-a-png".utf8)
         )
 
-      #expect(body.value.containsBytes(of: "Content-Type: image/png"))
+      #if canImport(UniformTypeIdentifiers)
+        #expect(body.value.containsBytes(of: "Content-Type: image/png"))
+      #else
+        #expect(body.value.containsBytes(of: "Content-Type: application/octet-stream"))
+      #endif
       #expect(!body.value.containsBytes(of: "text/plain"))
     }
 
@@ -1497,7 +1501,11 @@ extension StorageMockerTests {
           fileURL: Bundle.module.url(forResource: "sadcat", withExtension: "jpg")!
         )
 
-      #expect(body.value.containsBytes(of: "Content-Type: image/jpeg"))
+      #if canImport(UniformTypeIdentifiers)
+        #expect(body.value.containsBytes(of: "Content-Type: image/jpeg"))
+      #else
+        #expect(body.value.containsBytes(of: "Content-Type: application/octet-stream"))
+      #endif
       #expect(!body.value.containsBytes(of: "text/plain"))
     }
 

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -1410,7 +1410,7 @@ extension StorageMockerTests {
         curl \
         	--request PUT \
         	--header "Cache-Control: max-age=3600" \
-        	--header "Content-Length: 297" \
+        	--header "Content-Length: 283" \
         	--header "Content-Type: multipart/form-data; boundary=alamofire.boundary.e56f43407f772505" \
         	--header "X-Client-Info: storage-swift/0.0.0" \
         	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
@@ -1421,7 +1421,7 @@ extension StorageMockerTests {
         3600\#r
         --alamofire.boundary.e56f43407f772505\#r
         Content-Disposition: form-data; name=\"\"; filename=\"file.txt\"\#r
-        Content-Type: text/plain;charset=UTF-8\#r
+        Content-Type: text/plain\#r
         \#r
         hello world\#r
         --alamofire.boundary.e56f43407f772505--\#r
@@ -1436,6 +1436,71 @@ extension StorageMockerTests {
 
       #expect(response.path == "file.txt")
       #expect(response.fullPath == "bucket/file.txt")
+    }
+
+    /// Captures the request body directly instead of using `snapshotRequest`, so the assertion
+    /// actually fails when the emitted `Content-Type` is wrong.
+    private func makeBodyCapturingSUT(
+      body: LockIsolated<Data>
+    ) -> SupabaseStorageClient {
+      let respond: @Sendable (URLRequest) -> (Data, URLResponse) = { request in
+        (
+          Data(#"{"Key":"bucket/cat.png"}"#.utf8),
+          HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+          )!
+        )
+      }
+
+      return SupabaseStorageClient(
+        configuration: StorageClientConfiguration(
+          url: url,
+          headers: [:],
+          session: StorageHTTPSession(
+            fetch: { request in
+              body.setValue(request.httpBody ?? Data())
+              return respond(request)
+            },
+            upload: { request, data in
+              body.setValue(data)
+              return respond(request)
+            }
+          ),
+          logger: nil
+        )
+      )
+    }
+
+    @Test
+    func uploadToSignedURLDerivesContentTypeFromPathExtensionWhenOptionsOmitted() async throws {
+      let body = LockIsolated(Data())
+      let storage = makeBodyCapturingSUT(body: body)
+
+      _ = try await storage.from("bucket")
+        .uploadToSignedURL(
+          "cat.png",
+          token: "abc.def.ghi",
+          data: Data("not-really-a-png".utf8)
+        )
+
+      #expect(body.value.containsBytes(of: "Content-Type: image/png"))
+      #expect(!body.value.containsBytes(of: "text/plain"))
+    }
+
+    @Test
+    func uploadToSignedURLFromFileURLDerivesContentTypeWhenOptionsOmitted() async throws {
+      let body = LockIsolated(Data())
+      let storage = makeBodyCapturingSUT(body: body)
+
+      _ = try await storage.from("bucket")
+        .uploadToSignedURL(
+          "cat.jpg",
+          token: "abc.def.ghi",
+          fileURL: Bundle.module.url(forResource: "sadcat", withExtension: "jpg")!
+        )
+
+      #expect(body.value.containsBytes(of: "Content-Type: image/jpeg"))
+      #expect(!body.value.containsBytes(of: "text/plain"))
     }
 
     @Test
@@ -1601,5 +1666,13 @@ extension StorageMockerTests {
 
       #expect(data == Data("hello world".utf8))
     }
+  }
+}
+
+extension Data {
+  /// Searches the raw bytes for `string`, so bodies containing non-UTF-8 file content
+  /// (e.g. a real JPEG) can still be asserted on.
+  fileprivate func containsBytes(of string: String) -> Bool {
+    range(of: Data(string.utf8)) != nil
   }
 }


### PR DESCRIPTION
### Problem

`uploadToSignedURL` stamps `Content-Type: text/plain;charset=UTF-8` on every upload when `options` is omitted, so a PNG or JPEG sent through a signed upload URL is stored with that mimetype and served back as text. Browsers then download the file instead of rendering it, and `<img src>` breaks.

Both public overloads default `options` to `nil`:

```swift
public func uploadToSignedURL(_ path: String, token: String, data: Data, options: FileOptions? = nil)
public func uploadToSignedURL(_ path: String, token: String, fileURL: URL, options: FileOptions? = nil)
```

and `_uploadToSignedURL` resolved that `nil` against `defaultFileOptions`, whose `contentType` is `"text/plain;charset=UTF-8"`. Because that value is never `nil`, the extension-derived fallback on the encode path could not run:

```swift
mimeType: options.contentType ?? mimeType(forPathExtension: path.pathExtension)
```

### Fix

Resolve the missing options against `FileOptions()` instead. `cacheControl` (`"3600"`) and `upsert` (`false`) are identical between the two, so the only change is `contentType`, which becomes `nil` and lets the path extension decide, as the property already documents:

> The `Content-Type` header value, e.g. `"image/png"`. When `nil`, the type is inferred from the file extension.

Four things line up behind this:

- `upload()` and `update()` already default to `FileOptions()`. I confirmed by capturing the request body that `upload("file.txt", data:)` emits bare `Content-Type: text/plain`, which is exactly what `uploadToSignedURL` emits after this change. No new behavior is introduced anywhere in the SDK, a divergence is removed.
- The deprecated `uploadToSignedURL` overloads in `Deprecated.swift` pass `FileOptions()` and are therefore already correct. Moving off the deprecated API silently changed the stored mimetype.
- storage-js applies `DEFAULT_FILE_OPTIONS.contentType` only on the raw body branch (`headers['content-type'] = options.contentType`). On the Blob/FormData branch, the one this SDK always takes, it appends only `cacheControl` and `metadata` and lets the file's own type become the part's `Content-Type`. See [`StorageFileApi.ts`](https://github.com/supabase/storage-js/blob/master/src/packages/StorageFileApi.ts).
- #1124 added the `?? mimeType(forPathExtension:)` fallback for `fileURL` uploads, but on this path `defaultFileOptions` made it unreachable.

One consequence worth naming: `.txt` uploads through a signed URL no longer carry `;charset=UTF-8`. That matches what `upload()` has always sent for the same file, so it is alignment rather than a regression.

`defaultFileOptions` is left in place because `_uploadOrUpdate` still references it, though every caller there passes a non-optional `FileOptions`, so that fallback is already unreachable. Happy to remove the constant in a follow-up if you would prefer.

### Tests

Two tests asserting the emitted `Content-Type` for a `.png` (data) and a `.jpg` (fileURL) upload with `options` omitted. Both fail on `main` with 4 failed expectations and pass with the fix. 147 StorageTests green.

They capture the request body through `StorageHTTPSession` rather than using `snapshotRequest`, because `snapshotRequest` assertions in this suite do not currently fail. I changed an existing expected value to `Content-Type: totally/bogus` and `uploadToSignedURL()` still passed, so the request-shape snapshots in `StorageFileAPITests` are not gating anything since the Swift Testing migration. That looked worth reporting separately rather than working around silently, and it is why these two tests assert directly on the body.

The existing `uploadToSignedURL()` snapshot is updated to the values this change produces (`text/plain`, `Content-Length` 297 to 283, verified by capturing the real body).

No public API change.
