### PR TITLE
refactor(functions)!: make FunctionsClient stateless and a struct

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -1,4 +1,3 @@
-import ConcurrencyExtras
 public import Foundation
 import HTTPTypes
 public import Helpers
@@ -28,7 +27,7 @@ let version = Helpers.version
 /// ## Topics
 ///
 /// ### Creating a Client
-/// - ``init(url:headers:region:logger:fetch:decoder:)``
+/// - ``init(url:headers:region:logger:fetch:decoder:accessToken:)``
 /// - ``FetchHandler``
 ///
 /// ### Invoking Functions
@@ -40,8 +39,7 @@ let version = Helpers.version
 /// ### Configuration
 /// - ``decoder``
 /// - ``requestIdleTimeout``
-/// - ``setAuth(token:)``
-public final class FunctionsClient: Sendable {
+public struct FunctionsClient: Sendable {
   /// A handler that performs the underlying HTTP request for a function invocation.
   public typealias FetchHandler =
     @Sendable (_ request: URLRequest) async throws -> (
@@ -62,18 +60,11 @@ public final class FunctionsClient: Sendable {
   /// The JSON decoder used to decode function response bodies.
   public let decoder: JSONDecoder
 
-  struct MutableState {
-    /// Headers to be included in the requests.
-    var headers = HTTPFields()
-  }
+  let headers: HTTPFields
 
   private let http: any HTTPClientType
-  private let mutableState = LockIsolated(MutableState())
   private let sessionConfiguration: URLSessionConfiguration
-
-  var headers: HTTPFields {
-    mutableState.headers
-  }
+  private let accessToken: (@Sendable () async throws -> String?)?
 
   /// Creates a new Functions client.
   /// - Parameters:
@@ -83,14 +74,19 @@ public final class FunctionsClient: Sendable {
   ///   - logger: A logger for request and response diagnostics. Defaults to a build-config-aware logger.
   ///   - fetch: A custom fetch handler. Defaults to `URLSession.shared`.
   ///   - decoder: The JSON decoder used to decode response bodies.
+  ///   - accessToken: An async closure returning the current access token, resolved fresh for
+  ///     every request and sent as `Authorization: Bearer <token>`. `nil` (the default) sends no
+  ///     bearer token; a per-invocation header set via ``FunctionInvokeOptions`` still takes
+  ///     precedence over it.
   @_disfavoredOverload
-  public convenience init(
+  public init(
     url: URL,
     headers: [String: String] = [:],
     region: String? = nil,
     logger: Logging.Logger = supabaseDefaultLogger(label: "io.supabase.functions"),
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
-    decoder: JSONDecoder = JSONDecoder()
+    decoder: JSONDecoder = JSONDecoder(),
+    accessToken: (@Sendable () async throws -> String?)? = nil
   ) {
     self.init(
       url: url,
@@ -99,18 +95,20 @@ public final class FunctionsClient: Sendable {
       logger: logger,
       fetch: fetch,
       decoder: decoder,
-      sessionConfiguration: .default
+      sessionConfiguration: .default,
+      accessToken: accessToken
     )
   }
 
-  convenience init(
+  init(
     url: URL,
     headers: [String: String] = [:],
     region: String? = nil,
     logger: Logging.Logger = supabaseDefaultLogger(label: "io.supabase.functions"),
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
     decoder: JSONDecoder = JSONDecoder(),
-    sessionConfiguration: URLSessionConfiguration
+    sessionConfiguration: URLSessionConfiguration,
+    accessToken: (@Sendable () async throws -> String?)? = nil
   ) {
     var logger = logger
     logger[metadataKey: "system"] = "functions"
@@ -126,7 +124,8 @@ public final class FunctionsClient: Sendable {
       region: region,
       decoder: decoder,
       http: http,
-      sessionConfiguration: sessionConfiguration
+      sessionConfiguration: sessionConfiguration,
+      accessToken: accessToken
     )
   }
 
@@ -136,20 +135,21 @@ public final class FunctionsClient: Sendable {
     region: String?,
     decoder: JSONDecoder = JSONDecoder(),
     http: any HTTPClientType,
-    sessionConfiguration: URLSessionConfiguration = .default
+    sessionConfiguration: URLSessionConfiguration = .default,
+    accessToken: (@Sendable () async throws -> String?)? = nil
   ) {
     self.url = url
     self.region = region
     self.decoder = decoder
     self.http = http
     self.sessionConfiguration = sessionConfiguration
+    self.accessToken = accessToken
 
-    mutableState.withValue {
-      $0.headers = HTTPFields(headers)
-      if $0.headers[.xClientInfo] == nil {
-        $0.headers[.xClientInfo] = "functions-swift/\(version)"
-      }
+    var headers = HTTPFields(headers)
+    if headers[.xClientInfo] == nil {
+      headers[.xClientInfo] = "functions-swift/\(version)"
     }
+    self.headers = headers
   }
 
   /// Creates a new Functions client.
@@ -160,13 +160,18 @@ public final class FunctionsClient: Sendable {
   ///   - logger: A logger for request and response diagnostics. Defaults to a build-config-aware logger.
   ///   - fetch: A custom fetch handler. Defaults to `URLSession.shared`.
   ///   - decoder: The JSON decoder used to decode response bodies.
-  public convenience init(
+  ///   - accessToken: An async closure returning the current access token, resolved fresh for
+  ///     every request and sent as `Authorization: Bearer <token>`. `nil` (the default) sends no
+  ///     bearer token; a per-invocation header set via ``FunctionInvokeOptions`` still takes
+  ///     precedence over it.
+  public init(
     url: URL,
     headers: [String: String] = [:],
     region: FunctionRegion? = nil,
     logger: Logging.Logger = supabaseDefaultLogger(label: "io.supabase.functions"),
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
-    decoder: JSONDecoder = JSONDecoder()
+    decoder: JSONDecoder = JSONDecoder(),
+    accessToken: (@Sendable () async throws -> String?)? = nil
   ) {
     self.init(
       url: url,
@@ -174,20 +179,9 @@ public final class FunctionsClient: Sendable {
       region: region?.rawValue,
       logger: logger,
       fetch: fetch,
-      decoder: decoder
+      decoder: decoder,
+      accessToken: accessToken
     )
-  }
-
-  /// Sets or clears the JWT used in the Authorization header for subsequent requests.
-  /// - Parameter token: The JWT to send, or `nil` to remove the Authorization header.
-  public func setAuth(token: String?) {
-    mutableState.withValue {
-      if let token {
-        $0.headers[.authorization] = "Bearer \(token)"
-      } else {
-        $0.headers[.authorization] = nil
-      }
-    }
   }
 
   /// Invokes a function and decodes the response with a custom closure.
@@ -244,7 +238,7 @@ public final class FunctionsClient: Sendable {
     functionName: String,
     invokeOptions: FunctionInvokeOptions
   ) async throws -> Helpers.HTTPResponse {
-    let request = buildRequest(functionName: functionName, options: invokeOptions)
+    let request = try await buildRequest(functionName: functionName, options: invokeOptions)
     let response = try await http.send(request)
 
     let isRelayError = response.headers[.xRelayError] == "true"
@@ -287,12 +281,18 @@ public final class FunctionsClient: Sendable {
     let session = URLSession(
       configuration: sessionConfiguration, delegate: delegate, delegateQueue: nil)
 
-    let urlRequest = buildRequest(functionName: functionName, options: invokeOptions).urlRequest
-
-    let task = session.dataTask(with: urlRequest)
-    task.resume()
+    let requestTask = Task {
+      do {
+        let request = try await buildRequest(functionName: functionName, options: invokeOptions)
+        let task = session.dataTask(with: request.urlRequest)
+        task.resume()
+      } catch {
+        continuation.finish(throwing: error)
+      }
+    }
 
     continuation.onTermination = { _ in
+      requestTask.cancel()
       session.invalidateAndCancel()
     }
 
@@ -300,14 +300,20 @@ public final class FunctionsClient: Sendable {
   }
 
   private func buildRequest(functionName: String, options: FunctionInvokeOptions)
-    -> Helpers.HTTPRequest
+    async throws -> Helpers.HTTPRequest
   {
+    var headers = headers
+    if let token = try await accessToken?() {
+      headers[.authorization] = "Bearer \(token)"
+    }
+    headers = headers.merging(with: options.headers)
+
     var query = options.query
     var request = HTTPRequest(
       url: url.appendingPathComponent(functionName),
       method: FunctionInvokeOptions.httpMethod(options.method) ?? .post,
       query: query,
-      headers: mutableState.headers.merging(with: options.headers),
+      headers: headers,
       body: options.body,
       timeoutInterval: options.timeoutInterval ?? FunctionsClient.requestIdleTimeout
     )

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -464,7 +464,7 @@ public final class SupabaseClient: Sendable {
     try await accessTokenProvider()
   }
 
-  /// Mirrors Auth state onto the Functions and Realtime V2 sub-clients for the client's lifetime.
+  /// Mirrors Auth state onto the Realtime V2 sub-client for the client's lifetime.
   ///
   /// `authStateChanges` never finishes on its own, so the observing task must not capture `self`
   /// strongly: it would keep the client alive forever, and ``deinit`` — the only place that
@@ -501,9 +501,6 @@ public final class SupabaseClient: Sendable {
     }
 
     if let accessToken {
-      functions.setAuth(
-        token: APIKeyFormat.functionsBearerToken(accessToken: accessToken, supabaseKey: supabaseKey)
-      )
       await realtimeV2.setAuth(accessToken)
     }
   }

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -145,9 +145,6 @@ public final class SupabaseClient: Sendable {
   }
 
   /// The Functions client for invoking Supabase Edge Functions.
-  ///
-  /// `FunctionsClient` holds no mutable state, so this returns a new value on every access rather
-  /// than caching one in ``mutableState``.
   public var functions: FunctionsClient {
     var functionsHeaders = _headers
     if APIKeyFormat.isNew(supabaseKey) {

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -145,25 +145,22 @@ public final class SupabaseClient: Sendable {
   }
 
   /// The Functions client for invoking Supabase Edge Functions.
+  ///
+  /// `FunctionsClient` holds no mutable state, so this returns a new value on every access rather
+  /// than caching one in ``mutableState``.
   public var functions: FunctionsClient {
-    mutableState.withValue {
-      if $0.functions == nil {
-        var functionsHeaders = _headers
-        if APIKeyFormat.isNew(supabaseKey) {
-          functionsHeaders[.authorization] = nil
-        }
-        $0.functions = FunctionsClient(
-          url: functionsURL,
-          headers: functionsHeaders.dictionary,
-          region: options.functions.region,
-          logger: options.global.logger,
-          fetch: fetchWithAuth,
-          decoder: options.functions.decoder
-        )
-      }
-
-      return $0.functions!
+    var functionsHeaders = _headers
+    if APIKeyFormat.isNew(supabaseKey) {
+      functionsHeaders[.authorization] = nil
     }
+    return FunctionsClient(
+      url: functionsURL,
+      headers: functionsHeaders.dictionary,
+      region: options.functions.region,
+      logger: options.global.logger,
+      fetch: fetchWithAuth,
+      decoder: options.functions.decoder
+    )
   }
 
   let _headers: HTTPFields
@@ -179,7 +176,6 @@ public final class SupabaseClient: Sendable {
     var listenForAuthEventsTask: Task<Void, Never>?
     var storage: SupabaseStorageClient?
     var rest: PostgrestClient?
-    var functions: FunctionsClient?
     var realtime: RealtimeClientV2?
 
     var changedAccessToken: String?

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -148,13 +148,6 @@ public final class SupabaseClient: Sendable {
   ///
   /// `FunctionsClient` holds no mutable state, so this returns a new value on every access rather
   /// than caching one in ``mutableState``.
-  ///
-  /// Unlike `rest`/`storage`, this doesn't use `fetchWithAuth`: that closure overwrites
-  /// `Authorization` unconditionally with the live access token, which would clobber a
-  /// per-invocation header set via `FunctionInvokeOptions`. `FunctionsClient` resolves its own
-  /// bearer token instead (via `accessToken`, respecting that same per-invocation override), so
-  /// the `fetch` handler only needs to perform the transport and inject trace context — the same
-  /// split already used for `realtimeOptions.fetch`/`accessToken` below.
   public var functions: FunctionsClient {
     var functionsHeaders = _headers
     if APIKeyFormat.isNew(supabaseKey) {

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -148,6 +148,13 @@ public final class SupabaseClient: Sendable {
   ///
   /// `FunctionsClient` holds no mutable state, so this returns a new value on every access rather
   /// than caching one in ``mutableState``.
+  ///
+  /// Unlike `rest`/`storage`, this doesn't use `fetchWithAuth`: that closure overwrites
+  /// `Authorization` unconditionally with the live access token, which would clobber a
+  /// per-invocation header set via `FunctionInvokeOptions`. `FunctionsClient` resolves its own
+  /// bearer token instead (via `accessToken`, respecting that same per-invocation override), so
+  /// the `fetch` handler only needs to perform the transport and inject trace context — the same
+  /// split already used for `realtimeOptions.fetch`/`accessToken` below.
   public var functions: FunctionsClient {
     var functionsHeaders = _headers
     if APIKeyFormat.isNew(supabaseKey) {
@@ -158,8 +165,14 @@ public final class SupabaseClient: Sendable {
       headers: functionsHeaders.dictionary,
       region: options.functions.region,
       logger: options.global.logger,
-      fetch: fetchWithAuth,
-      decoder: options.functions.decoder
+      fetch: { [session = options.global.session] request in
+        try await session.data(for: TraceContext.inject(into: request))
+      },
+      decoder: options.functions.decoder,
+      accessToken: { [weak self] in
+        guard let self else { return nil }
+        return try? await self._getAccessToken()
+      }
     )
   }
 

--- a/Tests/FunctionsTests/FunctionsClientTests.swift
+++ b/Tests/FunctionsTests/FunctionsClientTests.swift
@@ -32,7 +32,10 @@ struct FunctionsClientTests {
   let apiKey =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
 
-  private func makeSUT(region: String? = nil) -> FunctionsClient {
+  private func makeSUT(
+    region: String? = nil,
+    accessToken: (@Sendable () async throws -> String?)? = nil
+  ) -> FunctionsClient {
     Mocker.removeAll()
 
     let sessionConfiguration = URLSessionConfiguration.ephemeral
@@ -43,7 +46,8 @@ struct FunctionsClientTests {
       headers: ["apikey": apiKey],
       region: region,
       fetch: { try await session.data(for: $0) },
-      sessionConfiguration: sessionConfiguration
+      sessionConfiguration: sessionConfiguration,
+      accessToken: accessToken
     )
   }
 
@@ -431,14 +435,132 @@ struct FunctionsClientTests {
   }
 
   @Test
-  func setAuth() {
-    let sut = makeSUT()
+  func accessTokenProviderSetsAuthorizationHeader() async throws {
+    let box = CapturedRequestBox()
+    let sut = FunctionsClient(
+      url: url,
+      headers: ["apikey": apiKey],
+      fetch: { request in
+        await box.set(request)
+        return (
+          Data(),
+          HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        )
+      },
+      accessToken: { "access.token" }
+    )
 
-    sut.setAuth(token: "access.token")
-    #expect(sut.headers[.authorization] == "Bearer access.token")
+    try await sut.invoke("hello-world")
 
-    sut.setAuth(token: nil)
-    #expect(sut.headers[.authorization] == nil)
+    let capturedRequest = await box.request
+    #expect(capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer access.token")
+  }
+
+  @Test
+  func accessTokenProviderIsResolvedPerInvoke() async throws {
+    actor TokenBox {
+      var token = "first.token"
+      func update(_ newValue: String) { token = newValue }
+    }
+    actor Capture {
+      var authorizationHeaders: [String?] = []
+      func record(_ value: String?) { authorizationHeaders.append(value) }
+    }
+
+    let tokenBox = TokenBox()
+    let capture = Capture()
+
+    let sut = FunctionsClient(
+      url: url,
+      headers: ["apikey": apiKey],
+      fetch: { request in
+        await capture.record(request.value(forHTTPHeaderField: "Authorization"))
+        return (
+          Data(),
+          HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        )
+      },
+      accessToken: { await tokenBox.token }
+    )
+
+    try await sut.invoke("hello-world")
+    await tokenBox.update("second.token")
+    try await sut.invoke("hello-world")
+
+    let recorded = await capture.authorizationHeaders
+    #expect(recorded == ["Bearer first.token", "Bearer second.token"])
+  }
+
+  @Test
+  func invokeOptionsHeaderOverridesAccessTokenProvider() async throws {
+    let box = CapturedRequestBox()
+    let sut = FunctionsClient(
+      url: url,
+      headers: ["apikey": apiKey],
+      fetch: { request in
+        await box.set(request)
+        return (
+          Data(),
+          HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        )
+      },
+      accessToken: { "provider.token" }
+    )
+
+    try await sut.invoke(
+      "hello-world",
+      options: .init(headers: ["Authorization": "Bearer override.token"])
+    )
+
+    let capturedRequest = await box.request
+    #expect(capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer override.token")
+  }
+
+  @Test
+  func accessTokenProviderErrorPropagatesToInvoke() async throws {
+    struct TokenError: Error {}
+
+    let sut = FunctionsClient(
+      url: url,
+      headers: ["apikey": apiKey],
+      fetch: { _ in
+        Issue.record("fetch should not be called when the access token provider throws")
+        throw TokenError()
+      },
+      accessToken: { throw TokenError() }
+    )
+
+    await #expect(throws: TokenError.self) {
+      try await sut.invoke("hello-world")
+    }
+  }
+
+  @Test
+  func invokeWithStreamedResponseUsesAccessTokenProvider() async throws {
+    let sut = makeSUT(accessToken: { "stream.token" })
+
+    Mock(
+      url: url.appendingPathComponent("stream"),
+      statusCode: 200,
+      data: [.post: Data("hello world".utf8)]
+    )
+    .snapshotRequest {
+      #"""
+      curl \
+      	--request POST \
+      	--header "Authorization: Bearer stream.token" \
+      	--header "X-Client-Info: functions-swift/0.0.0" \
+      	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+      	"http://localhost:5432/functions/v1/stream"
+      """#
+    }
+    .register()
+
+    let stream = sut._invokeWithStreamedResponse("stream")
+
+    for try await value in stream {
+      #expect(String(decoding: value, as: UTF8.self) == "hello world")
+    }
   }
 
   @Test

--- a/Tests/SupabaseTests/SupabaseClientFunctionsAuthTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientFunctionsAuthTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+
+@testable import Supabase
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// `.serialized`: shares `RequestCapturingProtocol`'s static request log with
+/// `SupabaseClientTests`/`TracingTests`, which would otherwise race against these tests under
+/// Swift Testing's default parallel execution.
+@Suite(.serialized)
+struct SupabaseClientFunctionsAuthTests {
+  @Test
+  func functionsInvokePerCallHeaderOverrideIsNotClobberedByLiveAccessToken() async throws {
+    RequestCapturingProtocol.capturedRequests = []
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        // A custom `accessToken` closure stands in for a real signed-in session, without needing
+        // to drive the full sign-in flow: it's what actually exercises the bug, since the
+        // transport-level auth injection this test guards against only fires when a live token
+        // is available to inject.
+        auth: SupabaseClientOptions.AuthOptions(
+          storage: AuthLocalStorageMock(),
+          accessToken: { "live-session-token" }
+        ),
+        global: SupabaseClientOptions.GlobalOptions(session: makeMockSession())
+      )
+    )
+
+    _ = try? await client.functions.invoke(
+      "hello-world",
+      options: FunctionInvokeOptions(headers: ["Authorization": "Bearer per-call-override"])
+    )
+
+    let request = try #require(RequestCapturingProtocol.capturedRequests.first)
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer per-call-override")
+  }
+
+  @Test
+  func functionsInvokeWithoutSessionDoesNotThrow() async throws {
+    RequestCapturingProtocol.capturedRequests = []
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        auth: SupabaseClientOptions.AuthOptions(
+          storage: AuthLocalStorageMock(),
+          autoRefreshToken: false
+        ),
+        global: SupabaseClientOptions.GlobalOptions(session: makeMockSession())
+      )
+    )
+
+    try await client.functions.invoke("hello-world")
+
+    let request = try #require(RequestCapturingProtocol.capturedRequests.first)
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer PUBLISHABLE_KEY")
+  }
+
+  @Test
+  func functionsInvokeUsesLiveAccessTokenWhenNoOverrideIsGiven() async throws {
+    RequestCapturingProtocol.capturedRequests = []
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        auth: SupabaseClientOptions.AuthOptions(
+          storage: AuthLocalStorageMock(),
+          accessToken: { "live-session-token" }
+        ),
+        global: SupabaseClientOptions.GlobalOptions(session: makeMockSession())
+      )
+    )
+
+    try await client.functions.invoke("hello-world")
+
+    let request = try #require(RequestCapturingProtocol.capturedRequests.first)
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer live-session-token")
+  }
+}

--- a/Tests/SupabaseTests/SupabaseClientFunctionsAuthTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientFunctionsAuthTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Foundation
 import Testing
 
@@ -7,14 +8,47 @@ import Testing
   import FoundationNetworking
 #endif
 
-/// `.serialized`: shares `RequestCapturingProtocol`'s static request log with
-/// `SupabaseClientTests`/`TracingTests`, which would otherwise race against these tests under
-/// Swift Testing's default parallel execution.
+/// Single-purpose capturing protocol, deliberately not the shared `RequestCapturingProtocol`:
+/// that's also used by `TracingTests` (a `.serialized` suite that still runs concurrently with
+/// this one), so touching its static storage here would race.
+private final class FunctionsAuthCapturingProtocol: URLProtocol {
+  private static let storage = LockIsolated<URLRequest?>(nil)
+  static var capturedRequest: URLRequest? {
+    get { storage.value }
+    set { storage.setValue(newValue) }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    Self.capturedRequest = request
+    let response = HTTPURLResponse(
+      url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+    )!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: Data("[]".utf8))
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
+private func makeFunctionsAuthCapturingSession() -> URLSession {
+  let config = URLSessionConfiguration.ephemeral
+  config.protocolClasses = [FunctionsAuthCapturingProtocol.self]
+  return URLSession(configuration: config)
+}
+
+/// `.serialized`: the three tests below share `FunctionsAuthCapturingProtocol`'s static request
+/// log, which would otherwise race against itself under Swift Testing's default parallel
+/// execution. That storage is private to this file, so — unlike the shared `RequestCapturingProtocol`
+/// — no other suite can race against it.
 @Suite(.serialized)
 struct SupabaseClientFunctionsAuthTests {
   @Test
   func functionsInvokePerCallHeaderOverrideIsNotClobberedByLiveAccessToken() async throws {
-    RequestCapturingProtocol.capturedRequests = []
+    FunctionsAuthCapturingProtocol.capturedRequest = nil
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,
       supabaseKey: "PUBLISHABLE_KEY",
@@ -27,7 +61,7 @@ struct SupabaseClientFunctionsAuthTests {
           storage: AuthLocalStorageMock(),
           accessToken: { "live-session-token" }
         ),
-        global: SupabaseClientOptions.GlobalOptions(session: makeMockSession())
+        global: SupabaseClientOptions.GlobalOptions(session: makeFunctionsAuthCapturingSession())
       )
     )
 
@@ -36,13 +70,13 @@ struct SupabaseClientFunctionsAuthTests {
       options: FunctionInvokeOptions(headers: ["Authorization": "Bearer per-call-override"])
     )
 
-    let request = try #require(RequestCapturingProtocol.capturedRequests.first)
+    let request = try #require(FunctionsAuthCapturingProtocol.capturedRequest)
     #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer per-call-override")
   }
 
   @Test
   func functionsInvokeWithoutSessionDoesNotThrow() async throws {
-    RequestCapturingProtocol.capturedRequests = []
+    FunctionsAuthCapturingProtocol.capturedRequest = nil
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,
       supabaseKey: "PUBLISHABLE_KEY",
@@ -51,19 +85,19 @@ struct SupabaseClientFunctionsAuthTests {
           storage: AuthLocalStorageMock(),
           autoRefreshToken: false
         ),
-        global: SupabaseClientOptions.GlobalOptions(session: makeMockSession())
+        global: SupabaseClientOptions.GlobalOptions(session: makeFunctionsAuthCapturingSession())
       )
     )
 
     try await client.functions.invoke("hello-world")
 
-    let request = try #require(RequestCapturingProtocol.capturedRequests.first)
+    let request = try #require(FunctionsAuthCapturingProtocol.capturedRequest)
     #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer PUBLISHABLE_KEY")
   }
 
   @Test
   func functionsInvokeUsesLiveAccessTokenWhenNoOverrideIsGiven() async throws {
-    RequestCapturingProtocol.capturedRequests = []
+    FunctionsAuthCapturingProtocol.capturedRequest = nil
     let client = SupabaseClient(
       supabaseURL: URL(string: "https://project-ref.supabase.co")!,
       supabaseKey: "PUBLISHABLE_KEY",
@@ -72,13 +106,13 @@ struct SupabaseClientFunctionsAuthTests {
           storage: AuthLocalStorageMock(),
           accessToken: { "live-session-token" }
         ),
-        global: SupabaseClientOptions.GlobalOptions(session: makeMockSession())
+        global: SupabaseClientOptions.GlobalOptions(session: makeFunctionsAuthCapturingSession())
       )
     )
 
     try await client.functions.invoke("hello-world")
 
-    let request = try #require(RequestCapturingProtocol.capturedRequests.first)
+    let request = try #require(FunctionsAuthCapturingProtocol.capturedRequest)
     #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer live-session-token")
   }
 }

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -523,3 +523,63 @@ let client = SupabaseClient(
 
 There's no reference implementation to swap in — implement `AuthLocalStorage` against whatever
 storage mechanism suits your app.
+
+## `FunctionsClient.setAuth(token:)` removed; pass an `accessToken` closure instead
+
+`FunctionsClient.setAuth(token:)` is removed. Every initializer now takes an optional
+`accessToken: (@Sendable () async throws -> String?)?` closure instead. `FunctionsClient` calls it
+fresh before each request and sends the result as `Authorization: Bearer <token>`.
+
+`setAuth` mutated a lock-protected header stored on the client — its only mutable state; every
+other property was already immutable configuration set at `init`. That mutation had no effect when
+`FunctionsClient` came from `SupabaseClient.functions`: that client's `fetch` handler already
+overwrites `Authorization` on every request with the live session token, so `SupabaseClient`'s
+internal `functions.setAuth(...)` call (made on every auth state change) never changed a request
+that actually went out on the wire. Moving to a pull-based closure removes the lock and that dead
+call, and gives a standalone `FunctionsClient` (built directly, not through `SupabaseClient`) a way
+to keep its token current without a separate setter.
+
+```swift
+// Before
+let client = FunctionsClient(url: url, headers: ["apikey": apiKey])
+client.setAuth(token: session.accessToken)
+
+// After
+let client = FunctionsClient(
+  url: url,
+  headers: ["apikey": apiKey],
+  accessToken: { session.accessToken }
+)
+```
+
+This is a compile error, not a silent behavior change: any call site using `setAuth` fails to
+build.
+
+If you only use `FunctionsClient` through `SupabaseClient.functions`, there's nothing to change —
+`SupabaseClient` removed its internal `setAuth` call along with the method, but it changed no
+header on the wire, since `SupabaseClient`'s request adapter already supplied the live bearer
+token.
+
+## `FunctionsClient` is now a `struct` instead of a `class`
+
+`FunctionsClient` no longer holds any mutable state — the `setAuth` removal above took away its
+only `let`-backed lock — so every stored property is now an immutable `let`, and the type itself is
+a `struct`.
+
+Calling methods (`invoke`, `_invokeWithStreamedResponse`, and friends) compiles unchanged; this
+only breaks code that depended on `FunctionsClient` being a reference type: a `weak var` holding
+one, an `AnyObject` constraint, or an identity check with `===`. None of those compile against a
+struct.
+
+```swift
+// Before
+weak var client: FunctionsClient?
+
+// After
+// Structs have no identity to hold weakly — keep a strong reference, or drop the field if it only
+// existed to avoid a retain cycle: `FunctionsClient` has never captured `self` from its owner.
+var client: FunctionsClient?
+```
+
+This is a compile error, not a silent behavior change. Search your codebase for `weak`, `unowned`,
+`AnyObject`, or `===` next to a `FunctionsClient` variable to find affected call sites.


### PR DESCRIPTION
## Summary

`FunctionsClient` is now stateless and a `struct` instead of a `final class`, and `SupabaseClient` wires it up correctly.

- Replaces `FunctionsClient.setAuth(token:)` (its only mutable state, lock-protected) with an `accessToken: (@Sendable () async throws -> String?)?` closure, resolved fresh on every request. Per-invocation `FunctionInvokeOptions.headers` still wins over it.
- With no mutable state left, `FunctionsClient` becomes a `struct`.
- `SupabaseClient.functions` no longer caches a `FunctionsClient` in `mutableState` — nothing to gain from caching a stateless value.
- Fixes a real bug found in review: `SupabaseClient.functions` still used `fetchWithAuth`, whose adapter unconditionally overwrites `Authorization` with the live access token — silently clobbering a per-invocation header override. Switched to a transport-only `fetch` + `FunctionsClient`'s own `accessToken`, mirroring the `fetch`/`accessToken` split already used for `RealtimeClientV2`.
- Two `V3_MIGRATION.md` entries document the breaking changes (`setAuth` removal, class→struct) with before/after code.

## Why

`FunctionsClient` carried a lock purely to support `setAuth`, even though every other property was already immutable config. That lock/mutation turned out to be dead weight in two ways: `SupabaseClient`'s shared fetch handler already re-injected the live token on every request (making the `setAuth` call from auth-state-change events a no-op), and once mutation is gone there's no reason for the type to be a reference type, or for `SupabaseClient` to cache an instance of it.

## Test plan

- `swift test` — full suite passing
- New coverage: access-token provider sets/refreshes the header, per-call header override survives a live session token, invoking without a session doesn't throw
- `./scripts/format.sh`, `./scripts/test-docs.sh`, `./scripts/spell-check.sh` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
