### PR TITLE
fix(auth)!: always emit locally stored session as initial session

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -1527,8 +1527,8 @@ public actor AuthClient {
 
     eventEmitter.emit(.initialSession, session: currentSession, token: token)
 
-    Task {
-      if currentSession.isExpired {
+    if currentSession.isExpired {
+      Task {
         _ = try? await sessionManager.refreshSession(currentSession.refreshToken)
         // No need to emit `tokenRefreshed` nor `signOut` event since the `refreshSession` does it already.
       }

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -1520,38 +1520,17 @@ public actor AuthClient {
   }
 
   private func emitInitialSession(forToken token: ObservationToken) async {
-    if configuration.emitLocalSessionAsInitialSession {
-      guard let currentSession else {
-        eventEmitter.emit(.initialSession, session: nil, token: token)
-        return
-      }
+    guard let currentSession else {
+      eventEmitter.emit(.initialSession, session: nil, token: token)
+      return
+    }
 
-      eventEmitter.emit(.initialSession, session: currentSession, token: token)
+    eventEmitter.emit(.initialSession, session: currentSession, token: token)
 
-      Task {
-        if currentSession.isExpired {
-          _ = try? await sessionManager.refreshSession(currentSession.refreshToken)
-          // No need to emit `tokenRefreshed` nor `signOut` event since the `refreshSession` does it already.
-        }
-      }
-    } else {
-      let session = try? await session
-      eventEmitter.emit(.initialSession, session: session, token: token)
-
-      // Properly expecting issues during tests isn't working as expected, I think because the reportIssue is usually triggered inside an unstructured Task
-      // because of this I'm disabling issue reporting during tests, so we can use it only for advising developers when running their applications.
-      if !isTesting {
-        reportIssue(
-          """
-          Initial session emitted after attempting to refresh the local stored session.
-          This is incorrect behavior and will be fixed in the next major release since it's a breaking change.
-          To opt-in to the new behavior now, set `emitLocalSessionAsInitialSession: true` in your AuthClient configuration.
-          The new behavior ensures that the locally stored session is always emitted, regardless of its validity or expiration.
-          If you rely on the initial session to opt users in, you need to add an additional check for `session.isExpired` in the session.
-
-          Check https://github.com/supabase/supabase-swift/pull/822 for more information.
-          """
-        )
+    Task {
+      if currentSession.isExpired {
+        _ = try? await sessionManager.refreshSession(currentSession.refreshToken)
+        // No need to emit `tokenRefreshed` nor `signOut` event since the `refreshSession` does it already.
       }
     }
   }

--- a/Sources/Auth/AuthClientConfiguration.swift
+++ b/Sources/Auth/AuthClientConfiguration.swift
@@ -41,7 +41,6 @@ extension AuthClient {
   /// ### Token refresh
   /// - ``autoRefreshToken``
   /// - ``defaultAutoRefreshToken``
-  /// - ``emitLocalSessionAsInitialSession``
   ///
   /// ### Defaults
   /// - ``defaultFlowType``
@@ -82,16 +81,6 @@ extension AuthClient {
     /// Set to `true` if you want to automatically refresh the token before expiring.
     public let autoRefreshToken: Bool
 
-    /// When `true`, emits the locally stored session immediately as the initial session,
-    /// regardless of its validity or expiration. When `false`, emits the initial session
-    /// after attempting to refresh the local stored session (legacy behavior).
-    ///
-    /// Default is `false` for backward compatibility. This will change to `true` in the next major release.
-    ///
-    /// - Note: If you rely on the initial session to opt users in, you need to add an additional
-    ///   check for `session.isExpired` when this is set to `true`.
-    public let emitLocalSessionAsInitialSession: Bool
-
     /// Initializes a AuthClient Configuration with optional parameters.
     ///
     /// - Parameters:
@@ -104,7 +93,6 @@ extension AuthClient {
     ///   - logger: The logger to use. Defaults to a build-config-aware logger — see `Configuration.logger`.
     ///   - fetch: The asynchronous fetch handler for network requests.
     ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
-    ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
     public init(
       url: URL? = nil,
       headers: [String: String] = [:],
@@ -114,8 +102,7 @@ extension AuthClient {
       localStorage: any AuthLocalStorage,
       logger: Logging.Logger = supabaseDefaultLogger(label: "io.supabase.auth"),
       fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
-      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
-      emitLocalSessionAsInitialSession: Bool = false
+      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken
     ) {
       self.init(
         url: url,
@@ -128,8 +115,7 @@ extension AuthClient {
         resolvedEncoder: AuthClient.Configuration.jsonEncoder,
         resolvedDecoder: AuthClient.Configuration.jsonDecoder,
         fetch: fetch,
-        autoRefreshToken: autoRefreshToken,
-        emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+        autoRefreshToken: autoRefreshToken
       )
     }
 
@@ -148,8 +134,7 @@ extension AuthClient {
       resolvedEncoder: JSONEncoder,
       resolvedDecoder: JSONDecoder,
       fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
-      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
-      emitLocalSessionAsInitialSession: Bool = false
+      autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken
     ) {
       let headers = headers.merging(Configuration.defaultHeaders) { l, _ in l }
 
@@ -166,7 +151,6 @@ extension AuthClient {
       self.resolvedDecoder = resolvedDecoder
       self.fetch = fetch
       self.autoRefreshToken = autoRefreshToken
-      self.emitLocalSessionAsInitialSession = emitLocalSessionAsInitialSession
     }
   }
 
@@ -182,7 +166,6 @@ extension AuthClient {
   ///   - logger: The logger to use. Defaults to a build-config-aware logger — see `Configuration.logger`.
   ///   - fetch: The asynchronous fetch handler for network requests.
   ///   - autoRefreshToken: Set to `true` if you want to automatically refresh the token before expiring.
-  ///   - emitLocalSessionAsInitialSession: When `true`, emits the locally stored session immediately as the initial session.
   public init(
     url: URL? = nil,
     headers: [String: String] = [:],
@@ -192,8 +175,7 @@ extension AuthClient {
     localStorage: any AuthLocalStorage,
     logger: Logging.Logger = supabaseDefaultLogger(label: "io.supabase.auth"),
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
-    autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
-    emitLocalSessionAsInitialSession: Bool = false
+    autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken
   ) {
     self.init(
       configuration: Configuration(
@@ -205,8 +187,7 @@ extension AuthClient {
         localStorage: localStorage,
         logger: logger,
         fetch: fetch,
-        autoRefreshToken: autoRefreshToken,
-        emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+        autoRefreshToken: autoRefreshToken
       )
     )
   }

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -267,8 +267,7 @@ public final class SupabaseClient: Sendable {
         // DON'T use `fetchWithAuth` method within the AuthClient as it may cause a deadlock.
         try await options.global.session.data(for: TraceContext.inject(into: $0))
       },
-      autoRefreshToken: options.auth.autoRefreshToken,
-      emitLocalSessionAsInitialSession: options.auth.emitLocalSessionAsInitialSession
+      autoRefreshToken: options.auth.autoRefreshToken
     )
 
     if options.auth.accessToken == nil {

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -64,13 +64,6 @@ public struct SupabaseClientOptions: Sendable {
     /// Set to `true` if you want to automatically refresh the token before expiring.
     public let autoRefreshToken: Bool
 
-    /// When `true`, emits the locally stored session immediately as the initial session,
-    /// regardless of its validity or expiration. When `false`, emits the initial session
-    /// after attempting to refresh the local stored session (legacy behavior).
-    ///
-    /// Default is `false` for backward compatibility. This will change to `true` in the next major release.
-    public let emitLocalSessionAsInitialSession: Bool
-
     /// Optional function for using a third-party authentication system with Supabase. The function should return an access token or ID token (JWT) by obtaining it from the third-party auth client library.
     /// Note that this function may be called concurrently and many times. Use memoization and locking techniques if this is not supported by the client libraries.
     /// When set, the `auth` namespace of the Supabase client cannot be used.
@@ -83,7 +76,6 @@ public struct SupabaseClientOptions: Sendable {
       storageKey: String? = nil,
       flowType: AuthFlowType = AuthClient.Configuration.defaultFlowType,
       autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
-      emitLocalSessionAsInitialSession: Bool = false,
       accessToken: (@Sendable () async throws -> String?)? = nil
     ) {
       self.storage = storage
@@ -91,7 +83,6 @@ public struct SupabaseClientOptions: Sendable {
       self.storageKey = storageKey
       self.flowType = flowType
       self.autoRefreshToken = autoRefreshToken
-      self.emitLocalSessionAsInitialSession = emitLocalSessionAsInitialSession
       self.accessToken = accessToken
     }
   }
@@ -205,7 +196,6 @@ extension SupabaseClientOptions.AuthOptions {
       storageKey: String? = nil,
       flowType: AuthFlowType = AuthClient.Configuration.defaultFlowType,
       autoRefreshToken: Bool = AuthClient.Configuration.defaultAutoRefreshToken,
-      emitLocalSessionAsInitialSession: Bool = false,
       accessToken: (@Sendable () async throws -> String?)? = nil
     ) {
       self.init(
@@ -214,7 +204,6 @@ extension SupabaseClientOptions.AuthOptions {
         storageKey: storageKey,
         flowType: flowType,
         autoRefreshToken: autoRefreshToken,
-        emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession,
         accessToken: accessToken
       )
     }

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -2957,51 +2957,6 @@ extension AuthMockerTests {
 
       Dependencies[sut.clientID].sessionStorage.store(.expiredSession)
 
-      let expectedEvents = [AuthChangeEvent.signedOut, .initialSession]
-
-      try await assertAuthStateChanges(
-        sut: sut,
-        action: {
-          do {
-            _ = try await sut.session
-            Issue.record("Expected failure")
-          } catch {
-            #expect(error as? AuthError == .sessionMissing)
-          }
-        },
-        expectedEvents: expectedEvents
-      )
-
-      #expect(Dependencies[sut.clientID].sessionStorage.get() == nil)
-    }
-
-    @Test
-    func
-      removeSessionAndSignoutIfRefreshTokenNotFoundErrorReturned_withEmitLocalSessionAsInitialSession()
-      async throws
-    {
-      let sut = makeSUT(emitLocalSessionAsInitialSession: true)
-
-      Mock(
-        url: clientURL.appendingPathComponent("token").appendingQueryItems([
-          URLQueryItem(name: "grant_type", value: "refresh_token")
-        ]),
-        statusCode: 403,
-        data: [
-          .post: Data(
-            """
-            {
-              "error_code": "refresh_token_not_found",
-              "message": "Invalid Refresh Token: Refresh Token Not Found"
-            }
-            """.utf8
-          )
-        ]
-      )
-      .register()
-
-      Dependencies[sut.clientID].sessionStorage.store(.expiredSession)
-
       let expectedEvents = [AuthChangeEvent.initialSession, .signedOut]
 
       try await assertAuthStateChanges(
@@ -3023,32 +2978,6 @@ extension AuthMockerTests {
     @Test
     func refreshToken() async throws {
       let sut = makeSUT()
-
-      Mock(
-        url: clientURL.appendingPathComponent("token").appendingQueryItems([
-          URLQueryItem(name: "grant_type", value: "refresh_token")
-        ]),
-        statusCode: 200,
-        data: [.post: try AuthClient.Configuration.jsonEncoder.encode(Session.validSession)]
-      )
-      .register()
-
-      Dependencies[sut.clientID].sessionStorage.store(.expiredSession)
-
-      let expectedEvents = [AuthChangeEvent.tokenRefreshed, .initialSession]
-
-      try await assertAuthStateChanges(
-        sut: sut,
-        action: {
-          _ = try await sut.session
-        },
-        expectedEvents: expectedEvents
-      )
-    }
-
-    @Test
-    func refreshToken_withEmitLocalSessionAsInitialSession() async throws {
-      let sut = makeSUT(emitLocalSessionAsInitialSession: true)
 
       Mock(
         url: clientURL.appendingPathComponent("token").appendingQueryItems([
@@ -3443,7 +3372,7 @@ extension AuthMockerTests {
     }
 
     private func makeSUT(
-      flowType: AuthFlowType = .pkce, emitLocalSessionAsInitialSession: Bool = false
+      flowType: AuthFlowType = .pkce
     ) -> AuthClient {
       let sessionConfiguration = URLSessionConfiguration.default
       sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
@@ -3459,8 +3388,7 @@ extension AuthMockerTests {
         localStorage: storage,
         fetch: { request in
           try await session.data(for: request)
-        },
-        emitLocalSessionAsInitialSession: emitLocalSessionAsInitialSession
+        }
       )
 
       let sut = AuthClient(configuration: configuration)

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -55,6 +55,46 @@ case .emailChangeConfirmationPending(let confirmation):
 `AuthResponse` itself is unchanged: `signUp` and the Passkey methods still return it, and `user` is
 still non-optional there, since neither endpoint can produce the confirmation-pending shape.
 
+## `emitLocalSessionAsInitialSession` removed — the locally stored session is now always emitted as the initial session
+
+`AuthClient.Configuration.emitLocalSessionAsInitialSession` and the matching parameter on
+`AuthClient.init`/`SupabaseClientOptions.AuthOptions.init` are removed. The behavior it used to gate
+behind `true` is now the only behavior.
+
+Previously, the `.initialSession` auth state change event was emitted only after the SDK tried to
+refresh the locally stored session, silently swallowing the difference between a session that was
+merely expired (refreshable) and one whose refresh token was actually invalid (e.g. revoked or
+already used) — both surfaced the same way to listeners, and every launch paid the cost of a
+network round-trip before `.initialSession` fired at all. `.initialSession` now always fires
+immediately with whatever session is stored locally, and a best-effort refresh happens in the
+background if it's expired. See
+[#822](https://github.com/supabase/supabase-swift/pull/822) for the original discussion.
+
+This is a compile error for anyone passing `emitLocalSessionAsInitialSession:` explicitly — the
+parameter no longer exists. It's also a silent behavior change for everyone else: search your
+codebase for `onAuthStateChange`/`authStateChanges` handlers that switch on `.initialSession` and
+assume the session they receive is always valid. Since the initial session may now be expired,
+check `session.isExpired` yourself:
+
+```swift
+// Before
+for await (event, session) in client.auth.authStateChanges {
+  if event == .initialSession, let session {
+    signIn(user: session.user)
+  }
+}
+
+// After
+for await (event, session) in client.auth.authStateChanges {
+  if event == .initialSession, let session, !session.isExpired {
+    signIn(user: session.user)
+  }
+}
+```
+
+There's no escape hatch back to the old behavior — the SDK no longer performs a blocking refresh
+before the initial session fires.
+
 ## Several public types narrowed from `Codable` to `Decodable` or `Encodable`
 
 Many public types only ever get used in one direction — either decoded from a server response, or


### PR DESCRIPTION
## Summary

- Removes `emitLocalSessionAsInitialSession` (`AuthClient.Configuration`, `AuthClient.init`, `SupabaseClientOptions.AuthOptions`) — the behavior it used to gate behind `true` is now the only behavior.
- `.initialSession` now always fires immediately with whatever session is stored locally, with a best-effort refresh in the background if it's expired. Previously it fired only after attempting to refresh the local session, collapsing "merely expired" and "refresh token invalid" into the same emitted session and adding a network round-trip delay to every launch.
- Removes the now-unreachable `reportIssue` runtime warning that told developers to opt in early.
- Adds a `V3_MIGRATION.md` entry (compile error for explicit `emitLocalSessionAsInitialSession:` callers, silent behavior change otherwise — check `session.isExpired` in `.initialSession` handlers).

See #822 for the original discussion. Tracked in [SDK-1489](https://linear.app/supabase/issue/SDK-1489).

## Test plan

- [x] `swift build --target Auth --target Supabase`
- [x] `swift test --filter AuthTests` (240 tests passing)
- [x] `./scripts/spell-check.sh`
- [x] `./scripts/format.sh`