### PR TITLE
refactor(helpers)!: rename AnyJSON to JSONValue

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		793D8EE32E983112006B6969 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793D8EB52E983112006B6969 /* Debug.swift */; };
 		793D8EE62E983112006B6969 /* TodoListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793D8ED52E983112006B6969 /* TodoListRow.swift */; };
 		793D8EE82E983112006B6969 /* UIViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793D8ED82E983112006B6969 /* UIViewControllerWrapper.swift */; };
-		793D8EEC2E983112006B6969 /* AnyJSONView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793D8EA12E983112006B6969 /* AnyJSONView.swift */; };
+		793D8EEC2E983112006B6969 /* JSONValueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793D8EA12E983112006B6969 /* JSONValueView.swift */; };
 		793D8EED2E983112006B6969 /* SupabaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793D8ED32E983112006B6969 /* SupabaseConfig.swift */; };
 		793D8EEF2E983112006B6969 /* ActionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793D8E9F2E983112006B6969 /* ActionState.swift */; };
 		793D8EF12E983112006B6969 /* UIApplicationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793D8ED72E983112006B6969 /* UIApplicationExtensions.swift */; };
@@ -69,7 +69,7 @@
 		793895C62954ABFF0044F2B8 /* Examples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Examples.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		793D8E9F2E983112006B6969 /* ActionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionState.swift; sourceTree = "<group>"; };
 		793D8EA02E983112006B6969 /* AddTodoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoListView.swift; sourceTree = "<group>"; };
-		793D8EA12E983112006B6969 /* AnyJSONView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyJSONView.swift; sourceTree = "<group>"; };
+		793D8EA12E983112006B6969 /* JSONValueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueView.swift; sourceTree = "<group>"; };
 		793D8EA22E983112006B6969 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		793D8EAE2E983112006B6969 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		793D8EB52E983112006B6969 /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
@@ -275,7 +275,7 @@
 			children = (
 				793D8E9F2E983112006B6969 /* ActionState.swift */,
 				793D8EA02E983112006B6969 /* AddTodoListView.swift */,
-				793D8EA12E983112006B6969 /* AnyJSONView.swift */,
+				793D8EA12E983112006B6969 /* JSONValueView.swift */,
 				793D8EA22E983112006B6969 /* Assets.xcassets */,
 				793D8EAD2E983112006B6969 /* Auth */,
 				793D8EAE2E983112006B6969 /* Constants.swift */,
@@ -545,7 +545,7 @@
 				793D8EE32E983112006B6969 /* Debug.swift in Sources */,
 				793D8EE62E983112006B6969 /* TodoListRow.swift in Sources */,
 				793D8EE82E983112006B6969 /* UIViewControllerWrapper.swift in Sources */,
-				793D8EEC2E983112006B6969 /* AnyJSONView.swift in Sources */,
+				793D8EEC2E983112006B6969 /* JSONValueView.swift in Sources */,
 				793D8EED2E983112006B6969 /* SupabaseConfig.swift in Sources */,
 				793D8EEF2E983112006B6969 /* ActionState.swift in Sources */,
 				793D8EF12E983112006B6969 /* UIApplicationExtensions.swift in Sources */,

--- a/Examples/Examples/JSONValueView.swift
+++ b/Examples/Examples/JSONValueView.swift
@@ -1,5 +1,5 @@
 //
-//  AnyJSONView.swift
+//  JSONValueView.swift
 //  Examples
 //
 //  Created by Guilherme Souza on 21/03/24.
@@ -8,8 +8,8 @@
 import Supabase
 import SwiftUI
 
