### PR TITLE
ci: use Blacksmith macOS runners for latest-image jobs

### DIFF
--- a/.github/workflows/api-stability.yml
+++ b/.github/workflows/api-stability.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   api-stability:
     name: API stability check
-    runs-on: macos-15
+    runs-on: blacksmith-6vcpu-macos-15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   macos:
     name: xcodebuild (macOS latest)
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -116,7 +116,7 @@ jobs:
         run: CONFIG=Release PLATFORM="${{ matrix.platform }}" XCODEBUILD_ARGUMENT="${{ matrix.command }}" ./scripts/xcodebuild.sh
 
   spm:
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -200,7 +200,7 @@ jobs:
 
   library-evolution:
     name: Library (evolution)
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -223,7 +223,7 @@ jobs:
 
   examples:
     name: Examples (${{ matrix.scheme }})
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -250,7 +250,7 @@ jobs:
 
   examples-spm:
     name: Examples SPM (${{ matrix.example }})
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -283,7 +283,7 @@ jobs:
 
   docs:
     name: Test docs
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -301,7 +301,7 @@ jobs:
   format-check:
     name: Format check (changed files only)
     if: github.event_name == 'pull_request'
-    runs-on: macos-26
+    runs-on: blacksmith-6vcpu-macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
   macos-legacy:
     name: xcodebuild (legacy)
-    runs-on: macos-15
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- Switch `macos`, `spm`, `library-evolution`, `examples`, `examples-spm`, `docs`, and `format-check` jobs from `macos-26` to `blacksmith-6vcpu-macos-latest`.
- `macos-legacy` (macos-15, Xcode 16.4) and `api-stability.yml` (macos-15) are left on GitHub-hosted runners for now.

Per Blacksmith's docs, their macOS runners "follow the corresponding GitHub-hosted macOS runner images," so the existing `xcode-select -s /Applications/Xcode_26.4.app` steps should resolve without changes — this PR is to confirm that live.

## Test plan
- [ ] CI run on this PR passes on all switched jobs (macos, spm, library-evolution, examples, examples-spm, docs, format-check)
- [ ] `xcode-select` for Xcode 26.4 succeeds on the Blacksmith image
- [ ] Test/coverage step and Coveralls upload still work on the `macos` job
- [ ] Compare job duration vs. previous `macos-26` runs