### PR TITLE
fix(auth): drop refresh token from log metadata, inject client logger into event emitter

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -223,6 +223,12 @@ public actor AuthClient {
   public init(configuration: Configuration) {
     clientID = AuthClient.nextClientID()
 
+    let logger: Logging.Logger = {
+      var logger = configuration.logger
+      logger[metadataKey: "client_id"] = "\(clientID)"
+      return logger
+    }()
+
     Dependencies[clientID] = Dependencies(
       configuration: configuration,
       http: HTTPClient(configuration: configuration),
@@ -230,11 +236,8 @@ public actor AuthClient {
       codeVerifierStorage: .live(clientID: clientID),
       sessionStorage: .live(clientID: clientID),
       sessionManager: .live(clientID: clientID),
-      logger: {
-        var logger = configuration.logger
-        logger[metadataKey: "client_id"] = "\(clientID)"
-        return logger
-      }()
+      eventEmitter: AuthStateChangeEventEmitter(logger: logger),
+      logger: logger
     )
 
     Task { @MainActor in observeAppLifecycleChanges() }

--- a/Sources/Auth/Internal/SessionManager.swift
+++ b/Sources/Auth/Internal/SessionManager.swift
@@ -72,7 +72,6 @@ private actor LiveSessionManager {
     let logger: Logging.Logger = {
       var scopedLogger = self.logger
       scopedLogger[metadataKey: "refresh_id"] = "\(UUID().uuidString)"
-      scopedLogger[metadataKey: "refresh_token"] = "\(refreshToken)"
       return scopedLogger
     }()
 


### PR DESCRIPTION
## Summary
- Follow-up to #1210, addressing two CodeRabbit findings that landed after merge:
  - [Security] `SessionManager.refreshSession` no longer puts the raw `refresh_token` into logger metadata — it's a reusable credential, and any log sink using this scoped logger could persist it. (https://github.com/supabase/supabase-swift/pull/1210#discussion_r3778425172)
  - [Correctness] `AuthClient` now injects its client-scoped logger into `AuthStateChangeEventEmitter` at init time, instead of the emitter always falling back to `supabaseDefaultLogger`. Custom `Logging.Logger` handlers configured via `Configuration.logger` now receive auth state-change records too. (https://github.com/supabase/supabase-swift/pull/1210#discussion_r3778425163)

## Test plan
- [x] `swift build --target Auth`
- [x] `swift test --filter AuthTests` (242 tests passing)