### PR TITLE
feat(ci): send Slack alert when CI fails on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,3 +382,58 @@ jobs:
             echo ""
             echo "✅ All CI jobs passed successfully"
           fi
+
+  notify-slack-on-failure:
+    name: Notify Slack on CI failure
+    needs: [ci-success]
+    # release-please (release.yml) only runs after a *successful* CI run on main,
+    # so a red main blocks it silently (no new release PR, no update to the open
+    # one) unless someone happens to look at Actions. Alert instead of relying on that.
+    if: always() && github.ref == 'refs/heads/main' && needs.ci-success.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack alert
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          payload=$(cat <<EOF
+          {
+            "text": "❌ CI failed on main in ${GITHUB_REPO}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": { "type": "plain_text", "text": "❌ CI failed on main", "emoji": true }
+              },
+              {
+                "type": "section",
+                "text": { "type": "mrkdwn", "text": "This blocks release-please from creating/updating the release PR until it's fixed." }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  { "type": "mrkdwn", "text": "*Repository*\n${GITHUB_REPO}" },
+                  { "type": "mrkdwn", "text": "*Actor*\n${GITHUB_ACTOR}" }
+                ]
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": { "type": "plain_text", "text": "View Run" },
+                    "url": "https://github.com/${GITHUB_REPO}/actions/runs/${{ github.run_id }}"
+                  },
+                  {
+                    "type": "button",
+                    "text": { "type": "plain_text", "text": "View Commit" },
+                    "url": "https://github.com/${GITHUB_REPO}/commit/${{ github.sha }}"
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          )
+
+          curl -sf -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_CLIENT_LIBS_WEBHOOK }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
     # release-please (release.yml) only runs after a *successful* CI run on main,
     # so a red main blocks it silently (no new release PR, no update to the open
     # one) unless someone happens to look at Actions. Alert instead of relying on that.
-    if: always() && github.ref == 'refs/heads/main' && needs.ci-success.result == 'failure'
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.ci-success.result == 'failure'
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack alert
@@ -436,4 +436,4 @@ jobs:
           EOF
           )
 
-          curl -sf -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_CLIENT_LIBS_WEBHOOK }}"
+          curl --proto '=https' -sf -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_CLIENT_LIBS_WEBHOOK }}"


### PR DESCRIPTION
## Summary
- Adds a `notify-slack-on-failure` job to `ci.yml` that posts a Slack alert when the `ci-success` gate fails on a push to `main`.
- Reuses `SLACK_CLIENT_LIBS_WEBHOOK`, the same secret name supabase-js uses for its release-notification Slack webhook.

## Why
A CI failure on `main` currently fails silently: `release.yml`'s `release-please` job only runs on a **successful** `CI` workflow_run, so a red main means no new release PR and no update to the currently open one — with no signal to anyone until they check Actions.

Closes [SDK-1389](https://linear.app/supabase/issue/SDK-1389/send-slack-alert-when-supabase-swift-main-branch-ci-fails).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses.
- [ ] Merge and verify the alert fires on the next real CI failure on `main` (or trigger via `workflow_dispatch` + a forced failing step, then revert).