### PR TITLE
fix(postgrest)!: convert PostgrestFilterBuilder.Operator to a RawRepresentable struct

### DIFF
--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -88,57 +88,69 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// Most operators have dedicated convenience methods (e.g., ``eq(_:value:)``, ``gt(_:value:)``).
   /// Use ``Operator`` directly only when you need ``not(_:operator:value:)`` or the raw
   /// ``filter(_:operator:value:)`` escape hatch.
-  public enum Operator: String, CaseIterable, Sendable {
+  public struct Operator: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
+    public let rawValue: String
+
+    /// Creates an ``Operator`` from a raw string value.
+    public init(rawValue: String) {
+      self.rawValue = rawValue
+    }
+
+    /// Creates an ``Operator`` from a string literal.
+    public init(stringLiteral value: String) {
+      self.init(rawValue: value)
+    }
+
     /// Equals (`=`).
-    case eq
+    public static let eq: Operator = "eq"
     /// Not equals (`!=`).
-    case neq
+    public static let neq: Operator = "neq"
     /// Greater than (`>`).
-    case gt
+    public static let gt: Operator = "gt"
     /// Greater than or equal (`>=`).
-    case gte
+    public static let gte: Operator = "gte"
     /// Less than (`<`).
-    case lt
+    public static let lt: Operator = "lt"
     /// Less than or equal (`<=`).
-    case lte
+    public static let lte: Operator = "lte"
     /// Case-sensitive LIKE pattern match.
-    case like
+    public static let like: Operator = "like"
     /// Case-insensitive ILIKE pattern match.
-    case ilike
+    public static let ilike: Operator = "ilike"
     /// Case-sensitive regex match.
-    case match
+    public static let match: Operator = "match"
     /// Case-insensitive regex match.
-    case imatch
+    public static let imatch: Operator = "imatch"
     /// IS (for NULL / boolean checks).
-    case `is`
+    public static let `is`: Operator = "is"
     /// IS DISTINCT FROM.
-    case isdistinct
+    public static let isdistinct: Operator = "isdistinct"
     /// IN — value is in a list.
-    case `in`
+    public static let `in`: Operator = "in"
     /// Contains (`@>`).
-    case cs
+    public static let cs: Operator = "cs"
     /// Contained by (`<@`).
-    case cd
+    public static let cd: Operator = "cd"
     /// Range strictly left of (`<<`).
-    case sl
+    public static let sl: Operator = "sl"
     /// Range strictly right of (`>>`).
-    case sr
+    public static let sr: Operator = "sr"
     /// Range does not extend to the left (`&>`).
-    case nxl
+    public static let nxl: Operator = "nxl"
     /// Range does not extend to the right (`&<`).
-    case nxr
+    public static let nxr: Operator = "nxr"
     /// Range is adjacent (`-|-`).
-    case adj
+    public static let adj: Operator = "adj"
     /// Overlaps (`&&`).
-    case ov
+    public static let ov: Operator = "ov"
     /// Full-text search using `to_tsquery`.
-    case fts
+    public static let fts: Operator = "fts"
     /// Full-text search using `plainto_tsquery`.
-    case plfts
+    public static let plfts: Operator = "plfts"
     /// Full-text search using `phraseto_tsquery`.
-    case phfts
+    public static let phfts: Operator = "phfts"
     /// Full-text search using `websearch_to_tsquery`.
-    case wfts
+    public static let wfts: Operator = "wfts"
   }
 
   // MARK: - Filters

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -106,7 +106,11 @@ struct BuildURLRequestTests {
       TestCase(name: "test all filters and count") { client in
         var query = client.from("todos").select()
 
-        for op in PostgrestFilterBuilder.Operator.allCases {
+        let allOperators: [PostgrestFilterBuilder.Operator] = [
+          .eq, .neq, .gt, .gte, .lt, .lte, .like, .ilike, .match, .imatch, .is, .isdistinct, .in,
+          .cs, .cd, .sl, .sr, .nxl, .nxr, .adj, .ov, .fts, .plfts, .phfts, .wfts,
+        ]
+        for op in allOperators {
           query = query.filter("column", operator: op.rawValue, value: "Some value")
         }
 

--- a/Tests/PostgRESTTests/OperatorTests.swift
+++ b/Tests/PostgRESTTests/OperatorTests.swift
@@ -1,0 +1,35 @@
+//
+//  OperatorTests.swift
+//
+//
+//  Created by Guilherme Souza on 13/08/26.
+//
+
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct OperatorTests {
+  @Test
+  func operatorStringLiteral() {
+    let op: PostgrestFilterBuilder.Operator = "future_op"
+    #expect(op.rawValue == "future_op")
+  }
+
+  @Test
+  func operatorHashability() {
+    let op1: PostgrestFilterBuilder.Operator = .eq
+    let op2: PostgrestFilterBuilder.Operator = "eq"
+    #expect(op1 == op2)
+  }
+
+  @Test
+  func operatorKnownRawValues() {
+    let known: [PostgrestFilterBuilder.Operator] = [
+      .eq, .neq, .gt, .gte, .lt, .lte, .like, .ilike, .match, .imatch, .is, .isdistinct, .in,
+      .cs, .cd, .sl, .sr, .nxl, .nxr, .adj, .ov, .fts, .plfts, .phfts, .wfts,
+    ]
+    #expect(known.map(\.rawValue).count == Set(known.map(\.rawValue)).count)
+  }
+}

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -831,3 +831,33 @@ default: ...  // a scope the SDK doesn't have a case for
 
 Compile error only if you have an exhaustive `switch` over `SignOutScope` — add a `default:` case.
 Passing `.global` / `.local` / `.others` as an argument works unchanged.
+
+## `PostgrestFilterBuilder.Operator` is now a struct, not an enum
+
+`PostgrestFilterBuilder.Operator` (passed to `not(_:operator:value:)`) is a `RawRepresentable`
+struct instead of an `enum`. It no longer conforms to `CaseIterable`.
+
+It's sent to PostgREST as part of a filter query string, not decoded from a response, but it's
+part of the public API surface — as an `enum`, using an operator PostgREST added after this SDK
+version shipped required an SDK upgrade even though constructing the value doesn't need one.
+
+```swift
+// Before
+switch op {
+case .eq: ...
+case .neq: ...
+// ...
+}
+
+// After
+switch op {
+case .eq: ...
+case .neq: ...
+// ...
+default: ...  // an operator the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `Operator` — add a `default:` case.
+`Operator.allCases` no longer exists, with no built-in replacement — maintain your own array if you
+were relying on it. Passing a known operator (`.eq`, `.gt`, ...) works unchanged.


### PR DESCRIPTION
## Summary

- Converts `PostgrestFilterBuilder.Operator` (25 filter operators — `eq`, `neq`, `gt`, ... `wfts`) from a `String` enum to a `RawRepresentable` struct. No `Codable` — the original enum wasn't either (`.rawValue` is read directly into a filter query string). Drops `CaseIterable` with no replacement.
- It's sent to PostgREST as part of a filter query string, not decoded from a response, but it's part of the public API surface — using an operator PostgREST adds later shouldn't require an SDK upgrade just to construct.
- `Tests/PostgRESTTests/BuildURLRequestTests.swift`'s `Operator.allCases` snapshot-test loop is replaced with an explicit array in the exact same order — the recorded snapshot is byte-for-byte unchanged.
- Adds `V3_MIGRATION.md` section. This is the **first PostgREST-module PR** in this stack.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 11 of 15**. Stacked on #1224 (`SignOutScope`, last Auth-module PR); review that first. This PR and everything after it touch only `PostgREST`/`Functions`, no further overlap with Auth.

## Test plan

- [x] New `Tests/PostgRESTTests/OperatorTests.swift`: string-literal construction, hashability, raw-value uniqueness across all 25 cases.
- [x] `PostgrestFilterBuilderTests`/`BuildURLRequestTests` snapshot unchanged — verified byte-for-byte.
- [x] Full `PostgRESTTests` suite passes (120/120), no regressions.