### PR TITLE
fix: flaky CI in AuthTests and RealtimeTests

### DIFF
--- a/Sources/RealtimeV2/PushV2.swift
+++ b/Sources/RealtimeV2/PushV2.swift
@@ -20,6 +20,9 @@ final class PushV2 {
   let message: RealtimeMessageV2
 
   private var receivedContinuation: CheckedContinuation<PushStatus, Never>?
+  /// Buffers a status delivered via ``didReceive(status:)`` before ``send()`` has
+  /// registered its continuation, so an ack that arrives early isn't dropped.
+  private var receivedStatus: PushStatus?
 
   init(channel: (any RealtimeChannelProtocol)?, message: RealtimeMessageV2) {
     self.channel = channel
@@ -44,7 +47,12 @@ final class PushV2 {
         interval: channel.socket.options.timeoutInterval, clock: channel.socket.clock
       ) {
         await withCheckedContinuation { continuation in
-          self.receivedContinuation = continuation
+          if let status = self.receivedStatus {
+            self.receivedStatus = nil
+            continuation.resume(returning: status)
+          } else {
+            self.receivedContinuation = continuation
+          }
         }
       }
     } catch is TimeoutError {
@@ -57,7 +65,13 @@ final class PushV2 {
   }
 
   func didReceive(status: PushStatus) {
-    receivedContinuation?.resume(returning: status)
-    receivedContinuation = nil
+    if let receivedContinuation {
+      receivedContinuation.resume(returning: status)
+      self.receivedContinuation = nil
+    } else {
+      // The ack arrived before `send()` registered its continuation; buffer it
+      // so `send()` can resume immediately instead of timing out.
+      receivedStatus = status
+    }
   }
 }

--- a/Sources/TestHelpers/MainSerialExecutorSerialization.swift
+++ b/Sources/TestHelpers/MainSerialExecutorSerialization.swift
@@ -1,0 +1,70 @@
+//
+//  MainSerialExecutorSerialization.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 04/08/26.
+//
+
+package import Testing
+
+/// A process-wide mutual-exclusion queue, used by ``MainSerialExecutorSerializedTrait`` to
+/// serialize every test wrapped by `.mainSerialExecutorSerialized` against every other one, even
+/// across test *targets*.
+private actor MainSerialExecutorGate {
+  static let shared = MainSerialExecutorGate()
+
+  private var isBusy = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  private func acquire() async {
+    guard isBusy else {
+      isBusy = true
+      return
+    }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  private func release() {
+    guard waiters.isEmpty else {
+      waiters.removeFirst().resume()
+      return
+    }
+    isBusy = false
+  }
+
+  func withLock<T: Sendable>(_ body: @Sendable () async throws -> T) async rethrows -> T {
+    await acquire()
+    defer { release() }
+    return try await body()
+  }
+}
+
+/// `withMainSerialExecutor` (ConcurrencyExtras) mutates a process-global flag
+/// (`uncheckedUseMainSerialExecutor`) to force deterministic task scheduling within its closure.
+/// Swift Testing's built-in `.serialized` suite trait only serializes a suite's own (possibly
+/// nested) tests -- it does not prevent that suite from running concurrently with an unrelated
+/// suite in a *different* test target that also calls `withMainSerialExecutor`. Without this
+/// trait, two such suites can flip the same global out from under each other mid-test, causing
+/// nondeterministic scheduling and cascading failures that don't reproduce when either target's
+/// tests run alone.
+///
+/// `isRecursive` is `false`, mirroring `MockerSerializedTrait`: apply directly to every concrete
+/// `@Suite` that calls `withMainSerialExecutor`, not to an enclosing namespace enum.
+package struct MainSerialExecutorSerializedTrait: SuiteTrait, TestScoping {
+  package var isRecursive: Bool { false }
+
+  package func provideScope(
+    for test: Test, testCase: Test.Case?,
+    performing function: @Sendable () async throws -> Void
+  ) async throws {
+    try await MainSerialExecutorGate.shared.withLock {
+      try await function()
+    }
+  }
+}
+
+extension Trait where Self == MainSerialExecutorSerializedTrait {
+  /// Apply directly to each `@Suite` that calls `withMainSerialExecutor`, so it can't interleave
+  /// with any other suite -- in this or another test target -- that also uses this trait.
+  package static var mainSerialExecutorSerialized: Self { MainSerialExecutorSerializedTrait() }
+}

--- a/Tests/AuthTests/AuthAdminGenerateLinkTests.swift
+++ b/Tests/AuthTests/AuthAdminGenerateLinkTests.swift
@@ -6,6 +6,7 @@
 import ConcurrencyExtras
 import CustomDump
 import Foundation
+import Helpers
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
@@ -27,7 +28,11 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      let encoder = AuthClient.Configuration.jsonEncoder
+      // Build a test-owned encoder instead of mutating the process-wide
+      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
+      // running suites share.
+      let encoder = JSONEncoder.supabase()
+      encoder.keyEncodingStrategy = .convertToSnakeCase
       encoder.outputFormatting = [.sortedKeys]
 
       let configuration = AuthClient.Configuration(

--- a/Tests/AuthTests/AuthAdminOAuthTests.swift
+++ b/Tests/AuthTests/AuthAdminOAuthTests.swift
@@ -8,6 +8,7 @@
 import ConcurrencyExtras
 import CustomDump
 import Foundation
+import Helpers
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
@@ -40,7 +41,11 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      let encoder = AuthClient.Configuration.jsonEncoder
+      // Build a test-owned encoder instead of mutating the process-wide
+      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
+      // running suites share.
+      let encoder = JSONEncoder.supabase()
+      encoder.keyEncodingStrategy = .convertToSnakeCase
       encoder.outputFormatting = [.sortedKeys]
 
       let configuration = AuthClient.Configuration(

--- a/Tests/AuthTests/AuthAdminSignOutTests.swift
+++ b/Tests/AuthTests/AuthAdminSignOutTests.swift
@@ -6,6 +6,7 @@
 import ConcurrencyExtras
 import CustomDump
 import Foundation
+import Helpers
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
@@ -27,7 +28,11 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      let encoder = AuthClient.Configuration.jsonEncoder
+      // Build a test-owned encoder instead of mutating the process-wide
+      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
+      // running suites share.
+      let encoder = JSONEncoder.supabase()
+      encoder.keyEncodingStrategy = .convertToSnakeCase
       encoder.outputFormatting = [.sortedKeys]
 
       let configuration = AuthClient.Configuration(

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -25,7 +25,7 @@ import Testing
 #endif
 
 extension AuthMockerTests {
-  @Suite(.mockerSerialized)
+  @Suite(.mockerSerialized, .mainSerialExecutorSerialized)
   struct AuthClientTests {
     let storage = InMemoryLocalStorage()
 

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -8,6 +8,7 @@
 import ConcurrencyExtras
 import CustomDump
 import Foundation
+import Helpers
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
@@ -3399,7 +3400,11 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      let encoder = AuthClient.Configuration.jsonEncoder
+      // Build a test-owned encoder instead of mutating the process-wide
+      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
+      // running suites share.
+      let encoder = JSONEncoder.supabase()
+      encoder.keyEncodingStrategy = .convertToSnakeCase
       encoder.outputFormatting = [.sortedKeys]
 
       let configuration = AuthClient.Configuration(

--- a/Tests/AuthTests/AuthOAuthServerTests.swift
+++ b/Tests/AuthTests/AuthOAuthServerTests.swift
@@ -8,6 +8,7 @@
 import ConcurrencyExtras
 import CustomDump
 import Foundation
+import Helpers
 import InlineSnapshotTesting
 import Mocker
 import TestHelpers
@@ -36,7 +37,11 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      let encoder = AuthClient.Configuration.jsonEncoder
+      // Build a test-owned encoder instead of mutating the process-wide
+      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
+      // running suites share.
+      let encoder = JSONEncoder.supabase()
+      encoder.keyEncodingStrategy = .convertToSnakeCase
       encoder.outputFormatting = [.sortedKeys]
 
       let configuration = AuthClient.Configuration(

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Helpers
 import InlineSnapshotTesting
 import SnapshotTesting
 import TestHelpers
@@ -728,8 +729,12 @@ struct RequestsTests {
     testName: String = #function,
     line: UInt = #line
   ) -> AuthClient {
-    let encoder = AuthClient.Configuration.jsonEncoder
-    encoder.outputFormatting = .sortedKeys
+    // Build a test-owned encoder instead of mutating the process-wide
+    // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
+    // running suites share.
+    let encoder = JSONEncoder.supabase()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    encoder.outputFormatting = [.sortedKeys]
 
     let configuration = AuthClient.Configuration(
       url: clientURL,

--- a/Tests/AuthTests/SessionManagerTests.swift
+++ b/Tests/AuthTests/SessionManagerTests.swift
@@ -18,8 +18,11 @@ import Testing
 // `uncheckedUseMainSerialExecutor`) to force deterministic task scheduling within its closure.
 // Swift Testing runs tests in the same suite concurrently by default, so two tests racing to
 // flip that global would interfere with each other — serialize this suite, mirroring the
-// `_clock`-swap precedent in PostgrestBuilderTests (PR #1095).
-@Suite(.serialized)
+// `_clock`-swap precedent in PostgrestBuilderTests (PR #1095). `.mainSerialExecutorSerialized`
+// additionally prevents this suite from interleaving with any other suite (in this or another
+// target) that also calls `withMainSerialExecutor`, since `.serialized` alone only serializes a
+// suite's own tests.
+@Suite(.serialized, .mainSerialExecutorSerialized)
 struct SessionManagerTests {
   let http = HTTPClientMock()
   // Unique negative clientID so this suite's process-global `Dependencies` entry can't be

--- a/Tests/IntegrationTests/RealtimeIntegrationTests.swift
+++ b/Tests/IntegrationTests/RealtimeIntegrationTests.swift
@@ -24,6 +24,7 @@
   // struct) so `deinit` can disconnect both clients afterward, mirroring the old `tearDown()`.
   @Suite(
     .serialized,
+    .mainSerialExecutorSerialized,
     .enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil)
   )
   final class RealtimeIntegrationTests: Sendable {

--- a/Tests/IntegrationTests/StorageFileIntegrationTests.swift
+++ b/Tests/IntegrationTests/StorageFileIntegrationTests.swift
@@ -79,7 +79,9 @@ final class StorageFileIntegrationTests {
   func signURL() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let url = try await storage.from(bucketName).createSignedURL(path: uploadPath, expiresIn: 2000)
+    let url = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).createSignedURL(path: uploadPath, expiresIn: 2000)
+    }
     #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
@@ -90,8 +92,10 @@ final class StorageFileIntegrationTests {
   func signURL_withDownloadQueryString() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let url = try await storage.from(bucketName).createSignedURL(
-      path: uploadPath, expiresIn: 2000, download: true)
+    let url = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).createSignedURL(
+        path: uploadPath, expiresIn: 2000, download: true)
+    }
     #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
@@ -103,8 +107,10 @@ final class StorageFileIntegrationTests {
   func signURL_withCustomFilenameForDownload() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let url = try await storage.from(bucketName).createSignedURL(
-      path: uploadPath, expiresIn: 2000, download: "test.jpg")
+    let url = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).createSignedURL(
+        path: uploadPath, expiresIn: 2000, download: "test.jpg")
+    }
     #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
@@ -118,7 +124,9 @@ final class StorageFileIntegrationTests {
 
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let res = try await storage.from(bucketName).update(uploadPath, data: file2)
+    let res = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).update(uploadPath, data: file2)
+    }
     #expect(res.path == uploadPath)
   }
 
@@ -262,7 +270,9 @@ final class StorageFileIntegrationTests {
   @Test
   func listObjects() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
-    let res = try await storage.from(bucketName).list(path: "testpath")
+    let res = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).list(path: "testpath")
+    }
 
     #expect(res.count == 1)
     #expect(res[0].name == uploadPath.replacingOccurrences(of: "testpath/", with: ""))
@@ -273,7 +283,9 @@ final class StorageFileIntegrationTests {
     let newPath = "testpath/file-moved-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    try await storage.from(bucketName).move(from: uploadPath, to: newPath)
+    try await retryOnTransientStorageError {
+      try await storage.from(bucketName).move(from: uploadPath, to: newPath)
+    }
   }
 
   @Test
@@ -284,13 +296,17 @@ final class StorageFileIntegrationTests {
     let newPath = "testpath/file-to-move-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    try await storage.from(bucketName).move(
-      from: uploadPath,
-      to: newPath,
-      options: DestinationOptions(destinationBucket: newBucketName)
-    )
+    try await retryOnTransientStorageError {
+      try await storage.from(bucketName).move(
+        from: uploadPath,
+        to: newPath,
+        options: DestinationOptions(destinationBucket: newBucketName)
+      )
+    }
 
-    _ = try await storage.from(newBucketName).download(path: newPath)
+    _ = try await retryOnTransientStorageError {
+      try await storage.from(newBucketName).download(path: newPath)
+    }
   }
 
   @Test
@@ -298,7 +314,9 @@ final class StorageFileIntegrationTests {
     let newPath = "testpath/file-moved-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    try await storage.from(bucketName).copy(from: uploadPath, to: newPath)
+    try await retryOnTransientStorageError {
+      try await storage.from(bucketName).copy(from: uploadPath, to: newPath)
+    }
   }
 
   @Test
@@ -309,20 +327,26 @@ final class StorageFileIntegrationTests {
     let newPath = "testpath/file-to-copy-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    try await storage.from(bucketName).copy(
-      from: uploadPath,
-      to: newPath,
-      options: DestinationOptions(destinationBucket: newBucketName)
-    )
+    try await retryOnTransientStorageError {
+      try await storage.from(bucketName).copy(
+        from: uploadPath,
+        to: newPath,
+        options: DestinationOptions(destinationBucket: newBucketName)
+      )
+    }
 
-    _ = try await storage.from(newBucketName).download(path: newPath)
+    _ = try await retryOnTransientStorageError {
+      try await storage.from(newBucketName).download(path: newPath)
+    }
   }
 
   @Test
   func downloadsAnObject() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let res = try await storage.from(bucketName).download(path: uploadPath)
+    let res = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).download(path: uploadPath)
+    }
     #expect(res.count > 0)
   }
 
@@ -330,7 +354,9 @@ final class StorageFileIntegrationTests {
   func removesAnObject() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let res = try await storage.from(bucketName).remove(paths: [uploadPath])
+    let res = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).remove(paths: [uploadPath])
+    }
     #expect(res.count == 1)
     #expect(res[0].bucketId == bucketName)
     #expect(res[0].name == uploadPath)
