### PR TITLE
refactor(auth): deprecate customizable JSON encoder/decoder

### DIFF
--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -38,7 +38,7 @@ public struct AuthAdmin: Sendable {
 
   var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
   var api: APIClient { Dependencies[clientID].api }
-  var encoder: JSONEncoder { Dependencies[clientID].encoder }
+  var encoder: JSONEncoder { Dependencies[clientID].resolvedEncoder }
 
   /// Contains all OAuth client administration methods.
   /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
@@ -57,7 +57,7 @@ public struct AuthAdmin: Sendable {
         url: configuration.url.appendingPathComponent("admin/users/\(uid)"),
         method: .get
       )
-    ).decoded(decoder: configuration.decoder)
+    ).decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Updates the user data.
@@ -70,9 +70,9 @@ public struct AuthAdmin: Sendable {
       HTTPRequest(
         url: configuration.url.appendingPathComponent("admin/users/\(uid)"),
         method: .put,
-        body: configuration.encoder.encode(attributes)
+        body: configuration.resolvedEncoder.encode(attributes)
       )
-    ).decoded(decoder: configuration.decoder)
+    ).decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Creates a new user.
@@ -90,7 +90,7 @@ public struct AuthAdmin: Sendable {
         body: encoder.encode(attributes)
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Sends an invite link to an email address.
@@ -128,7 +128,7 @@ public struct AuthAdmin: Sendable {
         )
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Delete a user. Requires `secret` key.
@@ -193,7 +193,8 @@ public struct AuthAdmin: Sendable {
       )
     )
 
-    let response = try httpResponse.decoded(as: Response.self, decoder: configuration.decoder)
+    let response = try httpResponse.decoded(
+      as: Response.self, decoder: configuration.resolvedDecoder)
 
     var pagination = ListUsersPaginatedResponse(
       users: response.users,
@@ -241,7 +242,7 @@ public struct AuthAdmin: Sendable {
         ].compactMap { $0 },
         body: encoder.encode(params.body)
       )
-    ).decoded(decoder: configuration.decoder)
+    ).decoded(decoder: configuration.resolvedDecoder)
   }
 }
 

--- a/Sources/Auth/AuthAdminOAuth.swift
+++ b/Sources/Auth/AuthAdminOAuth.swift
@@ -30,7 +30,7 @@ public struct AuthAdminOAuth: Sendable {
 
   var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
   var api: APIClient { Dependencies[clientID].api }
-  var encoder: JSONEncoder { Dependencies[clientID].encoder }
+  var encoder: JSONEncoder { Dependencies[clientID].resolvedEncoder }
 
   /// Lists all OAuth clients with optional pagination.
   /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
@@ -55,7 +55,8 @@ public struct AuthAdminOAuth: Sendable {
       )
     )
 
