### PR TITLE
fix(auth): address code-review findings on VerifyOTPResponse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,8 +236,9 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) w
 
 Example: `feat(auth): add PKCE flow support`
 
-Every `feat!:`/`fix!:` or `BREAKING CHANGE:` commit requires an entry in the root
-`V<N>_MIGRATION.md` — see the writing-migration-guides skill for the format.
+The `!`/`BREAKING CHANGE:` marker is the same one release-please and the API stability check key
+off to bump majors and flag reviewers. Every commit carrying it also requires an entry in the
+root `V<N>_MIGRATION.md` — see the writing-migration-guides skill for the format.
 
 ## CI/CD
 

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -701,16 +701,23 @@ public enum VerifyOTPResponse: Decodable, Hashable, Sendable {
   case session(Session)
 
   /// Neither a session nor a user was returned. GoTrue sends this for the first of the two
-  /// confirmations required by a secure email change: the new email address still needs to
-  /// confirm its own link before the change takes effect and a session is issued.
+  /// confirmations required by a secure email change: whichever of the current or new email
+  /// address hasn't confirmed its link yet still needs to, before the change takes effect and a
+  /// session is issued.
   case emailChangeConfirmationPending(EmailChangeConfirmation)
 
   public init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
     if let value = try? container.decode(Session.self) {
       self = .session(value)
+    } else if let value = try? container.decode(EmailChangeConfirmation.self) {
+      self = .emailChangeConfirmationPending(value)
     } else {
-      self = .emailChangeConfirmationPending(try container.decode(EmailChangeConfirmation.self))
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription:
+          "Data could not be decoded as any of the expected types (Session, EmailChangeConfirmation)."
+      )
     }
   }
 

--- a/Tests/AuthTests/AuthResponseTests.swift
+++ b/Tests/AuthTests/AuthResponseTests.swift
@@ -60,4 +60,17 @@ struct AuthResponseTests {
       )
     }
   }
+
+  @Test
+  func bareUser_isNotAValidVerifyOTPResponse() {
+    // The /verify endpoint verifyOTP calls never returns a bare user with no session: unlike signUp,
+    // every verification type either issues a session or (for the first of the two secure
+    // email change confirmations) the emailChangeConfirmationPending shape above.
+    #expect(throws: (any Error).self) {
+      try AuthClient.Configuration.jsonDecoder.decode(
+        VerifyOTPResponse.self,
+        from: json(named: "user")
+      )
+    }
+  }
 }

--- a/Tests/IntegrationTests/supabase-secure-email-change/supabase/config.toml
+++ b/Tests/IntegrationTests/supabase-secure-email-change/supabase/config.toml
@@ -8,7 +8,7 @@
 # flipped in the shared project without breaking the rest of the suite. Non-Auth services are
 # disabled here since this project only exists to run that one test.
 #
-# See docs/superpowers/ or AGENTS.md for how this is wired into CI and local runs.
+# See AGENTS.md for how this is wired into CI and local runs.
 project_id = "IntegrationTestsSecureEmailChange"
 
 [api]


### PR DESCRIPTION
## Summary

Follow-up to #1088 (already merged) addressing findings from a post-merge code review of that PR's `VerifyOTPResponse` change.

## Changes

- `Sources/Auth/Types.swift`: `VerifyOTPResponse.init(from:)` now throws a descriptive `dataCorruptedError` on an unrecognized shape instead of letting `EmailChangeConfirmation`'s own decode failure leak through unwrapped — matches `AuthResponse`'s existing behavior for the same situation.
- Fixed the `emailChangeConfirmationPending` doc comment, which assumed the *new* email always confirms second. GoTrue doesn't enforce an order between the two confirmations — whichever of the two hasn't confirmed yet is the one still pending.
- `Tests/AuthTests/AuthResponseTests.swift`: added a test locking in that a bare user (no session) is correctly *not* a valid `VerifyOTPResponse` shape, since `/verify` never returns one (unlike `signUp`, which can).
- Dropped a stray `docs/superpowers/` reference in the isolated integration-test project's `config.toml` comment — that path isn't documentation for this.
- Restored a sentence in `AGENTS.md` explaining why the breaking-change marker matters (release-please and the API stability check key off it) — this was dropped when this branch's migration-guide convention replaced main's equivalent section during a rebase, and got missed before merge.

## Test plan

- [x] `swift test --filter "AuthTests|SupabaseTests"` — 257 tests pass
- [x] Format check, spell-check clean
- [x] Verified against the `supabase/auth` Go source (`internal/api/verify.go`) that `verifyPost` has exactly two response paths — the `{msg,code}` map or a full session via `issueRefreshToken` — confirming `VerifyOTPResponse` correctly has no bare-user case