### PR TITLE
fix(supabase): break retain cycles that prevented SupabaseClient from ever deallocating

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -188,10 +188,6 @@ public final class SupabaseClient: Sendable {
 
   let mutableState = LockIsolated(MutableState())
 
-  private var session: URLSession {
-    options.global.session
-  }
-
   #if !os(Linux) && !os(Android)
     /// Creates a client with default options.
     /// - Parameters:
@@ -425,41 +421,72 @@ public final class SupabaseClient: Sendable {
     mutableState.listenForAuthEventsTask?.cancel()
   }
 
-  @Sendable
-  private func fetchWithAuth(_ request: URLRequest) async throws -> (Data, URLResponse) {
-    try await session.data(for: adapt(request: request))
-  }
-
-  @Sendable
-  private func uploadWithAuth(
-    _ request: URLRequest,
-    from data: Data
-  ) async throws -> (Data, URLResponse) {
-    try await session.upload(for: adapt(request: request), from: data)
-  }
-
-  private func adapt(request: URLRequest) async -> URLRequest {
-    let token = try? await _getAccessToken()
-
-    var request = TraceContext.inject(into: request)
-    if let token {
-      request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+  /// A `fetch` closure handed to the REST, Storage and Functions sub-clients.
+  ///
+  /// Captures only the dependencies it needs — never `self` — because each sub-client stores this
+  /// closure for its whole lifetime while being cached in ``mutableState``. Capturing `self` here
+  /// would form a `self -> mutableState -> sub-client -> closure -> self` retain cycle that keeps
+  /// ``deinit`` from ever running.
+  private var fetchWithAuth: @Sendable (_ request: URLRequest) async throws -> (Data, URLResponse) {
+    { [session = options.global.session, adapt = adaptRequest] request in
+      try await session.data(for: adapt(request))
     }
-    return request
+  }
+
+  /// An `upload` closure handed to the Storage sub-client.
+  ///
+  /// Same no-`self`-capture rationale as ``fetchWithAuth``.
+  private var uploadWithAuth:
+    @Sendable (_ request: URLRequest, _ data: Data) async throws -> (Data, URLResponse)
+  {
+    { [session = options.global.session, adapt = adaptRequest] request, data in
+      try await session.upload(for: adapt(request), from: data)
+    }
+  }
+
+  /// Builds a request adapter that injects trace context and the current access token.
+  ///
+  /// The returned closure captures the auth dependencies by value instead of `self`. `AuthClient`
+  /// holds no reference back to ``SupabaseClient``, so no cycle is formed.
+  private var adaptRequest: @Sendable (_ request: URLRequest) async -> URLRequest {
+    { [getAccessToken = accessTokenProvider] request in
+      let token = try? await getAccessToken()
+
+      var request = TraceContext.inject(into: request)
+      if let token {
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+      }
+      return request
+    }
+  }
+
+  /// Resolves the access token to send on outgoing requests, without capturing `self`.
+  private var accessTokenProvider: @Sendable () async throws -> String? {
+    { [accessToken = options.auth.accessToken, auth = _auth] in
+      if let accessToken {
+        try await accessToken()
+      } else {
+        try await auth.session.accessToken
+      }
+    }
   }
 
   private func _getAccessToken() async throws -> String? {
-    if let accessToken = options.auth.accessToken {
-      try await accessToken()
-    } else {
-      try await auth.session.accessToken
-    }
+    try await accessTokenProvider()
   }
 
+  /// Mirrors Auth state onto the Functions and Realtime sub-clients for the client's lifetime.
+  ///
+  /// `authStateChanges` never finishes on its own, so the observing task must not capture `self`
+  /// strongly: it would keep the client alive forever, and ``deinit`` — the only place that
+  /// cancels this task — could never run. The stream is therefore resolved up front (so the task
+  /// doesn't need `self` to reach `auth`) and `self` is captured weakly.
   private func listenForAuthEvents() {
-    let task = Task {
-      for await (event, session) in auth.authStateChanges {
-        await handleTokenChanged(event: event, session: session)
+    let task = Task { [weak self, authStateChanges = _auth.authStateChanges] in
+      for await (event, session) in authStateChanges {
+        // `handleTokenChanged` needs a live client; once it's gone there is nothing to update.
+        guard let self else { return }
+        await self.handleTokenChanged(event: event, session: session)
       }
     }
     mutableState.withValue {

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -274,6 +274,81 @@ struct SupabaseClientTests {
   }
 
   @Test
+  func listenForAuthEventsTaskDoesNotRetainClient() async {
+    final class WeakBox: @unchecked Sendable {
+      weak var client: SupabaseClient?
+    }
+    let box = WeakBox()
+
+    // Narrow scope so ARC drops the last strong reference when it returns.
+    func scope() {
+      let client = SupabaseClient(
+        supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+        supabaseKey: "PUBLISHABLE_KEY",
+        options: SupabaseClientOptions(
+          auth: SupabaseClientOptions.AuthOptions(
+            storage: AuthLocalStorageMock(),
+            autoRefreshToken: false
+          )
+        )
+      )
+      box.client = client
+
+      #expect(
+        client.mutableState.listenForAuthEventsTask != nil,
+        "test precondition: client should be listening for internal auth events"
+      )
+    }
+    scope()
+
+    // Let the auth-state-change plumbing drain before asserting.
+    await Task.megaYield()
+
+    #expect(
+      box.client == nil,
+      "SupabaseClient leaked: the listenForAuthEvents task retained self, preventing deinit."
+    )
+  }
+
+  @Test
+  func subClientsDoNotRetainClient() async {
+    final class WeakBox: @unchecked Sendable {
+      weak var client: SupabaseClient?
+    }
+    let box = WeakBox()
+
+    // Narrow scope so ARC drops the last strong reference when it returns.
+    func scope() {
+      let client = SupabaseClient(
+        supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+        supabaseKey: "PUBLISHABLE_KEY",
+        options: SupabaseClientOptions(
+          auth: SupabaseClientOptions.AuthOptions(
+            storage: AuthLocalStorageMock(),
+            autoRefreshToken: false
+          )
+        )
+      )
+      box.client = client
+
+      // Materialize every lazily-built sub-client: each one caches the `fetch`/`upload` closures
+      // in `mutableState`, so a `self` capture there would form a retain cycle.
+      _ = client.rest
+      _ = client.storage
+      _ = client.functions
+      _ = client.realtimeV2
+    }
+    scope()
+
+    await Task.megaYield()
+
+    #expect(
+      box.client == nil,
+      "SupabaseClient leaked: a cached sub-client retained self, preventing deinit."
+    )
+  }
+
+  @Test
   func functionsOmitsAuthorizationBearerForNewFormatKey() {
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,


### PR DESCRIPTION
## The bug

`SupabaseClient.init` calls `listenForAuthEvents()` whenever `options.auth.accessToken == nil` — the default and by far the most common configuration.

```swift
private func listenForAuthEvents() {
  let task = Task {
    for await (event, session) in auth.authStateChanges {
      await handleTokenChanged(event: event, session: session)  // implicit strong `self`
    }
  }
  mutableState.withValue { $0.listenForAuthEventsTask = task }
}
```

Calling the instance method `handleTokenChanged` captures `self` strongly, and `auth.authStateChanges` is a stream that never finishes while the client is alive, so the task holds that reference forever.

`deinit` tries to break the cycle by cancelling the task:

```swift
deinit {
  mutableState.listenForAuthEventsTask?.cancel()
}
```

but `deinit` only runs once the retain count hits zero, which the task itself prevents. The result is a deadlock: **every `SupabaseClient` created without a static `accessToken` leaks for the life of the process.** (#1187)

While verifying the client was actually deallocable, an identical pattern turned up on the cached sub-clients (#1186): `rest`, `storage` and `functions` were constructed with the `fetchWithAuth` / `uploadWithAuth` *method references*, which capture `self`, and each sub-client is then cached in `mutableState` — forming `self -> mutableState -> sub-client -> closure -> self`. Fixing only the auth-events task would still leave every client that ever touched `.storage`, `.functions`, `.from(...)` etc. leaking.

## The fix

The auth-events stream is now resolved *before* the task starts, so the task doesn't need `self` just to reach `auth`, and `self` is captured weakly:

```swift
let task = Task { [weak self, authStateChanges = _auth.authStateChanges] in
  for await (event, session) in authStateChanges {
    guard let self else { return }
    await self.handleTokenChanged(event: event, session: session)
  }
}
```

`handleTokenChanged` genuinely needs a live client (it touches `mutableState`, `functions`, `realtime` and `realtimeV2`), so each iteration re-acquires it and the loop simply exits once the client is gone. Behavior for a live client is unchanged. Once the client deallocates, `deinit` cancels the task, which terminates the stream and removes the underlying auth listener.

`fetchWithAuth`/`uploadWithAuth` are now closures capturing only the dependencies they need (the `URLSession` and an access-token provider that holds `AuthClient`, which has no reference back to `SupabaseClient`) instead of bare method references. No API or behavior change — `_getAccessToken()` resolves the token exactly as before, including the `options.auth.accessToken` precedence and `traceparent` injection.

## Test plan

Two regression tests added to `Tests/SupabaseTests/SupabaseClientTests.swift`, both building a client with default (non-`accessToken`) options inside a nested function so ARC drops the last strong reference on return, then asserting a `weak` reference is `nil`:

- `listenForAuthEventsTaskDoesNotRetainClient()` — asserts the client is listening for auth events, then that it deallocates.
- `subClientsDoNotRetainClient()` — materializes `rest`, `storage`, `functions` and `realtimeV2` first, then asserts it deallocates.

Both were confirmed to **fail before** the corresponding fix and pass after:

```
✘ Test listenForAuthEventsTaskDoesNotRetainClient() recorded an issue at SupabaseClientTests.swift:307:5:
  Expectation failed: (box.client → Supabase.SupabaseClient) == nil
↳ SupabaseClient leaked: the listenForAuthEvents task retained self, preventing deinit.
```

Verification on this branch:

- `swift build` — Build complete
- `swift test --filter SupabaseTests` — 13 tests in 2 suites passed
- `swift test --skip IntegrationTests` — 941 tests in 92 suites passed (9 pre-existing known issues)
- `./scripts/format.sh` — clean

Closes #1186
Closes #1187