### PR TITLE
fix(postgrest)!: convert CountOption to a RawRepresentable struct

### DIFF
--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -102,24 +102,36 @@ public struct PostgrestResponse<T> {
 /// | ``exact`` | Exact | Slow |
 /// | ``planned`` | Approximate | Fast |
 /// | ``estimated`` | Adaptive | Moderate |
-public enum CountOption: String, Sendable {
+public struct CountOption: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
+  public let rawValue: String
+
+  /// Creates a ``CountOption`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a ``CountOption`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
   /// Performs a `COUNT(*)` under the hood for an exact row count.
   ///
   /// Use this when you need a precise total. It can be slow on large tables.
-  case exact
+  public static let exact: CountOption = "exact"
 
   /// Uses PostgreSQL statistics for a fast but approximate row count.
   ///
   /// The estimate is derived from `pg_class.reltuples` and may be inaccurate  // cspell:ignore reltuples
   /// if the table statistics are stale.
-  case planned
+  public static let planned: CountOption = "planned"
 
   /// Uses exact count for low numbers and planned count for high numbers.
   ///
   /// PostgREST switches to the approximate algorithm automatically when the
   /// estimated count exceeds a threshold, trading accuracy for performance
   /// on large result sets.
-  case estimated
+  public static let estimated: CountOption = "estimated"
 }
 
 /// Controls which rows PostgREST returns after a write operation.

--- a/Tests/PostgRESTTests/OptionsTests.swift
+++ b/Tests/PostgRESTTests/OptionsTests.swift
@@ -1,0 +1,26 @@
+//
+//  OptionsTests.swift
+//
+//
+//  Created by Guilherme Souza on 13/08/26.
+//
+
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct OptionsTests {
+  @Test
+  func countOptionStringLiteral() {
+    let count: CountOption = "future_count_algorithm"
+    #expect(count.rawValue == "future_count_algorithm")
+  }
+
+  @Test
+  func countOptionHashability() {
+    let count1: CountOption = .exact
+    let count2: CountOption = "exact"
+    #expect(count1 == count2)
+  }
+}

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -861,3 +861,32 @@ default: ...  // an operator the SDK doesn't have a case for
 Compile error only if you have an exhaustive `switch` over `Operator` — add a `default:` case.
 `Operator.allCases` no longer exists, with no built-in replacement — maintain your own array if you
 were relying on it. Passing a known operator (`.eq`, `.gt`, ...) works unchanged.
+
+## `CountOption` is now a struct, not an enum
+
+`CountOption` (passed to query methods like `select(_:head:count:)`) is a `RawRepresentable`
+struct instead of an `enum`.
+
+It's sent to PostgREST as part of a `Prefer` header, not decoded from a response, but it's part of
+the public API surface — as an `enum`, using a count algorithm PostgREST added after this SDK
+version shipped required an SDK upgrade even though constructing the value doesn't need one.
+
+```swift
+// Before
+switch count {
+case .exact: ...
+case .planned: ...
+case .estimated: ...
+}
+
+// After
+switch count {
+case .exact: ...
+case .planned: ...
+case .estimated: ...
+default: ...  // a count algorithm the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `CountOption` — add a `default:` case.
+Passing `.exact` / `.planned` / `.estimated` as an argument works unchanged.


### PR DESCRIPTION
## Summary

- Converts `CountOption` (row-count algorithm — `exact`/`planned`/`estimated`) from a `String` enum to a `RawRepresentable` struct. No `Codable` — `.rawValue` is read directly into a `Prefer` header string, never through `JSONEncoder`.
- It's sent to PostgREST as part of a request header, not decoded from a response, but it's part of the public API surface — same forward-compatibility rationale as the rest of this stack.
- Adds `V3_MIGRATION.md` section.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 12 of 15**. Stacked on #1225 (`PostgrestFilterBuilder.Operator`); review that first.

## Test plan

- [x] New `Tests/PostgRESTTests/OptionsTests.swift` (created here, extended by the next two PRs): string-literal construction, hashability.
- [x] Full `PostgRESTTests` suite passes, no regressions — no `switch` over `CountOption` anywhere in the codebase.