### PR TITLE
fix(helpers): extend Swift version detection ladder

### DIFF
--- a/Sources/Helpers/Version.swift
+++ b/Sources/Helpers/Version.swift
@@ -67,21 +67,61 @@ private let _platformVersion: String? = {
   package let platformVersion = _platformVersion
 #endif
 
-private let _runtimeVersion: String? = {
-  #if swift(>=6.3)
+private func _swift6Version() -> String? {
+  #if swift(>=7.0)
+    return nil
+  #elseif swift(>=6.9)
+    return "6.9"
+  #elseif swift(>=6.8)
+    return "6.8"
+  #elseif swift(>=6.7)
+    return "6.7"
+  #elseif swift(>=6.6)
+    return "6.6"
+  #elseif swift(>=6.5)
+    return "6.5"
+  #elseif swift(>=6.4)
+    return "6.4"
+  #elseif swift(>=6.3)
     return "6.3"
   #elseif swift(>=6.2)
     return "6.2"
   #elseif swift(>=6.1)
     return "6.1"
-  #elseif swift(>=6.0)
-    return "6.0"
-  #elseif swift(>=5.10)
-    return "5.10"
   #else
     return nil
   #endif
-}()
+}
+
+private func _swift7Version() -> String? {
+  #if swift(>=8.0)
+    return nil
+  #elseif swift(>=7.9)
+    return "7.9"
+  #elseif swift(>=7.8)
+    return "7.8"
+  #elseif swift(>=7.7)
+    return "7.7"
+  #elseif swift(>=7.6)
+    return "7.6"
+  #elseif swift(>=7.5)
+    return "7.5"
+  #elseif swift(>=7.4)
+    return "7.4"
+  #elseif swift(>=7.3)
+    return "7.3"
+  #elseif swift(>=7.2)
+    return "7.2"
+  #elseif swift(>=7.1)
+    return "7.1"
+  #elseif swift(>=7.0)
+    return "7.0"
+  #else
+    return nil
+  #endif
+}
+
+private let _runtimeVersion: String? = _swift6Version() ?? _swift7Version()
 
 #if DEBUG
   package let runtimeVersion: String? = isTesting ? "0.0.0" : _runtimeVersion


### PR DESCRIPTION
## Summary
- Drop the Swift 6.0 / 5.10 rungs from `runtimeVersion`'s detection ladder — `Package.swift` already requires `swift-tools-version:6.1`, so those cases were unreachable dead code.
- Extend the ladder speculatively through Swift 7.9, split into `_swift6Version()` / `_swift7Version()` helpers, mirroring the pattern used by `smithy-swift` (AWS SDK's Swift runtime) and Shopify's `checkout-kit`. Future Swift minor releases resolve automatically without needing a follow-up PR.
- No true runtime introspection exists for the Swift compiler version — confirmed via research across several SDKs (AWS, Superwall, Shopify, Sentry, PostHog); `#if swift(>=)` compile-time ladders are the standard approach industry-wide.

## Test plan
- [x] `swift build --target Helpers` succeeds