### PR TITLE
fix(auth)!: convert MobileOTPType to a RawRepresentable struct

### DIFF
--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -645,12 +645,26 @@ struct VerifyMobileOTPParams: Encodable, Hashable {
 }
 
 /// The OTP type used when verifying a mobile (SMS/WhatsApp) one-time password.
-public enum MobileOTPType: String, Encodable, Sendable {
+public struct MobileOTPType: RawRepresentable, Encodable, Hashable, Sendable,
+  ExpressibleByStringLiteral
+{
+  public let rawValue: String
+
+  /// Creates a ``MobileOTPType`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a ``MobileOTPType`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
   /// A standard SMS OTP sent to the phone number.
-  case sms
+  public static let sms: MobileOTPType = "sms"
 
   /// An OTP used when confirming a phone number change.
-  case phoneChange = "phone_change"
+  public static let phoneChange: MobileOTPType = "phone_change"
 }
 
 /// The OTP type used when verifying an email one-time password.

--- a/Tests/AuthTests/TypesTests.swift
+++ b/Tests/AuthTests/TypesTests.swift
@@ -79,4 +79,23 @@ struct TypesTests {
     let provider: OpenIDConnectCredentials.Provider = "custom_oidc_provider"
     #expect(provider.rawValue == "custom_oidc_provider")
   }
+
+  @Test
+  func mobileOTPTypeEncodesAsRawString() throws {
+    let data = try JSONEncoder().encode(MobileOTPType.phoneChange)
+    #expect(String(decoding: data, as: UTF8.self) == "\"phone_change\"")
+  }
+
+  @Test
+  func mobileOTPTypeStringLiteral() {
+    let type: MobileOTPType = "new_channel"
+    #expect(type.rawValue == "new_channel")
+  }
+
+  @Test
+  func mobileOTPTypeHashability() {
+    let type1: MobileOTPType = .sms
+    let type2: MobileOTPType = "sms"
+    #expect(type1 == type2)
+  }
 }

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -692,3 +692,30 @@ default: ...  // a provider the SDK doesn't have a case for
 Compile error only if you have an exhaustive `switch` over this type — add a `default:` case.
 Constructing and comparing known providers (`OpenIDConnectCredentials(provider: .apple, ...)`,
 `provider == .google`) work unchanged.
+
+## `MobileOTPType` is now a struct, not an enum
+
+`MobileOTPType` (the OTP kind passed to `verifyOTP` for phone-based flows) is a `RawRepresentable`
+struct instead of an `enum`.
+
+It's sent to the backend, not decoded from it, but it's part of the public API surface — as an
+`enum`, using an OTP type GoTrue added after this SDK version shipped required an SDK upgrade
+even though constructing the value doesn't need one.
+
+```swift
+// Before
+switch type {
+case .sms: ...
+case .phoneChange: ...
+}
+
+// After
+switch type {
+case .sms: ...
+case .phoneChange: ...
+default: ...  // an OTP type the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `MobileOTPType` — add a `default:` case.
+Passing `.sms` / `.phoneChange` as an argument works unchanged.


### PR DESCRIPTION
## Summary

- Converts `MobileOTPType` (SMS/phone-change OTP kind for `verifyOTP`) from a `String` enum to a `RawRepresentable` struct (`Encodable`-only, matching the original — never `Decodable`).
- It's sent to the backend, not decoded from it, but it's `Codable` and part of the public API surface — converting now closes the gap ahead of an SDK upgrade being needed just to construct a value.
- Adds `V3_MIGRATION.md` section.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 6 of 15**. Stacked on #1219 (`OpenIDConnectCredentials.Provider`); review that first.

## Test plan

- [x] Appended tests: raw-string JSON encoding, string-literal construction, hashability.
- [x] Full `AuthTests` suite passes (262/262), no regressions — no `switch` over `MobileOTPType` anywhere in the codebase.