### PR TITLE
fix(auth)!: convert SignOutScope to a RawRepresentable struct

### DIFF
--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1296,17 +1296,29 @@ public struct AuthMFAGetAuthenticatorAssuranceLevelResponse: Decodable, Hashable
 }
 
 /// The scope of a sign-out operation.
-public enum SignOutScope: String, Sendable {
+public struct SignOutScope: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
+  public let rawValue: String
+
+  /// Creates a ``SignOutScope`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a ``SignOutScope`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
   /// All sessions by this account will be signed out.
-  case global
+  public static let global: SignOutScope = "global"
 
   /// Only this session will be signed out.
-  case local
+  public static let local: SignOutScope = "local"
 
   /// All other sessions except the current one will be signed out. When using
   /// ``SignOutScope/others``, there is no ``AuthChangeEvent/signedOut`` event fired on the current
   /// session.
-  case others
+  public static let others: SignOutScope = "others"
 }
 
 /// The type of email to resend when calling ``AuthClient/resend(email:type:emailRedirectTo:captchaToken:)``.

--- a/Tests/AuthTests/TypesTests.swift
+++ b/Tests/AuthTests/TypesTests.swift
@@ -141,4 +141,17 @@ struct TypesTests {
     let type: ResendMobileType = "new_resend_kind"
     #expect(type.rawValue == "new_resend_kind")
   }
+
+  @Test
+  func signOutScopeStringLiteral() {
+    let scope: SignOutScope = "future_scope"
+    #expect(scope.rawValue == "future_scope")
+  }
+
+  @Test
+  func signOutScopeHashability() {
+    let scope1: SignOutScope = .global
+    let scope2: SignOutScope = "global"
+    #expect(scope1 == scope2)
+  }
 }

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -803,3 +803,31 @@ default: ...  // a resend type the SDK doesn't have a case for
 
 Compile error only if you have an exhaustive `switch` over `ResendMobileType` — add a `default:`
 case. Passing `.sms` / `.phoneChange` as an argument works unchanged.
+
+## `SignOutScope` is now a struct, not an enum
+
+`SignOutScope` (passed to `signOut(scope:)`) is a `RawRepresentable` struct instead of an `enum`.
+
+It's sent to the backend as a query parameter, not decoded from it, but it's part of the public
+API surface — as an `enum`, using a scope GoTrue added after this SDK version shipped required an
+SDK upgrade even though constructing the value doesn't need one.
+
+```swift
+// Before
+switch scope {
+case .global: ...
+case .local: ...
+case .others: ...
+}
+
+// After
+switch scope {
+case .global: ...
+case .local: ...
+case .others: ...
+default: ...  // a scope the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `SignOutScope` — add a `default:` case.
+Passing `.global` / `.local` / `.others` as an argument works unchanged.


### PR DESCRIPTION
## Summary

- Converts `SignOutScope` (passed to `signOut(scope:)`) from a `String` enum to a `RawRepresentable` struct — **no `Codable` at all** this time, since the original enum never was (`AuthClient`/`AuthAdmin` read `.rawValue` directly into a URL query item, never through `JSONEncoder`).
- It's sent to the backend as a query parameter, not decoded from it, but it's part of the public API surface — same forward-compatibility rationale as the rest of this stack.
- Adds `V3_MIGRATION.md` section. This is the **last Auth-module PR** in this stack — PR 11 onward moves to PostgREST, then Functions.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 10 of 15**. Stacked on #1223 (`ResendMobileType`); review that first.

## Test plan

- [x] Appended tests: string-literal construction, hashability.
- [x] Full `AuthTests` suite passes (271/271), no regressions — both real call sites (`AuthClient.signOut`, `AuthAdmin.signOut`) verified to only read `.rawValue`/compare with `!=`, unaffected by the enum→struct change.