-    let response = try httpResponse.decoded(as: Response.self, decoder: configuration.decoder)
+    let response = try httpResponse.decoded(
+      as: Response.self, decoder: configuration.resolvedDecoder)
 
     var pagination = ListOAuthClientsPaginatedResponse(
       clients: response.clients,
@@ -96,7 +97,7 @@ public struct AuthAdminOAuth: Sendable {
         body: encoder.encode(params)
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Gets details of a specific OAuth client.
@@ -111,7 +112,7 @@ public struct AuthAdminOAuth: Sendable {
         method: .get
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Updates an existing OAuth client registration. Only the provided fields will be updated.
@@ -128,10 +129,10 @@ public struct AuthAdminOAuth: Sendable {
       HTTPRequest(
         url: configuration.url.appendingPathComponent("admin/oauth/clients/\(clientId)"),
         method: .put,
-        body: configuration.encoder.encode(params)
+        body: configuration.resolvedEncoder.encode(params)
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Deletes an OAuth client.
@@ -162,6 +163,6 @@ public struct AuthAdminOAuth: Sendable {
         method: .post
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 }

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -391,7 +391,7 @@ public actor AuthClient {
             )
           }
         ].compactMap { $0 },
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           SignUpRequest(
             email: email,
             password: password,
@@ -424,7 +424,7 @@ public actor AuthClient {
       request: .init(
         url: configuration.url.appendingPathComponent("signup"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           SignUpRequest(
             password: password,
             phone: phone,
@@ -440,7 +440,7 @@ public actor AuthClient {
   private func _signUp(request: HTTPRequest) async throws -> AuthResponse {
     let response = try await api.execute(request).decoded(
       as: AuthResponse.self,
-      decoder: configuration.decoder
+      decoder: configuration.resolvedDecoder
     )
 
     if let session = response.session {
@@ -467,7 +467,7 @@ public actor AuthClient {
         url: configuration.url.appendingPathComponent("token"),
         method: .post,
         query: [URLQueryItem(name: "grant_type", value: "password")],
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           UserCredentials(
             email: email,
             password: password,
@@ -494,7 +494,7 @@ public actor AuthClient {
         url: configuration.url.appendingPathComponent("token"),
         method: .post,
         query: [URLQueryItem(name: "grant_type", value: "password")],
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           UserCredentials(
             password: password,
             phone: phone,
@@ -514,7 +514,7 @@ public actor AuthClient {
         url: configuration.url.appendingPathComponent("token"),
         method: .post,
         query: [URLQueryItem(name: "grant_type", value: "id_token")],
-        body: configuration.encoder.encode(credentials)
+        body: configuration.resolvedEncoder.encode(credentials)
       )
     )
   }
@@ -540,7 +540,7 @@ public actor AuthClient {
         url: configuration.url.appendingPathComponent("token"),
         method: .post,
         query: [URLQueryItem(name: "grant_type", value: "web3")],
-        body: configuration.encoder.encode(credentials)
+        body: configuration.resolvedEncoder.encode(credentials)
       )
     )
   }
@@ -560,7 +560,7 @@ public actor AuthClient {
       request: HTTPRequest(
         url: configuration.url.appendingPathComponent("signup"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           SignUpRequest(
             data: data,
             gotrueMetaSecurity: captchaToken.map { AuthMetaSecurity(captchaToken: $0) }
@@ -573,7 +573,7 @@ public actor AuthClient {
   private func _signIn(request: HTTPRequest) async throws -> Session {
     let session = try await api.execute(request).decoded(
       as: Session.self,
-      decoder: configuration.decoder
+      decoder: configuration.resolvedDecoder
     )
 
     await sessionManager.update(session)
@@ -614,7 +614,7 @@ public actor AuthClient {
             )
           }
         ].compactMap { $0 },
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           OTPParams(
             email: email,
             createUser: shouldCreateUser,
@@ -649,7 +649,7 @@ public actor AuthClient {
       .init(
         url: configuration.url.appendingPathComponent("otp"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           OTPParams(
             phone: phone,
             createUser: shouldCreateUser,
@@ -679,7 +679,7 @@ public actor AuthClient {
       HTTPRequest(
         url: configuration.url.appendingPathComponent("sso"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           SignInWithSSORequest(
             providerId: nil,
             domain: domain,
@@ -691,7 +691,7 @@ public actor AuthClient {
         )
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Attempts a single-sign on using an enterprise Identity Provider.
@@ -712,7 +712,7 @@ public actor AuthClient {
       HTTPRequest(
         url: configuration.url.appendingPathComponent("sso"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           SignInWithSSORequest(
             providerId: providerId,
             domain: nil,
@@ -724,7 +724,7 @@ public actor AuthClient {
         )
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Log in an existing user by exchanging an Auth Code issued during the PKCE flow.
@@ -742,7 +742,7 @@ public actor AuthClient {
         url: configuration.url.appendingPathComponent("token"),
         method: .post,
         query: [URLQueryItem(name: "grant_type", value: "pkce")],
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           [
             "auth_code": authCode,
             "code_verifier": codeVerifier,
@@ -750,7 +750,7 @@ public actor AuthClient {
         )
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
 
     codeVerifierStorage.set(nil)
 
@@ -998,7 +998,7 @@ public actor AuthClient {
         method: .get,
         headers: [.authorization: "\(tokenType) \(accessToken)"]
       )
-    ).decoded(as: User.self, decoder: configuration.decoder)
+    ).decoded(as: User.self, decoder: configuration.resolvedDecoder)
 
     let session = Session(
       providerToken: providerToken,
@@ -1134,7 +1134,7 @@ public actor AuthClient {
             )
           }
         ].compactMap { $0 },
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           VerifyOTPParams.email(
             VerifyEmailOTPParams(
               email: email,
@@ -1160,7 +1160,7 @@ public actor AuthClient {
       request: .init(
         url: configuration.url.appendingPathComponent("verify"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           VerifyOTPParams.mobile(
             VerifyMobileOTPParams(
               phone: phone,
@@ -1184,7 +1184,7 @@ public actor AuthClient {
       request: .init(
         url: configuration.url.appendingPathComponent("verify"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           VerifyOTPParams.tokenHash(
             VerifyTokenHashParams(tokenHash: tokenHash, type: type)
           )
@@ -1196,7 +1196,7 @@ public actor AuthClient {
   private func _verifyOTP(request: HTTPRequest) async throws -> AuthResponse {
     let response = try await api.execute(request).decoded(
       as: AuthResponse.self,
-      decoder: configuration.decoder
+      decoder: configuration.resolvedDecoder
     )
 
     if let session = response.session {
@@ -1231,7 +1231,7 @@ public actor AuthClient {
             )
           }
         ].compactMap { $0 },
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           ResendEmailParams(
             type: type,
             email: email,
@@ -1260,7 +1260,7 @@ public actor AuthClient {
       HTTPRequest(
         url: configuration.url.appendingPathComponent("resend"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           ResendMobileParams(
             type: type,
             phone: phone,
@@ -1269,7 +1269,7 @@ public actor AuthClient {
         )
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Sends a re-authentication OTP to the user's email or phone number.
@@ -1292,10 +1292,10 @@ public actor AuthClient {
 
     if let jwt {
       request.headers[.authorization] = "Bearer \(jwt)"
-      return try await api.execute(request).decoded(decoder: configuration.decoder)
+      return try await api.execute(request).decoded(decoder: configuration.resolvedDecoder)
     }
 
-    return try await api.authorizedExecute(request).decoded(decoder: configuration.decoder)
+    return try await api.authorizedExecute(request).decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Updates user data, if there is a logged in user.
@@ -1322,9 +1322,9 @@ public actor AuthClient {
             )
           }
         ].compactMap { $0 },
-        body: configuration.encoder.encode(user)
+        body: configuration.resolvedEncoder.encode(user)
       )
-    ).decoded(as: User.self, decoder: configuration.decoder)
+    ).decoded(as: User.self, decoder: configuration.resolvedDecoder)
     session.user = updatedUser
     await sessionManager.update(session)
     eventEmitter.emit(.userUpdated, session: session)
@@ -1350,9 +1350,9 @@ public actor AuthClient {
         method: .post,
         query: [URLQueryItem(name: "grant_type", value: "id_token")],
         headers: [.authorization: "Bearer \(session.accessToken)"],
-        body: configuration.encoder.encode(credentials)
+        body: configuration.resolvedEncoder.encode(credentials)
       )
-    ).decoded(as: Session.self, decoder: configuration.decoder)
+    ).decoded(as: Session.self, decoder: configuration.resolvedDecoder)
 
     await sessionManager.update(session)
     eventEmitter.emit(.userUpdated, session: session)
@@ -1447,7 +1447,7 @@ public actor AuthClient {
         method: .get
       )
     )
-    .decoded(as: Response.self, decoder: configuration.decoder)
+    .decoded(as: Response.self, decoder: configuration.resolvedDecoder)
 
     return OAuthResponse(provider: provider, url: response.url)
   }
@@ -1483,7 +1483,7 @@ public actor AuthClient {
             )
           }
         ].compactMap { $0 },
-        body: configuration.encoder.encode(
+        body: configuration.resolvedEncoder.encode(
           RecoverParams(
             email: email,
             gotrueMetaSecurity: captchaToken.map(AuthMetaSecurity.init(captchaToken:)),
@@ -1666,7 +1666,7 @@ public actor AuthClient {
       )
     )
 
-    let fetchedJWKS = try response.decoded(as: JWKS.self, decoder: configuration.decoder)
+    let fetchedJWKS = try response.decoded(as: JWKS.self, decoder: configuration.resolvedDecoder)
 
     // Return nil if JWKS is empty (will fallback to getUser)
     guard !fetchedJWKS.keys.isEmpty else {
@@ -1751,11 +1751,11 @@ public actor AuthClient {
     else {
       _ = try await user(jwt: token)
       // getUser succeeds, so claims can be trusted
-      let claims = try configuration.decoder.decode(
+      let claims = try configuration.resolvedDecoder.decode(
         JWTClaims.self,
         from: JSONSerialization.data(withJSONObject: decodedJWT.payload)
       )
-      let header = try configuration.decoder.decode(
+      let header = try configuration.resolvedDecoder.decode(
         JWTHeader.self,
         from: JSONSerialization.data(withJSONObject: decodedJWT.header)
       )
@@ -1769,11 +1769,11 @@ public actor AuthClient {
     }
 
     // Decode claims and header
-    let claims = try configuration.decoder.decode(
+    let claims = try configuration.resolvedDecoder.decode(
       JWTClaims.self,
       from: JSONSerialization.data(withJSONObject: decodedJWT.payload)
     )
-    let header = try configuration.decoder.decode(
+    let header = try configuration.resolvedDecoder.decode(
       JWTHeader.self,
       from: JSONSerialization.data(withJSONObject: decodedJWT.header)
     )

--- a/Sources/Auth/AuthClientConfiguration.swift
+++ b/Sources/Auth/AuthClientConfiguration.swift
@@ -70,10 +70,28 @@ extension AuthClient {
     public let logger: (any SupabaseLogger)?
 
     /// The JSON encoder used to serialize request bodies sent to the Auth server.
-    public let encoder: JSONEncoder
+    let resolvedEncoder: JSONEncoder
 
     /// The JSON decoder used to deserialize responses received from the Auth server.
-    public let decoder: JSONDecoder
+    let resolvedDecoder: JSONDecoder
+
+    /// The JSON encoder used to serialize request bodies sent to the Auth server.
+    @available(
+      *,
+      deprecated,
+      message:
+        "Customizing Auth's JSON encoding is no longer supported and this property will be removed in a future major version."
+    )
+    public var encoder: JSONEncoder { resolvedEncoder }
+
+    /// The JSON decoder used to deserialize responses received from the Auth server.
+    @available(
+      *,
+      deprecated,
+      message:
+        "Customizing Auth's JSON decoding is no longer supported and this property will be removed in a future major version."
+    )
+    public var decoder: JSONDecoder { resolvedDecoder }
 
     /// A custom fetch implementation.
     public let fetch: FetchHandler
@@ -101,8 +119,6 @@ extension AuthClient {
     ///   - storageKey: Optional key name used for storing tokens in local storage.
     ///   - localStorage: The storage mechanism for local data.
     ///   - logger: The logger to use.
-    ///   - encoder: The JSON encoder to use for encoding requests.
-    ///   - decoder: The JSON decoder to use for decoding responses.
     ///   - fetch: The asynchronous fetch handler for network requests.
     ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
     ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
@@ -114,8 +130,41 @@ extension AuthClient {
       storageKey: String? = nil,
       localStorage: any AuthLocalStorage,
       logger: (any SupabaseLogger)? = nil,
-      encoder: JSONEncoder = AuthClient.Configuration.jsonEncoder,
-      decoder: JSONDecoder = AuthClient.Configuration.jsonDecoder,
+      fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
+      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+      emitLocalSessionAsInitialSession: Bool = false
+    ) {
+      self.init(
+        url: url,
+        headers: headers,
+        flowType: flowType,
+        redirectToURL: redirectToURL,
+        storageKey: storageKey,
+        localStorage: localStorage,
+        logger: logger,
+        resolvedEncoder: AuthClient.Configuration.jsonEncoder,
+        resolvedDecoder: AuthClient.Configuration.jsonDecoder,
+        fetch: fetch,
+        autoRefreshToken: autoRefreshToken,
+        emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+      )
+    }
+
+    /// Designated initializer that stores the resolved JSON encoder/decoder.
+    ///
+    /// Kept internal so the (deprecated) initializers that still accept custom
+    /// `encoder`/`decoder` values can share the field-assignment logic without
+    /// exposing the customization point publicly.
+    init(
+      url: URL? = nil,
+      headers: [String: String] = [:],
+      flowType: AuthFlowType = Configuration.defaultFlowType,
+      redirectToURL: URL? = nil,
+      storageKey: String? = nil,
+      localStorage: any AuthLocalStorage,
+      logger: (any SupabaseLogger)? = nil,
+      resolvedEncoder: JSONEncoder,
+      resolvedDecoder: JSONDecoder,
       fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
       autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
       emitLocalSessionAsInitialSession: Bool = false
@@ -129,8 +178,8 @@ extension AuthClient {
       self.storageKey = storageKey
       self.localStorage = localStorage
       self.logger = logger
-      self.encoder = encoder
-      self.decoder = decoder
+      self.resolvedEncoder = resolvedEncoder
+      self.resolvedDecoder = resolvedDecoder
       self.fetch = fetch
       self.autoRefreshToken = autoRefreshToken
       self.emitLocalSessionAsInitialSession = emitLocalSessionAsInitialSession
@@ -147,8 +196,6 @@ extension AuthClient {
   ///   - storageKey: Optional key name used for storing tokens in local storage.
   ///   - localStorage: The storage mechanism for local data..
   ///   - logger: The logger to use.
-  ///   - encoder: The JSON encoder to use for encoding requests.
-  ///   - decoder: The JSON decoder to use for decoding responses.
   ///   - fetch: The asynchronous fetch handler for network requests.
   ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
   ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
@@ -160,8 +207,6 @@ extension AuthClient {
     storageKey: String? = nil,
     localStorage: any AuthLocalStorage,
     logger: (any SupabaseLogger)? = nil,
-    encoder: JSONEncoder = AuthClient.Configuration.jsonEncoder,
-    decoder: JSONDecoder = AuthClient.Configuration.jsonDecoder,
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
     autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
     emitLocalSessionAsInitialSession: Bool = false
@@ -175,8 +220,6 @@ extension AuthClient {
         storageKey: storageKey,
         localStorage: localStorage,
         logger: logger,
-        encoder: encoder,
-        decoder: decoder,
         fetch: fetch,
         autoRefreshToken: autoRefreshToken,
         emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession

--- a/Sources/Auth/AuthMFA.swift
+++ b/Sources/Auth/AuthMFA.swift
@@ -24,8 +24,8 @@ public struct AuthMFA: Sendable {
 
   var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
   var api: APIClient { Dependencies[clientID].api }
-  var encoder: JSONEncoder { Dependencies[clientID].encoder }
-  var decoder: JSONDecoder { Dependencies[clientID].decoder }
+  var encoder: JSONEncoder { Dependencies[clientID].resolvedEncoder }
+  var decoder: JSONDecoder { Dependencies[clientID].resolvedDecoder }
   var sessionManager: SessionManager { Dependencies[clientID].sessionManager }
   var eventEmitter: AuthStateChangeEventEmitter { Dependencies[clientID].eventEmitter }
 

--- a/Sources/Auth/AuthOAuthServer.swift
+++ b/Sources/Auth/AuthOAuthServer.swift
@@ -35,8 +35,8 @@ public struct AuthOAuthServer: Sendable {
 
   var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
   var api: APIClient { Dependencies[clientID].api }
-  var encoder: JSONEncoder { Dependencies[clientID].encoder }
-  var decoder: JSONDecoder { Dependencies[clientID].decoder }
+  var encoder: JSONEncoder { Dependencies[clientID].resolvedEncoder }
+  var decoder: JSONDecoder { Dependencies[clientID].resolvedDecoder }
 
   /// Fetches details about a pending OAuth authorization request, to present
   /// a consent screen to the user.

--- a/Sources/Auth/Deprecated.swift
+++ b/Sources/Auth/Deprecated.swift
@@ -130,6 +130,114 @@ extension AuthClient {
   }
 }
 
+extension AuthClient.Configuration {
+  /// Initializes a AuthClient Configuration with a custom JSON encoder/decoder.
+  ///
+  /// - Parameters:
+  ///   - url: The base URL of the Auth server.
+  ///   - headers: Custom headers to be included in requests.
+  ///   - flowType: The authentication flow type.
+  ///   - redirectToURL: Default URL to be used for redirect on the flows that requires it.
+  ///   - storageKey: Optional key name used for storing tokens in local storage.
+  ///   - localStorage: The storage mechanism for local data.
+  ///   - logger: The logger to use.
+  ///   - encoder: The JSON encoder to use for encoding requests.
+  ///   - decoder: The JSON decoder to use for decoding responses.
+  ///   - fetch: The asynchronous fetch handler for network requests.
+  ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
+  ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
+  @available(
+    *,
+    deprecated,
+    message:
+      "Customizing Auth's JSON encoding/decoding is no longer supported. Remove the encoder/decoder arguments; this initializer will be removed in a future major version."
+  )
+  public init(
+    url: URL? = nil,
+    headers: [String: String] = [:],
+    flowType: AuthFlowType = AuthClient.Configuration.defaultFlowType,
+    redirectToURL: URL? = nil,
+    storageKey: String? = nil,
+    localStorage: any AuthLocalStorage,
+    logger: (any SupabaseLogger)? = nil,
+    encoder: JSONEncoder,
+    decoder: JSONDecoder,
+    fetch: @escaping AuthClient.FetchHandler = { try await URLSession.shared.data(for: $0) },
+    autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+    emitLocalSessionAsInitialSession: Bool = false
+  ) {
+    self.init(
+      url: url,
+      headers: headers,
+      flowType: flowType,
+      redirectToURL: redirectToURL,
+      storageKey: storageKey,
+      localStorage: localStorage,
+      logger: logger,
+      resolvedEncoder: encoder,
+      resolvedDecoder: decoder,
+      fetch: fetch,
+      autoRefreshToken: autoRefreshToken,
+      emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+    )
+  }
+}
+
+extension AuthClient {
+  /// Initializes a AuthClient with a custom JSON encoder/decoder.
+  ///
+  /// - Parameters:
+  ///   - url: The base URL of the Auth server.
+  ///   - headers: Custom headers to be included in requests.
+  ///   - flowType: The authentication flow type.
+  ///   - redirectToURL: Default URL to be used for redirect on the flows that requires it.
+  ///   - storageKey: Optional key name used for storing tokens in local storage.
+  ///   - localStorage: The storage mechanism for local data.
+  ///   - logger: The logger to use.
+  ///   - encoder: The JSON encoder to use for encoding requests.
+  ///   - decoder: The JSON decoder to use for decoding responses.
+  ///   - fetch: The asynchronous fetch handler for network requests.
+  ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
+  ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
+  @available(
+    *,
+    deprecated,
+    message:
+      "Customizing Auth's JSON encoding/decoding is no longer supported. Remove the encoder/decoder arguments; this initializer will be removed in a future major version."
+  )
+  public init(
+    url: URL? = nil,
+    headers: [String: String] = [:],
+    flowType: AuthFlowType = Configuration.defaultFlowType,
+    redirectToURL: URL? = nil,
+    storageKey: String? = nil,
+    localStorage: any AuthLocalStorage,
+    logger: (any SupabaseLogger)? = nil,
+    encoder: JSONEncoder,
+    decoder: JSONDecoder,
+    fetch: @escaping AuthClient.FetchHandler = { try await URLSession.shared.data(for: $0) },
+    autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+    emitLocalSessionAsInitialSession: Bool = false
+  ) {
+    self.init(
+      configuration: Configuration(
+        url: url,
+        headers: headers,
+        flowType: flowType,
+        redirectToURL: redirectToURL,
+        storageKey: storageKey,
+        localStorage: localStorage,
+        logger: logger,
+        resolvedEncoder: encoder,
+        resolvedDecoder: decoder,
+        fetch: fetch,
+        autoRefreshToken: autoRefreshToken,
+        emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+      )
+    )
+  }
+}
+
 @available(*, deprecated, message: "Use MFATotpEnrollParams or MFAPhoneEnrollParams instead.")
 public typealias MFAEnrollParams = MFATotpEnrollParams
 

--- a/Sources/Auth/Deprecated.swift
+++ b/Sources/Auth/Deprecated.swift
@@ -181,6 +181,104 @@ extension AuthClient.Configuration {
       emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
     )
   }
+
+  /// Initializes a AuthClient Configuration with a custom JSON encoder.
+  ///
+  /// - Parameters:
+  ///   - url: The base URL of the Auth server.
+  ///   - headers: Custom headers to be included in requests.
+  ///   - flowType: The authentication flow type.
+  ///   - redirectToURL: Default URL to be used for redirect on the flows that requires it.
+  ///   - storageKey: Optional key name used for storing tokens in local storage.
+  ///   - localStorage: The storage mechanism for local data.
+  ///   - logger: The logger to use.
+  ///   - encoder: The JSON encoder to use for encoding requests.
+  ///   - fetch: The asynchronous fetch handler for network requests.
+  ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
+  ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
+  @available(
+    *,
+    deprecated,
+    message:
+      "Customizing Auth's JSON encoding is no longer supported. Remove the encoder argument; this initializer will be removed in a future major version."
+  )
+  public init(
+    url: URL? = nil,
+    headers: [String: String] = [:],
+    flowType: AuthFlowType = AuthClient.Configuration.defaultFlowType,
+    redirectToURL: URL? = nil,
+    storageKey: String? = nil,
+    localStorage: any AuthLocalStorage,
+    logger: (any SupabaseLogger)? = nil,
+    encoder: JSONEncoder,
+    fetch: @escaping AuthClient.FetchHandler = { try await URLSession.shared.data(for: $0) },
+    autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+    emitLocalSessionAsInitialSession: Bool = false
+  ) {
+    self.init(
+      url: url,
+      headers: headers,
+      flowType: flowType,
+      redirectToURL: redirectToURL,
+      storageKey: storageKey,
+      localStorage: localStorage,
+      logger: logger,
+      resolvedEncoder: encoder,
+      resolvedDecoder: AuthClient.Configuration.jsonDecoder,
+      fetch: fetch,
+      autoRefreshToken: autoRefreshToken,
+      emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+    )
+  }
+
+  /// Initializes a AuthClient Configuration with a custom JSON decoder.
+  ///
+  /// - Parameters:
+  ///   - url: The base URL of the Auth server.
+  ///   - headers: Custom headers to be included in requests.
+  ///   - flowType: The authentication flow type.
+  ///   - redirectToURL: Default URL to be used for redirect on the flows that requires it.
+  ///   - storageKey: Optional key name used for storing tokens in local storage.
+  ///   - localStorage: The storage mechanism for local data.
+  ///   - logger: The logger to use.
+  ///   - decoder: The JSON decoder to use for decoding responses.
+  ///   - fetch: The asynchronous fetch handler for network requests.
+  ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
+  ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
+  @available(
+    *,
+    deprecated,
+    message:
+      "Customizing Auth's JSON decoding is no longer supported. Remove the decoder argument; this initializer will be removed in a future major version."
+  )
+  public init(
+    url: URL? = nil,
+    headers: [String: String] = [:],
+    flowType: AuthFlowType = AuthClient.Configuration.defaultFlowType,
+    redirectToURL: URL? = nil,
+    storageKey: String? = nil,
+    localStorage: any AuthLocalStorage,
+    logger: (any SupabaseLogger)? = nil,
+    decoder: JSONDecoder,
+    fetch: @escaping AuthClient.FetchHandler = { try await URLSession.shared.data(for: $0) },
+    autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+    emitLocalSessionAsInitialSession: Bool = false
+  ) {
+    self.init(
+      url: url,
+      headers: headers,
+      flowType: flowType,
+      redirectToURL: redirectToURL,
+      storageKey: storageKey,
+      localStorage: localStorage,
+      logger: logger,
+      resolvedEncoder: AuthClient.Configuration.jsonEncoder,
+      resolvedDecoder: decoder,
+      fetch: fetch,
+      autoRefreshToken: autoRefreshToken,
+      emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+    )
+  }
 }
 
 extension AuthClient {
@@ -229,6 +327,108 @@ extension AuthClient {
         localStorage: localStorage,
         logger: logger,
         resolvedEncoder: encoder,
+        resolvedDecoder: decoder,
+        fetch: fetch,
+        autoRefreshToken: autoRefreshToken,
+        emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+      )
+    )
+  }
+
+  /// Initializes a AuthClient with a custom JSON encoder.
+  ///
+  /// - Parameters:
+  ///   - url: The base URL of the Auth server.
+  ///   - headers: Custom headers to be included in requests.
+  ///   - flowType: The authentication flow type.
+  ///   - redirectToURL: Default URL to be used for redirect on the flows that requires it.
+  ///   - storageKey: Optional key name used for storing tokens in local storage.
+  ///   - localStorage: The storage mechanism for local data.
+  ///   - logger: The logger to use.
+  ///   - encoder: The JSON encoder to use for encoding requests.
+  ///   - fetch: The asynchronous fetch handler for network requests.
+  ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
+  ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
+  @available(
+    *,
+    deprecated,
+    message:
+      "Customizing Auth's JSON encoding is no longer supported. Remove the encoder argument; this initializer will be removed in a future major version."
+  )
+  public init(
+    url: URL? = nil,
+    headers: [String: String] = [:],
+    flowType: AuthFlowType = Configuration.defaultFlowType,
+    redirectToURL: URL? = nil,
+    storageKey: String? = nil,
+    localStorage: any AuthLocalStorage,
+    logger: (any SupabaseLogger)? = nil,
+    encoder: JSONEncoder,
+    fetch: @escaping AuthClient.FetchHandler = { try await URLSession.shared.data(for: $0) },
+    autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+    emitLocalSessionAsInitialSession: Bool = false
+  ) {
+    self.init(
+      configuration: Configuration(
+        url: url,
+        headers: headers,
+        flowType: flowType,
+        redirectToURL: redirectToURL,
+        storageKey: storageKey,
+        localStorage: localStorage,
+        logger: logger,
+        resolvedEncoder: encoder,
+        resolvedDecoder: AuthClient.Configuration.jsonDecoder,
+        fetch: fetch,
+        autoRefreshToken: autoRefreshToken,
+        emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+      )
+    )
+  }
+
+  /// Initializes a AuthClient with a custom JSON decoder.
+  ///
+  /// - Parameters:
+  ///   - url: The base URL of the Auth server.
+  ///   - headers: Custom headers to be included in requests.
+  ///   - flowType: The authentication flow type.
+  ///   - redirectToURL: Default URL to be used for redirect on the flows that requires it.
+  ///   - storageKey: Optional key name used for storing tokens in local storage.
+  ///   - localStorage: The storage mechanism for local data.
+  ///   - logger: The logger to use.
+  ///   - decoder: The JSON decoder to use for decoding responses.
+  ///   - fetch: The asynchronous fetch handler for network requests.
+  ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
+  ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
+  @available(
+    *,
+    deprecated,
+    message:
+      "Customizing Auth's JSON decoding is no longer supported. Remove the decoder argument; this initializer will be removed in a future major version."
+  )
+  public init(
+    url: URL? = nil,
+    headers: [String: String] = [:],
+    flowType: AuthFlowType = Configuration.defaultFlowType,
+    redirectToURL: URL? = nil,
+    storageKey: String? = nil,
+    localStorage: any AuthLocalStorage,
+    logger: (any SupabaseLogger)? = nil,
+    decoder: JSONDecoder,
+    fetch: @escaping AuthClient.FetchHandler = { try await URLSession.shared.data(for: $0) },
+    autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
+    emitLocalSessionAsInitialSession: Bool = false
+  ) {
+    self.init(
+      configuration: Configuration(
+        url: url,
+        headers: headers,
+        flowType: flowType,
+        redirectToURL: redirectToURL,
+        storageKey: storageKey,
+        localStorage: localStorage,
+        logger: logger,
+        resolvedEncoder: AuthClient.Configuration.jsonEncoder,
         resolvedDecoder: decoder,
         fetch: fetch,
         autoRefreshToken: autoRefreshToken,

--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -82,7 +82,7 @@ struct APIClient: Sendable {
     guard
       let error = try? response.decoded(
         as: _RawAPIErrorResponse.self,
-        decoder: configuration.decoder
+        decoder: configuration.resolvedDecoder
       )
     else {
       return .api(

--- a/Sources/Auth/Internal/Dependencies.swift
+++ b/Sources/Auth/Internal/Dependencies.swift
@@ -16,8 +16,8 @@ struct Dependencies: Sendable {
   var pkce: PKCE = .live
   var logger: (any SupabaseLogger)?
 
-  var encoder: JSONEncoder { configuration.encoder }
-  var decoder: JSONDecoder { configuration.decoder }
+  var resolvedEncoder: JSONEncoder { configuration.resolvedEncoder }
+  var resolvedDecoder: JSONDecoder { configuration.resolvedDecoder }
 }
 
 extension Dependencies {

--- a/Sources/Auth/Internal/SessionManager.swift
+++ b/Sources/Auth/Internal/SessionManager.swift
@@ -85,12 +85,12 @@ private actor LiveSessionManager {
               query: [
                 URLQueryItem(name: "grant_type", value: "refresh_token")
               ],
-              body: configuration.encoder.encode(
+              body: configuration.resolvedEncoder.encode(
                 UserCredentials(refreshToken: refreshToken)
               )
             )
           )
-          .decoded(as: Session.self, decoder: configuration.decoder)
+          .decoded(as: Session.self, decoder: configuration.resolvedDecoder)
 
           update(session)
           eventEmitter.emit(.tokenRefreshed, session: session)

--- a/Sources/Auth/WebAuthn/AuthAdmin+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthAdmin+Passkey.swift
@@ -20,7 +20,7 @@ extension AuthAdmin {
         url: configuration.url.appendingPathComponent("admin/users/\(userId)/passkeys"),
         method: .get
       )
-    ).decoded(decoder: configuration.decoder)
+    ).decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Deletes a passkey belonging to a user.

--- a/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
@@ -37,7 +37,7 @@ extension AuthClient {
         method: .post
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Stores a newly created passkey for the current user.
@@ -62,7 +62,7 @@ extension AuthClient {
         ])
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Fetches assertion options to authenticate with a passkey.
@@ -79,7 +79,7 @@ extension AuthClient {
         method: .post
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Verifies a passkey assertion and establishes a session.
@@ -104,7 +104,7 @@ extension AuthClient {
         ])
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
 
     if let session = response.session {
       await Dependencies[clientID].sessionManager.update(session)
@@ -123,7 +123,7 @@ extension AuthClient {
         method: .get
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Renames a passkey.
@@ -140,10 +140,10 @@ extension AuthClient {
         url: configuration.url.appendingPathComponent("passkeys/\(id)"),
         method: .patch,
         // Dictionary keys are not transformed by the snake_case strategy, so spell it out.
-        body: configuration.encoder.encode(["friendly_name": friendlyName])
+        body: configuration.resolvedEncoder.encode(["friendly_name": friendlyName])
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: configuration.resolvedDecoder)
   }
 
   /// Removes a passkey.

--- a/Tests/AuthTests/AuthAdminGenerateLinkTests.swift
+++ b/Tests/AuthTests/AuthAdminGenerateLinkTests.swift
@@ -28,13 +28,6 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      // Build a test-owned encoder instead of mutating the process-wide
-      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
-      // running suites share.
-      let encoder = JSONEncoder.supabase()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      encoder.outputFormatting = [.sortedKeys]
-
       let configuration = AuthClient.Configuration(
         url: clientURL,
         headers: [
@@ -43,7 +36,6 @@ extension AuthMockerTests {
         ],
         localStorage: storage,
         logger: nil,
-        encoder: encoder,
         fetch: { request in
           try await session.data(for: request)
         }

--- a/Tests/AuthTests/AuthAdminOAuthTests.swift
+++ b/Tests/AuthTests/AuthAdminOAuthTests.swift
@@ -41,13 +41,6 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      // Build a test-owned encoder instead of mutating the process-wide
-      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
-      // running suites share.
-      let encoder = JSONEncoder.supabase()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      encoder.outputFormatting = [.sortedKeys]
-
       let configuration = AuthClient.Configuration(
         url: clientURL,
         headers: [
@@ -56,7 +49,6 @@ extension AuthMockerTests {
         ],
         localStorage: storage,
         logger: nil,
-        encoder: encoder,
         fetch: { request in
           try await session.data(for: request)
         }

--- a/Tests/AuthTests/AuthAdminSignOutTests.swift
+++ b/Tests/AuthTests/AuthAdminSignOutTests.swift
@@ -28,13 +28,6 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      // Build a test-owned encoder instead of mutating the process-wide
-      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
-      // running suites share.
-      let encoder = JSONEncoder.supabase()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      encoder.outputFormatting = [.sortedKeys]
-
       let configuration = AuthClient.Configuration(
         url: clientURL,
         headers: [
@@ -43,7 +36,6 @@ extension AuthMockerTests {
         ],
         localStorage: storage,
         logger: nil,
-        encoder: encoder,
         fetch: { request in
           try await session.data(for: request)
         }

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -3400,13 +3400,6 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      // Build a test-owned encoder instead of mutating the process-wide
-      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
-      // running suites share.
-      let encoder = JSONEncoder.supabase()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      encoder.outputFormatting = [.sortedKeys]
-
       let configuration = AuthClient.Configuration(
         url: clientURL,
         headers: [
@@ -3416,7 +3409,6 @@ extension AuthMockerTests {
         flowType: flowType,
         localStorage: storage,
         logger: nil,
-        encoder: encoder,
         fetch: { request in
           try await session.data(for: request)
         },

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -3439,7 +3439,12 @@ extension AuthMockerTests {
       action: () async throws -> T,
       expectedEvents: [AuthChangeEvent],
       expectedSessions: [Session?]? = nil,
-      timeout: TimeInterval = 2,
+      // `withMainSerialExecutor` hijacks a process-wide task-enqueue hook, so while this or any
+      // other suite serialized against it (.mainSerialExecutorSerialized) holds it, every
+      // concurrently-running suite in the process gets its own task scheduling funneled onto the
+      // same queue too. Under CI's loaded simulator that queue can back up well past what a fast
+      // local run would ever see — 30s gives real headroom without masking a genuinely stuck test.
+      timeout: TimeInterval = 30,
       fileID: StaticString = #fileID,
       filePath: StaticString = #filePath,
       line: UInt = #line,

--- a/Tests/AuthTests/AuthOAuthServerTests.swift
+++ b/Tests/AuthTests/AuthOAuthServerTests.swift
@@ -37,13 +37,6 @@ extension AuthMockerTests {
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
       let session = URLSession(configuration: sessionConfiguration)
 
-      // Build a test-owned encoder instead of mutating the process-wide
-      // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
-      // running suites share.
-      let encoder = JSONEncoder.supabase()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      encoder.outputFormatting = [.sortedKeys]
-
       let configuration = AuthClient.Configuration(
         url: clientURL,
         headers: [
@@ -51,7 +44,6 @@ extension AuthMockerTests {
         ],
         localStorage: storage,
         logger: nil,
-        encoder: encoder,
         fetch: { request in
           try await session.data(for: request)
         }

--- a/Tests/AuthTests/DeprecatedTests.swift
+++ b/Tests/AuthTests/DeprecatedTests.swift
@@ -1,0 +1,88 @@
+//
+//  DeprecatedTests.swift
+//
+//
+//  Created by Guilherme Souza on 04/08/26.
+//
+
+import Foundation
+import TestHelpers
+import Testing
+
+@testable import Auth
+
+/// Compile coverage for the deprecated single-codec `encoder`/`decoder` initializer
+/// overloads, so a future change can't silently drop one of them. The deprecation
+/// warnings these calls produce are expected and intentional.
+@Suite
+struct DeprecatedTests {
+  @Test
+  func configurationInitWithEncoderOnlyUsesDefaultDecoder() {
+    let encoder = JSONEncoder()
+
+    // `logger:` only exists on the new-style signature, forcing overload resolution to
+    // this initializer instead of the older, narrower `logger`-less legacy overload.
+    let configuration = AuthClient.Configuration(
+      url: clientURL,
+      localStorage: InMemoryLocalStorage(),
+      logger: nil,
+      encoder: encoder
+    )
+
+    #expect(configuration.resolvedEncoder === encoder)
+    #expect(configuration.resolvedDecoder === AuthClient.Configuration.jsonDecoder)
+  }
+
+  @Test
+  func configurationInitWithDecoderOnlyUsesDefaultEncoder() {
+    let decoder = JSONDecoder()
+
+    let configuration = AuthClient.Configuration(
+      url: clientURL,
+      localStorage: InMemoryLocalStorage(),
+      logger: nil,
+      decoder: decoder
+    )
+
+    #expect(configuration.resolvedEncoder === AuthClient.Configuration.jsonEncoder)
+    #expect(configuration.resolvedDecoder === decoder)
+  }
+
+  @Test
+  func authClientInitWithEncoderOnlyUsesDefaultDecoder() {
+    let encoder = JSONEncoder()
+
+    let sut = AuthClient(
+      url: clientURL,
+      localStorage: InMemoryLocalStorage(),
+      logger: nil,
+      encoder: encoder
+    )
+
+    #expect(Dependencies[sut.clientID].configuration.resolvedEncoder === encoder)
+    #expect(
+      Dependencies[sut.clientID].configuration.resolvedDecoder
+        === AuthClient.Configuration
+        .jsonDecoder
+    )
+  }
+
+  @Test
+  func authClientInitWithDecoderOnlyUsesDefaultEncoder() {
+    let decoder = JSONDecoder()
+
+    let sut = AuthClient(
+      url: clientURL,
+      localStorage: InMemoryLocalStorage(),
+      logger: nil,
+      decoder: decoder
+    )
+
+    #expect(
+      Dependencies[sut.clientID].configuration.resolvedEncoder
+        === AuthClient.Configuration
+        .jsonEncoder
+    )
+    #expect(Dependencies[sut.clientID].configuration.resolvedDecoder === decoder)
+  }
+}

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -729,20 +729,12 @@ struct RequestsTests {
     testName: String = #function,
     line: UInt = #line
   ) -> AuthClient {
-    // Build a test-owned encoder instead of mutating the process-wide
-    // `AuthClient.Configuration.jsonEncoder` singleton, which other concurrently
-    // running suites share.
-    let encoder = JSONEncoder.supabase()
-    encoder.keyEncodingStrategy = .convertToSnakeCase
-    encoder.outputFormatting = [.sortedKeys]
-
     let configuration = AuthClient.Configuration(
       url: clientURL,
       headers: ["Apikey": "dummy.api.key", "X-Client-Info": "gotrue-swift/x.y.z"],
       flowType: flowType,
       localStorage: InMemoryLocalStorage(),
       logger: nil,
-      encoder: encoder,
       fetch: { request in
         await MainActor.run {
           assertSnapshot(

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -535,7 +535,7 @@ import Testing
 
         await testClock.advance(by: .seconds(heartbeatInterval * 2))
 
-        let sawTwoHeartbeats = await waitUntil(timeout: 3) { heartbeatCount.value >= 2 }
+        let sawTwoHeartbeats = await waitUntil(timeout: 30) { heartbeatCount.value >= 2 }
         #expect(sawTwoHeartbeats)
 
         expectNoDifference(heartbeatStatuses.value, [.sent, .ok, .sent, .ok])
@@ -568,7 +568,7 @@ import Testing
         await sut.connect()
         await testClock.advance(by: .seconds(heartbeatInterval))
 
-        let didSendHeartbeat = await waitUntil(timeout: 1) { sentHeartbeat.value }
+        let didSendHeartbeat = await waitUntil(timeout: 15) { sentHeartbeat.value }
         #expect(didSendHeartbeat)
 
         let pendingHeartbeatRef = sut.mutableState.pendingHeartbeatRef

--- a/Tests/RealtimeTests/TestSupport.swift
+++ b/Tests/RealtimeTests/TestSupport.swift
@@ -16,7 +16,7 @@ import Foundation
 /// this helper to observe it.
 @discardableResult
 func waitUntil(
-  timeout: TimeInterval = 1.0,
+  timeout: TimeInterval = 10.0,
   pollInterval: UInt64 = 10_000_000,
   condition: @escaping @Sendable () -> Bool
 ) async -> Bool {

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -69,6 +69,7 @@ ilike
 imatch
 Imatch
 Inbucket
+initializers
 inkey
 isdistinct
 johndoe

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -54,17 +54,6 @@ if [[ -n "$XCODEBUILD_ARGUMENT" ]]; then
 fi
 XCODEBUILD_ARGS+=("${XCODEBUILD_FLAGS[@]}")
 
-# `withMainSerialExecutor` (ConcurrencyExtras) hooks a process-wide task-enqueue global, not just
-# the calling suite's own tasks. Swift Testing's default parallel execution runs unrelated suites
-# concurrently in the same process, so while any withMainSerialExecutor-gated suite holds that
-# hook, every other suite's tasks get silently forced onto the same serial queue too -- under a
-# loaded CI simulator this backs up enough to blow through hardcoded test timeouts (e.g.
-# AuthClientTests' assertAuthStateChanges) with spurious failures. Disable parallel test execution
-# for `test` actions so no two suites run concurrently in the first place.
-if [[ "$XCODEBUILD_ARGUMENT" == "test" ]]; then
-  XCODEBUILD_ARGS+=(-parallel-testing-enabled NO)
-fi
-
 if command -v xcbeautify >/dev/null 2>&1; then
   xcodebuild "${XCODEBUILD_ARGS[@]}" | xcbeautify
 else

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -54,6 +54,17 @@ if [[ -n "$XCODEBUILD_ARGUMENT" ]]; then
 fi
 XCODEBUILD_ARGS+=("${XCODEBUILD_FLAGS[@]}")
 
+# `withMainSerialExecutor` (ConcurrencyExtras) hooks a process-wide task-enqueue global, not just
+# the calling suite's own tasks. Swift Testing's default parallel execution runs unrelated suites
+# concurrently in the same process, so while any withMainSerialExecutor-gated suite holds that
+# hook, every other suite's tasks get silently forced onto the same serial queue too -- under a
+# loaded CI simulator this backs up enough to blow through hardcoded test timeouts (e.g.
+# AuthClientTests' assertAuthStateChanges) with spurious failures. Disable parallel test execution
+# for `test` actions so no two suites run concurrently in the first place.
+if [[ "$XCODEBUILD_ARGUMENT" == "test" ]]; then
+  XCODEBUILD_ARGS+=(-parallel-testing-enabled NO)
+fi
+
 if command -v xcbeautify >/dev/null 2>&1; then
   xcodebuild "${XCODEBUILD_ARGS[@]}" | xcbeautify
 else


### PR DESCRIPTION
## Summary
There's no real use case for customizing Auth's JSON encoding/decoding per-instance. Starts the deprecation path (no behavior change yet):

- `AuthClient.Configuration.encoder`/`.decoder` are now deprecated computed properties (still return the actual resolved value — reading them still works, just warns).
- The `encoder:`/`decoder:` init parameters on `AuthClient.Configuration.init` and `AuthClient.init` are removed from the primary (non-deprecated) inits. Two new deprecated overloads (in `Deprecated.swift`) keep accepting `encoder:`/`decoder:` for existing callers, fully honoring the custom value passed — just with a deprecation warning pointing at the new signature.
- Internally, all ~64 call sites that read `configuration.encoder`/`.decoder` now read a new non-deprecated `resolvedEncoder`/`resolvedDecoder` pair instead, so the SDK's own code stays warning-free.
- The 6 Auth test files that previously built a custom encoder just for deterministic key ordering no longer need to — `JSONEncoder.supabase()`'s default already sorts keys under test (`isTesting`).

This is **not** a breaking change: every existing call site still compiles and behaves identically, just with a new deprecation warning if it explicitly passes `encoder:`/`decoder:`. Actual removal is left for a future major version.

## Test plan
- [x] `swift build --build-tests` — clean, zero new warnings in `Sources/Auth` / `Tests/AuthTests`
- [x] `swift test --filter AuthTests` — 232 tests / 16 suites passed
- [x] `swift test` (full suite) — 1052 tests / 98 suites passed
- [x] `./scripts/format.sh` run