### PR TITLE
fix(auth,storage,realtime,helpers)!: narrow Codable conformances to their actual usage direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,11 +134,14 @@ Use standard file headers with copyright:
   only when the same type is genuinely used in both directions (e.g. a type
   the SDK both sends and receives over the wire, or persists to disk via
   `JSONEncoder`/`JSONDecoder`, like Auth's `Session`).
-- Before widening a type from `Decodable`/`Encodable` to `Codable`, check
-  every stored property is at least as conformant — a `Decodable` type
-  embedding an `Encodable`-only type (or vice versa) won't compile, so
-  narrowing/widening a shared nested type can ripple into its container
-  types.
+- Before narrowing a type from `Codable` to `Decodable`/`Encodable`, check
+  whether any other type embeds it and relies on synthesized `Codable` — a
+  container relying on synthesized conformance stops compiling the moment a
+  field it holds drops the direction the container needs, so the container
+  must narrow the same way (or gain its own hand-written coder). The same
+  check applies in reverse when widening a type back toward `Codable`: every
+  stored property must be at least as conformant as the type you're widening
+  to.
 - Don't hand-write `encode(to:)`/`init(from:)` for the unused direction "for
   symmetry" — dead coders accumulate and mislead readers about how the type
   is actually used. See `V3_MIGRATION.md` for prior cleanup along these

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,24 @@ Use standard file headers with copyright:
 - Keep module dependencies minimal
 - Prefer protocol-oriented design
 
+### Codable Conformance
+
+- Only conform a type to the direction the SDK actually uses: a type the SDK
+  only decodes from a server response gets `Decodable`, a type the SDK only
+  encodes into a request body gets `Encodable`. Conform to full `Codable`
+  only when the same type is genuinely used in both directions (e.g. a type
+  the SDK both sends and receives over the wire, or persists to disk via
+  `JSONEncoder`/`JSONDecoder`, like Auth's `Session`).
+- Before widening a type from `Decodable`/`Encodable` to `Codable`, check
+  every stored property is at least as conformant — a `Decodable` type
+  embedding an `Encodable`-only type (or vice versa) won't compile, so
+  narrowing/widening a shared nested type can ripple into its container
+  types.
+- Don't hand-write `encode(to:)`/`init(from:)` for the unused direction "for
+  symmetry" — dead coders accumulate and mislead readers about how the type
+  is actually used. See `V3_MIGRATION.md` for prior cleanup along these
+  lines (`VerifyOTPResponse`, and the broader SDK-1473 pass).
+
 ### Error Handling
 
 - Use strongly-typed errors conforming to `Error` protocol

--- a/Examples/Examples/Storage/BucketDetailView.swift
+++ b/Examples/Examples/Storage/BucketDetailView.swift
@@ -72,7 +72,19 @@ struct BucketDetailView: View {
     }
     .popover(isPresented: $presentBucketDetails) {
       List {
-        AnyJSONView(rendering: bucket)
+        AnyJSONView(
+          value: .object([
+            "id": .string(bucket.id),
+            "name": .string(bucket.name),
+            "owner": .string(bucket.owner),
+            "isPublic": .bool(bucket.isPublic),
+            "createdAt": .string(bucket.createdAt.description),
+            "updatedAt": .string(bucket.updatedAt.description),
+            "allowedMimeTypes": bucket.allowedMimeTypes.map { .array($0.map(AnyJSON.string)) }
+              ?? .null,
+            "fileSizeLimit": bucket.fileSizeLimit.map { .integer(Int($0)) } ?? .null,
+          ])
+        )
       }
     }
     .navigationDestination(for: FileObject.self) {

--- a/Examples/Examples/Storage/FileObjectDetailView.swift
+++ b/Examples/Examples/Storage/FileObjectDetailView.swift
@@ -18,7 +18,19 @@ struct FileObjectDetailView: View {
   var body: some View {
     List {
       Section {
-        AnyJSONView(value: try! AnyJSON(fileObject))
+        AnyJSONView(
+          value: .object([
+            "name": .string(fileObject.name),
+            "bucketId": fileObject.bucketId.map(AnyJSON.string) ?? .null,
+            "owner": fileObject.owner.map(AnyJSON.string) ?? .null,
+            "id": fileObject.id.map { .string($0.uuidString) } ?? .null,
+            "updatedAt": fileObject.updatedAt.map { .string($0.description) } ?? .null,
+            "createdAt": fileObject.createdAt.map { .string($0.description) } ?? .null,
+            "lastAccessedAt": fileObject.lastAccessedAt.map { .string($0.description) } ?? .null,
+            "metadata": fileObject.metadata.map(AnyJSON.object) ?? .null,
+            "buckets": fileObject.buckets.map { .string($0.name) } ?? .null,
+          ])
+        )
       }
 
       Section("Actions") {

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -507,7 +507,8 @@ public struct AuthMetaSecurity: Encodable, Hashable, Sendable {
 }
 
 /// A Web3 chain supported by Sign in with Web3.
-public struct Web3Chain: RawRepresentable, Encodable, Hashable, Sendable, ExpressibleByStringLiteral {
+public struct Web3Chain: RawRepresentable, Encodable, Hashable, Sendable, ExpressibleByStringLiteral
+{
   public let rawValue: String
 
   /// Creates a ``Web3Chain`` from a raw string value.

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1295,7 +1295,7 @@ struct DeleteUserRequest: Encodable {
 }
 
 /// The messaging channel used to deliver OTPs.
-public enum MessagingChannel: String, Codable, Sendable {
+public enum MessagingChannel: String, Encodable, Sendable {
   /// Deliver the OTP via SMS.
   case sms
 
@@ -1326,6 +1326,16 @@ public struct OAuthResponse: Hashable, Sendable {
 
   /// The URL to open in order to start the OAuth flow.
   public let url: URL
+
+  /// Creates an ``OAuthResponse``.
+  ///
+  /// - Parameters:
+  ///   - provider: The OAuth provider.
+  ///   - url: The URL to open in order to start the OAuth flow.
+  public init(provider: Provider, url: URL) {
+    self.provider = provider
+    self.url = url
+  }
 }
 
 /// Pagination parameters for list endpoints.

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -408,7 +408,7 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
 }
 
 /// One of the providers supported by Auth.
-public enum Provider: String, Identifiable, Codable, CaseIterable, Sendable {
+public enum Provider: String, Identifiable, CaseIterable, Sendable {
   case apple
   case azure
   case bitbucket
@@ -646,7 +646,7 @@ public enum EmailOTPType: String, Encodable, CaseIterable, Sendable {
 
 /// The response from sign-up and passkey calls that may return either a session or a user,
 /// depending on whether email confirmation is required.
-public enum AuthResponse: Codable, Hashable, Sendable {
+public enum AuthResponse: Decodable, Hashable, Sendable {
   /// A full session was created, meaning the user is immediately signed in.
   case session(Session)
 
@@ -664,14 +664,6 @@ public enum AuthResponse: Codable, Hashable, Sendable {
         in: container,
         debugDescription: "Data could not be decoded as any of the expected types (Session, User)."
       )
-    }
-  }
-
-  public func encode(to encoder: any Encoder) throws {
-    var container = encoder.singleValueContainer()
-    switch self {
-    case .session(let value): try container.encode(value)
-    case .user(let value): try container.encode(value)
     }
   }
 
@@ -1320,14 +1312,14 @@ struct SignInWithSSORequest: Encodable {
 }
 
 /// The response from a single sign-on (SSO) initiation request.
-public struct SSOResponse: Codable, Hashable, Sendable {
+public struct SSOResponse: Decodable, Hashable, Sendable {
   /// URL to open in a browser which will complete the sign-in flow by taking the user to the
   /// identity provider's authentication flow.
   public let url: URL
 }
 
 /// The URL and provider returned when building an OAuth sign-in URL.
-public struct OAuthResponse: Codable, Hashable, Sendable {
+public struct OAuthResponse: Hashable, Sendable {
   /// The OAuth provider.
   public let provider: Provider
 
@@ -1588,7 +1580,7 @@ public struct OAuthClientResponseType: RawRepresentable, Codable, Hashable, Send
 
 /// OAuth client type indicating whether the client can keep credentials confidential.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-public struct OAuthClientType: RawRepresentable, Codable, Hashable, Sendable,
+public struct OAuthClientType: RawRepresentable, Decodable, Hashable, Sendable,
   ExpressibleByStringLiteral
 {
   /// The raw string value of the client type.
@@ -1613,7 +1605,7 @@ public struct OAuthClientType: RawRepresentable, Codable, Hashable, Sendable,
 
 /// OAuth client registration type.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-public struct OAuthClientRegistrationType: RawRepresentable, Codable, Hashable, Sendable,
+public struct OAuthClientRegistrationType: RawRepresentable, Decodable, Hashable, Sendable,
   ExpressibleByStringLiteral
 {
   /// The raw string value of the registration type.
@@ -1638,7 +1630,7 @@ public struct OAuthClientRegistrationType: RawRepresentable, Codable, Hashable, 
 
 /// OAuth client object returned from the OAuth 2.1 server.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-public struct OAuthClient: Codable, Hashable, Sendable {
+public struct OAuthClient: Decodable, Hashable, Sendable {
   /// Unique identifier for the OAuth client
   public let clientId: UUID
 
@@ -1793,7 +1785,7 @@ public struct ListOAuthClientsPaginatedResponse: Hashable, Sendable {
 
 /// Details about the OAuth client requesting authorization.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-public struct OAuthAuthorizationClient: Codable, Hashable, Sendable {
+public struct OAuthAuthorizationClient: Decodable, Hashable, Sendable {
   /// Unique identifier for the OAuth client.
   public let id: UUID
 
@@ -1809,7 +1801,7 @@ public struct OAuthAuthorizationClient: Codable, Hashable, Sendable {
 
 /// The authenticated user considering the authorization request.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-public struct OAuthAuthorizationUser: Codable, Hashable, Sendable {
+public struct OAuthAuthorizationUser: Decodable, Hashable, Sendable {
   /// Unique identifier for the user.
   public let id: UUID
 
@@ -1821,7 +1813,7 @@ public struct OAuthAuthorizationUser: Codable, Hashable, Sendable {
 /// ``AuthOAuthServer/getAuthorizationDetails(authorizationId:)`` when the
 /// request still requires the user's consent.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-public struct OAuthAuthorizationDetails: Codable, Hashable, Sendable {
+public struct OAuthAuthorizationDetails: Decodable, Hashable, Sendable {
   /// Opaque identifier for this authorization request.
   public let authorizationId: String
 
@@ -1842,7 +1834,7 @@ public struct OAuthAuthorizationDetails: Codable, Hashable, Sendable {
 /// request, or in place of ``OAuthAuthorizationDetails`` when the server
 /// auto-approves a request the user has already consented to.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-public struct OAuthRedirect: Codable, Hashable, Sendable {
+public struct OAuthRedirect: Decodable, Hashable, Sendable {
   /// The URL the client app should be redirected to. On denial, this URL's
   /// query string carries an `error=access_denied` parameter (RFC 6749) —
   /// denial is a successful API call, not a thrown error.
@@ -1887,7 +1879,7 @@ extension OAuthAuthorizationDetailsResponse: Decodable {
 /// An OAuth grant the user has given to a third-party client app, returned by
 /// ``AuthOAuthServer/listGrants()``.
 /// Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-public struct OAuthGrant: Codable, Hashable, Sendable {
+public struct OAuthGrant: Decodable, Hashable, Sendable {
   /// The OAuth client the grant was given to.
   public let client: OAuthAuthorizationClient
 
@@ -1901,7 +1893,7 @@ public struct OAuthGrant: Codable, Hashable, Sendable {
 // MARK: - JWT Claims
 
 /// JSON Web Key (JWK) representation.
-public struct JWK: Codable, Hashable, Sendable {
+public struct JWK: Decodable, Hashable, Sendable {
   /// Key type (e.g., `"RSA"`, `"EC"`, `"oct"`).
   public let kty: String
 
@@ -1950,13 +1942,13 @@ public struct JWK: Codable, Hashable, Sendable {
 }
 
 /// A JSON Web Key Set (JWKS) containing one or more JWKs.
-public struct JWKS: Codable, Hashable, Sendable {
+public struct JWKS: Decodable, Hashable, Sendable {
   /// The set of JSON Web Keys.
   public let keys: [JWK]
 }
 
 /// The header portion of a decoded JSON Web Token.
-public struct JWTHeader: Codable, Hashable, Sendable {
+public struct JWTHeader: Decodable, Hashable, Sendable {
   /// Algorithm (e.g., `"RS256"`, `"ES256"`, `"HS256"`).
   public let alg: String
 
@@ -1968,7 +1960,7 @@ public struct JWTHeader: Codable, Hashable, Sendable {
 }
 
 /// The decoded claims from a JSON Web Token.
-public struct JWTClaims: Codable, Hashable, Sendable {
+public struct JWTClaims: Decodable, Hashable, Sendable {
   /// Issuer (`iss` claim).
   public let iss: String?
 
@@ -2058,33 +2050,10 @@ public struct JWTClaims: Codable, Hashable, Sendable {
     }
     additionalClaims = additional
   }
-
-  public func encode(to encoder: any Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encodeIfPresent(self.iss, forKey: .iss)
-    try container.encodeIfPresent(self.sub, forKey: .sub)
-    try container.encodeIfPresent(self.aud, forKey: .aud)
-    try container.encodeIfPresent(self.exp, forKey: .exp)
-    try container.encodeIfPresent(self.iat, forKey: .iat)
-    try container.encodeIfPresent(self.nbf, forKey: .nbf)
-    try container.encodeIfPresent(self.jti, forKey: .jti)
-    try container.encodeIfPresent(self.role, forKey: .role)
-    try container.encodeIfPresent(self.aal, forKey: .aal)
-    try container.encodeIfPresent(self.sessionId, forKey: .sessionId)
-    try container.encodeIfPresent(self.email, forKey: .email)
-    try container.encodeIfPresent(self.phone, forKey: .phone)
-    try container.encodeIfPresent(self.appMetadata, forKey: .appMetadata)
-    try container.encodeIfPresent(self.userMetadata, forKey: .userMetadata)
-
-    var additionalClaimsContainer = encoder.container(keyedBy: AnyCodingKey.self)
-    for (key, value) in additionalClaims {
-      try additionalClaimsContainer.encode(value, forKey: AnyCodingKey(stringValue: key)!)
-    }
-  }
 }
 
 /// A JWT `aud` (audience) claim that may be either a single string or an array of strings.
-public enum AudienceClaim: Codable, Hashable, Sendable {
+public enum AudienceClaim: Decodable, Hashable, Sendable {
   /// A single audience string.
   case string(String)
 
@@ -2105,16 +2074,6 @@ public enum AudienceClaim: Codable, Hashable, Sendable {
           debugDescription: "Expected String or [String] for audience claim"
         )
       )
-    }
-  }
-
-  public func encode(to encoder: any Encoder) throws {
-    var container = encoder.singleValueContainer()
-    switch self {
-    case .string(let value):
-      try container.encode(value)
-    case .array(let value):
-      try container.encode(value)
     }
   }
 }

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -27,7 +27,7 @@ public enum AuthChangeEvent: String, Sendable {
   case mfaChallengeVerified = "MFA_CHALLENGE_VERIFIED"
 }
 
-struct UserCredentials: Codable, Hashable, Sendable {
+struct UserCredentials: Encodable, Hashable, Sendable {
   var email: String?
   var password: String?
   var phone: String?
@@ -49,7 +49,7 @@ struct UserCredentials: Codable, Hashable, Sendable {
   }
 }
 
-struct SignUpRequest: Codable, Hashable, Sendable {
+struct SignUpRequest: Encodable, Hashable, Sendable {
   var email: String?
   var password: String?
   var phone: String?
@@ -441,7 +441,7 @@ public enum Provider: String, Identifiable, CaseIterable, Sendable {
 }
 
 /// Credentials for signing in with an OpenID Connect (OIDC) ID token issued by a third-party.
-public struct OpenIDConnectCredentials: Codable, Hashable, Sendable {
+public struct OpenIDConnectCredentials: Encodable, Hashable, Sendable {
   /// Provider name or OIDC `iss` value identifying which provider should be used to verify the
   /// provided token. Supported names: `google`, `apple`, `azure`, `facebook`.
   public var provider: Provider
@@ -488,13 +488,13 @@ public struct OpenIDConnectCredentials: Codable, Hashable, Sendable {
   }
 
   /// Providers supported by the OIDC sign-in flow.
-  public enum Provider: String, Codable, Hashable, Sendable {
+  public enum Provider: String, Encodable, Hashable, Sendable {
     case google, apple, azure, facebook
   }
 }
 
 /// A captcha verification token used to secure Auth endpoints.
-public struct AuthMetaSecurity: Codable, Hashable, Sendable {
+public struct AuthMetaSecurity: Encodable, Hashable, Sendable {
   /// The captcha token obtained after the user completes a captcha challenge.
   public var captchaToken: String
 
@@ -507,7 +507,7 @@ public struct AuthMetaSecurity: Codable, Hashable, Sendable {
 }
 
 /// A Web3 chain supported by Sign in with Web3.
-public struct Web3Chain: RawRepresentable, Codable, Hashable, Sendable, ExpressibleByStringLiteral {
+public struct Web3Chain: RawRepresentable, Encodable, Hashable, Sendable, ExpressibleByStringLiteral {
   public let rawValue: String
 
   /// Creates a ``Web3Chain`` from a raw string value.
@@ -532,7 +532,7 @@ public struct Web3Chain: RawRepresentable, Codable, Hashable, Sendable, Expressi
 /// The caller is responsible for constructing a spec-compliant SIWE (EIP-4361) or SIWS message and
 /// obtaining a signature over it from the user's wallet (e.g. via WalletConnect or a native wallet
 /// SDK) — this type only carries the already-signed result to the server for verification.
-public struct Web3Credentials: Codable, Hashable, Sendable {
+public struct Web3Credentials: Encodable, Hashable, Sendable {
   public var chain: Web3Chain
 
   /// The SIWE- or SIWS-formatted message that was signed.
@@ -566,7 +566,7 @@ public struct Web3Credentials: Codable, Hashable, Sendable {
   }
 }
 
-struct OTPParams: Codable, Hashable, Sendable {
+struct OTPParams: Encodable, Hashable, Sendable {
   var email: String?
   var phone: String?
   var createUser: Bool
@@ -732,7 +732,7 @@ public struct EmailChangeConfirmation: Decodable, Hashable, Sendable {
 }
 
 /// Attributes that a user can update for their own account.
-public struct UserAttributes: Codable, Hashable, Sendable {
+public struct UserAttributes: Encodable, Hashable, Sendable {
   /// The user's email.
   public var email: String?
 
@@ -863,7 +863,7 @@ public struct AdminUserAttributes: Encodable, Hashable, Sendable {
   }
 }
 
-struct RecoverParams: Codable, Hashable, Sendable {
+struct RecoverParams: Encodable, Hashable, Sendable {
   var email: String
   var gotrueMetaSecurity: AuthMetaSecurity?
   var codeChallenge: String?

--- a/Sources/Auth/WebAuthn/WebAuthnTypes.swift
+++ b/Sources/Auth/WebAuthn/WebAuthnTypes.swift
@@ -55,7 +55,7 @@ public struct WebAuthnChallengeOptions: Encodable, Hashable, Sendable {
 ///
 /// - Warning: Experimental. See ``MFAWebAuthnEnrollParams``.
 @_spi(Experimental)
-public enum WebAuthnChallengeType: String, Codable, Hashable, Sendable {
+public enum WebAuthnChallengeType: String, Decodable, Hashable, Sendable {
   /// A registration ceremony (`navigator.credentials.create`).
   case create
   /// An authentication ceremony (`navigator.credentials.get`).

--- a/Sources/Auth/WebAuthn/WebAuthnTypes.swift
+++ b/Sources/Auth/WebAuthn/WebAuthnTypes.swift
@@ -81,7 +81,7 @@ public struct WebAuthnChallengeResponseData: Decodable, Hashable, Sendable {
 ///
 /// - Warning: Experimental. See ``MFAWebAuthnEnrollParams``.
 @_spi(Experimental)
-public struct PasskeyListItem: Codable, Identifiable, Hashable, Sendable {
+public struct PasskeyListItem: Decodable, Identifiable, Hashable, Sendable {
   /// Unique identifier of the passkey.
   public let id: UUID
 

--- a/Sources/Helpers/AnyJSON/AnyJSON+Codable.swift
+++ b/Sources/Helpers/AnyJSON/AnyJSON+Codable.swift
@@ -17,7 +17,7 @@ extension AnyJSON {
 
 extension AnyJSON {
   /// Initialize an ``AnyJSON`` from a ``Codable`` value.
-  public init(_ value: some Codable) throws {
+  public init(_ value: some Encodable) throws {
     if let value = value as? AnyJSON {
       self = value
     } else if let string = value as? String {
@@ -64,7 +64,7 @@ extension JSONObject {
   }
 
   /// Initialize JSONObject from a `Codable` type
-  public init(_ value: some Codable) throws {
+  public init(_ value: some Encodable) throws {
     guard let object = try AnyJSON(value).objectValue else {
       throw DecodingError.typeMismatch(
         JSONObject.self,

--- a/Sources/Helpers/AnyJSON/AnyJSON+Codable.swift
+++ b/Sources/Helpers/AnyJSON/AnyJSON+Codable.swift
@@ -16,7 +16,7 @@ extension AnyJSON {
 }
 
 extension AnyJSON {
-  /// Initialize an ``AnyJSON`` from a ``Codable`` value.
+  /// Initialize an ``AnyJSON`` from an ``Encodable`` value.
   public init(_ value: some Encodable) throws {
     if let value = value as? AnyJSON {
       self = value
@@ -63,7 +63,7 @@ extension JSONObject {
     try AnyJSON.object(self).decode(as: T.self, decoder: decoder)
   }
 
-  /// Initialize JSONObject from a `Codable` type
+  /// Initialize JSONObject from an `Encodable` type
   public init(_ value: some Encodable) throws {
     guard let object = try AnyJSON(value).objectValue else {
       throw DecodingError.typeMismatch(

--- a/Sources/Helpers/SharedModels/PostgrestError.swift
+++ b/Sources/Helpers/SharedModels/PostgrestError.swift
@@ -7,7 +7,7 @@
 
 public import Foundation
 
-public struct PostgrestError: Error, Codable, Sendable {
+public struct PostgrestError: Error, Decodable, Sendable {
   /// Additional detail about the error, as returned by PostgREST in the `details` field.
   public let details: String?
   public let hint: String?

--- a/Sources/RealtimeV2/PostgresAction.swift
+++ b/Sources/RealtimeV2/PostgresAction.swift
@@ -13,7 +13,7 @@ public import Foundation
 /// ### Properties
 /// - ``name``
 /// - ``type``
-public struct Column: Equatable, Codable, Sendable {
+public struct Column: Equatable, Decodable, Sendable {
   /// The column name in the database.
   public let name: String
 

--- a/Sources/RealtimeV2/PostgresActionData.swift
+++ b/Sources/RealtimeV2/PostgresActionData.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PostgresActionData: Codable {
+struct PostgresActionData: Decodable {
   var type: String
   var record: [String: AnyJSON]?
   var oldRecord: [String: AnyJSON]?

--- a/Sources/RealtimeV2/PresenceAction.swift
+++ b/Sources/RealtimeV2/PresenceAction.swift
@@ -27,7 +27,7 @@ public struct PresenceV2: Hashable, Sendable {
   public let state: JSONObject
 }
 
-extension PresenceV2: Codable {
+extension PresenceV2: Decodable {
   struct _StringCodingKey: CodingKey {
     var stringValue: String
 
@@ -80,12 +80,6 @@ extension PresenceV2: Codable {
 
     meta["phx_ref"] = nil
     self = PresenceV2(ref: presenceRef, state: meta)
-  }
-
-  public func encode(to encoder: any Encoder) throws {
-    var container = encoder.container(keyedBy: _StringCodingKey.self)
-    try container.encode(ref, forKey: _StringCodingKey("phx_ref"))
-    try container.encode(state, forKey: _StringCodingKey("state"))
   }
 
   /// Decodes the ``state`` dictionary into a `Decodable` model.

--- a/Sources/RealtimeV2/RealtimeJoinConfig.swift
+++ b/Sources/RealtimeV2/RealtimeJoinConfig.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // cspell:ignore pvzp
-struct RealtimeJoinPayload: Codable {
+struct RealtimeJoinPayload: Encodable {
   var config: RealtimeJoinConfig
   var accessToken: String?
   var version: String?
@@ -20,7 +20,7 @@ struct RealtimeJoinPayload: Codable {
   }
 }
 
-struct RealtimeJoinConfig: Codable, Hashable {
+struct RealtimeJoinConfig: Encodable, Hashable {
   var broadcast: BroadcastJoinConfig = .init()
   var presence: PresenceJoinConfig = .init()
   var postgresChanges: [PostgresJoinConfig] = []
@@ -45,7 +45,7 @@ struct RealtimeJoinConfig: Codable, Hashable {
 /// - ``limit``
 /// ### Initialization
 /// - ``init(since:limit:)``
-public struct ReplayOption: Codable, Hashable, Sendable {
+public struct ReplayOption: Encodable, Hashable, Sendable {
   /// Unix timestamp in milliseconds. Messages broadcast after this point will be replayed.
   public var since: Int
 
@@ -74,7 +74,7 @@ public struct ReplayOption: Codable, Hashable, Sendable {
 /// - ``replay``
 /// ### Initialization
 /// - ``init(acknowledgeBroadcasts:receiveOwnBroadcasts:replay:)``
-public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
+public struct BroadcastJoinConfig: Encodable, Hashable, Sendable {
   /// When `true`, the server acknowledges each broadcast message before delivering it.
   ///
   /// Useful in combination with ``RealtimeChannelV2/broadcast(event:message:)-2pvzp``
@@ -132,7 +132,7 @@ public struct BroadcastJoinConfig: Codable, Hashable, Sendable {
 /// - ``key``
 /// ### Initialization
 /// - ``init(key:)``
-public struct PresenceJoinConfig: Codable, Hashable, Sendable {
+public struct PresenceJoinConfig: Encodable, Hashable, Sendable {
   /// The client-defined key used to identify this client's presence entry in the presence map.
   ///
   /// All clients sharing the same key are grouped together in ``PresenceAction/joins``

--- a/Sources/Storage/StorageVectorsClient.swift
+++ b/Sources/Storage/StorageVectorsClient.swift
@@ -189,7 +189,7 @@ private struct ListVectorBucketsResponseBody: Decodable {
 ///
 /// - Warning: Experimental. See ``StorageVectorsClient``.
 @_spi(Experimental)
-public struct VectorBucket: Codable, Sendable, Hashable {
+public struct VectorBucket: Decodable, Sendable, Hashable {
   /// The name of the vector bucket.
   public var vectorBucketName: String
 

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -395,7 +395,7 @@ public struct DestinationOptions: Sendable {
 ///
 /// - ``metadata``
 /// - ``buckets``
-public struct FileObject: Identifiable, Hashable, Codable, Sendable {
+public struct FileObject: Identifiable, Hashable, Decodable, Sendable {
   /// The name of the file, including its extension.
   public var name: String
 
@@ -581,7 +581,7 @@ public struct FileObjectV2: Identifiable, Hashable, Decodable, Sendable {
 ///
 /// - ``createdAt``
 /// - ``updatedAt``
-public struct Bucket: Identifiable, Hashable, Codable, Sendable {
+public struct Bucket: Identifiable, Hashable, Decodable, Sendable {
   /// The unique identifier of the bucket.
   public var id: String
 

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -791,15 +791,10 @@ extension ResizeMode: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) { self.init(rawValue: value) }
 }
 
-extension ResizeMode: Codable {
+extension ResizeMode: Encodable {
   public func encode(to encoder: any Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(rawValue)
-  }
-
-  public init(from decoder: any Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    self.init(rawValue: try container.decode(String.self))
   }
 }
 
@@ -841,15 +836,10 @@ extension ImageFormat: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) { self.init(rawValue: value) }
 }
 
-extension ImageFormat: Codable {
+extension ImageFormat: Encodable {
   public func encode(to encoder: any Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(rawValue)
-  }
-
-  public init(from decoder: any Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    self.init(rawValue: try container.decode(String.self))
   }
 }
 
@@ -887,15 +877,10 @@ extension SortOrder: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) { self.init(rawValue: value) }
 }
 
-extension SortOrder: Codable {
+extension SortOrder: Encodable {
   public func encode(to encoder: any Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(rawValue)
-  }
-
-  public init(from decoder: any Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    self.init(rawValue: try container.decode(String.self))
   }
 }
 

--- a/Sources/Storage/VectorBucketClient.swift
+++ b/Sources/Storage/VectorBucketClient.swift
@@ -355,7 +355,7 @@ public struct VectorIndexMetadataConfiguration: Codable, Sendable, Hashable {
 ///
 /// - Warning: Experimental. See ``StorageVectorsClient``.
 @_spi(Experimental)
-public struct VectorIndex: Codable, Sendable, Hashable {
+public struct VectorIndex: Decodable, Sendable, Hashable {
   /// The name of the index.
   public var indexName: String
 
@@ -383,7 +383,7 @@ public struct VectorIndex: Codable, Sendable, Hashable {
 ///
 /// - Warning: Experimental. See ``StorageVectorsClient``.
 @_spi(Experimental)
-public struct VectorIndexSummary: Codable, Sendable, Hashable {
+public struct VectorIndexSummary: Decodable, Sendable, Hashable {
   /// The name of the index.
   public var indexName: String
 

--- a/Sources/Storage/VectorIndexClient.swift
+++ b/Sources/Storage/VectorIndexClient.swift
@@ -337,7 +337,7 @@ public struct VectorData: Codable, Sendable, Hashable {
 ///
 /// - Warning: Experimental. See ``StorageVectorsClient``.
 @_spi(Experimental)
-public struct VectorEntry: Codable, Sendable, Hashable {
+public struct VectorEntry: Encodable, Sendable, Hashable {
   /// A unique identifier for the vector within its index.
   public var key: String
 
@@ -366,7 +366,7 @@ public struct VectorEntry: Codable, Sendable, Hashable {
 ///
 /// - Warning: Experimental. See ``StorageVectorsClient``.
 @_spi(Experimental)
-public struct VectorMatch: Codable, Sendable, Hashable {
+public struct VectorMatch: Decodable, Sendable, Hashable {
   /// The vector's unique key.
   public var key: String
 

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -3203,23 +3203,25 @@ extension AuthMockerTests {
         "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2lkIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1NDMyMS9hdXRoL3YxIiwiYXVkIjoiYXV0aGVudGljYXRlZCIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlIjoiYXV0aGVudGljYXRlZCJ9.dummysignature"
 
       // Mock JWKS endpoint with different kid
-      let jwkDict: [String: Any] = [
-        "kty": "RSA",
-        "kid": "different-kid",
-        "alg": "RS256",
-        "n": "modulus",
-        "e": "AQAB",
+      let jwksDict: [String: Any] = [
+        "keys": [
+          [
+            "kty": "RSA",
+            "kid": "different-kid",
+            "alg": "RS256",
+            "n": "modulus",
+            "e": "AQAB",
+          ]
+        ]
       ]
-      let jwkData = try JSONSerialization.data(withJSONObject: jwkDict)
-      let jwk = try AuthClient.Configuration.jsonDecoder.decode(JWK.self, from: jwkData)
-      let jwks = JWKS(keys: [jwk])
+      let jwksData = try JSONSerialization.data(withJSONObject: jwksDict)
 
       Mock(
         url: clientURL.appendingPathComponent(".well-known/jwks.json"),
         ignoreQuery: true,
         contentType: .json,
         statusCode: 200,
-        data: [.get: try! AuthClient.Configuration.jsonEncoder.encode(jwks)]
+        data: [.get: jwksData]
       ).register()
 
       let user = User(fromMockNamed: "user")

--- a/Tests/HelpersTests/PostgrestErrorTests.swift
+++ b/Tests/HelpersTests/PostgrestErrorTests.swift
@@ -36,5 +36,4 @@ struct PostgrestErrorTests {
     #expect(error.code == "23505")
     #expect(error.message == "duplicate key value violates unique constraint \"users_pkey\"")
   }
-
 }

--- a/Tests/HelpersTests/PostgrestErrorTests.swift
+++ b/Tests/HelpersTests/PostgrestErrorTests.swift
@@ -37,16 +37,4 @@ struct PostgrestErrorTests {
     #expect(error.message == "duplicate key value violates unique constraint \"users_pkey\"")
   }
 
-  @Test
-  func encodesDetailsToWireKey() throws {
-    let error = PostgrestError(details: "a detail", message: "a message")
-
-    let data = try JSONEncoder().encode(error)
-    let object = try #require(
-      try JSONSerialization.jsonObject(with: data) as? [String: Any]
-    )
-
-    #expect(object["details"] as? String == "a detail")
-    #expect(object["detail"] == nil)
-  }
 }

--- a/Tests/IntegrationTests/StorageFileIntegrationTests.swift
+++ b/Tests/IntegrationTests/StorageFileIntegrationTests.swift
@@ -360,15 +360,8 @@ final class StorageFileIntegrationTests {
     try await storage.from(bucketName).upload(path, data: Data())
 
     let files = try await storage.from(bucketName).list()
-    assertInlineSnapshot(of: files, as: .json) {
-      """
-      [
-        {
-          "name" : "empty-folder"
-        }
-      ]
-      """
-    }
+    #expect(files.map(\.name) == ["empty-folder"])
+    #expect(files.allSatisfy { $0.id == nil })
   }
 
   @Test

--- a/Tests/RealtimeTests/PresenceActionTests.swift
+++ b/Tests/RealtimeTests/PresenceActionTests.swift
@@ -195,28 +195,6 @@ struct PresenceActionTests {
     }
   }
 
-  @Test
-  func presenceV2Encoding() throws {
-    let state: JSONObject = [
-      "user_id": .string("user_789"),
-      "status": .string("online"),
-      "count": .integer(42),
-    ]
-    let presence = PresenceV2(ref: "test_ref", state: state)
-
-    let encodedData = try JSONEncoder().encode(presence)
-    let decodedDict = try JSONSerialization.jsonObject(with: encodedData) as? [String: Any]
-
-    #expect(decodedDict != nil)
-    #expect(decodedDict?["phx_ref"] as? String == "test_ref")
-
-    let stateDict = decodedDict?["state"] as? [String: Any]
-    #expect(stateDict != nil)
-    #expect(stateDict?["user_id"] as? String == "user_789")
-    #expect(stateDict?["status"] as? String == "online")
-    #expect(stateDict?["count"] as? Int == 42)
-  }
-
   // MARK: - PresenceV2 decodeState Tests
 
   struct TestUser: Codable, Equatable {
@@ -561,9 +539,6 @@ struct PresenceActionTests {
       "metadata": .object(["key": .string("value")]),
     ]
     let originalPresence = PresenceV2(ref: "original_ref", state: originalState)
-
-    // Test that encoding works (we don't need the actual data for this test)
-    _ = try JSONEncoder().encode(originalPresence)
 
     // Create the expected server format manually by adding the state to metas with phx_ref
     let stateWithRef = originalState.merging(["phx_ref": .string(originalPresence.ref)]) { _, new in

--- a/Tests/RealtimeTests/PresenceActionTests.swift
+++ b/Tests/RealtimeTests/PresenceActionTests.swift
@@ -529,7 +529,7 @@ struct PresenceActionTests {
   }
 
   @Test
-  func presenceV2RoundTripCoding() throws {
+  func presenceV2DecodesRealisticServerPayload() throws {
     let originalState: JSONObject = [
       "user_id": .string("user_789"),
       "status": .string("online"),

--- a/Tests/RealtimeTests/RealtimeJoinConfigTests.swift
+++ b/Tests/RealtimeTests/RealtimeJoinConfigTests.swift
@@ -48,29 +48,6 @@ struct RealtimeJoinConfigTests {
     #expect(jsonObject?["version"] as? String == "1.0")
   }
 
-  @Test
-  func realtimeJoinPayloadDecoding() throws {
-    let jsonData = """
-      {
-        "config": {
-          "broadcast": {"ack": false, "self": false, "replication_ready": false},
-          "presence": {"key": "", "enabled": false},
-          "postgres_changes": [],
-          "private": false
-        },
-        "access_token": "token123",
-        "version": "1.0"
-      }
-      """.data(using: .utf8)!
-
-    let decoder = JSONDecoder()
-    let payload = try decoder.decode(RealtimeJoinPayload.self, from: jsonData)
-
-    #expect(payload.accessToken == "token123")
-    #expect(payload.version == "1.0")
-    #expect(!payload.config.isPrivate)
-  }
-
   // MARK: - RealtimeJoinConfig Tests
 
   @Test
@@ -184,23 +161,6 @@ struct RealtimeJoinConfigTests {
   }
 
   @Test
-  func broadcastJoinConfigDecoding() throws {
-    let jsonData = """
-      {
-        "ack": true,
-        "self": false,
-        "replication_ready": false
-      }
-      """.data(using: .utf8)!
-
-    let decoder = JSONDecoder()
-    let config = try decoder.decode(BroadcastJoinConfig.self, from: jsonData)
-
-    #expect(config.acknowledgeBroadcasts)
-    #expect(!config.receiveOwnBroadcasts)
-  }
-
-  @Test
   func broadcastJoinConfigReplicationReadyDefaultsFalse() {
     let config = BroadcastJoinConfig()
 
@@ -227,21 +187,6 @@ struct RealtimeJoinConfigTests {
     #expect(jsonObject?["replication_ready"] as? Bool == true)
   }
 
-  @Test
-  func broadcastJoinConfigDecodesReplicationReady() throws {
-    let jsonData = """
-      {
-        "ack": false,
-        "self": false,
-        "replication_ready": true
-      }
-      """.data(using: .utf8)!
-
-    let config = try JSONDecoder().decode(BroadcastJoinConfig.self, from: jsonData)
-
-    #expect(config.replicationReady)
-  }
-
   // MARK: - PresenceJoinConfig Tests
 
   @Test
@@ -263,7 +208,7 @@ struct RealtimeJoinConfigTests {
   }
 
   @Test
-  func presenceJoinConfigCodable() throws {
+  func presenceJoinConfigEncoding() throws {
     var config = PresenceJoinConfig()
     config.key = "user123"
     config.enabled = true
@@ -271,11 +216,9 @@ struct RealtimeJoinConfigTests {
     let encoder = JSONEncoder()
     let data = try encoder.encode(config)
 
-    let decoder = JSONDecoder()
-    let decodedConfig = try decoder.decode(PresenceJoinConfig.self, from: data)
-
-    #expect(decodedConfig.key == "user123")
-    #expect(decodedConfig.enabled)
+    let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    #expect(jsonObject?["key"] as? String == "user123")
+    #expect(jsonObject?["enabled"] as? Bool == true)
   }
 
   // MARK: - PostgresChangeEvent Tests

--- a/Tests/StorageTests/ValueTypesTests.swift
+++ b/Tests/StorageTests/ValueTypesTests.swift
@@ -125,13 +125,6 @@ struct ResizeModeTests {
     let encoded = try JSONEncoder().encode(ResizeMode.cover)
     #expect(String(data: encoded, encoding: .utf8) == "\"cover\"")
   }
-
-  @Test
-  func decodes() throws {
-    let data = "\"contain\"".data(using: .utf8)!
-    let mode = try JSONDecoder().decode(ResizeMode.self, from: data)
-    #expect(mode == .contain)
-  }
 }
 
 // MARK: - ImageFormat
@@ -155,13 +148,6 @@ struct ImageFormatTests {
   func encodes() throws {
     let encoded = try JSONEncoder().encode(ImageFormat.webp)
     #expect(String(data: encoded, encoding: .utf8) == "\"webp\"")
-  }
-
-  @Test
-  func decodes() throws {
-    let data = "\"avif\"".data(using: .utf8)!
-    let format = try JSONDecoder().decode(ImageFormat.self, from: data)
-    #expect(format == .avif)
   }
 }
 

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -55,6 +55,44 @@ case .emailChangeConfirmationPending(let confirmation):
 `AuthResponse` itself is unchanged: `signUp` and the Passkey methods still return it, and `user` is
 still non-optional there, since neither endpoint can produce the confirmation-pending shape.
 
+## Several public types narrowed from `Codable` to `Decodable` or `Encodable`
+
+Many public types only ever get used in one direction — either decoded from a server response, or
+encoded into a request body — but declared full `Codable` anyway. That's now narrowed to match
+actual usage, and a couple of hand-rolled coders that only existed for the unused direction were
+deleted along with it.
+
+**Narrowed to `Decodable`-only** (no longer `Encodable`): `AuthResponse`, `SSOResponse`,
+`OAuthClient`, `OAuthClientType`, `OAuthClientRegistrationType`, `OAuthAuthorizationClient`,
+`OAuthAuthorizationUser`, `OAuthAuthorizationDetails`, `OAuthRedirect`, `OAuthGrant`, `JWK`, `JWKS`,
+`JWTHeader`, `JWTClaims`, `AudienceClaim`, `PasskeyListItem` (Auth); `VectorBucket`, `VectorIndex`,
+`VectorIndexSummary`, `VectorMatch` (Storage); `Column`, `PresenceV2` (Realtime); `PostgrestError`
+(shared).
+
+**No longer conform to `Codable` at all** (never encoded or decoded through Codable machinery in
+the first place): `OAuthResponse`, `Provider` (Auth).
+
+**Narrowed to `Encodable`-only** (no longer `Decodable`): `OpenIDConnectCredentials`,
+`AuthMetaSecurity`, `Web3Credentials`, `Web3Chain`, `UserAttributes` (Auth); `ReplayOption`,
+`BroadcastJoinConfig`, `PresenceJoinConfig` (Realtime); `VectorEntry`, `ResizeMode`, `ImageFormat`,
+`SortOrder` (Storage).
+
+If you were relying on encoding one of the `Decodable`-only types (or decoding one of the
+`Encodable`-only types) yourself — e.g. to persist it to disk or pass it through your own
+`Codable`-based pipeline — wrap it in your own type instead:
+
+```swift
+// Before: encoding a response type directly
+let data = try JSONEncoder().encode(oauthClient)
+
+// After: wrap it in your own Codable type if you need to round-trip it
+struct MyOAuthClientCache: Codable {
+  let clientId: UUID
+  let clientName: String
+  // ...the fields you actually need to persist
+}
+```
+
 ## All previously-deprecated APIs have been removed
 
 Every API that carried an `@available(*, deprecated, ...)` annotation ahead of v3 has now been

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -65,17 +65,17 @@ deleted along with it.
 **Narrowed to `Decodable`-only** (no longer `Encodable`): `AuthResponse`, `SSOResponse`,
 `OAuthClient`, `OAuthClientType`, `OAuthClientRegistrationType`, `OAuthAuthorizationClient`,
 `OAuthAuthorizationUser`, `OAuthAuthorizationDetails`, `OAuthRedirect`, `OAuthGrant`, `JWK`, `JWKS`,
-`JWTHeader`, `JWTClaims`, `AudienceClaim`, `PasskeyListItem` (Auth); `VectorBucket`, `VectorIndex`,
-`VectorIndexSummary`, `VectorMatch` (Storage); `Column`, `PresenceV2` (Realtime); `PostgrestError`
-(shared).
+`JWTHeader`, `JWTClaims`, `AudienceClaim`, `PasskeyListItem` (Auth); `FileObject`, `Bucket`,
+`VectorBucket`, `VectorIndex`, `VectorIndexSummary`, `VectorMatch` (Storage); `Column`, `PresenceV2`
+(Realtime); `PostgrestError` (shared).
 
 **No longer conform to `Codable` at all** (never encoded or decoded through Codable machinery in
 the first place): `OAuthResponse`, `Provider` (Auth).
 
 **Narrowed to `Encodable`-only** (no longer `Decodable`): `OpenIDConnectCredentials`,
-`AuthMetaSecurity`, `Web3Credentials`, `Web3Chain`, `UserAttributes` (Auth); `ReplayOption`,
-`BroadcastJoinConfig`, `PresenceJoinConfig` (Realtime); `VectorEntry`, `ResizeMode`, `ImageFormat`,
-`SortOrder` (Storage).
+`OpenIDConnectCredentials.Provider`, `AuthMetaSecurity`, `Web3Credentials`, `Web3Chain`,
+`UserAttributes`, `MessagingChannel` (Auth); `ReplayOption`, `BroadcastJoinConfig`,
+`PresenceJoinConfig` (Realtime); `VectorEntry`, `ResizeMode`, `ImageFormat`, `SortOrder` (Storage).
 
 If you were relying on encoding one of the `Decodable`-only types (or decoding one of the
 `Encodable`-only types) yourself — e.g. to persist it to disk or pass it through your own
@@ -91,6 +91,22 @@ struct MyOAuthClientCache: Codable {
   let clientName: String
   // ...the fields you actually need to persist
 }
+```
+
+The mirror case — decoding an `Encodable`-only type from stored JSON instead of constructing it
+directly — needs the same wrapper:
+
+```swift
+// Before: decoding a request type from stored JSON
+let credentials = try JSONDecoder().decode(OpenIDConnectCredentials.self, from: data)
+
+// After: decode into your own Codable type, then construct the request type from it
+struct MyStoredCredentials: Codable {
+  let provider: String
+  let idToken: String
+}
+let stored = try JSONDecoder().decode(MyStoredCredentials.self, from: data)
+let credentials = OpenIDConnectCredentials(provider: .init(rawValue: stored.provider)!, idToken: stored.idToken)
 ```
 
 ## All previously-deprecated APIs have been removed


### PR DESCRIPTION
## Summary

Closes [SDK-1473](https://linear.app/supabase/issue/SDK-1473/remove-codable-conformance-from-types-that-should-be-only-decodable).

Many public (and a few internal) types conformed to full `Codable` even though the SDK only ever uses them in one direction — response-shaped types were only ever decoded, some request/credential types were only ever encoded. This narrows each type to `Decodable`-only or `Encodable`-only (or drops the conformance entirely where neither direction is used), and deletes the hand-rolled `encode(to:)`/`init(from:)` implementations that only existed for the unused direction.

- ~41 types narrowed across Auth, Storage, Realtime, and Helpers (full list in `V3_MIGRATION.md`)
- Dead hand-rolled coders removed (`AuthResponse`, `JWTClaims`, `AudienceClaim`, `PresenceV2`)
- `AnyJSON.init`/`JSONObject.init` (Helpers) relaxed from `some Codable` to `some Encodable` — neither implementation ever used the `Decodable` half, so this is a non-breaking widening
- New `V3_MIGRATION.md` entry documenting the change and the workaround if you need to round-trip one of these types yourself
- New `AGENTS.md` guideline codifying the convention for future additions

This is a breaking change, but v3 hasn't shipped yet — it's folded into the same pre-v3 cleanup track as #1206 and #1088.

## Test plan

- [x] `swift build` (full repo) — clean
- [x] `swift test --skip IntegrationTests` — 947 tests / 91 suites passing, 0 failures
- [x] `./scripts/format.sh` — no unexpected diff
- [x] Every conformance narrowing verified against actual call sites (no type narrowed without confirming its only usage direction)