### PR TITLE
docs: document enum-like value conventions (RawRepresentable for wire values)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,32 @@ Ensures DocC documentation builds without warnings.
 - Prefer `async/await` over completion handlers
 - Mark types as `Sendable` where appropriate for concurrency safety
 
+### Enum-like Values
+
+- Use a Swift `enum` only when the value is genuinely closed: every case is fixed by the language or protocol itself (HTTP methods, a `CodingKeys` set) or the value is entirely client-side and never crosses the wire (e.g. `AuthChangeEvent`, `LogLevel`).
+- Any enum-like value sent to or received from the backend must be a `RawRepresentable` struct instead, so a value the backend adds later (or that this SDK just doesn't have a case for yet) round-trips through `.rawValue` instead of failing to decode or blocking construction until an SDK upgrade:
+
+  ```swift
+  public struct Provider: RawRepresentable, Codable, Hashable, Sendable, ExpressibleByStringLiteral {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+      self.rawValue = rawValue
+    }
+
+    public init(stringLiteral value: String) {
+      self.init(rawValue: value)
+    }
+
+    public static let apple: Provider = "apple"
+    public static let github: Provider = "github"
+  }
+  ```
+
+- Conform to exactly what the value's actual usage needs — `Codable` only if it's ever decoded, `Encodable`-only if it's write-only, no `Codable`/`Encodable` at all if it's read via `.rawValue` directly into a header or query string (never through `JSONEncoder`/`JSONDecoder`). Don't upgrade a type's conformance just because a sibling type in the same file has more.
+- Don't add a `CaseIterable`/`Identifiable` replacement (a `knownCases` array, a custom `Identifiable`) to the SDK type unless something inside this package actually needs one — a consuming app can keep its own list of the values it cares about (see `Examples/Examples/Auth/KnownProviders.swift`).
+- `init(rawValue:)` is intentionally non-failable — it always succeeds, which is what makes constructing/decoding an unrecognized value safe instead of an error. Any breaking-change migration note for a type like this must call out that `if let x = X(rawValue:)` goes from compiling to a compile error, and that interpolating the value directly (`"\(x)"`) silently stops printing the case name.
+
 ### File Headers
 
 Use standard file headers with copyright:

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -241,3 +241,6 @@ vízrajzi
 állomás
 áéíóú
 deinits
+
+# Term from AGENTS.md's Enum-like Values section (describing non-failable init(rawValue:)).
+failable


### PR DESCRIPTION
## Summary

- Adds an "Enum-like Values" section to `AGENTS.md`, codifying the pattern used across the [SDK-637](https://linear.app/supabase/issue/SDK-637) stack (#1215-#1229): enums are fine when the case set is genuinely closed (fixed by the language/protocol) or entirely client-side, but any enum-like value sent to or received from the backend should be a `RawRepresentable` struct so an unrecognized value round-trips through `.rawValue` instead of failing to decode or requiring an SDK upgrade to construct.
- Covers: the enum-vs-struct decision, the exact conformance pattern (with a worked example), matching conformance to actual usage direction (don't add `Codable` a type never needed), not adding `CaseIterable`/`Identifiable` replacements the SDK itself doesn't need, and the migration-note requirement for the non-failable `init(rawValue:)` change.

This is a documentation-only change, independent of the SDK-637 PR stack — branched directly from `main` rather than stacked, since it's a general convention, not tied to those specific type conversions.

## Test plan

- [x] `./scripts/format.sh` — no changes (Markdown-only edit, `swift-format` doesn't touch it).
- [x] `./scripts/spell-check.sh` — clean on `AGENTS.md` (0 issues).