-struct AnyJSONView: View {
-  let value: AnyJSON
+struct JSONValueView: View {
+  let value: JSONValue
 
   var body: some View {
     switch value {
@@ -22,12 +22,12 @@ struct AnyJSONView: View {
       ForEach(0..<value.count, id: \.self) { index in
         if value[index].isPrimitive {
           LabeledContent("\(index)") {
-            AnyJSONView(value: value[index])
+            JSONValueView(value: value[index])
           }
         } else {
           NavigationLink("\(index)") {
             List {
-              AnyJSONView(value: value[index])
+              JSONValueView(value: value[index])
             }
             .navigationTitle("\(index)")
           }
@@ -38,12 +38,12 @@ struct AnyJSONView: View {
       ForEach(elements, id: \.key) { element in
         if element.value.isPrimitive {
           LabeledContent(element.key) {
-            AnyJSONView(value: element.value)
+            JSONValueView(value: element.value)
           }
         } else {
           NavigationLink(element.key) {
             List {
-              AnyJSONView(value: element.value)
+              JSONValueView(value: element.value)
             }
             .navigationTitle(element.key)
           }
@@ -53,7 +53,7 @@ struct AnyJSONView: View {
   }
 }
 
-extension AnyJSON {
+extension JSONValue {
   var isPrimitive: Bool {
     switch self {
     case .null, .bool, .integer, .double, .string:
@@ -64,15 +64,15 @@ extension AnyJSON {
   }
 }
 
-extension AnyJSONView {
+extension JSONValueView {
   init(rendering value: some Codable) {
-    self.init(value: try! AnyJSON(value))
+    self.init(value: try! JSONValue(value))
   }
 }
 
 #Preview {
   NavigationStack {
-    AnyJSONView(
+    JSONValueView(
       value: [
         "app_metadata": [
           "provider": "email",

--- a/Examples/Examples/Profile/ProfileView.swift
+++ b/Examples/Examples/Profile/ProfileView.swift
@@ -189,8 +189,8 @@ struct ProfileView: View {
 
           // Raw User Data
           Section("User Data (JSON)") {
-            if let json = try? AnyJSON(user) {
-              AnyJSONView(value: json)
+            if let json = try? JSONValue(user) {
+              JSONValueView(value: json)
             }
           }
         }

--- a/Examples/Examples/Profile/UserIdentityList.swift
+++ b/Examples/Examples/Profile/UserIdentityList.swift
@@ -104,7 +104,7 @@ struct UserIdentityList: View {
 
                 if let identityData = identity.identityData {
                   DisclosureGroup("Identity Data") {
-                    AnyJSONView(value: .object(identityData))
+                    JSONValueView(value: .object(identityData))
                       .font(.system(.caption, design: .monospaced))
                   }
                   .font(.caption)

--- a/Examples/Examples/Storage/BucketDetailView.swift
+++ b/Examples/Examples/Storage/BucketDetailView.swift
@@ -72,7 +72,7 @@ struct BucketDetailView: View {
     }
     .popover(isPresented: $presentBucketDetails) {
       List {
-        AnyJSONView(
+        JSONValueView(
           value: .object([
             "id": .string(bucket.id),
             "name": .string(bucket.name),
@@ -80,7 +80,7 @@ struct BucketDetailView: View {
             "isPublic": .bool(bucket.isPublic),
             "createdAt": .string(bucket.createdAt.description),
             "updatedAt": .string(bucket.updatedAt.description),
-            "allowedMimeTypes": bucket.allowedMimeTypes.map { .array($0.map(AnyJSON.string)) }
+            "allowedMimeTypes": bucket.allowedMimeTypes.map { .array($0.map(JSONValue.string)) }
               ?? .null,
             "fileSizeLimit": bucket.fileSizeLimit.map { .integer(Int($0)) } ?? .null,
           ])

--- a/Examples/Examples/Storage/FileObjectDetailView.swift
+++ b/Examples/Examples/Storage/FileObjectDetailView.swift
@@ -18,16 +18,16 @@ struct FileObjectDetailView: View {
   var body: some View {
     List {
       Section {
-        AnyJSONView(
+        JSONValueView(
           value: .object([
             "name": .string(fileObject.name),
-            "bucketId": fileObject.bucketId.map(AnyJSON.string) ?? .null,
-            "owner": fileObject.owner.map(AnyJSON.string) ?? .null,
+            "bucketId": fileObject.bucketId.map(JSONValue.string) ?? .null,
+            "owner": fileObject.owner.map(JSONValue.string) ?? .null,
             "id": fileObject.id.map { .string($0.uuidString) } ?? .null,
             "updatedAt": fileObject.updatedAt.map { .string($0.description) } ?? .null,
             "createdAt": fileObject.createdAt.map { .string($0.description) } ?? .null,
             "lastAccessedAt": fileObject.lastAccessedAt.map { .string($0.description) } ?? .null,
-            "metadata": fileObject.metadata.map(AnyJSON.object) ?? .null,
+            "metadata": fileObject.metadata.map(JSONValue.object) ?? .null,
             "buckets": fileObject.buckets.map { .string($0.name) } ?? .null,
           ])
         )

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -105,7 +105,7 @@ public struct AuthAdmin: Sendable {
   @discardableResult
   public func inviteUserByEmail(
     _ email: String,
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     redirectTo: URL? = nil
   ) async throws -> User {
     try await api.execute(
@@ -123,7 +123,7 @@ public struct AuthAdmin: Sendable {
         body: encoder.encode(
           [
             "email": .string(email),
-            "data": data.map({ AnyJSON.object($0) }) ?? .null,
+            "data": data.map({ JSONValue.object($0) }) ?? .null,
           ]
         )
       )

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -372,7 +372,7 @@ public actor AuthClient {
   public func signUp(
     email: String,
     password: String,
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     redirectTo: URL? = nil,
     captchaToken: String? = nil
   ) async throws -> AuthResponse {
@@ -416,7 +416,7 @@ public actor AuthClient {
     phone: String,
     password: String,
     channel: MessagingChannel = .sms,
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     captchaToken: String? = nil
   ) async throws -> AuthResponse {
     try await _signUp(
@@ -552,7 +552,7 @@ public actor AuthClient {
   ///   - captchaToken: Verification token received when the user completes the captcha.
   @discardableResult
   public func signInAnonymously(
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     captchaToken: String? = nil
   ) async throws -> Session {
     try await _signIn(
@@ -596,7 +596,7 @@ public actor AuthClient {
     email: String,
     redirectTo: URL? = nil,
     shouldCreateUser: Bool = true,
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     captchaToken: String? = nil
   ) async throws {
     let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
@@ -641,7 +641,7 @@ public actor AuthClient {
     phone: String,
     channel: MessagingChannel = .sms,
     shouldCreateUser: Bool = true,
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     captchaToken: String? = nil
   ) async throws {
     _ = try await api.execute(

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -54,7 +54,7 @@ struct SignUpRequest: Encodable, Hashable, Sendable {
   var password: String?
   var phone: String?
   var channel: MessagingChannel?
-  var data: [String: AnyJSON]?
+  var data: [String: JSONValue]?
   var gotrueMetaSecurity: AuthMetaSecurity?
   var codeChallenge: String?
   var codeChallengeMethod: String?
@@ -147,10 +147,10 @@ public struct User: Codable, Hashable, Identifiable, Sendable {
   public var id: UUID
 
   /// Application-specific metadata stored by the administrator in `auth.users.app_metadata`.
-  public var appMetadata: [String: AnyJSON]
+  public var appMetadata: [String: JSONValue]
 
   /// User-supplied metadata stored in `auth.users.raw_user_meta_data`.
-  public var userMetadata: [String: AnyJSON]
+  public var userMetadata: [String: JSONValue]
 
   /// The audience claim (`aud`) of the user's JWT.
   public var aud: String
@@ -236,8 +236,8 @@ public struct User: Codable, Hashable, Identifiable, Sendable {
   ///   - factors: Registered MFA factors.
   public init(
     id: UUID,
-    appMetadata: [String: AnyJSON],
-    userMetadata: [String: AnyJSON],
+    appMetadata: [String: JSONValue],
+    userMetadata: [String: JSONValue],
     aud: String,
     confirmationSentAt: Date? = nil,
     recoverySentAt: Date? = nil,
@@ -285,9 +285,10 @@ public struct User: Codable, Hashable, Identifiable, Sendable {
   public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     id = try container.decode(UUID.self, forKey: .id)
-    appMetadata = try container.decodeIfPresent([String: AnyJSON].self, forKey: .appMetadata) ?? [:]
+    appMetadata =
+      try container.decodeIfPresent([String: JSONValue].self, forKey: .appMetadata) ?? [:]
     userMetadata =
-      try container.decodeIfPresent([String: AnyJSON].self, forKey: .userMetadata) ?? [:]
+      try container.decodeIfPresent([String: JSONValue].self, forKey: .userMetadata) ?? [:]
     aud = try container.decode(String.self, forKey: .aud)
     confirmationSentAt = try container.decodeIfPresent(Date.self, forKey: .confirmationSentAt)
     recoverySentAt = try container.decodeIfPresent(Date.self, forKey: .recoverySentAt)
@@ -322,7 +323,7 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
   public var userId: UUID
 
   /// Provider-specific identity data returned by the third-party.
-  public var identityData: [String: AnyJSON]?
+  public var identityData: [String: JSONValue]?
 
   /// The name of the provider (e.g. `google`, `github`).
   public var provider: String
@@ -351,7 +352,7 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
     id: String,
     identityId: UUID,
     userId: UUID,
-    identityData: [String: AnyJSON],
+    identityData: [String: JSONValue],
     provider: String,
     createdAt: Date?,
     lastSignInAt: Date?,
@@ -386,7 +387,7 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
       try container.decodeIfPresent(UUID.self, forKey: .identityId)
       ?? UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
     userId = try container.decode(UUID.self, forKey: .userId)
-    identityData = try container.decodeIfPresent([String: AnyJSON].self, forKey: .identityData)
+    identityData = try container.decodeIfPresent([String: JSONValue].self, forKey: .identityData)
     provider = try container.decode(String.self, forKey: .provider)
     createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
     lastSignInAt = try container.decodeIfPresent(Date.self, forKey: .lastSignInAt)
@@ -572,7 +573,7 @@ struct OTPParams: Encodable, Hashable, Sendable {
   var phone: String?
   var createUser: Bool
   var channel: MessagingChannel?
-  var data: [String: AnyJSON]?
+  var data: [String: JSONValue]?
   var gotrueMetaSecurity: AuthMetaSecurity?
   var codeChallenge: String?
   var codeChallengeMethod: String?
@@ -751,7 +752,7 @@ public struct UserAttributes: Encodable, Hashable, Sendable {
   /// A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata`
   /// column. The `data` should be a JSON object that includes user-specific info, such as their
   /// first and last name.
-  public var data: [String: AnyJSON]?
+  public var data: [String: JSONValue]?
 
   var codeChallenge: String?
   var codeChallengeMethod: String?
@@ -769,7 +770,7 @@ public struct UserAttributes: Encodable, Hashable, Sendable {
     phone: String? = nil,
     password: String? = nil,
     nonce: String? = nil,
-    data: [String: AnyJSON]? = nil
+    data: [String: JSONValue]? = nil
   ) {
     self.email = email
     self.phone = phone
@@ -783,7 +784,7 @@ public struct UserAttributes: Encodable, Hashable, Sendable {
 public struct AdminUserAttributes: Encodable, Hashable, Sendable {
 
   /// A custom data object to store the user's application specific metadata. This maps to the `auth.users.app_metadata` column.
-  public var appMetadata: [String: AnyJSON]?
+  public var appMetadata: [String: JSONValue]?
 
   /// Determines how long a user is banned for.
   ///
@@ -818,7 +819,7 @@ public struct AdminUserAttributes: Encodable, Hashable, Sendable {
   public var role: String?
 
   /// A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
-  public var userMetadata: [String: AnyJSON]?
+  public var userMetadata: [String: JSONValue]?
 
   /// Creates admin user attributes.
   ///
@@ -836,7 +837,7 @@ public struct AdminUserAttributes: Encodable, Hashable, Sendable {
   ///   - role: The JWT role claim.
   ///   - userMetadata: User-supplied metadata.
   public init(
-    appMetadata: [String: AnyJSON]? = nil,
+    appMetadata: [String: JSONValue]? = nil,
     banDuration: String? = nil,
     email: String? = nil,
     emailConfirm: Bool? = nil,
@@ -847,7 +848,7 @@ public struct AdminUserAttributes: Encodable, Hashable, Sendable {
     phone: String? = nil,
     phoneConfirm: Bool? = nil,
     role: String? = nil,
-    userMetadata: [String: AnyJSON]? = nil
+    userMetadata: [String: JSONValue]? = nil
   ) {
     self.appMetadata = appMetadata
     self.banDuration = banDuration
@@ -1078,7 +1079,7 @@ public struct MFAVerifyParams: Encodable, Hashable {
 
   /// The W3C credential (assertion) response produced by the authenticator. Used for `webauthn`
   /// factors. Forwarded verbatim to the backend, preserving the W3C field names.
-  @_spi(Experimental) public let credentialResponse: AnyJSON?
+  @_spi(Experimental) public let credentialResponse: JSONValue?
 
   /// Verifies a `totp` or `phone` factor using a user-provided code.
   ///
@@ -1100,7 +1101,7 @@ public struct MFAVerifyParams: Encodable, Hashable {
   ///   - challengeId: The challenge ID being verified.
   ///   - credentialResponse: The W3C assertion produced by the platform authenticator.
   @_spi(Experimental)
-  public init(factorId: String, challengeId: String, credentialResponse: AnyJSON) {
+  public init(factorId: String, challengeId: String, credentialResponse: JSONValue) {
     self.factorId = factorId
     self.challengeId = challengeId
     self.code = ""
@@ -1382,7 +1383,7 @@ public struct GenerateLinkParams: Sendable {
     var email: String
     var password: String?
     var newEmail: String?
-    var data: [String: AnyJSON]?
+    var data: [String: JSONValue]?
   }
   var body: Body
   var redirectTo: URL?
@@ -1391,7 +1392,7 @@ public struct GenerateLinkParams: Sendable {
   public static func signUp(
     email: String,
     password: String,
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     redirectTo: URL? = nil
   ) -> GenerateLinkParams {
     GenerateLinkParams(
@@ -1408,7 +1409,7 @@ public struct GenerateLinkParams: Sendable {
   /// Generates an invite link.
   public static func invite(
     email: String,
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     redirectTo: URL? = nil
   ) -> GenerateLinkParams {
     GenerateLinkParams(
@@ -1424,7 +1425,7 @@ public struct GenerateLinkParams: Sendable {
   /// Generates a magic link.
   public static func magicLink(
     email: String,
-    data: [String: AnyJSON]? = nil,
+    data: [String: JSONValue]? = nil,
     redirectTo: URL? = nil
   ) -> GenerateLinkParams {
     GenerateLinkParams(
@@ -2009,13 +2010,13 @@ public struct JWTClaims: Decodable, Hashable, Sendable {
   public let phone: String?
 
   /// Application metadata.
-  public let appMetadata: [String: AnyJSON]?
+  public let appMetadata: [String: JSONValue]?
 
   /// User metadata.
-  public let userMetadata: [String: AnyJSON]?
+  public let userMetadata: [String: JSONValue]?
 
   /// Any claims not recognized by the standard set of ``CodingKeys``.
-  public var additionalClaims: [String: AnyJSON] = [:]
+  public var additionalClaims: [String: JSONValue] = [:]
 
   enum CodingKeys: String, CodingKey {
     case iss
@@ -2048,14 +2049,14 @@ public struct JWTClaims: Decodable, Hashable, Sendable {
     sessionId = try container.decodeIfPresent(String.self, forKey: .sessionId)
     email = try container.decodeIfPresent(String.self, forKey: .email)
     phone = try container.decodeIfPresent(String.self, forKey: .phone)
-    appMetadata = try container.decodeIfPresent([String: AnyJSON].self, forKey: .appMetadata)
-    userMetadata = try container.decodeIfPresent([String: AnyJSON].self, forKey: .userMetadata)
+    appMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .appMetadata)
+    userMetadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .userMetadata)
 
     // Decode additional claims
     let allKeys = try decoder.container(keyedBy: AnyCodingKey.self)
-    var additional: [String: AnyJSON] = [:]
+    var additional: [String: JSONValue] = [:]
     for key in allKeys.allKeys where CodingKeys(stringValue: key.stringValue) == nil {
-      if let value = try? allKeys.decode(AnyJSON.self, forKey: key) {
+      if let value = try? allKeys.decode(JSONValue.self, forKey: key) {
         additional[key.stringValue] = value
       }
     }

--- a/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
+++ b/Sources/Auth/WebAuthn/AuthClient+Passkey.swift
@@ -50,7 +50,7 @@ extension AuthClient {
   @discardableResult
   public func verifyPasskeyRegistration(
     challengeId: String,
-    credentialResponse: AnyJSON
+    credentialResponse: JSONValue
   ) async throws -> PasskeyListItem {
     try await Dependencies[clientID].api.authorizedExecute(
       HTTPRequest(
@@ -92,7 +92,7 @@ extension AuthClient {
   @discardableResult
   public func verifyPasskeyAuthentication(
     challengeId: String,
-    credentialResponse: AnyJSON
+    credentialResponse: JSONValue
   ) async throws -> AuthResponse {
     let response: AuthResponse = try await Dependencies[clientID].api.execute(
       HTTPRequest(

--- a/Sources/Auth/WebAuthn/WebAuthnAuthenticator.swift
+++ b/Sources/Auth/WebAuthn/WebAuthnAuthenticator.swift
@@ -23,7 +23,7 @@ enum WebAuthnError: Error, Equatable {
 
 // MARK: - W3C options parsing (platform independent, testable)
 
-extension AnyJSON {
+extension JSONValue {
   /// Base64url-decodes the `challenge` field of W3C credential options.
   func webAuthnChallengeData() throws -> Data {
     try base64URLDecoded(at: ["challenge"])
@@ -58,8 +58,8 @@ extension AnyJSON {
     return id
   }
 
-  private func value(at path: [String]) -> AnyJSON? {
-    var current: AnyJSON? = self
+  private func value(at path: [String]) -> JSONValue? {
+    var current: JSONValue? = self
     for key in path {
       current = current?.objectValue?[key]
     }
@@ -91,14 +91,14 @@ extension AnyJSON {
     /// Presents the registration UI for the given W3C creation options and returns the resulting
     /// W3C credential JSON.
     var register:
-      @MainActor @Sendable (_ options: AnyJSON, _ rpId: String, _ anchor: ASPresentationAnchor)
-        async throws -> AnyJSON
+      @MainActor @Sendable (_ options: JSONValue, _ rpId: String, _ anchor: ASPresentationAnchor)
+        async throws -> JSONValue
 
     /// Presents the assertion UI for the given W3C request options and returns the resulting W3C
     /// credential JSON.
     var authenticate:
-      @MainActor @Sendable (_ options: AnyJSON, _ rpId: String, _ anchor: ASPresentationAnchor)
-        async throws -> AnyJSON
+      @MainActor @Sendable (_ options: JSONValue, _ rpId: String, _ anchor: ASPresentationAnchor)
+        async throws -> JSONValue
   }
 
   extension WebAuthnAuthenticator {
@@ -129,7 +129,7 @@ extension AnyJSON {
   }
 
   /// Serializes a platform registration credential into the W3C JSON shape the backend expects.
-  private func registrationCredentialJSON(from authorization: ASAuthorization) throws -> AnyJSON {
+  private func registrationCredentialJSON(from authorization: ASAuthorization) throws -> JSONValue {
     guard
       let credential = authorization.credential
         as? ASAuthorizationPlatformPublicKeyCredentialRegistration
@@ -148,7 +148,7 @@ extension AnyJSON {
   }
 
   /// Serializes a platform assertion credential into the W3C JSON shape the backend expects.
-  private func assertionCredentialJSON(from authorization: ASAuthorization) throws -> AnyJSON {
+  private func assertionCredentialJSON(from authorization: ASAuthorization) throws -> JSONValue {
     guard
       let credential = authorization.credential
         as? ASAuthorizationPlatformPublicKeyCredentialAssertion

--- a/Sources/Auth/WebAuthn/WebAuthnTypes.swift
+++ b/Sources/Auth/WebAuthn/WebAuthnTypes.swift
@@ -72,7 +72,7 @@ public struct WebAuthnChallengeResponseData: Decodable, Hashable, Sendable {
 
   /// The W3C credential options (creation or request) to forward to the authenticator. Field
   /// names follow the W3C spec verbatim (camelCase) and are not transformed.
-  public let credentialOptions: AnyJSON
+  public let credentialOptions: JSONValue
 }
 
 // MARK: - First-factor passkeys
@@ -111,7 +111,7 @@ public struct PasskeyRegistrationOptions: Decodable, Hashable, Sendable {
   public let challengeId: String
 
   /// W3C `PublicKeyCredentialCreationOptions`, forwarded verbatim to the authenticator.
-  public let options: AnyJSON
+  public let options: JSONValue
 
   /// Unix timestamp (seconds since epoch) when the challenge expires.
   public let expiresAt: TimeInterval
@@ -126,7 +126,7 @@ public struct PasskeyAuthenticationOptions: Decodable, Hashable, Sendable {
   public let challengeId: String
 
   /// W3C `PublicKeyCredentialRequestOptions`, forwarded verbatim to the authenticator.
-  public let options: AnyJSON
+  public let options: JSONValue
 
   /// Unix timestamp (seconds since epoch) when the challenge expires.
   public let expiresAt: TimeInterval
@@ -135,7 +135,7 @@ public struct PasskeyAuthenticationOptions: Decodable, Hashable, Sendable {
 /// Encodes a WebAuthn request body without applying the snake_case key strategy, so the embedded
 /// W3C credential JSON (which uses camelCase field names such as `clientDataJSON`) reaches the
 /// backend verbatim. All backend field names must be spelled out explicitly by the caller.
-func encodeWebAuthnBody(_ json: AnyJSON) throws -> Data {
+func encodeWebAuthnBody(_ json: JSONValue) throws -> Data {
   let encoder = JSONEncoder()
   encoder.outputFormatting = [.sortedKeys]
   return try encoder.encode(json)

--- a/Sources/Helpers/JSONValue/JSONValue+Codable.swift
+++ b/Sources/Helpers/JSONValue/JSONValue+Codable.swift
@@ -1,5 +1,5 @@
 //
-//  AnyJSON+Codable.swift
+//  JSONValue+Codable.swift
 //
 //
 //  Created by Guilherme Souza on 20/01/24.
@@ -7,18 +7,18 @@
 
 public import Foundation
 
-extension AnyJSON {
-  /// The decoder instance used for transforming AnyJSON to some Codable type.
+extension JSONValue {
+  /// The decoder instance used for transforming JSONValue to some Codable type.
   public static let decoder: JSONDecoder = JSONDecoder.supabase()
 
-  /// The encoder instance used for transforming AnyJSON to some Codable type.
+  /// The encoder instance used for transforming JSONValue to some Codable type.
   public static let encoder: JSONEncoder = JSONEncoder.supabase()
 }
 
-extension AnyJSON {
-  /// Initialize an ``AnyJSON`` from an ``Encodable`` value.
+extension JSONValue {
+  /// Initialize an ``JSONValue`` from an ``Encodable`` value.
   public init(_ value: some Encodable) throws {
-    if let value = value as? AnyJSON {
+    if let value = value as? JSONValue {
       self = value
     } else if let string = value as? String {
       self = .string(string)
@@ -29,17 +29,17 @@ extension AnyJSON {
     } else if let double = value as? Double {
       self = .double(double)
     } else {
-      let data = try AnyJSON.encoder.encode(value)
-      self = try AnyJSON.decoder.decode(AnyJSON.self, from: data)
+      let data = try JSONValue.encoder.encode(value)
+      self = try JSONValue.decoder.decode(JSONValue.self, from: data)
     }
   }
 
   /// Decodes self instance as `Decodable` type.
   public func decode<T: Decodable>(
     as type: T.Type = T.self,
-    decoder: JSONDecoder = AnyJSON.decoder
+    decoder: JSONDecoder = JSONValue.decoder
   ) throws -> T {
-    let data = try AnyJSON.encoder.encode(self)
+    let data = try JSONValue.encoder.encode(self)
     return try decoder.decode(type, from: data)
   }
 }
@@ -48,9 +48,9 @@ extension JSONArray {
   /// Decodes self instance as array of `Decodable` type.
   public func decode<T: Decodable>(
     as _: T.Type = T.self,
-    decoder: JSONDecoder = AnyJSON.decoder
+    decoder: JSONDecoder = JSONValue.decoder
   ) throws -> [T] {
-    try AnyJSON.array(self).decode(as: [T].self, decoder: decoder)
+    try JSONValue.array(self).decode(as: [T].self, decoder: decoder)
   }
 }
 
@@ -58,14 +58,14 @@ extension JSONObject {
   /// Decodes self instance as `Decodable` type.
   public func decode<T: Decodable>(
     as _: T.Type = T.self,
-    decoder: JSONDecoder = AnyJSON.decoder
+    decoder: JSONDecoder = JSONValue.decoder
   ) throws -> T {
-    try AnyJSON.object(self).decode(as: T.self, decoder: decoder)
+    try JSONValue.object(self).decode(as: T.self, decoder: decoder)
   }
 
   /// Initialize JSONObject from an `Encodable` type
   public init(_ value: some Encodable) throws {
-    guard let object = try AnyJSON(value).objectValue else {
+    guard let object = try JSONValue(value).objectValue else {
       throw DecodingError.typeMismatch(
         JSONObject.self,
         DecodingError.Context(

--- a/Sources/Helpers/JSONValue/JSONValue.swift
+++ b/Sources/Helpers/JSONValue/JSONValue.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-public typealias JSONObject = [String: AnyJSON]
-public typealias JSONArray = [AnyJSON]
+public typealias JSONObject = [String: JSONValue]
+public typealias JSONArray = [JSONValue]
 
 /// An enumeration that represents JSON-compatible values of various types.
-public enum AnyJSON: Sendable, Codable, Hashable {
+public enum JSONValue: Sendable, Codable, Hashable {
   /// Represents a `null` JSON value.
   case null
   /// Represents a JSON boolean value.
@@ -20,9 +20,9 @@ public enum AnyJSON: Sendable, Codable, Hashable {
   /// Represents a JSON array (list) value.
   case array(JSONArray)
 
-  /// Returns the underlying Swift value corresponding to the `AnyJSON` instance.
+  /// Returns the underlying Swift value corresponding to the `JSONValue` instance.
   ///
-  /// - Note: For `.object` and `.array` cases, the returned value contains recursively transformed `AnyJSON` instances.
+  /// - Note: For `.object` and `.array` cases, the returned value contains recursively transformed `JSONValue` instances.
   public var value: Any {
     switch self {
     case .null: NSNull()
@@ -123,49 +123,49 @@ public enum AnyJSON: Sendable, Codable, Hashable {
   }
 }
 
-extension AnyJSON: ExpressibleByNilLiteral {
+extension JSONValue: ExpressibleByNilLiteral {
   public init(nilLiteral _: ()) {
     self = .null
   }
 }
 
-extension AnyJSON: ExpressibleByStringLiteral {
+extension JSONValue: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) {
     self = .string(value)
   }
 }
 
-extension AnyJSON: ExpressibleByArrayLiteral {
-  public init(arrayLiteral elements: AnyJSON...) {
+extension JSONValue: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: JSONValue...) {
     self = .array(elements)
   }
 }
 
-extension AnyJSON: ExpressibleByIntegerLiteral {
+extension JSONValue: ExpressibleByIntegerLiteral {
   public init(integerLiteral value: Int) {
     self = .integer(value)
   }
 }
 
-extension AnyJSON: ExpressibleByFloatLiteral {
+extension JSONValue: ExpressibleByFloatLiteral {
   public init(floatLiteral value: Double) {
     self = .double(value)
   }
 }
 
-extension AnyJSON: ExpressibleByBooleanLiteral {
+extension JSONValue: ExpressibleByBooleanLiteral {
   public init(booleanLiteral value: Bool) {
     self = .bool(value)
   }
 }
 
-extension AnyJSON: ExpressibleByDictionaryLiteral {
-  public init(dictionaryLiteral elements: (String, AnyJSON)...) {
+extension JSONValue: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (String, JSONValue)...) {
     self = .object(Dictionary(uniqueKeysWithValues: elements))
   }
 }
 
-extension AnyJSON: CustomStringConvertible {
+extension JSONValue: CustomStringConvertible {
   public var description: String {
     String(describing: value)
   }

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -309,7 +309,8 @@ public final class PostgrestClient: Sendable {
     if head || get {
       method = head ? .head : .get
 
-      guard case .object(let json) = try AnyJSON.decoder.decode(AnyJSON.self, from: bodyData) else {
+      guard case .object(let json) = try JSONValue.decoder.decode(JSONValue.self, from: bodyData)
+      else {
         throw PostgrestError(
           message: "Params should be a key-value type when using `GET` or `HEAD` options."
         )
@@ -387,7 +388,7 @@ public final class PostgrestClient: Sendable {
     return PostgrestClient(configuration: configuration, clock: clock)
   }
 
-  private func queryValue(for value: AnyJSON) -> String {
+  private func queryValue(for value: JSONValue) -> String {
     switch value {
     case .null:
       return "null"

--- a/Sources/PostgREST/PostgrestFilterValue.swift
+++ b/Sources/PostgREST/PostgrestFilterValue.swift
@@ -80,8 +80,8 @@ extension Array: PostgrestArrayLiteralElementEncodable where Element: PostgrestF
   package var postgrestArrayLiteralElement: String { rawValue }
 }
 
-/// `AnyJSON` can be used directly as a PostgREST filter value.
-extension AnyJSON: PostgrestFilterValue {
+/// `JSONValue` can be used directly as a PostgREST filter value.
+extension JSONValue: PostgrestFilterValue {
   public var rawValue: String {
     switch self {
     case .array(let array): array.rawValue
@@ -98,7 +98,7 @@ extension AnyJSON: PostgrestFilterValue {
 /// `.null` is an actual SQL `NULL` array member, not the string `"NULL"`, and
 /// `.array` is a nested array literal, not a scalar string — both are passed
 /// through unescaped rather than quoted as a scalar.
-extension AnyJSON: PostgrestArrayLiteralElementEncodable {
+extension JSONValue: PostgrestArrayLiteralElementEncodable {
   package var postgrestArrayLiteralElement: String {
     switch self {
     case .array(let array): array.postgrestArrayLiteralElement

--- a/Sources/RealtimeV2/PostgresAction.swift
+++ b/Sources/RealtimeV2/PostgresAction.swift
@@ -78,7 +78,7 @@ public struct InsertAction: PostgresAction, HasRecord, HasRawMessage {
   public let commitTimestamp: Date
 
   /// The newly-inserted row's data, keyed by column name.
-  public let record: [String: AnyJSON]
+  public let record: [String: JSONValue]
 
   /// The raw Realtime message that delivered this event.
   public let rawMessage: RealtimeMessageV2
@@ -107,10 +107,10 @@ public struct UpdateAction: PostgresAction, HasRecord, HasOldRecord, HasRawMessa
   public let commitTimestamp: Date
 
   /// The updated row's new data, keyed by column name.
-  public let record: [String: AnyJSON]
+  public let record: [String: JSONValue]
 
   /// The row's data before the update was applied, keyed by column name.
-  public let oldRecord: [String: AnyJSON]
+  public let oldRecord: [String: JSONValue]
 
   /// The raw Realtime message that delivered this event.
   public let rawMessage: RealtimeMessageV2
@@ -138,7 +138,7 @@ public struct DeleteAction: PostgresAction, HasOldRecord, HasRawMessage {
   public let commitTimestamp: Date
 
   /// The deleted row's data before removal, keyed by column name.
-  public let oldRecord: [String: AnyJSON]
+  public let oldRecord: [String: JSONValue]
 
   /// The raw Realtime message that delivered this event.
   public let rawMessage: RealtimeMessageV2
@@ -200,7 +200,7 @@ extension HasRecord {
   ///
   /// - Parameters:
   ///   - type: The target `Decodable` type. Can be inferred from context.
-  ///   - decoder: A `JSONDecoder` to use for decoding. Defaults to `AnyJSON.decoder`.
+  ///   - decoder: A `JSONDecoder` to use for decoding. Defaults to `JSONValue.decoder`.
   /// - Returns: An instance of `T` decoded from the record data.
   /// - Throws: A `DecodingError` if the record cannot be decoded into `T`.
   public func decodeRecord<T: Decodable>(as _: T.Type = T.self, decoder: JSONDecoder) throws -> T {
@@ -213,7 +213,7 @@ extension HasOldRecord {
   ///
   /// - Parameters:
   ///   - type: The target `Decodable` type. Can be inferred from context.
-  ///   - decoder: A `JSONDecoder` to use for decoding. Defaults to `AnyJSON.decoder`.
+  ///   - decoder: A `JSONDecoder` to use for decoding. Defaults to `JSONValue.decoder`.
   /// - Returns: An instance of `T` decoded from the old record data.
   /// - Throws: A `DecodingError` if the old record cannot be decoded into `T`.
   public func decodeOldRecord<T: Decodable>(

--- a/Sources/RealtimeV2/PostgresActionData.swift
+++ b/Sources/RealtimeV2/PostgresActionData.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct PostgresActionData: Decodable {
   var type: String
-  var record: [String: AnyJSON]?
-  var oldRecord: [String: AnyJSON]?
+  var record: [String: JSONValue]?
+  var oldRecord: [String: JSONValue]?
   var columns: [Column]
   var commitTimestamp: Date
 

--- a/Sources/RealtimeV2/PresenceAction.swift
+++ b/Sources/RealtimeV2/PresenceAction.swift
@@ -89,12 +89,12 @@ extension PresenceV2: Decodable {
   ///
   /// - Parameters:
   ///   - type: The target `Decodable` type. Can be inferred from context.
-  ///   - decoder: A `JSONDecoder` to use. Defaults to `AnyJSON.decoder`.
+  ///   - decoder: A `JSONDecoder` to use. Defaults to `JSONValue.decoder`.
   /// - Returns: An instance of `T` decoded from the state data.
   /// - Throws: A `DecodingError` if the state cannot be decoded into `T`.
   public func decodeState<T: Decodable>(
     as _: T.Type = T.self,
-    decoder: JSONDecoder = AnyJSON.decoder
+    decoder: JSONDecoder = JSONValue.decoder
   ) throws -> T {
     try state.decode(as: T.self, decoder: decoder)
   }
@@ -129,13 +129,13 @@ extension PresenceAction {
   ///   - type: The target `Decodable` type. Can be inferred from context.
   ///   - ignoreOtherTypes: When `true`, presences whose state cannot be decoded to `T` are
   ///     silently skipped (e.g. your own presence without a state payload). Defaults to `true`.
-  ///   - decoder: A `JSONDecoder` to use. Defaults to `AnyJSON.decoder`.
+  ///   - decoder: A `JSONDecoder` to use. Defaults to `JSONValue.decoder`.
   /// - Returns: An array of `T` values decoded from the joined presences.
   /// - Throws: A `DecodingError` when `ignoreOtherTypes` is `false` and any presence cannot be decoded.
   public func decodeJoins<T: Decodable>(
     as _: T.Type = T.self,
     ignoreOtherTypes: Bool = true,
-    decoder: JSONDecoder = AnyJSON.decoder
+    decoder: JSONDecoder = JSONValue.decoder
   ) throws -> [T] {
     if ignoreOtherTypes {
       return joins.values.compactMap { try? $0.decodeState(as: T.self, decoder: decoder) }
@@ -150,13 +150,13 @@ extension PresenceAction {
   ///   - type: The target `Decodable` type. Can be inferred from context.
   ///   - ignoreOtherTypes: When `true`, presences whose state cannot be decoded to `T` are
   ///     silently skipped. Defaults to `true`.
-  ///   - decoder: A `JSONDecoder` to use. Defaults to `AnyJSON.decoder`.
+  ///   - decoder: A `JSONDecoder` to use. Defaults to `JSONValue.decoder`.
   /// - Returns: An array of `T` values decoded from the leaving presences.
   /// - Throws: A `DecodingError` when `ignoreOtherTypes` is `false` and any presence cannot be decoded.
   public func decodeLeaves<T: Decodable>(
     as _: T.Type = T.self,
     ignoreOtherTypes: Bool = true,
-    decoder: JSONDecoder = AnyJSON.decoder
+    decoder: JSONDecoder = JSONValue.decoder
   ) throws -> [T] {
     if ignoreOtherTypes {
       return leaves.values.compactMap { try? $0.decodeState(as: T.self, decoder: decoder) }

--- a/Sources/RealtimeV2/RealtimeSerializer.swift
+++ b/Sources/RealtimeV2/RealtimeSerializer.swift
@@ -44,7 +44,7 @@ struct RealtimeSerializer: Sendable {
 
   /// Encodes a ``RealtimeMessageV2`` as a JSON array string: `[joinRef, ref, topic, event, payload]`.
   func encodeText(_ message: RealtimeMessageV2) throws -> String {
-    let array: [AnyJSON] = [
+    let array: [JSONValue] = [
       message.joinRef.map { .string($0) } ?? .null,
       message.ref.map { .string($0) } ?? .null,
       .string(message.topic),
@@ -64,7 +64,7 @@ struct RealtimeSerializer: Sendable {
   /// Decodes a JSON array string `[joinRef, ref, topic, event, payload]` into a ``RealtimeMessageV2``.
   func decodeText(_ text: String) throws -> RealtimeMessageV2 {
     let data = Data(text.utf8)
-    let array = try JSONDecoder().decode([AnyJSON].self, from: data)
+    let array = try JSONDecoder().decode([JSONValue].self, from: data)
 
     guard array.count >= 5 else {
       throw RealtimeError(

--- a/Sources/Storage/Helpers.swift
+++ b/Sources/Storage/Helpers.swift
@@ -24,7 +24,7 @@ import Foundation
 #endif
 
 func encodeMetadata(_ metadata: JSONObject) -> Data {
-  let encoder = AnyJSON.encoder
+  let encoder = JSONValue.encoder
   return (try? encoder.encode(metadata)) ?? "{}".data(using: .utf8)!
 }
 

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -139,7 +139,7 @@ public struct FileOptions: Sendable {
 
   /// Arbitrary key-value metadata to attach to the uploaded object. You can later use this to
   /// filter or search for files.
-  public var metadata: [String: AnyJSON]?
+  public var metadata: [String: JSONValue]?
 
   /// Extra HTTP headers to include with the upload request.
   public var headers: [String: String]?
@@ -158,7 +158,7 @@ public struct FileOptions: Sendable {
     contentType: String? = nil,
     upsert: Bool = false,
     duplex: String? = nil,
-    metadata: [String: AnyJSON]? = nil,
+    metadata: [String: JSONValue]? = nil,
     headers: [String: String]? = nil
   ) {
     self.cacheControl = cacheControl
@@ -418,7 +418,7 @@ public struct FileObject: Identifiable, Hashable, Decodable, Sendable {
   public var lastAccessedAt: Date?
 
   /// Arbitrary key-value metadata attached to the file at upload time.
-  public var metadata: [String: AnyJSON]?
+  public var metadata: [String: JSONValue]?
 
   /// The bucket associated with this file, if it was eagerly loaded.
   public var buckets: Bucket?
@@ -443,7 +443,7 @@ public struct FileObject: Identifiable, Hashable, Decodable, Sendable {
     updatedAt: Date? = nil,
     createdAt: Date? = nil,
     lastAccessedAt: Date? = nil,
-    metadata: [String: AnyJSON]? = nil,
+    metadata: [String: JSONValue]? = nil,
     buckets: Bucket? = nil
   ) {
     self.name = name
@@ -539,7 +539,7 @@ public struct FileObjectV2: Identifiable, Hashable, Decodable, Sendable {
   public let lastModified: Date?
 
   /// Arbitrary key-value metadata attached to the file at upload time.
-  public let metadata: [String: AnyJSON]?
+  public let metadata: [String: JSONValue]?
 
   enum CodingKeys: String, CodingKey {
     case id

--- a/Sources/Storage/VectorIndexClient.swift
+++ b/Sources/Storage/VectorIndexClient.swift
@@ -214,7 +214,7 @@ public struct VectorIndexClient: Sendable {
   public func queryVectors(
     _ queryVector: VectorData,
     topK: Int,
-    filter: [String: AnyJSON]? = nil,
+    filter: [String: JSONValue]? = nil,
     returnDistance: Bool = false,
     returnMetadata: Bool = false
   ) async throws -> QueryVectorsResponse {
@@ -301,7 +301,7 @@ private struct QueryVectorsBody: Encodable {
   var indexName: String
   var queryVector: VectorData
   var topK: Int
-  var filter: [String: AnyJSON]?
+  var filter: [String: JSONValue]?
   var returnDistance: Bool
   var returnMetadata: Bool
 }
@@ -345,7 +345,7 @@ public struct VectorEntry: Encodable, Sendable, Hashable {
   public var data: VectorData
 
   /// Arbitrary metadata to store alongside the vector.
-  public var metadata: [String: AnyJSON]?
+  public var metadata: [String: JSONValue]?
 
   /// Creates a ``VectorEntry``.
   ///
@@ -353,7 +353,7 @@ public struct VectorEntry: Encodable, Sendable, Hashable {
   ///   - key: A unique identifier for the vector within its index.
   ///   - data: The vector's embedding data.
   ///   - metadata: Arbitrary metadata to store alongside the vector.
-  public init(key: String, data: VectorData, metadata: [String: AnyJSON]? = nil) {
+  public init(key: String, data: VectorData, metadata: [String: JSONValue]? = nil) {
     self.key = key
     self.data = data
     self.metadata = metadata
@@ -374,7 +374,7 @@ public struct VectorMatch: Decodable, Sendable, Hashable {
   public var data: VectorData?
 
   /// The vector's metadata, present when the request set `returnMetadata: true`.
-  public var metadata: [String: AnyJSON]?
+  public var metadata: [String: JSONValue]?
 
   /// The similarity distance from the query vector, present when the request set
   /// `returnDistance: true`. Only populated by

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -2505,7 +2505,7 @@ extension AuthMockerTests {
 
     @Test
     func webAuthnCredentialOptionsParsing() throws {
-      let options: AnyJSON = [
+      let options: JSONValue = [
         "challenge": "Y2hhbGxlbmdl",
         "user": [
           "id": "dXNlci1pZA",
@@ -2527,7 +2527,7 @@ extension AuthMockerTests {
 
     @Test
     func webAuthnChallengeParsingThrowsWhenMissing() {
-      let options: AnyJSON = ["user": ["id": "dXNlci1pZA"]]
+      let options: JSONValue = ["user": ["id": "dXNlci1pZA"]]
       #expect(throws: (any Error).self) { try options.webAuthnChallengeData() }
     }
 
@@ -2553,7 +2553,7 @@ extension AuthMockerTests {
         .register()
 
         // Capture what the SDK hands to the authenticator to prove it forwards the backend options.
-        let forwardedOptions = LockIsolated<AnyJSON?>(nil)
+        let forwardedOptions = LockIsolated<JSONValue?>(nil)
         let authenticator = WebAuthnAuthenticator(
           register: { _, _, _ in [:] },
           authenticate: { options, _, _ in

--- a/Tests/AuthTests/StoredSessionTests.swift
+++ b/Tests/AuthTests/StoredSessionTests.swift
@@ -129,7 +129,7 @@ struct StoredSessionTests {
 
   private final class DiskTestStorage: AuthLocalStorage {
     let url: URL
-    let storage: LockIsolated<[String: AnyJSON]>
+    let storage: LockIsolated<[String: JSONValue]>
 
     let encoder = JSONEncoder()
     let decoder = JSONDecoder()
@@ -148,11 +148,11 @@ struct StoredSessionTests {
       }
 
       let contents = try Data(contentsOf: url)
-      storage = try LockIsolated(decoder.decode([String: AnyJSON].self, from: contents))
+      storage = try LockIsolated(decoder.decode([String: JSONValue].self, from: contents))
     }
 
     func store(key: String, value: Data) throws {
-      let json = try decoder.decode(AnyJSON.self, from: value)
+      let json = try decoder.decode(JSONValue.self, from: value)
       storage.withValue {
         $0[key] = json
       }

--- a/Tests/HelpersTests/JSONValueTests.swift
+++ b/Tests/HelpersTests/JSONValueTests.swift
@@ -1,5 +1,5 @@
 //
-//  AnyJSONTests.swift
+//  JSONValueTests.swift
 //
 //
 //  Created by Guilherme Souza on 28/12/23.
@@ -11,7 +11,7 @@ import Helpers
 import Testing
 
 @Suite
-struct AnyJSONTests {
+struct JSONValueTests {
   let jsonString = """
     {
       "array" : [
@@ -46,7 +46,7 @@ struct AnyJSONTests {
     }
     """
 
-  let jsonObject: AnyJSON = [
+  let jsonObject: JSONValue = [
     "integer": 1,
     "double": 3.14,
     "string": "A string value",
@@ -67,14 +67,14 @@ struct AnyJSONTests {
   @Test
   func decode() throws {
     let data = try #require(jsonString.data(using: .utf8))
-    let decodedJSON = try AnyJSON.decoder.decode(AnyJSON.self, from: data)
+    let decodedJSON = try JSONValue.decoder.decode(JSONValue.self, from: data)
 
     expectNoDifference(decodedJSON, jsonObject)
   }
 
   @Test
   func encode() throws {
-    let encoder = AnyJSON.encoder
+    let encoder = JSONValue.encoder
     let originalFormatting = encoder.outputFormatting
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     defer { encoder.outputFormatting = originalFormatting }
@@ -87,7 +87,7 @@ struct AnyJSONTests {
 
   @Test
   func initFromCodable() {
-    try expectNoDifference(AnyJSON(jsonObject), jsonObject)
+    try expectNoDifference(JSONValue(jsonObject), jsonObject)
 
     let codableValue = CodableValue(
       integer: 1,
@@ -99,7 +99,7 @@ struct AnyJSONTests {
       anyJSON: jsonObject
     )
 
-    let json: AnyJSON = [
+    let json: JSONValue = [
       "integer": 1,
       "double": 3.14,
       "string": "A String value",
@@ -109,7 +109,7 @@ struct AnyJSONTests {
       "any_json": jsonObject,
     ]
 
-    try expectNoDifference(AnyJSON(codableValue), json)
+    try expectNoDifference(JSONValue(codableValue), json)
     try expectNoDifference(codableValue, json.decode(as: CodableValue.self))
   }
 
@@ -118,28 +118,28 @@ struct AnyJSONTests {
   @Test
   func valueProperty() {
     // Test null value
-    #expect(AnyJSON.null.value is NSNull)
+    #expect(JSONValue.null.value is NSNull)
 
     // Test string value
-    #expect(AnyJSON.string("test").value as? String == "test")
+    #expect(JSONValue.string("test").value as? String == "test")
 
     // Test integer value
-    #expect(AnyJSON.integer(42).value as? Int == 42)
+    #expect(JSONValue.integer(42).value as? Int == 42)
 
     // Test double value
-    #expect(AnyJSON.double(3.14).value as? Double == 3.14)
+    #expect(JSONValue.double(3.14).value as? Double == 3.14)
 
     // Test bool value
-    #expect(AnyJSON.bool(true).value as? Bool == true)
-    #expect(AnyJSON.bool(false).value as? Bool == false)
+    #expect(JSONValue.bool(true).value as? Bool == true)
+    #expect(JSONValue.bool(false).value as? Bool == false)
 
     // Test object value
-    let object: AnyJSON = ["key": "value"]
+    let object: JSONValue = ["key": "value"]
     let objectValue = object.value as? [String: Any]
     #expect(objectValue?["key"] as? String == "value")
 
     // Test array value
-    let array: AnyJSON = [1, 2, 3]
+    let array: JSONValue = [1, 2, 3]
     let arrayValue = array.value as? [Any]
     #expect(arrayValue?[0] as? Int == 1)
     #expect(arrayValue?[1] as? Int == 2)
@@ -150,129 +150,129 @@ struct AnyJSONTests {
 
   @Test
   func isNil() {
-    #expect(AnyJSON.null.isNil)
-    #expect(!AnyJSON.string("test").isNil)
-    #expect(!AnyJSON.integer(42).isNil)
-    #expect(!AnyJSON.double(3.14).isNil)
-    #expect(!AnyJSON.bool(true).isNil)
-    #expect(!AnyJSON.object([:]).isNil)
-    #expect(!AnyJSON.array([]).isNil)
+    #expect(JSONValue.null.isNil)
+    #expect(!JSONValue.string("test").isNil)
+    #expect(!JSONValue.integer(42).isNil)
+    #expect(!JSONValue.double(3.14).isNil)
+    #expect(!JSONValue.bool(true).isNil)
+    #expect(!JSONValue.object([:]).isNil)
+    #expect(!JSONValue.array([]).isNil)
   }
 
   @Test
   func boolValue() {
-    #expect(AnyJSON.bool(true).boolValue == true)
-    #expect(AnyJSON.bool(false).boolValue == false)
-    #expect(AnyJSON.string("test").boolValue == nil)
-    #expect(AnyJSON.integer(42).boolValue == nil)
-    #expect(AnyJSON.double(3.14).boolValue == nil)
-    #expect(AnyJSON.null.boolValue == nil)
-    #expect(AnyJSON.object([:]).boolValue == nil)
-    #expect(AnyJSON.array([]).boolValue == nil)
+    #expect(JSONValue.bool(true).boolValue == true)
+    #expect(JSONValue.bool(false).boolValue == false)
+    #expect(JSONValue.string("test").boolValue == nil)
+    #expect(JSONValue.integer(42).boolValue == nil)
+    #expect(JSONValue.double(3.14).boolValue == nil)
+    #expect(JSONValue.null.boolValue == nil)
+    #expect(JSONValue.object([:]).boolValue == nil)
+    #expect(JSONValue.array([]).boolValue == nil)
   }
 
   @Test
   func stringValue() {
-    #expect(AnyJSON.string("test").stringValue == "test")
-    #expect(AnyJSON.bool(true).stringValue == nil)
-    #expect(AnyJSON.integer(42).stringValue == nil)
-    #expect(AnyJSON.double(3.14).stringValue == nil)
-    #expect(AnyJSON.null.stringValue == nil)
-    #expect(AnyJSON.object([:]).stringValue == nil)
-    #expect(AnyJSON.array([]).stringValue == nil)
+    #expect(JSONValue.string("test").stringValue == "test")
+    #expect(JSONValue.bool(true).stringValue == nil)
+    #expect(JSONValue.integer(42).stringValue == nil)
+    #expect(JSONValue.double(3.14).stringValue == nil)
+    #expect(JSONValue.null.stringValue == nil)
+    #expect(JSONValue.object([:]).stringValue == nil)
+    #expect(JSONValue.array([]).stringValue == nil)
   }
 
   @Test
   func intValue() {
-    #expect(AnyJSON.integer(42).intValue == 42)
-    #expect(AnyJSON.string("test").intValue == nil)
-    #expect(AnyJSON.bool(true).intValue == nil)
-    #expect(AnyJSON.double(3.14).intValue == nil)
-    #expect(AnyJSON.null.intValue == nil)
-    #expect(AnyJSON.object([:]).intValue == nil)
-    #expect(AnyJSON.array([]).intValue == nil)
+    #expect(JSONValue.integer(42).intValue == 42)
+    #expect(JSONValue.string("test").intValue == nil)
+    #expect(JSONValue.bool(true).intValue == nil)
+    #expect(JSONValue.double(3.14).intValue == nil)
+    #expect(JSONValue.null.intValue == nil)
+    #expect(JSONValue.object([:]).intValue == nil)
+    #expect(JSONValue.array([]).intValue == nil)
   }
 
   @Test
   func doubleValue() {
-    #expect(AnyJSON.double(3.14).doubleValue == 3.14)
-    #expect(AnyJSON.string("test").doubleValue == nil)
-    #expect(AnyJSON.bool(true).doubleValue == nil)
-    #expect(AnyJSON.integer(42).doubleValue == nil)
-    #expect(AnyJSON.null.doubleValue == nil)
-    #expect(AnyJSON.object([:]).doubleValue == nil)
-    #expect(AnyJSON.array([]).doubleValue == nil)
+    #expect(JSONValue.double(3.14).doubleValue == 3.14)
+    #expect(JSONValue.string("test").doubleValue == nil)
+    #expect(JSONValue.bool(true).doubleValue == nil)
+    #expect(JSONValue.integer(42).doubleValue == nil)
+    #expect(JSONValue.null.doubleValue == nil)
+    #expect(JSONValue.object([:]).doubleValue == nil)
+    #expect(JSONValue.array([]).doubleValue == nil)
   }
 
   @Test
   func objectValue() {
     let object: JSONObject = ["key": "value"]
-    #expect(AnyJSON.object(object).objectValue == object)
-    #expect(AnyJSON.string("test").objectValue == nil)
-    #expect(AnyJSON.bool(true).objectValue == nil)
-    #expect(AnyJSON.integer(42).objectValue == nil)
-    #expect(AnyJSON.double(3.14).objectValue == nil)
-    #expect(AnyJSON.null.objectValue == nil)
-    #expect(AnyJSON.array([]).objectValue == nil)
+    #expect(JSONValue.object(object).objectValue == object)
+    #expect(JSONValue.string("test").objectValue == nil)
+    #expect(JSONValue.bool(true).objectValue == nil)
+    #expect(JSONValue.integer(42).objectValue == nil)
+    #expect(JSONValue.double(3.14).objectValue == nil)
+    #expect(JSONValue.null.objectValue == nil)
+    #expect(JSONValue.array([]).objectValue == nil)
   }
 
   @Test
   func arrayValue() {
     let array: JSONArray = [1, 2, 3]
-    #expect(AnyJSON.array(array).arrayValue == array)
-    #expect(AnyJSON.string("test").arrayValue == nil)
-    #expect(AnyJSON.bool(true).arrayValue == nil)
-    #expect(AnyJSON.integer(42).arrayValue == nil)
-    #expect(AnyJSON.double(3.14).arrayValue == nil)
-    #expect(AnyJSON.null.arrayValue == nil)
-    #expect(AnyJSON.object([:]).arrayValue == nil)
+    #expect(JSONValue.array(array).arrayValue == array)
+    #expect(JSONValue.string("test").arrayValue == nil)
+    #expect(JSONValue.bool(true).arrayValue == nil)
+    #expect(JSONValue.integer(42).arrayValue == nil)
+    #expect(JSONValue.double(3.14).arrayValue == nil)
+    #expect(JSONValue.null.arrayValue == nil)
+    #expect(JSONValue.object([:]).arrayValue == nil)
   }
 
   // MARK: - ExpressibleByLiteral Tests
 
   @Test
   func expressibleByNilLiteral() {
-    let json: AnyJSON = nil
+    let json: JSONValue = nil
     #expect(json == .null)
   }
 
   @Test
   func expressibleByStringLiteral() {
-    let json: AnyJSON = "test string"
+    let json: JSONValue = "test string"
     #expect(json == .string("test string"))
   }
 
   @Test
   func expressibleByIntegerLiteral() {
-    let json: AnyJSON = 42
+    let json: JSONValue = 42
     #expect(json == .integer(42))
   }
 
   @Test
   func expressibleByFloatLiteral() {
-    let json: AnyJSON = 3.14
+    let json: JSONValue = 3.14
     #expect(json == .double(3.14))
   }
 
   @Test
   func expressibleByBooleanLiteral() {
-    let json: AnyJSON = true
+    let json: JSONValue = true
     #expect(json == .bool(true))
 
-    let jsonFalse: AnyJSON = false
+    let jsonFalse: JSONValue = false
     #expect(jsonFalse == .bool(false))
   }
 
   @Test
   func expressibleByArrayLiteral() {
-    let json: AnyJSON = [1, "test", true, nil]
+    let json: JSONValue = [1, "test", true, nil]
     #expect(json == .array([.integer(1), .string("test"), .bool(true), .null]))
   }
 
   @Test
   func expressibleByDictionaryLiteral() {
-    let json: AnyJSON = ["key1": "value1", "key2": 42, "key3": true]
-    let expected: AnyJSON = .object([
+    let json: JSONValue = ["key1": "value1", "key2": 42, "key3": true]
+    let expected: JSONValue = .object([
       "key1": .string("value1"),
       "key2": .integer(42),
       "key3": .bool(true),
@@ -284,20 +284,20 @@ struct AnyJSONTests {
 
   @Test
   func description() {
-    #expect(AnyJSON.null.description == "<null>")
-    #expect(AnyJSON.string("test").description == "test")
-    #expect(AnyJSON.integer(42).description == "42")
-    #expect(AnyJSON.double(3.14).description == "3.14")
-    #expect(AnyJSON.bool(true).description == "true")
-    #expect(AnyJSON.bool(false).description == "false")
+    #expect(JSONValue.null.description == "<null>")
+    #expect(JSONValue.string("test").description == "test")
+    #expect(JSONValue.integer(42).description == "42")
+    #expect(JSONValue.double(3.14).description == "3.14")
+    #expect(JSONValue.bool(true).description == "true")
+    #expect(JSONValue.bool(false).description == "false")
 
     // Test object description
-    let object: AnyJSON = ["key": "value"]
+    let object: JSONValue = ["key": "value"]
     #expect(object.description.contains("key"))
     #expect(object.description.contains("value"))
 
     // Test array description
-    let array: AnyJSON = [1, 2, 3]
+    let array: JSONValue = [1, 2, 3]
     #expect(array.description.contains("1"))
     #expect(array.description.contains("2"))
     #expect(array.description.contains("3"))
@@ -308,42 +308,42 @@ struct AnyJSONTests {
   @Test
   func equality() {
     // Test same values
-    #expect(AnyJSON.null == AnyJSON.null)
-    #expect(AnyJSON.string("test") == AnyJSON.string("test"))
-    #expect(AnyJSON.integer(42) == AnyJSON.integer(42))
-    #expect(AnyJSON.double(3.14) == AnyJSON.double(3.14))
-    #expect(AnyJSON.bool(true) == AnyJSON.bool(true))
-    #expect(AnyJSON.bool(false) == AnyJSON.bool(false))
+    #expect(JSONValue.null == JSONValue.null)
+    #expect(JSONValue.string("test") == JSONValue.string("test"))
+    #expect(JSONValue.integer(42) == JSONValue.integer(42))
+    #expect(JSONValue.double(3.14) == JSONValue.double(3.14))
+    #expect(JSONValue.bool(true) == JSONValue.bool(true))
+    #expect(JSONValue.bool(false) == JSONValue.bool(false))
 
     // Test different values
-    #expect(AnyJSON.string("test") != AnyJSON.string("different"))
-    #expect(AnyJSON.integer(42) != AnyJSON.integer(43))
-    #expect(AnyJSON.double(3.14) != AnyJSON.double(3.15))
-    #expect(AnyJSON.bool(true) != AnyJSON.bool(false))
+    #expect(JSONValue.string("test") != JSONValue.string("different"))
+    #expect(JSONValue.integer(42) != JSONValue.integer(43))
+    #expect(JSONValue.double(3.14) != JSONValue.double(3.15))
+    #expect(JSONValue.bool(true) != JSONValue.bool(false))
 
     // Test different types
-    #expect(AnyJSON.string("42") != AnyJSON.integer(42))
-    #expect(AnyJSON.integer(42) != AnyJSON.double(42.0))
-    #expect(AnyJSON.null != AnyJSON.string(""))
+    #expect(JSONValue.string("42") != JSONValue.integer(42))
+    #expect(JSONValue.integer(42) != JSONValue.double(42.0))
+    #expect(JSONValue.null != JSONValue.string(""))
 
     // Test objects
-    let object1: AnyJSON = ["key": "value"]
-    let object2: AnyJSON = ["key": "value"]
-    let object3: AnyJSON = ["key": "different"]
+    let object1: JSONValue = ["key": "value"]
+    let object2: JSONValue = ["key": "value"]
+    let object3: JSONValue = ["key": "different"]
     #expect(object1 == object2)
     #expect(object1 != object3)
 
     // Test arrays
-    let array1: AnyJSON = [1, 2, 3]
-    let array2: AnyJSON = [1, 2, 3]
-    let array3: AnyJSON = [1, 2, 4]
+    let array1: JSONValue = [1, 2, 3]
+    let array2: JSONValue = [1, 2, 3]
+    let array3: JSONValue = [1, 2, 4]
     #expect(array1 == array2)
     #expect(array1 != array3)
   }
 
   @Test
   func hashable() {
-    let set: Set<AnyJSON> = [
+    let set: Set<JSONValue> = [
       .null,
       .string("test"),
       .integer(42),
@@ -367,7 +367,7 @@ struct AnyJSONTests {
 
   @Test
   func jsonArrayDecode() throws {
-    let jsonArray: JSONArray = [AnyJSON.integer(1), AnyJSON.integer(2), AnyJSON.integer(3)]
+    let jsonArray: JSONArray = [JSONValue.integer(1), JSONValue.integer(2), JSONValue.integer(3)]
     // Decode each element individually since the JSONArray.decode method has issues
     let decoded: [Int] = try jsonArray.map { try $0.decode(as: Int.self) }
     #expect(decoded == [1, 2, 3])
@@ -375,7 +375,7 @@ struct AnyJSONTests {
 
   @Test
   func jsonObjectDecode() throws {
-    let jsonObject: JSONObject = ["name": AnyJSON.string("John"), "age": AnyJSON.integer(30)]
+    let jsonObject: JSONObject = ["name": JSONValue.string("John"), "age": JSONValue.integer(30)]
     let decoded: Person = try jsonObject.decode(as: Person.self)
     #expect(decoded.name == "John")
     #expect(decoded.age == 30)
@@ -410,7 +410,7 @@ struct AnyJSONTests {
     let data = invalidJSON.data(using: .utf8)!
 
     #expect(throws: (any Error).self) {
-      try AnyJSON.decoder.decode(AnyJSON.self, from: data)
+      try JSONValue.decoder.decode(JSONValue.self, from: data)
     }
   }
 
@@ -419,7 +419,7 @@ struct AnyJSONTests {
     let customDecoder = JSONDecoder()
     customDecoder.keyDecodingStrategy = .convertFromSnakeCase
 
-    let json: AnyJSON = ["user_name": "John", "user_age": 30]
+    let json: JSONValue = ["user_name": "John", "user_age": 30]
     let decoded: CustomPerson = try json.decode(as: CustomPerson.self, decoder: customDecoder)
     #expect(decoded.userName == "John")
     #expect(decoded.userAge == 30)
@@ -429,8 +429,8 @@ struct AnyJSONTests {
 
   @Test
   func emptyObjectAndArray() {
-    let emptyObject: AnyJSON = [:]
-    let emptyArray: AnyJSON = []
+    let emptyObject: JSONValue = [:]
+    let emptyArray: JSONValue = []
 
     #expect(emptyObject == .object([:]))
     #expect(emptyArray == .array([]))
@@ -441,7 +441,7 @@ struct AnyJSONTests {
 
   @Test
   func nestedStructures() {
-    let nested: AnyJSON = [
+    let nested: JSONValue = [
       "level1": [
         "level2": [
           "level3": [
@@ -461,7 +461,7 @@ struct AnyJSONTests {
 
   @Test
   func mixedArrayTypes() {
-    let mixedArray: AnyJSON = [1, "string", true, nil, ["nested": "value"]]
+    let mixedArray: JSONValue = [1, "string", true, nil, ["nested": "value"]]
 
     #expect(mixedArray.arrayValue?[0] == .integer(1))
     #expect(mixedArray.arrayValue?[1] == .string("string"))
@@ -472,8 +472,8 @@ struct AnyJSONTests {
 
   @Test
   func largeNumbers() {
-    let largeInt: AnyJSON = 9_223_372_036_854_775_807  // Int.max
-    let largeDouble: AnyJSON = 1.7976931348623157e+308  // Double.max
+    let largeInt: JSONValue = 9_223_372_036_854_775_807  // Int.max
+    let largeDouble: JSONValue = 1.7976931348623157e+308  // Double.max
 
     #expect(largeInt.intValue == 9_223_372_036_854_775_807)
     #expect(largeDouble.doubleValue == 1.7976931348623157e+308)
@@ -481,9 +481,9 @@ struct AnyJSONTests {
 
   @Test
   func specialStringValues() {
-    let emptyString: AnyJSON = ""
-    let unicodeString: AnyJSON = "Hello, 世界! 🌍"
-    let escapedString: AnyJSON = "Line 1\nLine 2\tTab"
+    let emptyString: JSONValue = ""
+    let unicodeString: JSONValue = "Hello, 世界! 🌍"
+    let escapedString: JSONValue = "Line 1\nLine 2\tTab"
 
     #expect(emptyString.stringValue == "")
     #expect(unicodeString.stringValue == "Hello, 世界! 🌍")
@@ -500,7 +500,7 @@ struct CodableValue: Codable, Equatable {
   let bool: Bool
   let array: [Int]
   let dictionary: [String: String]
-  let anyJSON: AnyJSON
+  let anyJSON: JSONValue
 
   enum CodingKeys: String, CodingKey {
     case integer

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -62,7 +62,7 @@ struct AuthClientIntegrationTests {
       let email = mockEmail()
       let password = mockPassword()
 
-      let metadata: [String: AnyJSON] = [
+      let metadata: [String: JSONValue] = [
         "test": .integer(42)
       ]
 
@@ -153,7 +153,7 @@ struct AuthClientIntegrationTests {
   //    try await expectAuthChangeEvents([.initialSession, .signedIn, .signedOut, .signedIn]) {
   //      let phone = mockPhoneNumber()
   //      let password = mockPassword()
-  //      let metadata: [String: AnyJSON] = [
+  //      let metadata: [String: JSONValue] = [
   //        "test": .integer(42),
   //      ]
   //      let response = try await authClient.signUp(phone: phone, password: password, data: metadata)

--- a/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgresTransformsTests.swift
@@ -25,7 +25,7 @@ struct PostgrestTransformsTests {
   init() async throws {
     // Clean up test data before running tests.
     // Delete users with email (test data), preserving seed data (users with username only).
-    try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
+    try await client.from("users").delete().not("email", operator: .is, value: JSONValue.null)
       .execute()
   }
 
@@ -35,7 +35,7 @@ struct PostgrestTransformsTests {
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
       .order("username", ascending: false)
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -80,7 +80,7 @@ struct PostgrestTransformsTests {
       .select()
       .order("channel_id", ascending: false)
       .order("username", ascending: false)
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -110,7 +110,7 @@ struct PostgrestTransformsTests {
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
       .limit(1)
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -133,7 +133,7 @@ struct PostgrestTransformsTests {
       try await client.from("users")
       .select("age_range,catchphrase,data,status,username")
       .range(from: 1, to: 3)
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -171,7 +171,7 @@ struct PostgrestTransformsTests {
       .select("age_range,catchphrase,data,status,username")
       .limit(1)
       .single()
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -193,7 +193,7 @@ struct PostgrestTransformsTests {
       .select("age_range,catchphrase,data,status,username")
       .eq("username", value: "supabot")
       .maybeSingle()
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -210,7 +210,7 @@ struct PostgrestTransformsTests {
 
   @Test
   func maybeSingleReturnsNilOnZeroRows() async throws {
-    let res: AnyJSON? =
+    let res: JSONValue? =
       try await client.from("users")
       .select("username")
       .eq("username", value: "does-not-exist")
@@ -240,7 +240,7 @@ struct PostgrestTransformsTests {
       .select("catchphrase")
       .eq("username", value: "dry-run-scratch")
       .single()
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: after, as: .json) {
       """
@@ -258,7 +258,7 @@ struct PostgrestTransformsTests {
       .insert(["username": "foo"])
       .select("age_range,catchphrase,data,status,username")
       .single()
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -284,7 +284,7 @@ struct PostgrestTransformsTests {
       try await client.from("users")
       .insert(["username": "foo"])
       .select("status")
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -307,7 +307,7 @@ struct PostgrestTransformsTests {
     let res =
       try await client.rpc("get_username_and_status", params: ["name_param": "supabot"])
       .select("status")
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """

--- a/Tests/IntegrationTests/Postgrest/PostgrestBasicTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgrestBasicTests.swift
@@ -24,7 +24,7 @@ struct PostgrestBasicTests {
   init() async throws {
     // Clean up test data before running tests.
     // Delete users with email (test data), preserving seed data (users with username only).
-    try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
+    try await client.from("users").delete().not("email", operator: .is, value: JSONValue.null)
       .execute()
     // Delete messages except seed data (id 1 and 2).
     try await client.from("messages").delete().gt("id", value: 2).execute()
@@ -34,7 +34,7 @@ struct PostgrestBasicTests {
   func basicSelectTable() async throws {
     let response =
       try await client.from("users").select("age_range,catchphrase,data,status,username").execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: response, as: .json) {
       """
       [
@@ -73,7 +73,7 @@ struct PostgrestBasicTests {
 
   @Test
   func basicSelectView() async throws {
-    let response = try await client.from("updatable_view").select().execute().value as AnyJSON
+    let response = try await client.from("updatable_view").select().execute().value as JSONValue
     assertInlineSnapshot(of: response, as: .json) {
       """
       [
@@ -102,7 +102,7 @@ struct PostgrestBasicTests {
   func rpc() async throws {
     let response =
       try await client.rpc("get_status", params: ["name_param": "supabot"]).execute().value
-      as AnyJSON
+      as JSONValue
     assertInlineSnapshot(of: response, as: .json) {
       """
       "ONLINE"
@@ -121,7 +121,7 @@ struct PostgrestBasicTests {
     let response =
       try await client.from("users")
       .upsert(["username": "dragarcia"], onConflict: "username", ignoreDuplicates: true)
-      .select().execute().value as AnyJSON
+      .select().execute().value as JSONValue
     assertInlineSnapshot(of: response, as: .json) {
       """
       [
@@ -136,10 +136,10 @@ struct PostgrestBasicTests {
     // Basic insert
     var response =
       try await client.from("messages")
-      .insert(AnyJSON.object(["message": "foo", "username": "supabot", "channel_id": 1]))
+      .insert(JSONValue.object(["message": "foo", "username": "supabot", "channel_id": 1]))
       .select("channel_id,data,message,username")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: response, as: .json) {
       """
       [
@@ -185,7 +185,7 @@ struct PostgrestBasicTests {
     response =
       try await client.from("messages")
       .upsert(
-        AnyJSON.object(
+        JSONValue.object(
           [
             "id": 1000,
             "message": "foo",
@@ -196,7 +196,7 @@ struct PostgrestBasicTests {
       )
       .select("channel_id,data,message,username")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: response, as: .json) {
       """
       [
@@ -247,7 +247,7 @@ struct PostgrestBasicTests {
 
     response = try await client.from("messages")
       .insert(
-        AnyJSON.array([
+        JSONValue.array([
           ["message": "foo", "username": "supabot", "channel_id": 1],
           ["message": "foo", "username": "supabot", "channel_id": 1],
         ])

--- a/Tests/IntegrationTests/Postgrest/PostgrestFilterTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgrestFilterTests.swift
@@ -24,7 +24,7 @@ struct PostgrestFilterTests {
   init() async throws {
     // Clean up test data before running tests.
     // Delete users with email (test data), preserving seed data (users with username only).
-    try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
+    try await client.from("users").delete().not("email", operator: .is, value: JSONValue.null)
       .execute()
   }
 
@@ -35,7 +35,7 @@ struct PostgrestFilterTests {
       .select("status")
       .not("status", operator: .eq, value: "OFFLINE")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -60,7 +60,7 @@ struct PostgrestFilterTests {
       .select("status,username")
       .or("status.eq.OFFLINE,username.eq.supabot")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -84,7 +84,7 @@ struct PostgrestFilterTests {
       .select("username")
       .eq("username", value: "supabot")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -103,7 +103,7 @@ struct PostgrestFilterTests {
       .select("username")
       .neq("username", value: "supabot")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -128,7 +128,7 @@ struct PostgrestFilterTests {
       .select("id")
       .gt("id", value: 1)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -147,7 +147,7 @@ struct PostgrestFilterTests {
       .select("id")
       .gte("id", value: 1)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -169,7 +169,7 @@ struct PostgrestFilterTests {
       .select("id")
       .lt("id", value: 2)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -188,7 +188,7 @@ struct PostgrestFilterTests {
       .select("id")
       .lte("id", value: 2)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -210,7 +210,7 @@ struct PostgrestFilterTests {
       .select("username")
       .like("username", pattern: "%supa%")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -229,7 +229,7 @@ struct PostgrestFilterTests {
       .select("username")
       .likeAllOf("username", patterns: ["%supa%", "%bot%"])
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -248,7 +248,7 @@ struct PostgrestFilterTests {
       .select("username")
       .likeAnyOf("username", patterns: ["%supa%", "%kiwi%"])
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -270,7 +270,7 @@ struct PostgrestFilterTests {
       .select("username")
       .ilike("username", pattern: "%SUPA%")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -289,7 +289,7 @@ struct PostgrestFilterTests {
       .select("username")
       .iLikeAllOf("username", patterns: ["%SUPA%", "%bot%"])
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -308,7 +308,7 @@ struct PostgrestFilterTests {
       .select("username")
       .iLikeAnyOf("username", patterns: ["%supa%", "%KIWI%"])
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
     assertInlineSnapshot(of: res, as: .json) {
       """
       [
@@ -328,7 +328,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("data").is("data", value: nil)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -356,7 +356,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("status").in("status", values: statuses)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -383,7 +383,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("status").notIn("status", values: ["OFFLINE"])
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -407,7 +407,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("age_range").contains("age_range", value: "[1,2)")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -425,7 +425,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("age_range").containedBy("age_range", value: "[1,2)")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -443,7 +443,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("age_range").rangeLt("age_range", range: "[2,25)")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -461,7 +461,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("age_range").rangeGt("age_range", range: "[2,25)")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -482,7 +482,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("age_range").rangeLte("age_range", range: "[2,25)")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -500,7 +500,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("age_range").rangeGte("age_range", range: "[2,25)")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -524,7 +524,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("age_range").rangeAdjacent("age_range", range: "[2,25)")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -548,7 +548,7 @@ struct PostgrestFilterTests {
     let res =
       try await client.from("users").select("age_range").overlaps("age_range", value: "[2,25)")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -567,7 +567,7 @@ struct PostgrestFilterTests {
       try await client.from("users").select("catchphrase")
       .textSearch("catchphrase", query: "'fat' & 'cat'", config: "english")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -586,7 +586,7 @@ struct PostgrestFilterTests {
       try await client.from("users").select("catchphrase")
       .textSearch("catchphrase", query: "'fat' & 'cat'", config: "english", type: .plain)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -605,7 +605,7 @@ struct PostgrestFilterTests {
       try await client.from("users").select("catchphrase")
       .textSearch("catchphrase", query: "cat", config: "english", type: .phrase)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -627,7 +627,7 @@ struct PostgrestFilterTests {
       try await client.from("users").select("catchphrase")
       .textSearch("catchphrase", query: "'fat' & 'cat'", config: "english", type: .websearch)
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -651,7 +651,7 @@ struct PostgrestFilterTests {
       .eq("status", value: "ONLINE")
       .textSearch("catchphrase", query: "cat")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -675,7 +675,7 @@ struct PostgrestFilterTests {
       .select("username")
       .filter("username", operator: "eq", value: "supabot")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -695,7 +695,7 @@ struct PostgrestFilterTests {
       .select("username,status")
       .match(["username": "supabot", "status": "ONLINE"])
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -715,7 +715,7 @@ struct PostgrestFilterTests {
       try await client.rpc("get_username_and_status", params: ["name_param": "supabot"])
       .neq("status", value: "ONLINE")
       .execute()
-      .value as AnyJSON
+      .value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """

--- a/Tests/IntegrationTests/Postgrest/PostgrestResourceEmbeddingTests.swift
+++ b/Tests/IntegrationTests/Postgrest/PostgrestResourceEmbeddingTests.swift
@@ -24,13 +24,13 @@ struct PostgrestResourceEmbeddingTests {
   init() async throws {
     // Clean up test data before running tests.
     // Delete users with email (test data), preserving seed data (users with username only).
-    try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
+    try await client.from("users").delete().not("email", operator: .is, value: JSONValue.null)
       .execute()
   }
 
   @Test
   func embeddedSelect() async throws {
-    let res = try await client.from("users").select("messages(*)").execute().value as AnyJSON
+    let res = try await client.from("users").select("messages(*)").execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -79,7 +79,7 @@ struct PostgrestResourceEmbeddingTests {
       try await client.from("users")
       .select("messages(*)")
       .eq("messages.channel_id", value: 1)
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -121,7 +121,7 @@ struct PostgrestResourceEmbeddingTests {
       try await client.from("users")
       .select("messages(*)")
       .or("channel_id.eq.2,message.eq.Hello World 👋", referencedTable: "messages")
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -173,7 +173,7 @@ struct PostgrestResourceEmbeddingTests {
         "channel_id.eq.2,and(message.eq.Hello World 👋,username.eq.supabot)",
         referencedTable: "messages"
       )
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -222,7 +222,7 @@ struct PostgrestResourceEmbeddingTests {
       try await client.from("users")
       .select("messages(*)")
       .order("channel_id", ascending: false, referencedTable: "messages")
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -272,7 +272,7 @@ struct PostgrestResourceEmbeddingTests {
       .select("messages(*)")
       .order("channel_id", ascending: false, referencedTable: "messages")
       .order("username", ascending: false, referencedTable: "messages")
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -321,7 +321,7 @@ struct PostgrestResourceEmbeddingTests {
       try await client.from("users")
       .select("messages(*)")
       .limit(1, referencedTable: "messages")
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """
@@ -363,7 +363,7 @@ struct PostgrestResourceEmbeddingTests {
       try await client.from("users")
       .select("messages(*)")
       .range(from: 1, to: 1, referencedTable: "messages")
-      .execute().value as AnyJSON
+      .execute().value as JSONValue
 
     assertInlineSnapshot(of: res, as: .json) {
       """

--- a/Tests/IntegrationTests/PostgrestIntegrationTests.swift
+++ b/Tests/IntegrationTests/PostgrestIntegrationTests.swift
@@ -51,7 +51,7 @@ struct PostgrestIntegrationTests {
     // to do this `neq` trick to delete all data. For users, only delete rows with email (test data),
     // leaving seed data with username intact.
     try await client.from("todos").delete().neq("id", value: UUID().uuidString).execute()
-    try await client.from("users").delete().not("email", operator: .is, value: AnyJSON.null)
+    try await client.from("users").delete().not("email", operator: .is, value: JSONValue.null)
       .execute()
   }
 

--- a/Tests/IntegrationTests/RealtimeIntegrationTests.swift
+++ b/Tests/IntegrationTests/RealtimeIntegrationTests.swift
@@ -394,7 +394,7 @@
 
         struct Entry: Codable, Equatable {
           let key: String
-          let value: AnyJSON
+          let value: JSONValue
         }
 
         let allChangesTask = Task {
@@ -469,7 +469,7 @@
 
         struct Entry: Codable, Equatable {
           let key: String
-          let value: AnyJSON
+          let value: JSONValue
         }
 
         let testKey1 = UUID().uuidString
@@ -523,7 +523,7 @@
 
         struct Entry: Codable, Equatable {
           let key: String
-          let value: AnyJSON
+          let value: JSONValue
         }
 
         let insertTask = Task {

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -237,7 +237,7 @@ struct BuildURLRequestTests {
       TestCase(name: "rpc call with get and params") { client in
         try client.rpc(
           "get_array_element",
-          params: ["array": [37, 420, 64], "index": 2] as AnyJSON,
+          params: ["array": [37, 420, 64], "index": 2] as JSONValue,
           get: true
         )
       },

--- a/Tests/PostgRESTTests/PostgrestFilterValueTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterValueTests.swift
@@ -55,28 +55,28 @@ struct PostgrestFilterValueTests {
   }
 
   @Test
-  func arrayEncodesAnyJSONNullElementsAsRealNull() {
-    #expect(AnyJSON.array([.integer(1), .null]).rawValue == "{1,NULL}")
+  func arrayEncodesJSONValueNullElementsAsRealNull() {
+    #expect(JSONValue.array([.integer(1), .null]).rawValue == "{1,NULL}")
   }
 
   @Test
   func anyJSONArrayEscapesReservedCharacters() {
-    #expect(AnyJSON.array(["a,b"]).rawValue == "{\"a,b\"}")
+    #expect(JSONValue.array(["a,b"]).rawValue == "{\"a,b\"}")
   }
 
   @Test
   func anyJSON() {
     #expect(
-      AnyJSON.array(["is:online", "faction:red"]).rawValue == "{is:online,faction:red}"
+      JSONValue.array(["is:online", "faction:red"]).rawValue == "{is:online,faction:red}"
     )
     #expect(
-      AnyJSON.object(["postalcode": 90210]).rawValue == "{\"postalcode\":90210}"
+      JSONValue.object(["postalcode": 90210]).rawValue == "{\"postalcode\":90210}"
     )
-    #expect(AnyJSON.string("string").rawValue == "string")
-    #expect(AnyJSON.double(3.14).rawValue == "3.14")
-    #expect(AnyJSON.integer(3).rawValue == "3")
-    #expect(AnyJSON.bool(true).rawValue == "true")
-    #expect(AnyJSON.null.rawValue == "NULL")
+    #expect(JSONValue.string("string").rawValue == "string")
+    #expect(JSONValue.double(3.14).rawValue == "3.14")
+    #expect(JSONValue.integer(3).rawValue == "3")
+    #expect(JSONValue.bool(true).rawValue == "true")
+    #expect(JSONValue.null.rawValue == "NULL")
   }
 
   @Test

--- a/Tests/RealtimeTests/ExportsTests.swift
+++ b/Tests/RealtimeTests/ExportsTests.swift
@@ -21,8 +21,8 @@ struct ExportsTests {
     let jsonObject: JSONObject = [:]
     #expect(jsonObject.isEmpty)
 
-    // Test that we can access AnyJSON from Helpers via Realtime
-    let anyJSON: AnyJSON = .string("test")
+    // Test that we can access JSONValue from Helpers via Realtime
+    let anyJSON: JSONValue = .string("test")
     #expect(anyJSON == .string("test"))
 
     // Test that we can access ObservationToken from Helpers via Realtime

--- a/Tests/RealtimeTests/RealtimeSerializerTests.swift
+++ b/Tests/RealtimeTests/RealtimeSerializerTests.swift
@@ -28,7 +28,7 @@ struct RealtimeSerializerTests {
     )
 
     let text = try serializer.encodeText(message)
-    let array = try JSONDecoder().decode([AnyJSON].self, from: Data(text.utf8))
+    let array = try JSONDecoder().decode([JSONValue].self, from: Data(text.utf8))
 
     #expect(array.count == 5)
     #expect(array[0].stringValue == "1")
@@ -49,7 +49,7 @@ struct RealtimeSerializerTests {
     )
 
     let text = try serializer.encodeText(message)
-    let array = try JSONDecoder().decode([AnyJSON].self, from: Data(text.utf8))
+    let array = try JSONDecoder().decode([JSONValue].self, from: Data(text.utf8))
 
     #expect(array.count == 5)
     #expect(array[0].stringValue == nil)

--- a/Tests/StorageTests/FileOptionsTests.swift
+++ b/Tests/StorageTests/FileOptionsTests.swift
@@ -16,7 +16,7 @@ struct FileOptionsTests {
 
   @Test
   func customInitialization() {
-    let metadata: [String: AnyJSON] = ["key": .string("value")]
+    let metadata: [String: JSONValue] = ["key": .string("value")]
     let options = FileOptions(
       cacheControl: "7200",
       contentType: "image/jpeg",

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -523,3 +523,24 @@ let client = SupabaseClient(
 
 There's no reference implementation to swap in — implement `AuthLocalStorage` against whatever
 storage mechanism suits your app.
+
+## `AnyJSON` renamed to `JSONValue`
+
+The `Helpers` type `AnyJSON` is now `JSONValue`. `AnyJSON` described a Postgres/JSON column value
+long before the SDK had any other `Any`-prefixed types; `JSONValue` names what the type actually
+holds and matches the naming used for the same concept in supabase-js. `JSONObject` and
+`JSONArray` keep their names — only the enum itself is renamed.
+
+```swift
+// Before
+let json: AnyJSON = ["id": 1, "name": "Bo"]
+func decode(_ value: AnyJSON) throws -> User { try value.decode() }
+
+// After
+let json: JSONValue = ["id": 1, "name": "Bo"]
+func decode(_ value: JSONValue) throws -> User { try value.decode() }
+```
+
+This is a compile error everywhere `AnyJSON` is spelled out as a type — search your codebase for
+`AnyJSON` and replace it with `JSONValue`. Values and call sites that never name the type
+explicitly (e.g. `let json: JSONObject = [...]`, or `try SomeType(from: value)`) are unaffected.

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -3,6 +3,33 @@ sdk: swift
 # Full declaration of all features from the supabase/sdk capability registry.
 # See https://github.com/supabase/sdk for the canonical feature registry.
 
+# JSONValue (formerly AnyJSON) is a JSON value type shared across Auth,
+# PostgREST, Storage, and Realtime rather than owned by a single feature.
+supporting_symbols:
+  - JSONValue
+  - JSONValue.init
+  - JSONValue.decode
+  - JSONValue.encode
+  - JSONValue.decoder
+  - JSONValue.encoder
+  - JSONValue.null
+  - JSONValue.bool
+  - JSONValue.integer
+  - JSONValue.double
+  - JSONValue.string
+  - JSONValue.object
+  - JSONValue.array
+  - JSONValue.value
+  - JSONValue.isNil
+  - JSONValue.boolValue
+  - JSONValue.objectValue
+  - JSONValue.arrayValue
+  - JSONValue.stringValue
+  - JSONValue.intValue
+  - JSONValue.doubleValue
+  - JSONValue.description
+  - JSONValue.rawValue
+
 features:
 
   # ── Auth ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Renames the `Helpers` type `AnyJSON` to `JSONValue`, matching the name supabase-js uses for the same concept and dropping a stale `Any`-prefix from before the SDK had other `Any`-prefixed types.
- Updates every usage across `Auth`, `PostgREST`, `Storage`, `RealtimeV2`, `Tests`, and `Examples` (37 Swift files). `JSONObject`/`JSONArray` keep their names — only the enum itself is renamed.
- Renames the backing files/directory: `Sources/Helpers/AnyJSON/` → `Sources/Helpers/JSONValue/`, `AnyJSONTests.swift` → `JSONValueTests.swift`, `AnyJSONView.swift` → `JSONValueView.swift` (including the `Examples.xcodeproj` file reference).
- Adds a migration section to `V3_MIGRATION.md` covering the compile-error impact.

**Breaking change** — any call site that spells out `AnyJSON` as a type needs to become `JSONValue`; this is a compile error, not a silent behavior change. `CHANGELOG.md`'s historical mention of `AnyJSON` is left as-is since it documents a past release.

Linear: https://linear.app/supabase/issue/SDK-1437/rename-anyjson-to-jsonvalue

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — all 1136 tests pass
- [x] `./scripts/format.sh` — applied
- [x] `./scripts/spell-check.sh` — 0 issues