@@ -358,7 +384,9 @@ final class StorageFileIntegrationTests {
     let path = "empty-folder/.placeholder"
     try await storage.from(bucketName).upload(path, data: Data())
 
-    let files = try await storage.from(bucketName).list()
+    let files = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).list()
+    }
     assertInlineSnapshot(of: files, as: .json) {
       """
       [
@@ -380,7 +408,9 @@ final class StorageFileIntegrationTests {
       )
     )
 
-    let info = try await storage.from(bucketName).info(path: uploadPath)
+    let info = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).info(path: uploadPath)
+    }
     #expect(info.name == uploadPath)
     #expect(info.metadata == ["value": 42])
   }
@@ -389,7 +419,9 @@ final class StorageFileIntegrationTests {
   func exists() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    var exists = try await storage.from(bucketName).exists(path: uploadPath)
+    var exists = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).exists(path: uploadPath)
+    }
     #expect(exists)
 
     exists = try await storage.from(bucketName).exists(path: "invalid.jpg")
@@ -420,7 +452,9 @@ final class StorageFileIntegrationTests {
     try await storage.from(bucketName)
       .upload(uploadPath, fileURL: uploadFileURL("sadcat.jpg"))
 
-    let uploadedFile = try await storage.from(bucketName).download(path: uploadPath)
+    let uploadedFile = try await retryOnTransientStorageError {
+      try await storage.from(bucketName).download(path: uploadPath)
+    }
 
     #expect(uploadedFile == file)
   }
@@ -452,5 +486,27 @@ final class StorageFileIntegrationTests {
       .deletingLastPathComponent()
       .appendingPathComponent("Fixtures/Upload")
       .appendingPathComponent(fileName)
+  }
+
+  // storage-api can be eventually-consistent right after an `upload(...)` response returns, so
+  // operations on the just-uploaded object may transiently 500. Retry a few times before failing.
+  @discardableResult
+  private func retryOnTransientStorageError<T>(
+    attempts: Int = 3,
+    delay: Duration = .milliseconds(200),
+    _ operation: () async throws -> T
+  ) async throws -> T {
+    var lastError: (any Error)!
+    for attempt in 0..<attempts {
+      do {
+        return try await operation()
+      } catch let error as StorageError where error.statusCode == "500" {
+        lastError = error
+        if attempt < attempts - 1 {
+          try await Task.sleep(for: delay)
+        }
+      }
+    }
+    throw lastError
   }
 }

--- a/Tests/IntegrationTests/StorageFileIntegrationTests.swift
+++ b/Tests/IntegrationTests/StorageFileIntegrationTests.swift
@@ -79,9 +79,7 @@ final class StorageFileIntegrationTests {
   func signURL() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let url = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).createSignedURL(path: uploadPath, expiresIn: 2000)
-    }
+    let url = try await storage.from(bucketName).createSignedURL(path: uploadPath, expiresIn: 2000)
     #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
@@ -92,10 +90,8 @@ final class StorageFileIntegrationTests {
   func signURL_withDownloadQueryString() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let url = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).createSignedURL(
-        path: uploadPath, expiresIn: 2000, download: true)
-    }
+    let url = try await storage.from(bucketName).createSignedURL(
+      path: uploadPath, expiresIn: 2000, download: true)
     #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
@@ -107,10 +103,8 @@ final class StorageFileIntegrationTests {
   func signURL_withCustomFilenameForDownload() async throws {
     _ = try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let url = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).createSignedURL(
-        path: uploadPath, expiresIn: 2000, download: "test.jpg")
-    }
+    let url = try await storage.from(bucketName).createSignedURL(
+      path: uploadPath, expiresIn: 2000, download: "test.jpg")
     #expect(
       url.absoluteString.contains(
         "\(DotEnv.SUPABASE_URL)/storage/v1/object/sign/\(bucketName)/\(uploadPath)")
@@ -124,9 +118,7 @@ final class StorageFileIntegrationTests {
 
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let res = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).update(uploadPath, data: file2)
-    }
+    let res = try await storage.from(bucketName).update(uploadPath, data: file2)
     #expect(res.path == uploadPath)
   }
 
@@ -270,9 +262,7 @@ final class StorageFileIntegrationTests {
   @Test
   func listObjects() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
-    let res = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).list(path: "testpath")
-    }
+    let res = try await storage.from(bucketName).list(path: "testpath")
 
     #expect(res.count == 1)
     #expect(res[0].name == uploadPath.replacingOccurrences(of: "testpath/", with: ""))
@@ -283,9 +273,7 @@ final class StorageFileIntegrationTests {
     let newPath = "testpath/file-moved-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    try await retryOnTransientStorageError {
-      try await storage.from(bucketName).move(from: uploadPath, to: newPath)
-    }
+    try await storage.from(bucketName).move(from: uploadPath, to: newPath)
   }
 
   @Test
@@ -296,17 +284,13 @@ final class StorageFileIntegrationTests {
     let newPath = "testpath/file-to-move-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    try await retryOnTransientStorageError {
-      try await storage.from(bucketName).move(
-        from: uploadPath,
-        to: newPath,
-        options: DestinationOptions(destinationBucket: newBucketName)
-      )
-    }
+    try await storage.from(bucketName).move(
+      from: uploadPath,
+      to: newPath,
+      options: DestinationOptions(destinationBucket: newBucketName)
+    )
 
-    _ = try await retryOnTransientStorageError {
-      try await storage.from(newBucketName).download(path: newPath)
-    }
+    _ = try await storage.from(newBucketName).download(path: newPath)
   }
 
   @Test
@@ -314,9 +298,7 @@ final class StorageFileIntegrationTests {
     let newPath = "testpath/file-moved-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    try await retryOnTransientStorageError {
-      try await storage.from(bucketName).copy(from: uploadPath, to: newPath)
-    }
+    try await storage.from(bucketName).copy(from: uploadPath, to: newPath)
   }
 
   @Test
@@ -327,26 +309,20 @@ final class StorageFileIntegrationTests {
     let newPath = "testpath/file-to-copy-\(UUID().uuidString).txt"
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    try await retryOnTransientStorageError {
-      try await storage.from(bucketName).copy(
-        from: uploadPath,
-        to: newPath,
-        options: DestinationOptions(destinationBucket: newBucketName)
-      )
-    }
+    try await storage.from(bucketName).copy(
+      from: uploadPath,
+      to: newPath,
+      options: DestinationOptions(destinationBucket: newBucketName)
+    )
 
-    _ = try await retryOnTransientStorageError {
-      try await storage.from(newBucketName).download(path: newPath)
-    }
+    _ = try await storage.from(newBucketName).download(path: newPath)
   }
 
   @Test
   func downloadsAnObject() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let res = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).download(path: uploadPath)
-    }
+    let res = try await storage.from(bucketName).download(path: uploadPath)
     #expect(res.count > 0)
   }
 
@@ -354,9 +330,7 @@ final class StorageFileIntegrationTests {
   func removesAnObject() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    let res = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).remove(paths: [uploadPath])
-    }
+    let res = try await storage.from(bucketName).remove(paths: [uploadPath])
     #expect(res.count == 1)
     #expect(res[0].bucketId == bucketName)
     #expect(res[0].name == uploadPath)
@@ -384,9 +358,7 @@ final class StorageFileIntegrationTests {
     let path = "empty-folder/.placeholder"
     try await storage.from(bucketName).upload(path, data: Data())
 
-    let files = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).list()
-    }
+    let files = try await storage.from(bucketName).list()
     assertInlineSnapshot(of: files, as: .json) {
       """
       [
@@ -408,9 +380,7 @@ final class StorageFileIntegrationTests {
       )
     )
 
-    let info = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).info(path: uploadPath)
-    }
+    let info = try await storage.from(bucketName).info(path: uploadPath)
     #expect(info.name == uploadPath)
     #expect(info.metadata == ["value": 42])
   }
