### PR TITLE
fix(auth): stop auto-refresh task on AuthClient deinit

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -249,7 +249,16 @@ public actor AuthClient {
   }
 
   deinit {
+    // Grab the session manager before dropping the dependencies entry, and capture only it in the
+    // task below, capturing `self` would resurrect this client while it is being deallocated.
+    let sessionManager = Dependencies.instances.value[clientID]?.sessionManager
+
     Dependencies.instances.withValue { $0.removeValue(forKey: clientID) }
+
+    // The auto-refresh loop retains the session manager, so it keeps ticking forever unless it is
+    // explicitly stopped. `observeAppLifecycleChanges()` only stops it when the app resigns active,
+    // which never happens for short-lived clients, or when auto-refresh was started manually.
+    Task { await sessionManager?.stopAutoRefresh() }
   }
 
   #if canImport(ObjectiveC) && canImport(Combine)

--- a/Sources/Auth/Internal/SessionManager.swift
+++ b/Sources/Auth/Internal/SessionManager.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Foundation
 import HTTPTypes
 
@@ -9,6 +10,9 @@ struct SessionManager: Sendable {
 
   var startAutoRefresh: @Sendable () async -> Void
   var stopAutoRefresh: @Sendable () async -> Void
+
+  /// Whether the auto-refresh loop is currently scheduled.
+  var isAutoRefreshRunning: @Sendable () async -> Bool
 }
 
 extension SessionManager {
@@ -20,7 +24,8 @@ extension SessionManager {
       update: { await instance.update($0) },
       remove: { await instance.remove() },
       startAutoRefresh: { await instance.startAutoRefreshToken() },
-      stopAutoRefresh: { await instance.stopAutoRefreshToken() }
+      stopAutoRefresh: { await instance.stopAutoRefreshToken() },
+      isAutoRefreshRunning: { await instance.isAutoRefreshTokenRunning() }
     )
   }
 }
