### PR TITLE
feat(storage): add vector index and vector data operations (alpha)

### DIFF
--- a/Sources/Storage/StorageVectorsClient.swift
+++ b/Sources/Storage/StorageVectorsClient.swift
@@ -57,7 +57,7 @@ public struct StorageVectorsClient: Sendable {
   /// - Parameter vectorBucketName: The name of the vector bucket to operate on.
   /// - Returns: A ``VectorBucketClient`` configured for the given bucket.
   public func from(_ vectorBucketName: String) -> VectorBucketClient {
-    VectorBucketClient(vectorBucketName: vectorBucketName, configuration: api.configuration)
+    VectorBucketClient(vectorBucketName: vectorBucketName, api: api)
   }
 
   /// Creates a new vector bucket.

--- a/Sources/Storage/StorageVectorsClient.swift
+++ b/Sources/Storage/StorageVectorsClient.swift
@@ -33,12 +33,31 @@ import HTTPTypes
 /// - ``getBucket(_:)``
 /// - ``listBuckets(prefix:maxResults:nextToken:)``
 /// - ``deleteBucket(_:)``
+///
+/// ### Managing indexes and vector data
+///
+/// - ``from(_:)``
 @_spi(Experimental)
 public struct StorageVectorsClient: Sendable {
   private let api: StorageApi
 
   init(api: StorageApi) {
     self.api = api
+  }
+
+  /// Returns a client scoped to the given vector bucket, for managing its indexes and vector data.
+  ///
+  /// ```swift
+  /// let bucket = client.storage.vectors.from("documents")
+  /// try await bucket.createIndex("embeddings", dimension: 1536, distanceMetric: .cosine)
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameter vectorBucketName: The name of the vector bucket to operate on.
+  /// - Returns: A ``VectorBucketClient`` configured for the given bucket.
+  public func from(_ vectorBucketName: String) -> VectorBucketClient {
+    VectorBucketClient(vectorBucketName: vectorBucketName, configuration: api.configuration)
   }
 
   /// Creates a new vector bucket.

--- a/Sources/Storage/VectorBucketClient.swift
+++ b/Sources/Storage/VectorBucketClient.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 06/08/26.
 //
 
-import Foundation
+public import Foundation
 import HTTPTypes
 
 #if canImport(FoundationNetworking)
@@ -372,8 +372,8 @@ public struct VectorIndex: Codable, Sendable, Hashable {
   /// Configuration for which metadata keys are excluded from filtering, if any.
   public var metadataConfiguration: VectorIndexMetadataConfiguration?
 
-  /// Unix timestamp (seconds) of when the index was created, if known.
-  public var creationTime: Int?
+  /// UNIX timestamp (seconds) of when the index was created, if known.
+  public var creationTime: TimeInterval?
 }
 
 /// A summary of a vector index, as returned by
@@ -388,8 +388,8 @@ public struct VectorIndexSummary: Codable, Sendable, Hashable {
   /// The name of the vector bucket this index belongs to.
   public var vectorBucketName: String
 
-  /// Unix timestamp (seconds) of when the index was created, if known.
-  public var creationTime: Int?
+  /// UNIX timestamp (seconds) of when the index was created, if known.
+  public var creationTime: TimeInterval?
 }
 
 /// A page of vector indexes, as returned by

--- a/Sources/Storage/VectorBucketClient.swift
+++ b/Sources/Storage/VectorBucketClient.swift
@@ -1,0 +1,406 @@
+//
+//  VectorBucketClient.swift
+//  Storage
+//
+//  Created by Guilherme Souza on 06/08/26.
+//
+
+import Foundation
+import HTTPTypes
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// A client scoped to a single vector bucket, for managing its indexes and vector data.
+///
+/// Obtain an instance via ``StorageVectorsClient/from(_:)``:
+///
+/// ```swift
+/// let bucket = client.storage.vectors.from("documents")
+/// try await bucket.createIndex("embeddings", dimension: 1536, distanceMetric: .cosine)
+/// let index = bucket.index("embeddings")
+/// ```
+///
+/// - Warning: Vector buckets are a public alpha feature of Supabase Storage and this API is
+///   experimental — it may change in a breaking way, or be unavailable on your project, until it
+///   reaches general availability. Opt in with `@_spi(Experimental) import Supabase`.
+///
+/// ## Topics
+///
+/// ### Managing indexes
+///
+/// - ``createIndex(_:dimension:distanceMetric:dataType:metadataConfiguration:)``
+/// - ``getIndex(_:)``
+/// - ``listIndexes(prefix:maxResults:nextToken:)``
+/// - ``deleteIndex(_:)``
+///
+/// ### Accessing vector data
+///
+/// - ``index(_:)``
+@_spi(Experimental)
+public class VectorBucketClient: StorageApi, @unchecked Sendable {
+  /// The name of the vector bucket this client operates on.
+  public let vectorBucketName: String
+
+  init(vectorBucketName: String, configuration: StorageClientConfiguration) {
+    self.vectorBucketName = vectorBucketName
+    super.init(configuration: configuration)
+  }
+
+  /// Creates a new vector index within this bucket.
+  ///
+  /// ```swift
+  /// try await bucket.createIndex(
+  ///   "embeddings",
+  ///   dimension: 1536,
+  ///   distanceMetric: .cosine,
+  ///   metadataConfiguration: VectorIndexMetadataConfiguration(
+  ///     nonFilterableMetadataKeys: ["raw_text"]
+  ///   )
+  /// )
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameters:
+  ///   - indexName: A unique name for the index within this bucket. 3-63 characters: lowercase
+  ///     letters, numbers, hyphens, and dots, starting and ending with a letter or number.
+  ///   - dimension: The dimensionality of vectors stored in this index (e.g. `1536`).
+  ///   - distanceMetric: The similarity metric used when querying this index.
+  ///   - dataType: The data type of vector components. Defaults to ``VectorDataType/float32``,
+  ///     currently the only supported value.
+  ///   - metadataConfiguration: Configuration for which metadata keys are excluded from filtering.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func createIndex(
+    _ indexName: String,
+    dimension: Int,
+    distanceMetric: VectorDistanceMetric,
+    dataType: VectorDataType = .float32,
+    metadataConfiguration: VectorIndexMetadataConfiguration? = nil
+  ) async throws {
+    try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/CreateIndex"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          CreateIndexBody(
+            vectorBucketName: vectorBucketName,
+            indexName: indexName,
+            dataType: dataType,
+            dimension: dimension,
+            distanceMetric: distanceMetric,
+            metadataConfiguration: metadataConfiguration
+          )
+        )
+      )
+    )
+  }
+
+  /// Retrieves metadata for an existing vector index in this bucket.
+  ///
+  /// ```swift
+  /// let index = try await bucket.getIndex("embeddings")
+  /// print(index.dimension)
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameter indexName: The name of the index to retrieve.
+  /// - Returns: The matching ``VectorIndex``.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func getIndex(_ indexName: String) async throws -> VectorIndex {
+    let response: GetIndexResponseBody = try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/GetIndex"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          VectorBucketIndexNameBody(vectorBucketName: vectorBucketName, indexName: indexName)
+        )
+      )
+    )
+    .decoded(decoder: .supabase())
+    return response.index
+  }
+
+  /// Lists the vector indexes in this bucket, optionally filtered by name prefix.
+  ///
+  /// Results are paginated: pass the ``ListVectorIndexesResponse/nextToken`` of a previous
+  /// response as `nextToken` to fetch the following page.
+  ///
+  /// ```swift
+  /// let page = try await bucket.listIndexes(prefix: "embeddings-")
+  /// for index in page.indexes {
+  ///   print(index.indexName)
+  /// }
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameters:
+  ///   - prefix: Returns only indexes whose name starts with this prefix. Pass `nil` for all
+  ///     indexes.
+  ///   - maxResults: The maximum number of indexes to return in this page.
+  ///   - nextToken: The pagination token from a previous response.
+  /// - Returns: A page of indexes, plus the token for the next page when more results exist.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func listIndexes(
+    prefix: String? = nil,
+    maxResults: Int? = nil,
+    nextToken: String? = nil
+  ) async throws -> ListVectorIndexesResponse {
+    let response: ListIndexesResponseBody = try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/ListIndexes"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          ListIndexesBody(
+            vectorBucketName: vectorBucketName,
+            prefix: prefix,
+            maxResults: maxResults,
+            nextToken: nextToken
+          )
+        )
+      )
+    )
+    .decoded(decoder: .supabase())
+    return ListVectorIndexesResponse(indexes: response.indexes, nextToken: response.nextToken)
+  }
+
+  /// Deletes a vector index and all of its vector data.
+  ///
+  /// ```swift
+  /// try await bucket.deleteIndex("embeddings")
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameter indexName: The name of the index to delete.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func deleteIndex(_ indexName: String) async throws {
+    try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/DeleteIndex"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          VectorBucketIndexNameBody(vectorBucketName: vectorBucketName, indexName: indexName)
+        )
+      )
+    )
+  }
+
+  /// Returns a client scoped to the given index, for reading and writing vector data.
+  ///
+  /// ```swift
+  /// let index = client.storage.vectors.from("documents").index("embeddings")
+  /// try await index.putVectors([
+  ///   VectorEntry(key: "doc-1", data: VectorData(float32: [0.1, 0.2, 0.3]))
+  /// ])
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameter indexName: The name of the index.
+  /// - Returns: A ``VectorIndexClient`` configured for the given index.
+  public func index(_ indexName: String) -> VectorIndexClient {
+    VectorIndexClient(
+      vectorBucketName: vectorBucketName,
+      indexName: indexName,
+      configuration: configuration
+    )
+  }
+}
+
+private struct VectorBucketIndexNameBody: Encodable {
+  var vectorBucketName: String
+  var indexName: String
+}
+
+private struct CreateIndexBody: Encodable {
+  var vectorBucketName: String
+  var indexName: String
+  var dataType: VectorDataType
+  var dimension: Int
+  var distanceMetric: VectorDistanceMetric
+  var metadataConfiguration: VectorIndexMetadataConfiguration?
+}
+
+private struct ListIndexesBody: Encodable {
+  var vectorBucketName: String
+  var prefix: String?
+  var maxResults: Int?
+  var nextToken: String?
+}
+
+private struct GetIndexResponseBody: Decodable {
+  var index: VectorIndex
+}
+
+private struct ListIndexesResponseBody: Decodable {
+  var indexes: [VectorIndexSummary]
+  var nextToken: String?
+}
+
+/// The data type of the components stored in a vector index.
+///
+/// ```swift
+/// try await bucket.createIndex("embeddings", dimension: 1536, distanceMetric: .cosine, dataType: .float32)
+/// ```
+///
+/// ## Topics
+///
+/// ### Predefined data types
+///
+/// - ``float32``
+@_spi(Experimental)
+public struct VectorDataType: RawRepresentable, Hashable, Sendable {
+  /// The raw string value sent to the API.
+  public let rawValue: String
+
+  /// Creates a ``VectorDataType`` from a raw string value.
+  ///
+  /// - Parameter rawValue: The data type string understood by the Storage vectors API.
+  public init(rawValue: String) { self.rawValue = rawValue }
+
+  /// 32-bit floating point vector components. Currently the only supported data type.
+  public static let float32 = VectorDataType(rawValue: "float32")
+}
+
+extension VectorDataType: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) { self.init(rawValue: value) }
+}
+
+extension VectorDataType: Codable {
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.init(rawValue: try container.decode(String.self))
+  }
+}
+
+/// The similarity metric used to rank results when querying a vector index.
+///
+/// ```swift
+/// try await bucket.createIndex("embeddings", dimension: 1536, distanceMetric: .cosine)
+/// ```
+///
+/// ## Topics
+///
+/// ### Predefined metrics
+///
+/// - ``cosine``
+/// - ``euclidean``
+/// - ``dotProduct``
+@_spi(Experimental)
+public struct VectorDistanceMetric: RawRepresentable, Hashable, Sendable {
+  /// The raw string value sent to the API.
+  public let rawValue: String
+
+  /// Creates a ``VectorDistanceMetric`` from a raw string value.
+  ///
+  /// - Parameter rawValue: The distance metric string understood by the Storage vectors API.
+  public init(rawValue: String) { self.rawValue = rawValue }
+
+  /// Cosine similarity.
+  public static let cosine = VectorDistanceMetric(rawValue: "cosine")
+
+  /// Euclidean (L2) distance.
+  public static let euclidean = VectorDistanceMetric(rawValue: "euclidean")
+
+  /// Dot product similarity.
+  ///
+  /// - Note: Support depends on the underlying vector store backend.
+  public static let dotProduct = VectorDistanceMetric(rawValue: "dotproduct")
+}
+
+extension VectorDistanceMetric: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) { self.init(rawValue: value) }
+}
+
+extension VectorDistanceMetric: Codable {
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.init(rawValue: try container.decode(String.self))
+  }
+}
+
+/// Configuration for which metadata keys are excluded from filtering on a vector index.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct VectorIndexMetadataConfiguration: Codable, Sendable, Hashable {
+  /// Metadata keys that can be stored but not used in ``VectorIndexClient`` query filters.
+  public var nonFilterableMetadataKeys: [String]
+
+  /// Creates a ``VectorIndexMetadataConfiguration``.
+  ///
+  /// - Parameter nonFilterableMetadataKeys: Metadata keys to exclude from filtering.
+  public init(nonFilterableMetadataKeys: [String]) {
+    self.nonFilterableMetadataKeys = nonFilterableMetadataKeys
+  }
+}
+
+/// A vector index, as returned by ``VectorBucketClient``.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct VectorIndex: Codable, Sendable, Hashable {
+  /// The name of the index.
+  public var indexName: String
+
+  /// The name of the vector bucket this index belongs to.
+  public var vectorBucketName: String
+
+  /// The data type of the vector components stored in this index.
+  public var dataType: VectorDataType
+
+  /// The dimensionality of vectors stored in this index.
+  public var dimension: Int
+
+  /// The similarity metric used when querying this index.
+  public var distanceMetric: VectorDistanceMetric
+
+  /// Configuration for which metadata keys are excluded from filtering, if any.
+  public var metadataConfiguration: VectorIndexMetadataConfiguration?
+
+  /// Unix timestamp (seconds) of when the index was created, if known.
+  public var creationTime: Int?
+}
+
+/// A summary of a vector index, as returned by
+/// ``VectorBucketClient/listIndexes(prefix:maxResults:nextToken:)``.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct VectorIndexSummary: Codable, Sendable, Hashable {
+  /// The name of the index.
+  public var indexName: String
+
+  /// The name of the vector bucket this index belongs to.
+  public var vectorBucketName: String
+
+  /// Unix timestamp (seconds) of when the index was created, if known.
+  public var creationTime: Int?
+}
+
+/// A page of vector indexes, as returned by
+/// ``VectorBucketClient/listIndexes(prefix:maxResults:nextToken:)``.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct ListVectorIndexesResponse: Sendable {
+  /// The indexes in this page.
+  public var indexes: [VectorIndexSummary]
+
+  /// The pagination token to pass to fetch the next page, or `nil` when there are no more results.
+  public var nextToken: String?
+}

