### PR TITLE
fix(auth): remove AuthClient from Dependencies registry on deinit

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -181,6 +181,11 @@ public actor AuthClient {
   nonisolated private var sessionStorage: SessionStorage { Dependencies[clientID].sessionStorage }
   nonisolated private var pkce: PKCE { Dependencies[clientID].pkce }
 
+  #if canImport(ObjectiveC) && canImport(Combine)
+    @MainActor
+    private var appLifecycleCancellables = Set<AnyCancellable>()
+  #endif
+
   /// Returns the session, refreshing it if necessary.
   ///
   /// If no session can be found, a ``AuthError/sessionMissing`` error is thrown.
@@ -243,6 +248,10 @@ public actor AuthClient {
     Task { @MainActor in observeAppLifecycleChanges() }
   }
 
+  deinit {
+    Dependencies.instances.withValue { $0.removeValue(forKey: clientID) }
+  }
+
   #if canImport(ObjectiveC) && canImport(Combine)
     @MainActor
     private func observeAppLifecycleChanges() {
@@ -263,37 +272,23 @@ public actor AuthClient {
       #endif
 
       if let didBecomeActiveNotification, let willResignActiveNotification {
-        var cancellables = Set<AnyCancellable>()
-
         NotificationCenter.default
           .publisher(for: didBecomeActiveNotification)
-          .sink(
-            receiveCompletion: { _ in
-              // hold ref to cancellable until it completes
-              _ = cancellables
-            },
-            receiveValue: { [weak self] _ in
-              Task {
-                await self?.handleDidBecomeActive()
-              }
+          .sink { [weak self] _ in
+            Task {
+              await self?.handleDidBecomeActive()
             }
-          )
-          .store(in: &cancellables)
+          }
+          .store(in: &appLifecycleCancellables)
 
         NotificationCenter.default
           .publisher(for: willResignActiveNotification)
-          .sink(
-            receiveCompletion: { _ in
-              // hold ref to cancellable until it completes
-              _ = cancellables
-            },
-            receiveValue: { [weak self] _ in
-              Task {
-                await self?.handleWillResignActive()
-              }
+          .sink { [weak self] _ in
+            Task {
+              await self?.handleWillResignActive()
             }
-          )
-          .store(in: &cancellables)
+          }
+          .store(in: &appLifecycleCancellables)
       }
 
     }

--- a/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
+++ b/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
@@ -5,6 +5,7 @@
 //  Created by Guilherme Souza on 05/07/24.
 //
 
+import ConcurrencyExtras
 import Foundation
 import TestHelpers
 import Testing

--- a/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
+++ b/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
@@ -47,4 +47,28 @@ struct AuthClientMultipleInstancesTests {
         === client2Storage
     )
   }
+
+  @Test
+  func deinitRemovesDependenciesEntry() async {
+    let url = URL(string: "http://localhost:54321/auth")!
+
+    let clientID: AuthClientID
+    do {
+      let client = AuthClient(
+        configuration: AuthClient.Configuration(
+          url: url,
+          localStorage: InMemoryLocalStorage(),
+          logger: nil
+        )
+      )
+      clientID = client.clientID
+      #expect(Dependencies.instances.value[clientID] != nil)
+    }
+
+    // `init` kicks off a `Task { @MainActor in ... }` that briefly holds a
+    // strong reference to `self`; let it run so `client` can actually deinit.
+    await Task.megaYield()
+
+    #expect(Dependencies.instances.value[clientID] == nil)
+  }
 }

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -468,7 +468,8 @@ struct AuthClientIntegrationTests {
 
     // Should complete without throwing: the admin client is authenticating with
     // the target user's access token, not its own secret key.
-    try await Self.makeClient(serviceRole: true).admin.signOut(jwt: accessToken)
+    let adminClient = Self.makeClient(serviceRole: true)
+    try await adminClient.admin.signOut(jwt: accessToken)
   }
 
   @discardableResult


### PR DESCRIPTION
## Summary

- `AuthClient` registered its `Dependencies` (APIClient, SessionManager, event
  emitter, etc.) in a process-global `Dependencies.instances` dictionary keyed by
  an ever-incrementing `clientID`, but nothing ever removed entries — every
  `AuthClient` leaked for the lifetime of the process. Added a `deinit` that
  removes the entry.
- The app-lifecycle Combine subscriptions (`observeAppLifecycleChanges`) were
  stored in a local `var cancellables` kept alive only via a self-referential
  `receiveCompletion` closure, so they could never be released or cancelled.
  Moved them to an instance property (`appLifecycleCancellables`) so they're
  released deterministically alongside the client.
- Point 2 from the original issue (replacing the global registry with
  instance-stored dependencies) is a bigger architectural change, tracked
  separately in #1175.

Fixes #1174

## Test plan

- [x] Added `deinitRemovesDependenciesEntry` in `AuthClientMultipleInstancesTests`
      verifying the `Dependencies.instances` entry is removed after the client
      deallocates.
- [x] `swift build --target Auth` succeeds under Swift 6 strict concurrency with
      no new warnings.
- [ ] Full `swift test` / CI run (couldn't run Swift Testing locally in this
      sandbox — no Xcode toolchain available).