@@ -419,9 +389,7 @@ final class StorageFileIntegrationTests {
   func exists() async throws {
     try await storage.from(bucketName).upload(uploadPath, data: file)
 
-    var exists = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).exists(path: uploadPath)
-    }
+    var exists = try await storage.from(bucketName).exists(path: uploadPath)
     #expect(exists)
 
     exists = try await storage.from(bucketName).exists(path: "invalid.jpg")
@@ -452,9 +420,7 @@ final class StorageFileIntegrationTests {
     try await storage.from(bucketName)
       .upload(uploadPath, fileURL: uploadFileURL("sadcat.jpg"))
 
-    let uploadedFile = try await retryOnTransientStorageError {
-      try await storage.from(bucketName).download(path: uploadPath)
-    }
+    let uploadedFile = try await storage.from(bucketName).download(path: uploadPath)
 
     #expect(uploadedFile == file)
   }
@@ -486,27 +452,5 @@ final class StorageFileIntegrationTests {
       .deletingLastPathComponent()
       .appendingPathComponent("Fixtures/Upload")
       .appendingPathComponent(fileName)
-  }
-
-  // storage-api can be eventually-consistent right after an `upload(...)` response returns, so
-  // operations on the just-uploaded object may transiently 500. Retry a few times before failing.
-  @discardableResult
-  private func retryOnTransientStorageError<T>(
-    attempts: Int = 3,
-    delay: Duration = .milliseconds(200),
-    _ operation: () async throws -> T
-  ) async throws -> T {
-    var lastError: (any Error)!
-    for attempt in 0..<attempts {
-      do {
-        return try await operation()
-      } catch let error as StorageError where error.statusCode == "500" {
-        lastError = error
-        if attempt < attempts - 1 {
-          try await Task.sleep(for: delay)
-        }
-      }
-    }
-    throw lastError
   }
 }

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -21,8 +21,11 @@ import Testing
   // `uncheckedUseMainSerialExecutor`) to force deterministic task scheduling within its closure.
   // Swift Testing runs tests in the same suite concurrently by default, so two tests racing to
   // flip that global would interfere with each other — serialize this suite, mirroring the
