### PR TITLE
fix(postgrest)!: convert PostgrestReturningOptions to a RawRepresentable struct

### DIFF
--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -142,18 +142,32 @@ public struct CountOption: RawRepresentable, Hashable, Sendable, ExpressibleBySt
 ///
 /// See the [PostgREST documentation](https://postgrest.org/en/v9.0/api.html?highlight=PREFER#insertions-updates)
 /// for more detail.
-public enum PostgrestReturningOptions: String, Sendable {
+public struct PostgrestReturningOptions: RawRepresentable, Hashable, Sendable,
+  ExpressibleByStringLiteral
+{
+  public let rawValue: String
+
+  /// Creates a ``PostgrestReturningOptions`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a ``PostgrestReturningOptions`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
   /// Returns nothing from the server after the write.
   ///
   /// Use this option when you do not need the affected rows, as it avoids
   /// the overhead of serializing and transmitting them.
-  case minimal
+  public static let minimal: PostgrestReturningOptions = "minimal"
 
   /// Returns a copy of the written rows.
   ///
   /// Use this option (or chain `.select()` after the call) when you need the
   /// server-generated values such as `id`, `created_at`, or computed columns.
-  case representation
+  public static let representation: PostgrestReturningOptions = "representation"
 }
 
 /// The conversion strategy used to turn a plain-text search query into a `tsquery` expression.

--- a/Tests/PostgRESTTests/OptionsTests.swift
+++ b/Tests/PostgRESTTests/OptionsTests.swift
@@ -23,4 +23,17 @@ struct OptionsTests {
     let count2: CountOption = "exact"
     #expect(count1 == count2)
   }
+
+  @Test
+  func returningOptionsStringLiteral() {
+    let returning: PostgrestReturningOptions = "future_returning_mode"
+    #expect(returning.rawValue == "future_returning_mode")
+  }
+
+  @Test
+  func returningOptionsHashability() {
+    let returning1: PostgrestReturningOptions = .minimal
+    let returning2: PostgrestReturningOptions = "minimal"
+    #expect(returning1 == returning2)
+  }
 }

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -890,3 +890,30 @@ default: ...  // a count algorithm the SDK doesn't have a case for
 
 Compile error only if you have an exhaustive `switch` over `CountOption` — add a `default:` case.
 Passing `.exact` / `.planned` / `.estimated` as an argument works unchanged.
+
+## `PostgrestReturningOptions` is now a struct, not an enum
+
+`PostgrestReturningOptions` (passed to `insert`/`update`/`upsert`/`delete`) is a `RawRepresentable`
+struct instead of an `enum`.
+
+It's sent to PostgREST as part of a `Prefer` header, not decoded from a response, but it's part of
+the public API surface — as an `enum`, using a returning mode PostgREST added after this SDK
+version shipped required an SDK upgrade even though constructing the value doesn't need one.
+
+```swift
+// Before
+switch returning {
+case .minimal: ...
+case .representation: ...
+}
+
+// After
+switch returning {
+case .minimal: ...
+case .representation: ...
+default: ...  // a returning mode the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `PostgrestReturningOptions` — add a
+`default:` case. Passing `.minimal` / `.representation` as an argument works unchanged.


### PR DESCRIPTION
## Summary

- Converts `PostgrestReturningOptions` (`minimal`/`representation`) from a `String` enum to a `RawRepresentable` struct. No `Codable` — `.rawValue` is read directly into a `Prefer` header string.
- It's sent to PostgREST as part of a request header, not decoded from a response, but it's part of the public API surface — same rationale as the rest of this stack.
- Adds `V3_MIGRATION.md` section.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 13 of 15**. Stacked on #1226 (`CountOption`); review that first.

## Test plan

- [x] Appended tests to `OptionsTests.swift`: string-literal construction, hashability.
- [x] Full `PostgRESTTests` suite passes, no regressions.