### PR TITLE
fix(auth)!: convert EmailOTPType to a RawRepresentable struct

### DIFF
--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -668,24 +668,38 @@ public struct MobileOTPType: RawRepresentable, Encodable, Hashable, Sendable,
 }
 
 /// The OTP type used when verifying an email one-time password.
-public enum EmailOTPType: String, Encodable, CaseIterable, Sendable {
+public struct EmailOTPType: RawRepresentable, Encodable, Hashable, Sendable,
+  ExpressibleByStringLiteral
+{
+  public let rawValue: String
+
+  /// Creates an ``EmailOTPType`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates an ``EmailOTPType`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
   /// OTP sent during initial sign-up email confirmation.
-  case signup
+  public static let signup: EmailOTPType = "signup"
 
   /// OTP sent when an admin invites a user by email.
-  case invite
+  public static let invite: EmailOTPType = "invite"
 
   /// OTP sent as part of a magic-link sign-in flow.
-  case magiclink
+  public static let magiclink: EmailOTPType = "magiclink"
 
   /// OTP sent when the user requests a password reset.
-  case recovery
+  public static let recovery: EmailOTPType = "recovery"
 
   /// OTP sent when the user requests an email address change.
-  case emailChange = "email_change"
+  public static let emailChange: EmailOTPType = "email_change"
 
   /// Generic email OTP.
-  case email
+  public static let email: EmailOTPType = "email"
 }
 
 /// The response from sign-up and passkey calls that may return either a session or a user,

--- a/Tests/AuthTests/TypesTests.swift
+++ b/Tests/AuthTests/TypesTests.swift
@@ -98,4 +98,23 @@ struct TypesTests {
     let type2: MobileOTPType = "sms"
     #expect(type1 == type2)
   }
+
+  @Test
+  func emailOTPTypeEncodesAsRawString() throws {
+    let data = try JSONEncoder().encode(EmailOTPType.emailChange)
+    #expect(String(decoding: data, as: UTF8.self) == "\"email_change\"")
+  }
+
+  @Test
+  func emailOTPTypeStringLiteral() {
+    let type: EmailOTPType = "new_flow"
+    #expect(type.rawValue == "new_flow")
+  }
+
+  @Test
+  func emailOTPTypeHashability() {
+    let type1: EmailOTPType = .signup
+    let type2: EmailOTPType = "signup"
+    #expect(type1 == type2)
+  }
 }

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -719,3 +719,33 @@ default: ...  // an OTP type the SDK doesn't have a case for
 
 Compile error only if you have an exhaustive `switch` over `MobileOTPType` — add a `default:` case.
 Passing `.sms` / `.phoneChange` as an argument works unchanged.
+
+## `EmailOTPType` is now a struct, not an enum
+
+`EmailOTPType` (the OTP kind passed to `verifyOTP` for email-based flows) is a `RawRepresentable`
+struct instead of an `enum`. It no longer conforms to `CaseIterable`.
+
+It's sent to the backend, not decoded from it, but it's part of the public API surface — as an
+`enum`, using an OTP type GoTrue added after this SDK version shipped required an SDK upgrade
+even though constructing the value doesn't need one.
+
+```swift
+// Before
+switch type {
+case .signup: ...
+case .recovery: ...
+// ...
+}
+
+// After
+switch type {
+case .signup: ...
+case .recovery: ...
+// ...
+default: ...  // an OTP type the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `EmailOTPType` — add a `default:` case.
+`EmailOTPType.allCases` no longer exists, with no built-in replacement — maintain your own array if
+you were relying on it.


### PR DESCRIPTION
## Summary

- Converts `EmailOTPType` (email OTP kind for `verifyOTP`) from a `String` enum to a `RawRepresentable` struct (`Encodable`-only). Drops `CaseIterable` with no replacement — zero call sites relied on `.allCases` anywhere in the codebase.
- It's sent to the backend, not decoded from it, but it's `Codable` and part of the public API surface — same forward-compatibility rationale as the rest of this stack.
- Adds `V3_MIGRATION.md` section.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 7 of 15**. Stacked on #1220 (`MobileOTPType`); review that first.

## Test plan

- [x] Appended tests: raw-string JSON encoding, string-literal construction, hashability.
- [x] Full `AuthTests` suite passes (265/265), no regressions.