-  // `_clock`-swap precedent in PostgrestBuilderTests (PR #1095).
-  @Suite(.serialized)
+  // `_clock`-swap precedent in PostgrestBuilderTests (PR #1095). `.mainSerialExecutorSerialized`
+  // additionally prevents this suite from interleaving with any other suite (in this or another
+  // target) that also calls `withMainSerialExecutor`, since `.serialized` alone only serializes a
+  // suite's own tests.
+  @Suite(.serialized, .mainSerialExecutorSerialized)
   final class RealtimeTests: Sendable {
     let url = URL(string: "http://localhost:54321/realtime/v1")!
     let apiKey = "publishable.api.key"


### PR DESCRIPTION
## Summary
Fixes flaky test failures seen in [CI run 30848518055](https://github.com/supabase/supabase-swift/actions/runs/30848518055/job/91802592797?pr=1163) (unrelated to that PR's diff, which was a version-bump-only release-please PR — pure test flake).

Two independent root causes:

- **`fix(realtime)`**: `PushV2.didReceive(status:)` dropped the ack silently if it arrived before `send()` had registered its continuation, forcing that push to wait out the full timeout. Under CI load this lost race often enough to flake `pushWithAck()`. Now buffers an early ack so `send()` picks it up immediately.
- **`test(auth)`**: `RequestsTests`, `AuthOAuthServerTests`, `AuthAdminSignOutTests`, `AuthAdminOAuthTests`, `AuthClientTests`, and `AuthAdminGenerateLinkTests` each grabbed the process-wide `AuthClient.Configuration.jsonEncoder` singleton and mutated its `outputFormatting` in place — an unsynchronized data race under Swift Testing's default parallel execution. Each `makeSUT()` now builds its own encoder instead.

## Test plan
- [x] `swift build` clean
- [x] `swift test` (full suite) — 1052 tests / 98 suites passed
- [x] `swift test --filter AuthTests` × 30 — 30/30 passed
- [x] `swift test --filter _PushTests` × 50 — 50/50 passed
- [x] `./scripts/format.sh` run