### PR TITLE
fix(postgrest): throw on multi-row result from maybeSingle when throw-on-error is enabled

### DIFF
--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -298,14 +298,16 @@ extension PostgrestError {
   /// than one row.
   ///
   /// PostgREST reports both cases with the same error code; the row count is only distinguishable
-  /// via the `details` message, e.g. "Results contain 0 rows, application/vnd.pgrst.object+json
-  /// requires 1 row".
+  /// via the `details` message. The exact wording has varied across PostgREST versions, e.g.
+  /// "Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row" and "The result
+  /// contains 0 rows". Both mention the matched row count immediately before a "row"/"rows" word,
+  /// so look for that instead of matching a fixed prefix.
   fileprivate var matchedZeroRows: Bool {
-    guard let details,
-      let rangeAfterPrefix = details.range(of: "Results contain "),
-      let rangeOfRowsSuffix = details.range(
-        of: " row", range: rangeAfterPrefix.upperBound..<details.endIndex)
+    guard let details else { return false }
+    let words = details.split(separator: " ")
+    guard let rowsIndex = words.firstIndex(where: { $0.hasPrefix("row") }), rowsIndex > 0,
+      let count = Int(words[rowsIndex - 1])
     else { return false }
-    return details[rangeAfterPrefix.upperBound..<rangeOfRowsSuffix.lowerBound] == "0"
+    return count == 0
   }
 }

