### PR TITLE
fix(helpers): make OSLogHandler internal-only

### DIFF
--- a/Sources/Helpers/Logger/OSLogHandler.swift
+++ b/Sources/Helpers/Logger/OSLogHandler.swift
@@ -3,42 +3,38 @@
 //  Helpers
 //
 
-public import Foundation
-public import Logging
+import Foundation
+import Logging
 
 #if canImport(OSLog)
   import OSLog
 
-  /// A `Logging.LogHandler` backed by `OSLog`, giving OSLog/Console.app integration to callers
-  /// who want it explicitly — construct it and pass the resulting `Logger` in, no process-wide
-  /// `LoggingSystem.bootstrap` required:
-  ///
-  /// ```swift
-  /// let logger = Logging.Logger(label: "io.supabase.auth") { OSLogHandler(label: $0) }
-  /// ```
-  public struct OSLogHandler: LogHandler {
+  /// A `Logging.LogHandler` backed by `OSLog`, used internally to exercise OSLog/Console.app
+  /// integration in tests. Not exposed publicly — customers who want this should write their own
+  /// minimal `LogHandler` backed by `OSLog`; see the "OSLog parity" section of `V3_MIGRATION.md`.
+  struct OSLogHandler: LogHandler {
     private let osLogger: os.Logger
 
-    public var metadata: Logging.Logger.Metadata = [:]
+    var metadata: Logging.Logger.Metadata = [:]
 
     /// Defaults to `.trace`, so every level is forwarded to OSLog by default — matching the old
     /// `OSLogSupabaseLogger`, which had no threshold at all and let Console.app's own UI handle
     /// level-based filtering on the viewing side. Set this to raise the threshold instead.
-    public var logLevel: Logging.Logger.Level = .trace
+    var logLevel: Logging.Logger.Level = .trace
 
     /// - Parameters:
     ///   - label: Used as the OSLog category.
     ///   - subsystem: The OSLog subsystem. Defaults to the host app's bundle identifier.
-    public init(label: String, subsystem: String = Bundle.main.bundleIdentifier ?? "") {
+    init(label: String, subsystem: String = Bundle.main.bundleIdentifier ?? "") {
       osLogger = os.Logger(subsystem: subsystem, category: label)
     }
 
-    public subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+    subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
       get { metadata[key] }
       set { metadata[key] = newValue }
     }
 
-    public func log(
+    func log(
       level: Logging.Logger.Level,
       message: Logging.Logger.Message,
       metadata: Logging.Logger.Metadata?,

--- a/Tests/IntegrationTests/RealtimeIntegrationTests.swift
+++ b/Tests/IntegrationTests/RealtimeIntegrationTests.swift
@@ -16,6 +16,7 @@
   import TestHelpers
   import Testing
 
+  @testable import Helpers
   @testable import Realtime
   @testable import RealtimeV2
 

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -326,30 +326,31 @@ pass a `Logger` backed by `SwiftLogNoOpLogHandler` (add `import Logging` to this
 logger: Logger(label: "myapp") { _ in SwiftLogNoOpLogHandler() }
 ```
 
-**OSLog parity.** `OSLogSupabaseLogger`'s zero-config OSLog/Console.app integration is replaced by
-`OSLogHandler`, constructed explicitly and installed as the backing handler for a `Logger` (add
-`import Logging` to this file):
+**OSLog parity.** `OSLogSupabaseLogger`'s zero-config OSLog/Console.app integration has no
+replacement shipped by the SDK. Implement your own `LogHandler` conforming type that wraps an
+`os.Logger` and forwards each `Logging.Logger.Level` to the matching OSLog level, then install it
+as the backing handler for a `Logger` (add `import Logging` to this file):
 
 ```swift
-logger: Logger(label: "myapp") { OSLogHandler(label: $0) }
+logger: Logger(label: "myapp") { MyOSLogHandler(label: $0) }
 ```
 
-`OSLogHandler` forwards every level by default (`logLevel` defaults to `.trace`), matching
-`OSLogSupabaseLogger`'s old always-forward behavior — use Console.app's own filtering, or set
-`logger.logLevel` yourself, to narrow what's emitted.
+Default your handler's `logLevel` to `.trace` to match `OSLogSupabaseLogger`'s old always-forward
+behavior — use Console.app's own filtering, or set `logger.logLevel` yourself, to narrow what's
+emitted.
 
-If this file also has `import OSLog` — which it will if you're wiring up `OSLogHandler` alongside
-your app's own OSLog-based logging — you'll hit a `'Logger' is ambiguous for type lookup` compile
-error, because both `Logging.Logger` and `os.Logger` are now in scope unqualified in that file.
-Fix it by fully qualifying whichever type you mean less often, e.g. `os.Logger` for OSLog's own
-type:
+If this file also has `import OSLog` — which it will if you're implementing `MyOSLogHandler`
+alongside your app's own OSLog-based logging — you'll hit a `'Logger' is ambiguous for type
+lookup` compile error, because both `Logging.Logger` and `os.Logger` are now in scope unqualified
+in that file. Fix it by fully qualifying whichever type you mean less often, e.g. `os.Logger` for
+OSLog's own type:
 
 ```swift
 import Logging
 import OSLog
 
 let appLogger = os.Logger(subsystem: "myapp", category: "app")
-let supabaseLogger = Logging.Logger(label: "myapp") { OSLogHandler(label: $0) }
+let supabaseLogger = Logging.Logger(label: "myapp") { MyOSLogHandler(label: $0) }
 ```
 
 or keep the two imports in separate files so the ambiguity never arises.


### PR DESCRIPTION
## Summary
- `OSLogHandler` shipped as public API in #1210, documented in `V3_MIGRATION.md` as the OSLog/Console.app parity replacement for the old `OSLogSupabaseLogger`. This drops it back to internal-only — customers who want OSLog integration should implement their own `LogHandler` instead of relying on one the SDK ships as public API.
- Since v3 hasn't released yet, this is a same-cycle correction rather than a new breaking change against a released version.
- Updates the "OSLog parity" section of `V3_MIGRATION.md` to show customers how to implement their own minimal `OSLog`-backed `LogHandler`, without a copy-pasteable reference implementation.
- Adds `@testable import Helpers` to `RealtimeIntegrationTests.swift`, which constructs `OSLogHandler` directly.

Closes [SDK-1488](https://linear.app/supabase/issue/SDK-1488/make-osloghandler-internal-only).

## Test plan
- [x] `swift build`
- [x] `swift build --build-tests` (including `IntegrationTests`)
- [x] `swift test` (1107 tests passing)
- [x] `./scripts/format.sh` (no changes)
- [x] `./scripts/spell-check.sh` (0 issues)