--- a/Sources/Storage/VectorBucketClient.swift
+++ b/Sources/Storage/VectorBucketClient.swift
@@ -39,13 +39,15 @@ import HTTPTypes
 ///
 /// - ``index(_:)``
 @_spi(Experimental)
-public class VectorBucketClient: StorageApi, @unchecked Sendable {
+public struct VectorBucketClient: Sendable {
   /// The name of the vector bucket this client operates on.
   public let vectorBucketName: String
 
-  init(vectorBucketName: String, configuration: StorageClientConfiguration) {
+  private let api: StorageApi
+
+  init(vectorBucketName: String, api: StorageApi) {
     self.vectorBucketName = vectorBucketName
-    super.init(configuration: configuration)
+    self.api = api
   }
 
   /// Creates a new vector index within this bucket.
@@ -79,9 +81,9 @@ public class VectorBucketClient: StorageApi, @unchecked Sendable {
     dataType: VectorDataType = .float32,
     metadataConfiguration: VectorIndexMetadataConfiguration? = nil
   ) async throws {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/CreateIndex"),
+        url: api.configuration.url.appendingPathComponent("vector/CreateIndex"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           CreateIndexBody(
@@ -110,9 +112,9 @@ public class VectorBucketClient: StorageApi, @unchecked Sendable {
   /// - Returns: The matching ``VectorIndex``.
   /// - Throws: ``StorageError`` when the API rejects the request.
   public func getIndex(_ indexName: String) async throws -> VectorIndex {
-    let response: GetIndexResponseBody = try await execute(
+    let response: GetIndexResponseBody = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/GetIndex"),
+        url: api.configuration.url.appendingPathComponent("vector/GetIndex"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           VectorBucketIndexNameBody(vectorBucketName: vectorBucketName, indexName: indexName)
@@ -149,9 +151,9 @@ public class VectorBucketClient: StorageApi, @unchecked Sendable {
     maxResults: Int? = nil,
     nextToken: String? = nil
   ) async throws -> ListVectorIndexesResponse {
-    let response: ListIndexesResponseBody = try await execute(
+    let response: ListIndexesResponseBody = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/ListIndexes"),
+        url: api.configuration.url.appendingPathComponent("vector/ListIndexes"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           ListIndexesBody(
@@ -178,9 +180,9 @@ public class VectorBucketClient: StorageApi, @unchecked Sendable {
   /// - Parameter indexName: The name of the index to delete.
   /// - Throws: ``StorageError`` when the API rejects the request.
   public func deleteIndex(_ indexName: String) async throws {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/DeleteIndex"),
+        url: api.configuration.url.appendingPathComponent("vector/DeleteIndex"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           VectorBucketIndexNameBody(vectorBucketName: vectorBucketName, indexName: indexName)
@@ -206,7 +208,7 @@ public class VectorBucketClient: StorageApi, @unchecked Sendable {
     VectorIndexClient(
       vectorBucketName: vectorBucketName,
       indexName: indexName,
-      configuration: configuration
+      api: api
     )
   }
 }

--- a/Sources/Storage/VectorIndexClient.swift
+++ b/Sources/Storage/VectorIndexClient.swift
@@ -1,0 +1,433 @@
+//
+//  VectorIndexClient.swift
+//  Storage
+//
+//  Created by Guilherme Souza on 06/08/26.
+//
+
+import Foundation
+import HTTPTypes
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// A client scoped to a single vector index, for reading and writing its vector data.
+///
+/// Obtain an instance via ``VectorBucketClient/index(_:)``:
+///
+/// ```swift
+/// let index = client.storage.vectors.from("documents").index("embeddings")
+///
+/// try await index.putVectors([
+///   VectorEntry(key: "doc-1", data: VectorData(float32: [0.1, 0.2, 0.3]), metadata: ["title": "Intro"])
+/// ])
+///
+/// let results = try await index.queryVectors(
+///   VectorData(float32: [0.1, 0.2, 0.3]),
+///   topK: 5,
+///   returnMetadata: true
+/// )
+/// ```
+///
+/// - Warning: Vector buckets are a public alpha feature of Supabase Storage and this API is
+///   experimental — it may change in a breaking way, or be unavailable on your project, until it
+///   reaches general availability. Opt in with `@_spi(Experimental) import Supabase`.
+///
+/// ## Topics
+///
+/// ### Writing vectors
+///
+/// - ``putVectors(_:)``
+/// - ``deleteVectors(keys:)``
+///
+/// ### Reading vectors
+///
+/// - ``getVectors(keys:returnData:returnMetadata:)``
+/// - ``listVectors(maxResults:nextToken:returnData:returnMetadata:segment:)``
+/// - ``queryVectors(_:topK:filter:returnDistance:returnMetadata:)``
+@_spi(Experimental)
+public class VectorIndexClient: StorageApi, @unchecked Sendable {
+  /// The name of the vector bucket containing ``indexName``.
+  public let vectorBucketName: String
+
+  /// The name of the index this client operates on.
+  public let indexName: String
+
+  init(vectorBucketName: String, indexName: String, configuration: StorageClientConfiguration) {
+    self.vectorBucketName = vectorBucketName
+    self.indexName = indexName
+    super.init(configuration: configuration)
+  }
+
+  /// Inserts or updates vectors in this index, in batches of 1-500 entries.
+  ///
+  /// Entries are upserted by ``VectorEntry/key``: an existing vector with the same key is
+  /// replaced.
+  ///
+  /// ```swift
+  /// try await index.putVectors([
+  ///   VectorEntry(
+  ///     key: "doc-1",
+  ///     data: VectorData(float32: [0.1, 0.2, 0.3]),
+  ///     metadata: ["title": "Introduction", "page": 1]
+  ///   )
+  /// ])
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameter vectors: The vectors to insert or update.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func putVectors(_ vectors: [VectorEntry]) async throws {
+    try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/PutVectors"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          PutVectorsBody(
+            vectorBucketName: vectorBucketName,
+            indexName: indexName,
+            vectors: vectors
+          )
+        )
+      )
+    )
+  }
+
+  /// Retrieves vectors by key, in batches of up to 100 keys.
+  ///
+  /// ```swift
+  /// let vectors = try await index.getVectors(keys: ["doc-1", "doc-2"], returnMetadata: true)
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameters:
+  ///   - keys: The keys of the vectors to retrieve.
+  ///   - returnData: Whether to include vector embedding data in the response. Defaults to `false`.
+  ///   - returnMetadata: Whether to include metadata in the response. Defaults to `false`.
+  /// - Returns: The matching vectors, in no particular order.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func getVectors(
+    keys: [String],
+    returnData: Bool = false,
+    returnMetadata: Bool = false
+  ) async throws -> [VectorMatch] {
+    let response: GetVectorsResponseBody = try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/GetVectors"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          GetVectorsBody(
+            vectorBucketName: vectorBucketName,
+            indexName: indexName,
+            keys: keys,
+            returnData: returnData,
+            returnMetadata: returnMetadata
+          )
+        )
+      )
+    )
+    .decoded(decoder: .supabase())
+    return response.vectors
+  }
+
+  /// Lists vectors in this index with pagination.
+  ///
+  /// Results are paginated: pass the ``ListVectorsResponse/nextToken`` of a previous response as
+  /// `nextToken` to fetch the following page. Use `segment` to scan the index in parallel across
+  /// multiple workers.
+  ///
+  /// ```swift
+  /// let page = try await index.listVectors(maxResults: 500, returnMetadata: true)
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameters:
+  ///   - maxResults: The maximum number of vectors to return in this page (up to 1000).
+  ///   - nextToken: The pagination token from a previous response.
+  ///   - returnData: Whether to include vector embedding data in the response. Defaults to `false`.
+  ///   - returnMetadata: Whether to include metadata in the response. Defaults to `false`.
+  ///   - segment: Scans only the given slice of the index, for parallel listing.
+  /// - Returns: A page of vectors, plus the token for the next page when more results exist.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func listVectors(
+    maxResults: Int? = nil,
+    nextToken: String? = nil,
+    returnData: Bool = false,
+    returnMetadata: Bool = false,
+    segment: VectorListSegment? = nil
+  ) async throws -> ListVectorsResponse {
+    let response: ListVectorsResponseBody = try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/ListVectors"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          ListVectorsBody(
+            vectorBucketName: vectorBucketName,
+            indexName: indexName,
+            maxResults: maxResults,
+            nextToken: nextToken,
+            returnData: returnData,
+            returnMetadata: returnMetadata,
+            segmentCount: segment?.count,
+            segmentIndex: segment?.index
+          )
+        )
+      )
+    )
+    .decoded(decoder: .supabase())
+    return ListVectorsResponse(vectors: response.vectors, nextToken: response.nextToken)
+  }
+
+  /// Queries for the vectors most similar to `queryVector` using approximate nearest neighbor
+  /// search.
+  ///
+  /// ```swift
+  /// let results = try await index.queryVectors(
+  ///   VectorData(float32: [0.1, 0.2, 0.3]),
+  ///   topK: 5,
+  ///   filter: ["category": "technical"],
+  ///   returnDistance: true,
+  ///   returnMetadata: true
+  /// )
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameters:
+  ///   - queryVector: The vector to find similar vectors for. Must match the index's dimension.
+  ///   - topK: The number of nearest neighbors to return (up to 100).
+  ///   - filter: A metadata filter expression. Supports field operators (`$eq`, `$ne`, `$gt`,
+  ///     `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`) and logical operators (`$and`, `$or`)
+  ///     with arbitrary nesting, e.g. `["category": "technical"]` or
+  ///     `["price": ["$gte": 10]]`.
+  ///   - returnDistance: Whether to include the similarity distance for each match. Defaults to
+  ///     `false`.
+  ///   - returnMetadata: Whether to include metadata in the response. Defaults to `false`.
+  /// - Returns: The nearest vectors, ordered by ascending distance.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func queryVectors(
+    _ queryVector: VectorData,
+    topK: Int,
+    filter: [String: AnyJSON]? = nil,
+    returnDistance: Bool = false,
+    returnMetadata: Bool = false
+  ) async throws -> QueryVectorsResponse {
+    let response: QueryVectorsResponseBody = try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/QueryVectors"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          QueryVectorsBody(
+            vectorBucketName: vectorBucketName,
+            indexName: indexName,
+            queryVector: queryVector,
+            topK: topK,
+            filter: filter,
+            returnDistance: returnDistance,
+            returnMetadata: returnMetadata
+          )
+        )
+      )
+    )
+    .decoded(decoder: .supabase())
+    return QueryVectorsResponse(vectors: response.vectors, distanceMetric: response.distanceMetric)
+  }
+
+  /// Deletes vectors by key, in batches of up to 500 keys.
+  ///
+  /// ```swift
+  /// try await index.deleteVectors(keys: ["doc-1", "doc-2"])
+  /// ```
+  ///
+  /// - Warning: Experimental. See ``StorageVectorsClient``.
+  ///
+  /// - Parameter keys: The keys of the vectors to delete.
+  /// - Throws: ``StorageError`` when the API rejects the request.
+  public func deleteVectors(keys: [String]) async throws {
+    try await execute(
+      HTTPRequest(
+        url: configuration.url.appendingPathComponent("vector/DeleteVectors"),
+        method: .post,
+        body: JSONEncoder.unconfiguredEncoder.encode(
+          DeleteVectorsBody(vectorBucketName: vectorBucketName, indexName: indexName, keys: keys)
+        )
+      )
+    )
+  }
+}
+
+private struct PutVectorsBody: Encodable {
+  var vectorBucketName: String
+  var indexName: String
+  var vectors: [VectorEntry]
+}
+
+private struct GetVectorsBody: Encodable {
+  var vectorBucketName: String
+  var indexName: String
+  var keys: [String]
+  var returnData: Bool
+  var returnMetadata: Bool
+}
+
+private struct GetVectorsResponseBody: Decodable {
+  var vectors: [VectorMatch]
+}
+
+private struct ListVectorsBody: Encodable {
+  var vectorBucketName: String
+  var indexName: String
+  var maxResults: Int?
+  var nextToken: String?
+  var returnData: Bool
+  var returnMetadata: Bool
+  var segmentCount: Int?
+  var segmentIndex: Int?
+}
+
+private struct ListVectorsResponseBody: Decodable {
+  var vectors: [VectorMatch]
+  var nextToken: String?
+}
+
+private struct QueryVectorsBody: Encodable {
+  var vectorBucketName: String
+  var indexName: String
+  var queryVector: VectorData
+  var topK: Int
+  var filter: [String: AnyJSON]?
+  var returnDistance: Bool
+  var returnMetadata: Bool
+}
+
+private struct QueryVectorsResponseBody: Decodable {
+  var vectors: [VectorMatch]
+  var distanceMetric: VectorDistanceMetric?
+}
+
+private struct DeleteVectorsBody: Encodable {
+  var vectorBucketName: String
+  var indexName: String
+  var keys: [String]
+}
+
+/// A vector embedding, currently always 32-bit floating point components.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct VectorData: Codable, Sendable, Hashable {
+  /// The vector's components.
+  public var float32: [Float]
+
+  /// Creates a ``VectorData`` value.
+  ///
+  /// - Parameter float32: The vector's components. Must match the index's configured dimension.
+  public init(float32: [Float]) {
+    self.float32 = float32
+  }
+}
+
+/// A single vector to insert or update via ``VectorIndexClient/putVectors(_:)``.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct VectorEntry: Codable, Sendable, Hashable {
+  /// A unique identifier for the vector within its index.
+  public var key: String
+
+  /// The vector's embedding data.
+  public var data: VectorData
+
+  /// Arbitrary metadata to store alongside the vector.
+  public var metadata: [String: AnyJSON]?
+
+  /// Creates a ``VectorEntry``.
+  ///
+  /// - Parameters:
+  ///   - key: A unique identifier for the vector within its index.
+  ///   - data: The vector's embedding data.
+  ///   - metadata: Arbitrary metadata to store alongside the vector.
+  public init(key: String, data: VectorData, metadata: [String: AnyJSON]? = nil) {
+    self.key = key
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// A vector returned from ``VectorIndexClient/getVectors(keys:returnData:returnMetadata:)``,
+/// ``VectorIndexClient/listVectors(maxResults:nextToken:returnData:returnMetadata:segment:)``, or
+/// ``VectorIndexClient/queryVectors(_:topK:filter:returnDistance:returnMetadata:)``.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct VectorMatch: Codable, Sendable, Hashable {
+  /// The vector's unique key.
+  public var key: String
+
+  /// The vector's embedding data, present when the request set `returnData: true`.
+  public var data: VectorData?
+
+  /// The vector's metadata, present when the request set `returnMetadata: true`.
+  public var metadata: [String: AnyJSON]?
+
+  /// The similarity distance from the query vector, present when the request set
+  /// `returnDistance: true`. Only populated by
+  /// ``VectorIndexClient/queryVectors(_:topK:filter:returnDistance:returnMetadata:)``.
+  public var distance: Double?
+}
+
+/// A parallel scan segment for
+/// ``VectorIndexClient/listVectors(maxResults:nextToken:returnData:returnMetadata:segment:)``.
+///
+/// Splitting a list operation across `count` segments and listing each `index` concurrently lets
+/// multiple workers scan a large index in parallel.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct VectorListSegment: Sendable, Hashable {
+  /// The total number of parallel segments (1-16).
+  public var count: Int
+
+  /// This segment's zero-based index (`0..<count`).
+  public var index: Int
+
+  /// Creates a ``VectorListSegment``.
+  ///
+  /// - Parameters:
+  ///   - count: The total number of parallel segments (1-16).
+  ///   - index: This segment's zero-based index (`0..<count`).
+  public init(count: Int, index: Int) {
+    self.count = count
+    self.index = index
+  }
+}
+
+/// A page of vectors, as returned by
+/// ``VectorIndexClient/listVectors(maxResults:nextToken:returnData:returnMetadata:segment:)``.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct ListVectorsResponse: Sendable {
+  /// The vectors in this page.
+  public var vectors: [VectorMatch]
+
+  /// The pagination token to pass to fetch the next page, or `nil` when there are no more results.
+  public var nextToken: String?
+}
+
+/// The result of a similarity search, as returned by
+/// ``VectorIndexClient/queryVectors(_:topK:filter:returnDistance:returnMetadata:)``.
+///
+/// - Warning: Experimental. See ``StorageVectorsClient``.
+@_spi(Experimental)
+public struct QueryVectorsResponse: Sendable {
+  /// The nearest vectors, ordered by ascending distance.
+  public var vectors: [VectorMatch]
+
+  /// The distance metric used for the similarity search.
+  public var distanceMetric: VectorDistanceMetric?
+}

