### PR TITLE
fix(realtime): retry auto-reconnect with backoff instead of giving up after one attempt

### DIFF
--- a/Sources/RealtimeV2/ConnectionManager.swift
+++ b/Sources/RealtimeV2/ConnectionManager.swift
@@ -195,15 +195,23 @@ actor ConnectionManager {
   /// mid-retry and misclassify the eventual success as a fresh `connect()`
   /// instead of a reconnect, skipping `rejoinChannels()` (issue #1147).
   private func initiateReconnect(reason: String) {
+    // Captured by value so the sleep below doesn't need `self` at all — held
+    // only while actually attempting a connection, not for the whole backoff
+    // wait. Otherwise a released client would keep this actor (and everything
+    // it captures) alive for up to the current attempt's delay.
+    let clock = self.clock
+    let baseDelay = reconnectDelay
+    let logger = self.logger
+
     let reconnectTask = Task { [weak self] in
       var attempt = 0
       while true {
-        guard let self else { return }
-
         attempt += 1
-        let delay = Self.reconnectBackoffDelay(attempt: attempt, baseDelay: self.reconnectDelay)
-        try await self.clock.sleep(for: .seconds(delay))
-        self.logger?.debug("Attempting to reconnect (attempt \(attempt))...")
+        let delay = Self.reconnectBackoffDelay(attempt: attempt, baseDelay: baseDelay)
+        try await clock.sleep(for: .seconds(delay))
+
+        guard let self else { return }
+        logger?.debug("Attempting to reconnect (attempt \(attempt))...")
 
         do {
           try await self.performReconnectAttempt()
@@ -211,7 +219,7 @@ actor ConnectionManager {
         } catch is CancellationError {
           throw CancellationError()
         } catch {
-          self.logger?.debug(
+          logger?.debug(
             "Reconnect attempt \(attempt) failed: \(error.localizedDescription). Retrying with backoff."
           )
         }
@@ -252,8 +260,17 @@ actor ConnectionManager {
     // underlying WebSocket (and the dedicated URLSession backing it, along with its
     // self-rescheduling receive loop) stays alive forever. `deinit` only runs once no other
     // code can reference the actor, so reading isolated state here is safe.
-    if case .connected(let conn) = state {
+    switch state {
+    case .connected(let conn):
       conn.close(code: nil, reason: "Deallocated")
+    case .reconnecting(let task, _):
+      // The retry loop only holds `self` while actually attempting a
+      // connection, not while sleeping out the backoff — so this actor can
+      // reach `deinit` while a reconnect is still pending. Cancel it instead
+      // of leaving it to wake up, find `self` gone, and exit on its own.
+      task.cancel()
+    case .connecting, .disconnected:
+      break
     }
     stateContinuation.finish()
   }

--- a/Sources/RealtimeV2/ConnectionManager.swift
+++ b/Sources/RealtimeV2/ConnectionManager.swift
@@ -186,14 +186,60 @@ actor ConnectionManager {
     }
   }
 
+  /// Keep retrying the reconnect with exponential backoff until a connection
+  /// is established or the task is cancelled (`disconnect()`/`deinit`).
+  ///
+  /// State stays `.reconnecting` for every attempt — unlike `performConnection()`,
+  /// a failed attempt here does not flip state to `.disconnected`. That would
+  /// make `RealtimeClientV2`'s reconnect-completion latch see a `.disconnected`
+  /// mid-retry and misclassify the eventual success as a fresh `connect()`
+  /// instead of a reconnect, skipping `rejoinChannels()` (issue #1147).
   private func initiateReconnect(reason: String) {
-    let reconnectTask = Task {
-      try await clock.sleep(for: .seconds(reconnectDelay))
-      logger?.debug("Attempting to reconnect...")
-      try await performConnection()
+    let reconnectTask = Task { [weak self] in
+      var attempt = 0
+      while true {
+        guard let self else { return }
+
+        attempt += 1
+        let delay = Self.reconnectBackoffDelay(attempt: attempt, baseDelay: self.reconnectDelay)
+        try await self.clock.sleep(for: .seconds(delay))
+        self.logger?.debug("Attempting to reconnect (attempt \(attempt))...")
+
+        do {
+          try await self.performReconnectAttempt()
+          return
+        } catch is CancellationError {
+          throw CancellationError()
+        } catch {
+          self.logger?.debug(
+            "Reconnect attempt \(attempt) failed: \(error.localizedDescription). Retrying with backoff."
+          )
+        }
+      }
     }
 
     updateState(.reconnecting(reconnectTask, reason: reason))
+  }
+
+  /// A single reconnect attempt. Only updates state on success (`.connected`);
+  /// a failure is left for `initiateReconnect`'s loop to retry, so the outer
+  /// `.reconnecting` state is preserved across attempts.
+  private func performReconnectAttempt() async throws {
+    let conn = try await transport(url, headers)
+    try Task.checkCancellation()
+    updateState(.connected(conn))
+  }
+
+  /// Exponential backoff capped at 30s (phoenix.js's `reconnectAfterMs` ladder
+  /// is the same shape: a growing delay that levels off rather than giving up).
+  /// Deliberately no jitter — unlike `ChannelStateManager.defaultRetryDelay`,
+  /// this backoff has no bounded attempt count to spread out, and jitter would
+  /// make the delay before any given attempt unpredictable for callers using a
+  /// manual/test clock.
+  private static func reconnectBackoffDelay(attempt: Int, baseDelay: TimeInterval) -> TimeInterval {
+    let maxDelay: TimeInterval = 30
+    let exponentialDelay = baseDelay * pow(2.0, Double(attempt - 1))
+    return min(exponentialDelay, maxDelay)
   }
 
   private func updateState(_ state: State) {

--- a/Sources/RealtimeV2/Types.swift
+++ b/Sources/RealtimeV2/Types.swift
@@ -109,7 +109,9 @@ public struct RealtimeClientOptions: Sendable {
   /// Default interval, in seconds, between heartbeat messages sent to keep the connection alive.
   public static let defaultHeartbeatInterval: TimeInterval = 25
 
-  /// Default delay, in seconds, before attempting to reconnect after a connection drop.
+  /// Default base delay, in seconds, before attempting to reconnect after a connection drop.
+  /// Later automatic attempts back off exponentially (capped at 30s) from this base until
+  /// the connection is reestablished.
   public static let defaultReconnectDelay: TimeInterval = 7
 
   /// Default maximum time, in seconds, to wait for a server reply before treating a request as timed out.
@@ -147,7 +149,7 @@ public struct RealtimeClientOptions: Sendable {
   /// - Parameters:
   ///   - headers: Additional HTTP headers sent with each WebSocket upgrade request.
   ///   - heartbeatInterval: Interval in seconds between heartbeat messages. Defaults to ``defaultHeartbeatInterval``.
-  ///   - reconnectDelay: Delay in seconds before attempting to reconnect after a disconnection. Defaults to ``defaultReconnectDelay``.
+  ///   - reconnectDelay: Base delay in seconds before attempting to reconnect after a disconnection; later automatic attempts back off exponentially from this base until reconnected. Defaults to ``defaultReconnectDelay``.
   ///   - timeoutInterval: Maximum time in seconds to wait for a server reply. Defaults to ``defaultTimeoutInterval``.
   ///   - disconnectOnSessionLoss: Whether to disconnect the channel when the authentication session is lost. Defaults to ``defaultDisconnectOnSessionLoss``.
   ///   - connectOnSubscribe: Whether to automatically call ``RealtimeClientV2/connect()`` when subscribing to a channel. Defaults to ``defaultConnectOnSubscribe``.

--- a/Tests/RealtimeTests/ConnectionManagerTests.swift
+++ b/Tests/RealtimeTests/ConnectionManagerTests.swift
@@ -338,6 +338,46 @@ struct ConnectionManagerTests {
   }
 
   @Test
+  func handleErrorKeepsRetryingReconnectAfterAFailedAttempt() async throws {
+    // Issue #1147: the original auto-reconnect scheduled exactly one attempt.
+    // If that attempt failed (network still down), nothing scheduled another
+    // one and the client stayed parked in `.disconnected` forever.
+    let connectionCount = LockIsolated(0)
+    let ws = self.ws
+
+    let sut = makeSUT(
+      reconnectDelay: 0.01,
+      transport: { _, _ in
+        let attempt = connectionCount.withValue { count -> Int in
+          count += 1
+          return count
+        }
+        // Attempt 1 is the initial `connect()`. Attempt 2 (the first
+        // automatic reconnect) fails, simulating an outage still in
+        // progress. Attempt 3 succeeds once the network recovers.
+        if attempt == 2 {
+          throw TestError.sample
+        }
+        return ws
+      }
+    )
+
+    try await sut.connect()
+    await sut.handleError(TestError.sample)
+
+    let recoveredWithoutExternalHelp = await waitUntil(timeout: 5) {
+      connectionCount.value >= 3
+    }
+    #expect(
+      recoveredWithoutExternalHelp,
+      "ConnectionManager should retry the reconnect after a failed attempt instead of giving up"
+    )
+
+    let isConnected = await sut.connection != nil
+    #expect(isConnected)
+  }
+
+  @Test
   func handleCloseDoesNotReconnectForApplicationCloseCode() async throws {
     let sut = makeSUT(reconnectDelay: 0.01)
     try await sut.connect()

--- a/Tests/RealtimeTests/RealtimeReconnectRecoveryTests.swift
+++ b/Tests/RealtimeTests/RealtimeReconnectRecoveryTests.swift
@@ -34,6 +34,14 @@ struct RealtimeReconnectRecoveryTests {
   /// channel's `connectOnSubscribe` — was misclassified as a reconnect
   /// completion. The resulting `rejoinChannels()` reset cancelled the very
   /// join that connect was performing, surfacing as `CancellationError`.
+  ///
+  /// Issue #1147 closed the underlying window this defect needed: auto-reconnect
+  /// used to be single-shot, so a failed attempt parked the client in
+  /// `.disconnected` and needed an external trigger (like the workaround this
+  /// test used to exercise) to recover — that's exactly the state where the
+  /// stale latch could bite. Now `ConnectionManager` keeps retrying with
+  /// backoff and never surfaces `.disconnected` mid-retry, so recovery (and
+  /// the resulting `rejoinChannels()`) happens automatically.
   @Test
   func subscribeConvergesAfterFailedAutoReconnect() async throws {
     let sockets = LockIsolated<[AsyncFakeWebSocket]>([])
@@ -47,7 +55,8 @@ struct RealtimeReconnectRecoveryTests {
           count += 1
           return count
         }
-        // Attempt 2 is the automatic reconnect — the network is still down.
+        // Attempt 2 is the first automatic reconnect — the network is still
+        // down. Attempt 3, a later automatic retry, succeeds once it recovers.
         if attempt == 2 {
           throw RealtimeError("network down")
         }
@@ -65,28 +74,16 @@ struct RealtimeReconnectRecoveryTests {
     try await channel.subscribeWithError()
     #expect(channel.status == .subscribed)
 
-    // Outage: the socket errors out, the single auto-reconnect attempt fails.
+    // Outage: the socket errors out and the first auto-reconnect attempt fails.
     sockets.value[0].receiveFromServer(.text("not a valid frame"))
-    let parkedDisconnected = await waitUntil(timeout: 5) {
-      connectAttempts.value >= 2 && sut.status == .disconnected
-    }
-    guard parkedDisconnected else {
-      Issue.record("Client did not settle in .disconnected after failed reconnect")
-      return
-    }
 
-    // Network is back. A supervisor rebuilds with a fresh channel;
-    // `connectOnSubscribe` brings the socket up. Before the fix, the stale
-    // latch fired `rejoinChannels()`, whose reset cancelled this in-flight
-    // join (`CancellationError`).
-    let channel2 = sut.channel("room-2")
-    do {
-      try await channel2.subscribeWithError()
-    } catch {
-      Issue.record("Subscribe after failed auto-reconnect threw: \(error)")
-      return
+    // No external trigger (no new channel, no manual `connect()`): the client
+    // must retry on its own until the network recovers, then rejoin the
+    // existing channel automatically.
+    let recovered = await waitUntil(timeout: 5) {
+      connectAttempts.value >= 3 && sut.status == .connected && channel.status == .subscribed
     }
-    #expect(channel2.status == .subscribed)
+    #expect(recovered, "Client did not recover automatically after a failed auto-reconnect attempt")
   }
 
   /// Defect 3 in #1145: `phx_close` was routed by topic only. A close


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #1147 — a follow-up to #1145/#1146.

## Root cause

`ConnectionManager.initiateReconnect` scheduled exactly one reconnect attempt: it slept `reconnectDelay` and called `performConnection()` once. If that single attempt failed — the common case during a real outage, where the network is still down when the timer fires — nothing scheduled another attempt, and the client stayed parked in `.disconnected` indefinitely. Recovery only happened if something external called `connect()` (a new subscribe with `connectOnSubscribe`, an app-foreground event, or an application-level supervisor).

## Fix

`initiateReconnect` now retries with exponential backoff (capped at 30s, based on `reconnectDelay`) until either:

* a connection is established (channels rejoin as before), or
* `disconnect()`/`deinit` cancels the retry loop.

Deliberately no jitter: `ChannelStateManager`'s subscribe retry uses jitter because it has a bounded attempt count to spread out, but here jitter made the delay before any given attempt unpredictable for `TestClock`-based tests — while implementing this I hit an actual test-suite hang from it (a jittered delay overran what a deterministic test advanced its clock by, leaving the retry loop's `self`-holding sleep permanently suspended). Dropped jitter in favor of a plain exponential ladder, matching the shape of phoenix.js's `reconnectAfterMs`.

Internally, state stays `.reconnecting` for every attempt instead of bouncing through `.connecting`/`.disconnected` on each failure — the latter would make `RealtimeClientV2`'s reconnect-completion latch see a `.disconnected` mid-retry and misclassify the eventual success as a fresh `connect()`, skipping `rejoinChannels()`.

Application close codes (4000–4999) still skip reconnect, and heartbeat-timeout-triggered reconnects feed the same retry loop — both unchanged.

## Tests

* New `ConnectionManagerTests.handleErrorKeepsRetryingReconnectAfterAFailedAttempt` — fails against the pre-fix code (confirmed before implementing the fix), passes after.
* Updated `RealtimeReconnectRecoveryTests.subscribeConvergesAfterFailedAutoReconnect` (from #1145/#1146): its old scenario relied on the client parking in `.disconnected` after one failed attempt and needing an external trigger to recover — exactly what this fix removes. It now asserts the client and its existing channel recover automatically with no external trigger.

Full suite (1103 tests), `./scripts/format.sh`, and spell-check are clean.

Fixes #1147