### PR TITLE
fix(supabase): break retain cycle between SupabaseClient and rest/storage/functions sub-clients

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -188,10 +188,6 @@ public final class SupabaseClient: Sendable {
 
   let mutableState = LockIsolated(MutableState())
 
-  private var session: URLSession {
-    options.global.session
-  }
-
   #if !os(Linux) && !os(Android)
     /// Creates a client with default options.
     /// - Parameters:
@@ -425,41 +421,73 @@ public final class SupabaseClient: Sendable {
     mutableState.listenForAuthEventsTask?.cancel()
   }
 
-  @Sendable
-  private func fetchWithAuth(_ request: URLRequest) async throws -> (Data, URLResponse) {
-    try await session.data(for: adapt(request: request))
-  }
-
-  @Sendable
-  private func uploadWithAuth(
-    _ request: URLRequest,
-    from data: Data
-  ) async throws -> (Data, URLResponse) {
-    try await session.upload(for: adapt(request: request), from: data)
-  }
-
-  private func adapt(request: URLRequest) async -> URLRequest {
-    let token = try? await _getAccessToken()
-
-    var request = TraceContext.inject(into: request)
-    if let token {
-      request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+  /// The `fetch` closure handed to the REST, Storage and Functions sub-clients.
+  ///
+  /// Captures only the dependencies it needs — never `self`. Each sub-client stores this closure
+  /// for its whole lifetime and is itself cached in ``mutableState``, so capturing `self` would
+  /// form a `self -> mutableState -> sub-client -> closure -> self` retain cycle that keeps
+  /// ``deinit`` from ever running.
+  private var fetchWithAuth: @Sendable (_ request: URLRequest) async throws -> (Data, URLResponse) {
+    { [session = options.global.session, adapt = adaptRequest] request in
+      try await session.data(for: adapt(request))
     }
-    return request
+  }
+
+  /// The `upload` closure handed to the Storage sub-client.
+  ///
+  /// Same no-`self`-capture rationale as ``fetchWithAuth``.
+  private var uploadWithAuth:
+    @Sendable (_ request: URLRequest, _ data: Data) async throws -> (Data, URLResponse)
+  {
+    { [session = options.global.session, adapt = adaptRequest] request, data in
+      try await session.upload(for: adapt(request), from: data)
+    }
+  }
+
+  /// Builds a request adapter that injects trace context and the current access token.
+  ///
+  /// The returned closure captures its auth dependencies by value instead of `self`. `AuthClient`
+  /// holds no reference back to ``SupabaseClient``, so no cycle is formed.
+  private var adaptRequest: @Sendable (_ request: URLRequest) async -> URLRequest {
+    { [getAccessToken = accessTokenProvider] request in
+      let token = try? await getAccessToken()
+
+      var request = TraceContext.inject(into: request)
+      if let token {
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+      }
+      return request
+    }
+  }
+
+  /// Resolves the access token to send on outgoing requests, without capturing `self`.
+  private var accessTokenProvider: @Sendable () async throws -> String? {
+    { [accessToken = options.auth.accessToken, auth = _auth] in
+      if let accessToken {
+        try await accessToken()
+      } else {
+        try await auth.session.accessToken
+      }
+    }
   }
 
   private func _getAccessToken() async throws -> String? {
-    if let accessToken = options.auth.accessToken {
-      try await accessToken()
-    } else {
-      try await auth.session.accessToken
-    }
+    try await accessTokenProvider()
   }
 
   private func listenForAuthEvents() {
-    let task = Task {
-      for await (event, session) in auth.authStateChanges {
-        await handleTokenChanged(event: event, session: session)
+    // Grab the stream up front so the task doesn't need to capture `self` just to reach `auth`.
+    // `authStateChanges` never finishes on its own, so a strong `self` capture here would keep
+    // the client alive forever and `deinit` — the only place that cancels this task — would
+    // never run.
+    let authStateChanges = auth.authStateChanges
+
+    let task = Task { [weak self] in
+      for await (event, session) in authStateChanges {
+        // `handleTokenChanged` needs a live client; once it's gone there is nothing left to
+        // update, so stop observing.
+        guard let self else { return }
+        await self.handleTokenChanged(event: event, session: session)
       }
     }
     mutableState.withValue {

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -296,4 +296,33 @@ struct SupabaseClientTests {
     #expect(client.functions.headers.dictionary["Authorization"] == "Bearer legacy-jwt-key")
     #expect(client.functions.headers.dictionary["Apikey"] == "legacy-jwt-key")
   }
+
+  @Test
+  func clientIsDeallocatedAfterSubClientsAreCreated() {
+    weak var weakClient: SupabaseClient?
+
+    do {
+      let client = SupabaseClient(
+        supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+        supabaseKey: "PUBLISHABLE_KEY",
+        options: SupabaseClientOptions(
+          auth: SupabaseClientOptions.AuthOptions(
+            storage: AuthLocalStorageMock(),
+            autoRefreshToken: false
+          )
+        )
+      )
+      weakClient = client
+
+      // Force lazy initialization of every sub-client that receives a `fetch`/`upload` closure.
+      _ = client.rest
+      _ = client.storage
+      _ = client.functions
+    }
+
+    #expect(
+      weakClient == nil,
+      "SupabaseClient should not be retained by its own rest/storage/functions sub-clients"
+    )
+  }
 }


### PR DESCRIPTION
## The bug

`SupabaseClient.rest`, `.storage` and `.functions` were constructed with `fetch: fetchWithAuth` / `upload: uploadWithAuth` — bare references to `SupabaseClient` instance methods. A bare instance-method reference produces a closure that strongly captures `self`.

Each sub-client (`PostgrestClient`, `SupabaseStorageClient`, `FunctionsClient`) stores that closure for its whole lifetime, and each sub-client is itself cached in `self.mutableState`:

```
self -> mutableState -> {rest, storage, functions} -> closure -> self
```

`deinit` could therefore never run. The client, its `AuthClient`, and the auth-event observation task leaked for the lifetime of the process — including the `listenForAuthEventsTask?.cancel()` that `deinit` is supposed to perform.

`listenForAuthEvents()` had the same problem independently: its `Task` captured `self` strongly while being stored on `self`, and `auth.authStateChanges` never finishes on its own.

## The fix

`fetchWithAuth` / `uploadWithAuth` are now computed properties returning closures that capture only the dependencies they need — the global `URLSession`, the configured `accessToken` provider, and `_auth` — instead of `self`. This mirrors the existing `_initRealtimeClient()` style in the same file, which already captures `[session = options.global.session]` and `[weak self]`.

Token resolution moved into an `accessTokenProvider` closure that captures `options.auth.accessToken` and `_auth` by value. `AuthClient` holds no reference back to `SupabaseClient`, so no cycle is formed and **auth token injection behavior is unchanged** — the third-party `accessToken` closure still takes priority, and `auth.session.accessToken` is still used otherwise.

`listenForAuthEvents()` now grabs the stream up front and captures `self` weakly, returning from the loop once the client is gone.

No public API signatures changed. Call sites (`fetch: fetchWithAuth`, `StorageHTTPSession(fetch:upload:)`) are untouched.

The now-unused `private var session` helper was removed.

## Test plan

New regression test `clientIsDeallocatedAfterSubClientsAreCreated()` in `Tests/SupabaseTests/SupabaseClientTests.swift`: constructs a `SupabaseClient` in a narrower scope, forces lazy init of `.rest`, `.storage` and `.functions`, holds a `weak var weakClient`, and asserts `weakClient == nil` after the scope exits.

Verified the test genuinely catches the regression — with the `SupabaseClient.swift` change stashed it fails:

```
✘ Test clientIsDeallocatedAfterSubClientsAreCreated() recorded an issue:
  Expectation failed: (weakClient → Supabase.SupabaseClient) == nil
  ↳ SupabaseClient should not be retained by its own rest/storage/functions sub-clients
```

- `swift build` → Build complete
- `swift test --filter SupabaseTests` → 12 tests in 2 suites passed
- `swift test` (full suite) → 1084 tests in 104 suites passed
- `./scripts/format.sh` run

Closes #1186