@@ -29,7 +34,9 @@ private actor LiveSessionManager {
   private var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
   private var sessionStorage: SessionStorage { Dependencies[clientID].sessionStorage }
   private var eventEmitter: AuthStateChangeEventEmitter { Dependencies[clientID].eventEmitter }
-  private var logger: (any SupabaseLogger)? { Dependencies[clientID].logger }
+  // Looked up leniently, as the session manager outlives its client while the auto-refresh loop is
+  // torn down from `AuthClient.deinit`, at which point the dependencies entry is already gone.
+  private var logger: (any SupabaseLogger)? { Dependencies.instances.value[clientID]?.logger }
   private var api: APIClient { Dependencies[clientID].api }
 
   private var inFlightRefreshTask: Task<Session, any Error>?
@@ -127,6 +134,10 @@ private actor LiveSessionManager {
     logger?.debug("stop auto refresh token")
     startAutoRefreshTokenTask?.cancel()
     startAutoRefreshTokenTask = nil
+  }
+
+  func isAutoRefreshTokenRunning() -> Bool {
+    startAutoRefreshTokenTask != nil
   }
 
   private func autoRefreshTokenTick() async {

--- a/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
+++ b/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
@@ -7,12 +7,16 @@
 
 import ConcurrencyExtras
 import Foundation
+import Helpers
 import TestHelpers
 import Testing
 
 @testable import Auth
 
-@Suite
+// These tests assert on client deallocation, which only happens after the `Task { @MainActor in ...
+// }` scheduled by `AuthClient.init` releases its strong reference to the client. Running them
+// concurrently makes them race for the main actor, so serialize the suite.
+@Suite(.serialized)
 struct AuthClientMultipleInstancesTests {
   @Test
   func multipleAuthClientInstances() {
@@ -71,5 +75,39 @@ struct AuthClientMultipleInstancesTests {
     await Task.megaYield()
 
     #expect(Dependencies.instances.value[clientID] == nil)
+  }
+
+  @Test
+  func deinitStopsAutoRefreshTask() async {
+    let url = URL(string: "http://localhost:54321/auth")!
+
+    // Held on purpose, so the auto-refresh state is still observable after the client is gone.
+    let sessionManager: SessionManager
+
+    do {
+      let client = AuthClient(
+        configuration: AuthClient.Configuration(
+          url: url,
+          localStorage: InMemoryLocalStorage(),
+          logger: nil
+        )
+      )
+      sessionManager = Dependencies[client.clientID].sessionManager
+
+      await client.startAutoRefresh()
+      await Task.megaYield()
+
+      #expect(await sessionManager.isAutoRefreshRunning())
+    }
+
+    // `deinit` stops the auto-refresh loop from a detached task, so poll instead of asserting
+    // right away.
+    var isAutoRefreshRunning = await sessionManager.isAutoRefreshRunning()
+    for _ in 0..<100 where isAutoRefreshRunning {
+      try? await Task.sleep(nanoseconds: NSEC_PER_MSEC * 10)
+      isAutoRefreshRunning = await sessionManager.isAutoRefreshRunning()
+    }
+
+    #expect(isAutoRefreshRunning == false)
   }
 }

--- a/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
+++ b/Tests/AuthTests/AuthClientMultipleInstancesTests.swift
@@ -70,11 +70,17 @@ struct AuthClientMultipleInstancesTests {
       #expect(Dependencies.instances.value[clientID] != nil)
     }
 
-    // `init` kicks off a `Task { @MainActor in ... }` that briefly holds a
-    // strong reference to `self`; let it run so `client` can actually deinit.
-    await Task.megaYield()
+    // `init` kicks off a `Task { @MainActor in ... }` that briefly holds a strong reference to
+    // `self`, and `deinit` itself hops off to a detached task to stop auto-refresh; poll instead
+    // of asserting after a single yield; the number of hops needed to actually deinit isn't fixed
+    // and grows under scheduler load (e.g. on Linux CI with a small cooperative thread pool).
+    var instance = Dependencies.instances.value[clientID]
+    for _ in 0..<100 where instance != nil {
+      try? await Task.sleep(nanoseconds: NSEC_PER_MSEC * 10)
+      instance = Dependencies.instances.value[clientID]
+    }
 
-    #expect(Dependencies.instances.value[clientID] == nil)
+    #expect(instance == nil)
   }
 
   @Test


### PR DESCRIPTION
## What

`AuthClient.deinit` now stops the session manager's auto-refresh loop, in addition to removing the client's `Dependencies.instances` entry.

## Why

`LiveSessionManager` stores its background auto-refresh loop in `startAutoRefreshTokenTask: Task<Void, Never>?`. The task's closure calls the actor-isolated `autoRefreshTokenTick()`, so it captures the actor strongly, forming `self -> Task -> self`. Nothing breaks that cycle unless `stopAutoRefreshToken()` is called.

The only place that stopped it was `observeAppLifecycleChanges()`, which reacts to app resign-active notifications. That path never runs for:

- short-lived clients (tests, CLI tools, server-side usage) that never go through a foreground/background transition,
- platforms/configurations where the lifecycle observer isn't exercised,
- auto-refresh started manually via `startAutoRefresh()`.

Result: a deallocated `AuthClient` leaves behind a session manager that keeps ticking (and refreshing tokens) for the lifetime of the process.

## How

- `AuthClient.deinit` grabs the `SessionManager` from the registry, removes the dependencies entry as before, then fires `Task { await sessionManager?.stopAutoRefresh() }`. The task captures only the session manager, never `self`, so no new retain cycle (and no resurrection of a deallocating actor) is introduced.
- `LiveSessionManager.logger` is now looked up leniently (`Dependencies.instances.value[clientID]?.logger`), since the stop now happens after the dependencies entry is gone and the subscript `fatalError`s on a missing entry.
- Added an internal `SessionManager.isAutoRefreshRunning` accessor so the teardown is assertable.

Closes #1189

## Test plan

- New regression test `AuthClientMultipleInstancesTests.deinitStopsAutoRefreshTask`: starts auto-refresh on an `AuthClient`, keeps a handle on its `SessionManager`, drops the client, and asserts the auto-refresh loop is no longer scheduled. Verified it fails on the unfixed `deinit` and passes with the fix.
- The suite is now `.serialized`: both deinit tests depend on the `Task { @MainActor in ... }` scheduled by `AuthClient.init` releasing its strong reference, and running them concurrently makes them race for the main actor.
- `swift build` -> pass
- `swift test` -> 1084 tests in 104 suites passed
- `./scripts/format.sh` and `./scripts/spell-check.sh` -> clean