### PR TITLE
fix(auth)!: convert ResendMobileType to a RawRepresentable struct

### DIFF
--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1341,12 +1341,26 @@ struct ResendEmailParams: Encodable {
 }
 
 /// The type of mobile OTP to resend when calling ``AuthClient/resend(phone:type:captchaToken:)``.
-public enum ResendMobileType: String, Hashable, Sendable, Encodable {
+public struct ResendMobileType: RawRepresentable, Encodable, Hashable, Sendable,
+  ExpressibleByStringLiteral
+{
+  public let rawValue: String
+
+  /// Creates a ``ResendMobileType`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a ``ResendMobileType`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
   /// Resends the SMS OTP for the current phone sign-in.
-  case sms
+  public static let sms: ResendMobileType = "sms"
 
   /// Resends the OTP for confirming a phone number change.
-  case phoneChange = "phone_change"
+  public static let phoneChange: ResendMobileType = "phone_change"
 }
 
 struct ResendMobileParams: Encodable {

--- a/Tests/AuthTests/TypesTests.swift
+++ b/Tests/AuthTests/TypesTests.swift
@@ -129,4 +129,16 @@ struct TypesTests {
     let type: ResendEmailType = "new_resend_kind"
     #expect(type.rawValue == "new_resend_kind")
   }
+
+  @Test
+  func resendMobileTypeEncodesAsRawString() throws {
+    let data = try JSONEncoder().encode(ResendMobileType.phoneChange)
+    #expect(String(decoding: data, as: UTF8.self) == "\"phone_change\"")
+  }
+
+  @Test
+  func resendMobileTypeStringLiteral() {
+    let type: ResendMobileType = "new_resend_kind"
+    #expect(type.rawValue == "new_resend_kind")
+  }
 }

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -776,3 +776,30 @@ default: ...  // a resend type the SDK doesn't have a case for
 
 Compile error only if you have an exhaustive `switch` over `ResendEmailType` — add a `default:`
 case. Passing `.signup` / `.emailChange` as an argument works unchanged.
+
+## `ResendMobileType` is now a struct, not an enum
+
+`ResendMobileType` (the resend kind passed to `resend` for phone-based flows) is a
+`RawRepresentable` struct instead of an `enum`.
+
+It's sent to the backend, not decoded from it, but it's part of the public API surface — as an
+`enum`, using a resend type GoTrue added after this SDK version shipped required an SDK upgrade
+even though constructing the value doesn't need one.
+
+```swift
+// Before
+switch type {
+case .sms: ...
+case .phoneChange: ...
+}
+
+// After
+switch type {
+case .sms: ...
+case .phoneChange: ...
+default: ...  // a resend type the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `ResendMobileType` — add a `default:`
+case. Passing `.sms` / `.phoneChange` as an argument works unchanged.


### PR DESCRIPTION
## Summary

- Converts `ResendMobileType` (resend kind for phone-based `resend`) from a `String` enum to a `RawRepresentable` struct (`Encodable`-only).
- It's sent to the backend, not decoded from it, but it's `Codable` and part of the public API surface — same rationale as the rest of this stack.
- Adds `V3_MIGRATION.md` section.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 9 of 15**. Stacked on #1222 (`ResendEmailType`); review that first.

## Test plan

- [x] Appended tests: raw-string JSON encoding, string-literal construction.
- [x] Full `AuthTests` suite passes (269/269), no regressions.