### PR TITLE
fix(release): select the prerelease versioning strategy

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "beta",
       "extra-files": [


### PR DESCRIPTION
## What

Adds `"versioning": "prerelease"` to `release-please-config.json`, and forces the next release to `2.55.1` via a `Release-As:` trailer.

## Why

release-please's default versioning strategy never looks at `prerelease`/`prerelease-type` — those are only consumed by the `prerelease` versioning strategy, selected via `"versioning": "prerelease"`. #1199 added the two fields but not the strategy selector, so they were silently no-ops.

#1201 is the proof: it computed a plain `3.0.0` instead of `3.0.0-beta.1`.

#1201's `3.0.0` proposal is also spurious on its own terms — an earlier commit's message described the conventional-commits breaking-change footer in prose, and release-please's scan picked up the literal text as if it were a real breaking-change note. Nothing breaking has actually shipped. `main` doesn't allow force-pushes, so the commit text can't be edited out of history; the `Release-As: 2.55.1` trailer here tells release-please to treat the pending commits as an ordinary patch instead, which clears them from the "unreleased" window. One side effect: `CHANGELOG.md` will carry a stray, garbled breaking-change bullet under `2.55.1` — harmless, just odd-looking.

Once this merges, #1201 should update to (or be superseded by) a `2.55.1` release PR. I'll close #1201 once that happens.

## Context

- Faulty prerelease config: #1199
- Spurious major-bump PR: #1201