### PR TITLE
fix(auth)!: convert ResendEmailType to a RawRepresentable struct

### DIFF
--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1310,12 +1310,26 @@ public enum SignOutScope: String, Sendable {
 }
 
 /// The type of email to resend when calling ``AuthClient/resend(email:type:emailRedirectTo:captchaToken:)``.
-public enum ResendEmailType: String, Hashable, Sendable, Encodable {
+public struct ResendEmailType: RawRepresentable, Encodable, Hashable, Sendable,
+  ExpressibleByStringLiteral
+{
+  public let rawValue: String
+
+  /// Creates a ``ResendEmailType`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a ``ResendEmailType`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
   /// Resends the initial sign-up confirmation email.
-  case signup
+  public static let signup: ResendEmailType = "signup"
 
   /// Resends the email-change confirmation email.
-  case emailChange = "email_change"
+  public static let emailChange: ResendEmailType = "email_change"
 }
 
 struct ResendEmailParams: Encodable {

--- a/Tests/AuthTests/TypesTests.swift
+++ b/Tests/AuthTests/TypesTests.swift
@@ -117,4 +117,16 @@ struct TypesTests {
     let type2: EmailOTPType = "signup"
     #expect(type1 == type2)
   }
+
+  @Test
+  func resendEmailTypeEncodesAsRawString() throws {
+    let data = try JSONEncoder().encode(ResendEmailType.emailChange)
+    #expect(String(decoding: data, as: UTF8.self) == "\"email_change\"")
+  }
+
+  @Test
+  func resendEmailTypeStringLiteral() {
+    let type: ResendEmailType = "new_resend_kind"
+    #expect(type.rawValue == "new_resend_kind")
+  }
 }

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -749,3 +749,30 @@ default: ...  // an OTP type the SDK doesn't have a case for
 Compile error only if you have an exhaustive `switch` over `EmailOTPType` — add a `default:` case.
 `EmailOTPType.allCases` no longer exists, with no built-in replacement — maintain your own array if
 you were relying on it.
+
+## `ResendEmailType` is now a struct, not an enum
+
+`ResendEmailType` (the resend kind passed to `resend`) is a `RawRepresentable` struct instead of
+an `enum`.
+
+It's sent to the backend, not decoded from it, but it's part of the public API surface — as an
+`enum`, using a resend type GoTrue added after this SDK version shipped required an SDK upgrade
+even though constructing the value doesn't need one.
+
+```swift
+// Before
+switch type {
+case .signup: ...
+case .emailChange: ...
+}
+
+// After
+switch type {
+case .signup: ...
+case .emailChange: ...
+default: ...  // a resend type the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `ResendEmailType` — add a `default:`
+case. Passing `.signup` / `.emailChange` as an argument works unchanged.


### PR DESCRIPTION
## Summary

- Converts `ResendEmailType` (resend kind for `resend`) from a `String` enum to a `RawRepresentable` struct (`Encodable`-only).
- It's sent to the backend, not decoded from it, but it's `Codable` and part of the public API surface — same rationale as the rest of this stack.
- Adds `V3_MIGRATION.md` section.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 8 of 15**. Stacked on #1221 (`EmailOTPType`); review that first.

## Test plan

- [x] Appended tests: raw-string JSON encoding, string-literal construction.
- [x] Full `AuthTests` suite passes (267/267), no regressions.