--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -243,8 +243,10 @@ public class PostgrestBuilder: @unchecked Sendable {
       }
 
       if let error = try? configuration.decoder.decode(PostgrestError.self, from: response.data) {
-        // `maybeSingle()` turns the "no/too many rows" error (PGRST116) into a `nil` value.
-        if isMaybeSingle, error.code == "PGRST116" {
+        // `maybeSingle()` turns the "no rows" variant of PGRST116 into a `nil` value, but
+        // rethrows the "multiple rows" variant since that indicates a query that should have
+        // been scoped to match at most one row.
+        if isMaybeSingle, error.code == "PGRST116", error.matchedZeroRows {
           let value = try decode(Data("null".utf8))
           return PostgrestResponse(
             data: response.data, response: response.underlyingResponse, value: value)
@@ -289,4 +291,21 @@ extension HTTPField.Name {
   static let acceptProfile = Self("Accept-Profile")!
   static let contentProfile = Self("Content-Profile")!
   static let xRetryCount = Self("X-Retry-Count")!
+}
+
+extension PostgrestError {
+  /// Whether a `PGRST116` error was caused by the query matching zero rows, as opposed to more
+  /// than one row.
+  ///
+  /// PostgREST reports both cases with the same error code; the row count is only distinguishable
+  /// via the `details` message, e.g. "Results contain 0 rows, application/vnd.pgrst.object+json
+  /// requires 1 row".
+  fileprivate var matchedZeroRows: Bool {
+    guard let details,
+      let rangeAfterPrefix = details.range(of: "Results contain "),
+      let rangeOfRowsSuffix = details.range(
+        of: " row", range: rangeAfterPrefix.upperBound..<details.endIndex)
+    else { return false }
+    return details[rangeAfterPrefix.upperBound..<rangeOfRowsSuffix.lowerBound] == "0"
+  }
 }

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -205,13 +205,15 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   /// Instructs PostgREST to return a single JSON object, returning `nil` when no row matches.
   ///
   /// Like ``single()``, this sets the `application/vnd.pgrst.object+json` accept header so the
-  /// server enforces a single result. Unlike ``single()``, when the query does not match exactly
-  /// one row the resulting `PGRST116` error is not thrown — ``PostgrestResponse/value`` is `nil`
-  /// instead. Decode into an optional type to observe the `nil`.
+  /// server enforces a single result. Unlike ``single()``, when the query matches zero rows the
+  /// resulting `PGRST116` error is not thrown — ``PostgrestResponse/value`` is `nil` instead.
+  /// Decode into an optional type to observe the `nil`.
   ///
   /// > Note: PostgREST returns `PGRST116` both when zero rows match and when more than one row
-  /// > matches. This method returns `nil` for either case; use ``single()`` for the strict variant
-  /// > that always throws when the query does not match exactly one row.
+  /// > matches. Only the zero-row case is turned into `nil`; a match of more than one row still
+  /// > throws, since it indicates the query should have been scoped to match at most one row.
+  /// > Use ``single()`` for the strict variant that always throws when the query does not match
+  /// > exactly one row.
   ///
   /// ```swift
   /// let todo: Todo? = try await client

--- a/Tests/PostgRESTTests/PostgrestBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestBuilderTests.swift
@@ -104,6 +104,7 @@ extension PostgrestMockerTests {
             """
             {
               "code": "PGRST116",
+              "details": "Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row",
               "message": "JSON object requested, multiple (or no) rows returned"
             }
             """.utf8
@@ -121,6 +122,40 @@ extension PostgrestMockerTests {
         .value
 
       #expect(user == nil)
+    }
+
+    @Test
+    func maybeSingleThrowsOnMultipleRows() async throws {
+      Mock(
+        url: url.appendingPathComponent("users"),
+        ignoreQuery: true,
+        statusCode: 406,
+        data: [
+          .get: Data(
+            """
+            {
+              "code": "PGRST116",
+              "details": "Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row",
+              "message": "JSON object requested, multiple (or no) rows returned"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .register()
+
+      do {
+        let _: User? =
+          try await sut
+          .from("users")
+          .select()
+          .maybeSingle()
+          .execute()
+          .value
+        Issue.record("Expected error to be thrown")
+      } catch let error as PostgrestError {
+        #expect(error.code == "PGRST116")
+      }
     }
 
     @Test

--- a/Tests/PostgRESTTests/PostgrestBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestBuilderTests.swift
@@ -125,6 +125,37 @@ extension PostgrestMockerTests {
     }
 
     @Test
+    func maybeSingleReturnsNilOnZeroRowsWithNewerPostgrestWording() async throws {
+      Mock(
+        url: url.appendingPathComponent("users"),
+        ignoreQuery: true,
+        statusCode: 406,
+        data: [
+          .get: Data(
+            """
+            {
+              "code": "PGRST116",
+              "details": "The result contains 0 rows",
+              "message": "Cannot coerce the result to a single JSON object"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .register()
+
+      let user: User? =
+        try await sut
+        .from("users")
+        .select()
+        .maybeSingle()
+        .execute()
+        .value
+
+      #expect(user == nil)
+    }
+
+    @Test
     func maybeSingleThrowsOnMultipleRows() async throws {
       Mock(
         url: url.appendingPathComponent("users"),


### PR DESCRIPTION
## What

`maybeSingle()` unconditionally swallowed `PGRST116` ("no/too many rows"), so a query that unexpectedly matched more than one row silently returned `nil` instead of surfacing an error — hiding a real bug where the query should have been scoped to match at most one row.

- Zero rows: still returns `nil` (unchanged)
- More than one row: now throws a `PostgrestError`, matching the behavior of `single()`

PostgREST reports both cases with the same `PGRST116` code; the row count is only distinguishable via the `details` message (`"Results contain N rows, application/vnd.pgrst.object+json requires 1 row"`), so `maybeSingle()` now inspects that to decide whether to swallow or rethrow.

Fixes #1170

## Depends on #1159

This fix relies on `PostgrestError.details` actually decoding from the server response — which it doesn't today on `main` (see #1159: the wire key is `"details"`, but the property/synthesized decoding key was `detail`, so it silently dropped).

The first commit on this branch (`fix(helpers): decode PostgREST error details field`) mirrors #1159's change so this PR is self-contained and testable independently. Once #1159 merges into `main`, rebasing this branch will produce a trivial no-op conflict on that one commit (identical change) — drop it and keep the second commit.

## Verification

- `swift test --filter "PostgRESTTests|HelpersTests"` — 229 tests pass
- `swift package diagnose-api-breaking-changes origin/main` — no breaking changes in any module
- `./scripts/format.sh` — no-op

## Acceptance criteria

- [x] Fix implemented matching the intended `maybeSingle()` behavior
- [x] Unit tests cover zero-row (unchanged), single-row (unchanged), and multi-row (new, throws)
- [x] Doc comments updated
- [x] No breaking changes to existing public API
