### PR TITLE
test(auth): keep adminClient alive across awaited signOut in integration test

### DIFF
--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -470,6 +470,7 @@ struct AuthClientIntegrationTests {
     // the target user's access token, not its own secret key.
     let adminClient = Self.makeClient(serviceRole: true)
     try await adminClient.admin.signOut(jwt: accessToken)
+    withExtendedLifetime(adminClient) {}
   }
 
   @discardableResult


### PR DESCRIPTION
## Summary

- Follow-up to #1176. CodeRabbit flagged that `adminSignOut()` created the
  temporary admin `AuthClient` as a local `let` and used it only in the
  expression building the awaited `signOut(jwt:)` call. Since nothing kept a
  strong reference past that point, ARC could release (and deinit) the
  client — removing its `Dependencies` registry entry — while the request
  was still in flight.
- Added `withExtendedLifetime(adminClient) {}` after the awaited call so the
  client is guaranteed to outlive the request.

Addresses https://github.com/supabase/supabase-swift/pull/1176#discussion_r3729811787

## Test plan

- [x] `swift build --target Auth` succeeds.
- [ ] Full `swift test` / CI run (this sandbox has no Xcode toolchain, so
      `IntegrationTests` can't be compiled locally — same limitation noted
      in #1176).