--- a/Sources/Storage/VectorIndexClient.swift
+++ b/Sources/Storage/VectorIndexClient.swift
@@ -47,17 +47,19 @@ import HTTPTypes
 /// - ``listVectors(maxResults:nextToken:returnData:returnMetadata:segment:)``
 /// - ``queryVectors(_:topK:filter:returnDistance:returnMetadata:)``
 @_spi(Experimental)
-public class VectorIndexClient: StorageApi, @unchecked Sendable {
+public struct VectorIndexClient: Sendable {
   /// The name of the vector bucket containing ``indexName``.
   public let vectorBucketName: String
 
   /// The name of the index this client operates on.
   public let indexName: String
 
-  init(vectorBucketName: String, indexName: String, configuration: StorageClientConfiguration) {
+  private let api: StorageApi
+
+  init(vectorBucketName: String, indexName: String, api: StorageApi) {
     self.vectorBucketName = vectorBucketName
     self.indexName = indexName
-    super.init(configuration: configuration)
+    self.api = api
   }
 
   /// Inserts or updates vectors in this index, in batches of 1-500 entries.
@@ -80,9 +82,9 @@ public class VectorIndexClient: StorageApi, @unchecked Sendable {
   /// - Parameter vectors: The vectors to insert or update.
   /// - Throws: ``StorageError`` when the API rejects the request.
   public func putVectors(_ vectors: [VectorEntry]) async throws {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/PutVectors"),
+        url: api.configuration.url.appendingPathComponent("vector/PutVectors"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           PutVectorsBody(
@@ -114,9 +116,9 @@ public class VectorIndexClient: StorageApi, @unchecked Sendable {
     returnData: Bool = false,
     returnMetadata: Bool = false
   ) async throws -> [VectorMatch] {
-    let response: GetVectorsResponseBody = try await execute(
+    let response: GetVectorsResponseBody = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/GetVectors"),
+        url: api.configuration.url.appendingPathComponent("vector/GetVectors"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           GetVectorsBody(
@@ -160,9 +162,9 @@ public class VectorIndexClient: StorageApi, @unchecked Sendable {
     returnMetadata: Bool = false,
     segment: VectorListSegment? = nil
   ) async throws -> ListVectorsResponse {
-    let response: ListVectorsResponseBody = try await execute(
+    let response: ListVectorsResponseBody = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/ListVectors"),
+        url: api.configuration.url.appendingPathComponent("vector/ListVectors"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           ListVectorsBody(
@@ -216,9 +218,9 @@ public class VectorIndexClient: StorageApi, @unchecked Sendable {
     returnDistance: Bool = false,
     returnMetadata: Bool = false
   ) async throws -> QueryVectorsResponse {
-    let response: QueryVectorsResponseBody = try await execute(
+    let response: QueryVectorsResponseBody = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/QueryVectors"),
+        url: api.configuration.url.appendingPathComponent("vector/QueryVectors"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           QueryVectorsBody(
@@ -248,9 +250,9 @@ public class VectorIndexClient: StorageApi, @unchecked Sendable {
   /// - Parameter keys: The keys of the vectors to delete.
   /// - Throws: ``StorageError`` when the API rejects the request.
   public func deleteVectors(keys: [String]) async throws {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("vector/DeleteVectors"),
+        url: api.configuration.url.appendingPathComponent("vector/DeleteVectors"),
         method: .post,
         body: JSONEncoder.unconfiguredEncoder.encode(
           DeleteVectorsBody(vectorBucketName: vectorBucketName, indexName: indexName, keys: keys)

--- a/Tests/IntegrationTests/StorageVectorsClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/StorageVectorsClientIntegrationTests.swift
@@ -10,7 +10,7 @@ import InlineSnapshotTesting
 @_spi(Experimental) import Storage
 import Testing
 
-@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil), .serialized)
 struct StorageVectorsClientIntegrationTests {
   let vectors = SupabaseStorageClient(
     configuration: StorageClientConfiguration(

--- a/Tests/IntegrationTests/VectorIndexClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/VectorIndexClientIntegrationTests.swift
@@ -1,0 +1,138 @@
+//
+//  VectorIndexClientIntegrationTests.swift
+//
+//
+//  Created by Guilherme Souza on 06/08/26.
+//
+
+import Foundation
+@_spi(Experimental) import Storage
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+@Suite(.enabled(if: ProcessInfo.processInfo.environment["INTEGRATION_TESTS"] != nil))
+final class VectorIndexClientIntegrationTests {
+  let vectors = SupabaseStorageClient(
+    configuration: StorageClientConfiguration(
+      url: URL(string: "\(DotEnv.SUPABASE_URL)/storage/v1")!,
+      headers: [
+        "Authorization": "Bearer \(DotEnv.SUPABASE_SECRET_KEY)"
+      ],
+      logger: nil
+    )
+  ).vectors
+
+  var bucketName = ""
+
+  init() async throws {
+    bucketName = "test-vector-bucket-\(UUID().uuidString)"
+    try await vectors.createBucket(bucketName)
+  }
+
+  // Async cleanup can outlive the test if the process exits immediately after — acceptable for
+  // local dev/CI cleanup, not correctness-critical.
+  deinit {
+    let vectors = vectors
+    let bucketName = bucketName
+    Task {
+      let bucket = vectors.from(bucketName)
+      if let indexes = try? await bucket.listIndexes() {
+        for index in indexes.indexes {
+          try? await bucket.deleteIndex(index.indexName)
+        }
+      }
+      try? await vectors.deleteBucket(bucketName)
+    }
+  }
+
+  @Test
+  func index_CRUD() async throws {
+    let bucket = vectors.from(bucketName)
+    let indexName = "test-index"
+
+    var page = try await bucket.listIndexes()
+    #expect(!page.indexes.contains { $0.indexName == indexName })
+
+    try await bucket.createIndex(
+      indexName,
+      dimension: 3,
+      distanceMetric: .cosine,
+      metadataConfiguration: VectorIndexMetadataConfiguration(
+        nonFilterableMetadataKeys: ["raw_text"]
+      )
+    )
+
+    let index = try await bucket.getIndex(indexName)
+    #expect(index.indexName == indexName)
+    #expect(index.vectorBucketName == bucketName)
+    #expect(index.dataType == .float32)
+    #expect(index.dimension == 3)
+    #expect(index.distanceMetric == .cosine)
+
+    page = try await bucket.listIndexes()
+    #expect(page.indexes.contains { $0.indexName == indexName })
+
+    try await bucket.deleteIndex(indexName)
+
+    page = try await bucket.listIndexes()
+    #expect(!page.indexes.contains { $0.indexName == indexName })
+  }
+
+  @Test
+  func putGetListDeleteVectors() async throws {
+    let indexName = "test-index"
+    let bucket = vectors.from(bucketName)
+    try await bucket.createIndex(indexName, dimension: 3, distanceMetric: .cosine)
+    let index = bucket.index(indexName)
+
+    try await index.putVectors([
+      VectorEntry(
+        key: "a", data: VectorData(float32: [0.1, 0.2, 0.3]), metadata: ["type": "doc"]),
+      VectorEntry(key: "b", data: VectorData(float32: [0.4, 0.5, 0.6])),
+    ])
+
+    let fetched = try await index.getVectors(
+      keys: ["a", "b"], returnData: true, returnMetadata: true)
+    #expect(fetched.count == 2)
+    let a = try #require(fetched.first { $0.key == "a" })
+    // The pgvector backend stores embeddings as `halfvec` (half precision), so components
+    // round-trip with reduced precision rather than exactly.
+    let aData = try #require(a.data?.float32)
+    for (actual, expected) in zip(aData, [0.1, 0.2, 0.3] as [Float]) {
+      #expect(abs(actual - expected) < 0.001)
+    }
+    #expect(a.metadata?["type"]?.stringValue == "doc")
+
+    let listed = try await index.listVectors(returnData: true)
+    #expect(listed.vectors.map(\.key).sorted() == ["a", "b"])
+
+    try await index.deleteVectors(keys: ["a"])
+
+    let afterDelete = try await index.listVectors()
+    #expect(afterDelete.vectors.map(\.key) == ["b"])
+  }
+
+  @Test
+  func queryVectors() async throws {
+    let indexName = "test-index"
+    let bucket = vectors.from(bucketName)
+    try await bucket.createIndex(indexName, dimension: 2, distanceMetric: .cosine)
+    let index = bucket.index(indexName)
+
+    try await index.putVectors([
+      VectorEntry(key: "close", data: VectorData(float32: [1.0, 0.0])),
+      VectorEntry(key: "far", data: VectorData(float32: [0.0, 1.0])),
+    ])
+
+    let response = try await index.queryVectors(
+      VectorData(float32: [0.9, 0.1]),
+      topK: 2,
+      returnDistance: true
+    )
+    #expect(response.vectors.map(\.key) == ["close", "far"])
+    #expect(response.distanceMetric == .cosine)
+  }
+}

--- a/Tests/StorageTests/VectorBucketClientTests.swift
+++ b/Tests/StorageTests/VectorBucketClientTests.swift
@@ -28,14 +28,16 @@ extension StorageMockerTests {
       let session = URLSession(configuration: configuration)
 
       return StorageVectorsClient(
-        configuration: StorageClientConfiguration(
-          url: url,
-          headers: [:],
-          session: StorageHTTPSession(
-            fetch: { try await session.data(for: $0) },
-            upload: { try await session.upload(for: $0, from: $1) }
-          ),
-          logger: nil
+        api: StorageApi(
+          configuration: StorageClientConfiguration(
+            url: url,
+            headers: [:],
+            session: StorageHTTPSession(
+              fetch: { try await session.data(for: $0) },
+              upload: { try await session.upload(for: $0, from: $1) }
+            ),
+            logger: nil
+          )
         )
       ).from("documents")
     }

--- a/Tests/StorageTests/VectorBucketClientTests.swift
+++ b/Tests/StorageTests/VectorBucketClientTests.swift
@@ -1,0 +1,156 @@
+//
+//  VectorBucketClientTests.swift
+//  Storage
+//
+//  Created by Guilherme Souza on 06/08/26.
+//
+import Foundation
+import Mocker
+import TestHelpers
+import Testing
+
+@_spi(Experimental) @testable import Storage
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension StorageMockerTests {
+  @Suite(.mockerSerialized)
+  struct VectorBucketClientTests {
+    let url = URL(string: "http://localhost:54321/storage/v1")!
+
+    private func makeSUT() -> VectorBucketClient {
+      Mocker.removeAll()
+
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.protocolClasses = [MockingURLProtocol.self]
+      let session = URLSession(configuration: configuration)
+
+      return StorageVectorsClient(
+        configuration: StorageClientConfiguration(
+          url: url,
+          headers: [:],
+          session: StorageHTTPSession(
+            fetch: { try await session.data(for: $0) },
+            upload: { try await session.upload(for: $0, from: $1) }
+          ),
+          logger: nil
+        )
+      ).from("documents")
+    }
+
+    @Test
+    func createIndex() async throws {
+      let bucket = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/CreateIndex"),
+        statusCode: 200,
+        data: [.post: Data()]
+      ).register()
+
+      try await bucket.createIndex(
+        "embeddings",
+        dimension: 1536,
+        distanceMetric: .cosine,
+        metadataConfiguration: VectorIndexMetadataConfiguration(
+          nonFilterableMetadataKeys: ["raw_text"]
+        )
+      )
+    }
+
+    @Test
+    func deleteIndex() async throws {
+      let bucket = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/DeleteIndex"),
+        statusCode: 200,
+        data: [.post: Data()]
+      ).register()
+
+      try await bucket.deleteIndex("embeddings")
+    }
+
+    @Test
+    func getIndexDecodesVectorIndex() async throws {
+      let bucket = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/GetIndex"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {"index":{"indexName":"embeddings","vectorBucketName":"documents","dataType":"float32",\
+            "dimension":1536,"distanceMetric":"cosine","creationTime":1730000000}}
+            """.utf8
+          )
+        ]
+      ).register()
+
+      let index = try await bucket.getIndex("embeddings")
+      #expect(index.indexName == "embeddings")
+      #expect(index.vectorBucketName == "documents")
+      #expect(index.dataType == .float32)
+      #expect(index.dimension == 1536)
+      #expect(index.distanceMetric == .cosine)
+      #expect(index.creationTime == 1_730_000_000)
+    }
+
+    @Test
+    func listIndexesDecodesIndexesAndNextToken() async throws {
+      let bucket = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/ListIndexes"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {"indexes":[{"indexName":"embeddings","vectorBucketName":"documents"},\
+            {"indexName":"summaries","vectorBucketName":"documents"}],"nextToken":"page-2"}
+            """.utf8
+          )
+        ]
+      ).register()
+
+      let response = try await bucket.listIndexes(prefix: "e", maxResults: 2)
+      #expect(response.indexes.map(\.indexName) == ["embeddings", "summaries"])
+      #expect(response.nextToken == "page-2")
+    }
+
+    @Test
+    func indexReturnsScopedClient() {
+      let bucket = makeSUT()
+      let index = bucket.index("embeddings")
+      #expect(index.vectorBucketName == "documents")
+      #expect(index.indexName == "embeddings")
+    }
+
+    @Test
+    func forbiddenThrowsStorageError() async throws {
+      let bucket = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/CreateIndex"),
+        statusCode: 403,
+        data: [
+          .post: Data(
+            """
+            {"code":"403","error":"Unauthorized","message":"new row violates row-level security",\
+            "statusCode":"403"}
+            """.utf8
+          )
+        ]
+      ).register()
+
+      let error = await #expect(throws: StorageError.self) {
+        try await bucket.createIndex("embeddings", dimension: 1536, distanceMetric: .cosine)
+      }
+      #expect(error?.message == "new row violates row-level security")
+      #expect(error?.error == "Unauthorized")
+    }
+  }
+}

--- a/Tests/StorageTests/VectorIndexClientTests.swift
+++ b/Tests/StorageTests/VectorIndexClientTests.swift
@@ -28,14 +28,16 @@ extension StorageMockerTests {
       let session = URLSession(configuration: configuration)
 
       return StorageVectorsClient(
-        configuration: StorageClientConfiguration(
-          url: url,
-          headers: [:],
-          session: StorageHTTPSession(
-            fetch: { try await session.data(for: $0) },
-            upload: { try await session.upload(for: $0, from: $1) }
-          ),
-          logger: nil
+        api: StorageApi(
+          configuration: StorageClientConfiguration(
+            url: url,
+            headers: [:],
+            session: StorageHTTPSession(
+              fetch: { try await session.data(for: $0) },
+              upload: { try await session.upload(for: $0, from: $1) }
+            ),
+            logger: nil
+          )
         )
       ).from("documents").index("embeddings")
     }

--- a/Tests/StorageTests/VectorIndexClientTests.swift
+++ b/Tests/StorageTests/VectorIndexClientTests.swift
@@ -1,0 +1,175 @@
+//
+//  VectorIndexClientTests.swift
+//  Storage
+//
+//  Created by Guilherme Souza on 06/08/26.
+//
+import Foundation
+import Mocker
+import TestHelpers
+import Testing
+
+@_spi(Experimental) @testable import Storage
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension StorageMockerTests {
+  @Suite(.mockerSerialized)
+  struct VectorIndexClientTests {
+    let url = URL(string: "http://localhost:54321/storage/v1")!
+
+    private func makeSUT() -> VectorIndexClient {
+      Mocker.removeAll()
+
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.protocolClasses = [MockingURLProtocol.self]
+      let session = URLSession(configuration: configuration)
+
+      return StorageVectorsClient(
+        configuration: StorageClientConfiguration(
+          url: url,
+          headers: [:],
+          session: StorageHTTPSession(
+            fetch: { try await session.data(for: $0) },
+            upload: { try await session.upload(for: $0, from: $1) }
+          ),
+          logger: nil
+        )
+      ).from("documents").index("embeddings")
+    }
+
+    @Test
+    func putVectors() async throws {
+      let index = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/PutVectors"),
+        statusCode: 200,
+        data: [.post: Data()]
+      ).register()
+
+      try await index.putVectors([
+        VectorEntry(
+          key: "doc-1",
+          data: VectorData(float32: [0.1, 0.2, 0.3]),
+          metadata: ["title": "Introduction"]
+        )
+      ])
+    }
+
+    @Test
+    func deleteVectors() async throws {
+      let index = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/DeleteVectors"),
+        statusCode: 200,
+        data: [.post: Data()]
+      ).register()
+
+      try await index.deleteVectors(keys: ["doc-1", "doc-2"])
+    }
+
+    @Test
+    func getVectorsDecodesVectors() async throws {
+      let index = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/GetVectors"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {"vectors":[{"key":"doc-1","data":{"float32":[0.1,0.2,0.3]},"metadata":{"title":"Intro"}}]}
+            """.utf8
+          )
+        ]
+      ).register()
+
+      let vectors = try await index.getVectors(
+        keys: ["doc-1"], returnData: true, returnMetadata: true)
+      #expect(vectors.count == 1)
+      #expect(vectors[0].key == "doc-1")
+      #expect(vectors[0].data?.float32 == [0.1, 0.2, 0.3])
+      #expect(vectors[0].metadata?["title"]?.stringValue == "Intro")
+    }
+
+    @Test
+    func listVectorsDecodesVectorsAndNextToken() async throws {
+      let index = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/ListVectors"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {"vectors":[{"key":"doc-1"},{"key":"doc-2"}],"nextToken":"page-2"}
+            """.utf8
+          )
+        ]
+      ).register()
+
+      let response = try await index.listVectors(
+        maxResults: 2, segment: VectorListSegment(count: 4, index: 0))
+      #expect(response.vectors.map(\.key) == ["doc-1", "doc-2"])
+      #expect(response.nextToken == "page-2")
+    }
+
+    @Test
+    func queryVectorsDecodesMatchesAndDistanceMetric() async throws {
+      let index = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/QueryVectors"),
+        statusCode: 200,
+        data: [
+          .post: Data(
+            """
+            {"vectors":[{"key":"doc-1","distance":0.12},{"key":"doc-2","distance":0.34}],\
+            "distanceMetric":"cosine"}
+            """.utf8
+          )
+        ]
+      ).register()
+
+      let response = try await index.queryVectors(
+        VectorData(float32: [0.1, 0.2, 0.3]),
+        topK: 5,
+        filter: ["category": "technical"],
+        returnDistance: true
+      )
+      #expect(response.vectors.map(\.key) == ["doc-1", "doc-2"])
+      #expect(response.vectors.map(\.distance) == [0.12, 0.34])
+      #expect(response.distanceMetric == .cosine)
+    }
+
+    @Test
+    func forbiddenThrowsStorageError() async throws {
+      let index = makeSUT()
+
+      Mock(
+        url: url.appendingPathComponent("vector/PutVectors"),
+        statusCode: 403,
+        data: [
+          .post: Data(
+            """
+            {"code":"403","error":"Unauthorized","message":"new row violates row-level security",\
+            "statusCode":"403"}
+            """.utf8
+          )
+        ]
+      ).register()
+
+      let error = await #expect(throws: StorageError.self) {
+        try await index.putVectors([
+          VectorEntry(key: "doc-1", data: VectorData(float32: [0.1]))
+        ])
+      }
+      #expect(error?.message == "new row violates row-level security")
+      #expect(error?.error == "Unauthorized")
+    }
+  }
+}

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -38,10 +38,12 @@ decoratee
 deeplinking
 discardable
 dollarsign
+dotproduct
 dont
 dragarcia
 dummysignature
 ecdsa
+halfvec
 emaillink
 entrancy
 etag
@@ -118,6 +120,7 @@ Passwordless
 Pathable
 PCREDENTIALW
 pgrst
+pgvector
 phfts
 phraseto
 pkce


### PR DESCRIPTION
## Summary

Stacked on #1153. Adds the remaining `storage.vectors` API surface for Supabase Storage's alpha "vector buckets" feature:

- `storage.vectors.from(_:) -> VectorBucketClient` — bucket-scoped index management: `createIndex`, `getIndex`, `listIndexes`, `deleteIndex`.
- `VectorBucketClient.index(_:) -> VectorIndexClient` — index-scoped vector data operations: `putVectors`, `getVectors`, `listVectors`, `queryVectors`, `deleteVectors`.

Implemented by hand on the existing `StorageApi`/`StorageHTTPSession` HTTP stack (no code generation), matching:
- `@supabase/storage-js`'s `VectorBucketApi`/`VectorIndexApi`/`VectorDataApi` for the public API shape (`from(bucket).index(name)` scoping, method names, options).
- The `supabase/storage` backend's route/schema definitions for the exact wire format (`/vector/CreateIndex`, `/vector/PutVectors`, etc.), including response shapes like `GetIndex`'s `{ index: {...} }` wrapper and `QueryVectors`' `{ vectors, distanceMetric }`.

API design notes:
- `VectorDataType` and `VectorDistanceMetric` are open, string-backed structs (`RawRepresentable` + `ExpressibleByStringLiteral`), matching this module's existing `ResizeMode`/`ImageFormat`/`SortOrder` convention — forward-compatible with new server-side values without a client update.
- `metadata` and `filter` use `[String: AnyJSON]`, the module's existing idiom for arbitrary JSON (already used by `FileOptions.metadata`).
- `VectorListSegment` bundles `segmentCount`/`segmentIndex` into one type, since the backend requires both or neither — making the invalid state unrepresentable instead of validating it at the call site.
- `getVectors` returns `[VectorMatch]` directly (no wrapper struct) since the wire response has no pagination or other fields, consistent with `listBuckets() -> [Bucket]` elsewhere in this module.
- `VectorIndex.creationTime`/`VectorIndexSummary.creationTime` are `TimeInterval?`, not `Int?` — same fix as #1153's `VectorBucket.creationTime` (raw UNIX timestamp on the wire, not an ISO8601 string).
- `VectorBucketClient`/`VectorIndexClient` are `struct`s holding a `StorageApi` dependency (composition, matching #1153's `StorageVectorsClient`), not `StorageApi` subclasses. `from(_:)`/`index(_:)` thread that same dependency through each scoping step.

Vector buckets are a public alpha feature upstream; the new API surface is gated behind `@_spi(Experimental)`.

## Test plan

- [x] `swift build`
- [x] `swift test` (full suite)
- [x] Integration tests (`INTEGRATION_TESTS=1 swift test --filter VectorIndexClientIntegrationTests`) run against a local Supabase stack (`supabase start`): index CRUD, put/get/list/delete vectors, and similarity query, all passing against the real pgvector-backed backend.
- [x] `./scripts/format.sh`
- [x] `./scripts/spell-check.sh`
- [x] `./scripts/test-docs.sh`