### PR TITLE
fix(postgrest)!: convert TextSearchType to a RawRepresentable struct

### DIFF
--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -174,25 +174,37 @@ public struct PostgrestReturningOptions: RawRepresentable, Hashable, Sendable,
 ///
 /// Pass a ``TextSearchType`` to ``PostgrestFilterBuilder/textSearch(_:query:config:type:)`` to
 /// control how user-supplied text is interpreted by PostgreSQL's full-text search engine.
-public enum TextSearchType: String, Sendable {
+public struct TextSearchType: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
+  public let rawValue: String
+
+  /// Creates a ``TextSearchType`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a ``TextSearchType`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
   /// Converts the query using PostgreSQL's `plainto_tsquery` function.
   ///
   /// Words in the query are combined with the `&` (AND) operator. Punctuation
   /// and special characters are ignored.
-  case plain = "pl"
+  public static let plain: TextSearchType = "pl"
 
   /// Converts the query using PostgreSQL's `phraseto_tsquery` function.
   ///
   /// Words must appear in the specified order, making this suitable for
   /// exact phrase searches.
-  case phrase = "ph"
+  public static let phrase: TextSearchType = "ph"
 
   /// Converts the query using PostgreSQL's `websearch_to_tsquery` function.
   ///
   /// This function accepts a web-search–style syntax (`"exact phrase"`, `-exclude`,
   /// `OR`) and never raises syntax errors, making it safe to use with raw
   /// user-supplied input.
-  case websearch = "w"
+  public static let websearch: TextSearchType = "w"
 }
 
 /// The output format of a PostgREST EXPLAIN plan.

--- a/Tests/PostgRESTTests/OptionsTests.swift
+++ b/Tests/PostgRESTTests/OptionsTests.swift
@@ -36,4 +36,17 @@ struct OptionsTests {
     let returning2: PostgrestReturningOptions = "minimal"
     #expect(returning1 == returning2)
   }
+
+  @Test
+  func textSearchTypeStringLiteral() {
+    let type: TextSearchType = "future_search_type"
+    #expect(type.rawValue == "future_search_type")
+  }
+
+  @Test
+  func textSearchTypeHashability() {
+    let type1: TextSearchType = .plain
+    let type2: TextSearchType = "pl"
+    #expect(type1 == type2)
+  }
 }

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -917,3 +917,33 @@ default: ...  // a returning mode the SDK doesn't have a case for
 
 Compile error only if you have an exhaustive `switch` over `PostgrestReturningOptions` — add a
 `default:` case. Passing `.minimal` / `.representation` as an argument works unchanged.
+
+## `TextSearchType` is now a struct, not an enum
+
+`TextSearchType` (passed to `textSearch(_:query:config:type:)`) is a `RawRepresentable` struct
+instead of an `enum`.
+
+It's sent to PostgREST as part of a filter query string, not decoded from a response, but it's
+part of the public API surface — as an `enum`, using a search conversion strategy PostgreSQL added
+after this SDK version shipped required an SDK upgrade even though constructing the value doesn't
+need one.
+
+```swift
+// Before
+switch type {
+case .plain: ...
+case .phrase: ...
+case .websearch: ...
+}
+
+// After
+switch type {
+case .plain: ...
+case .phrase: ...
+case .websearch: ...
+default: ...  // a search type the SDK doesn't have a case for
+}
+```
+
+Compile error only if you have an exhaustive `switch` over `TextSearchType` — add a `default:`
+case. Passing `.plain` / `.phrase` / `.websearch` as an argument works unchanged.


### PR DESCRIPTION
## Summary

- Converts `TextSearchType` (`plain`/`phrase`/`websearch`, raw values `"pl"`/`"ph"`/`"w"`) from a `String` enum to a `RawRepresentable` struct. No `Codable` — `.rawValue` is read directly into a filter query string.
- It's sent to PostgREST as part of a filter query string, not decoded from a response, but it's part of the public API surface — same rationale as the rest of this stack.
- Adds `V3_MIGRATION.md` section. This is the **last PostgREST-module PR** in this stack — PR 15 moves to Functions.

Part of [SDK-637](https://linear.app/supabase/issue/SDK-637/swift-refactor-backend-response-string-enums-to-rawrepresentable) — **PR 14 of 15**. Stacked on #1227 (`PostgrestReturningOptions`); review that first.

## Test plan

- [x] Appended tests to `OptionsTests.swift`: string-literal construction, hashability.
- [x] Full `PostgRESTTests` suite passes, no regressions — the abbreviated raw values (`"pl"`/`"ph"`/`"w"`) are unchanged from the original enum.