### PR TITLE
fix(supabase): propagate access-token provider errors instead of swallowing them

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -437,20 +437,9 @@ public final class SupabaseClient: Sendable {
   ///
   /// The returned closure captures the auth dependencies by value instead of `self`. `AuthClient`
   /// holds no reference back to ``SupabaseClient``, so no cycle is formed.
-  ///
-  /// Only ``AuthError/sessionMissing`` is swallowed here — that's the expected "no signed-in
-  /// user" case, and the request should still go out under the anon key. Any other error
-  /// (a network failure refreshing the session, or one thrown by a configured
-  /// ``SupabaseClientOptions/AuthOptions/accessToken`` third-party auth provider) must fail the
-  /// request instead of silently downgrading it to an anonymous one.
   private var adaptRequest: @Sendable (_ request: URLRequest) async throws -> URLRequest {
     { [getAccessToken = accessTokenProvider] request in
-      let token: String?
-      do {
-        token = try await getAccessToken()
-      } catch AuthError.sessionMissing {
-        token = nil
-      }
+      let token = try await getAccessToken()
 
       var request = TraceContext.inject(into: request)
       if let token {
@@ -461,12 +450,21 @@ public final class SupabaseClient: Sendable {
   }
 
   /// Resolves the access token to send on outgoing requests, without capturing `self`.
+  ///
+  /// Swallows only ``AuthError/sessionMissing`` — the expected "no signed-in user" case, which
+  /// should resolve to `nil` (falling back to the anon key) rather than failing the caller. Every
+  /// other error (a network failure refreshing the session, or one thrown by a configured
+  /// ``SupabaseClientOptions/AuthOptions/accessToken`` third-party auth provider) propagates, so
+  /// callers of this closure never need their own knowledge of which auth errors are benign.
   private var accessTokenProvider: @Sendable () async throws -> String? {
     { [accessToken = options.auth.accessToken, auth = _auth] in
-      if let accessToken {
-        try await accessToken()
-      } else {
-        try await auth.session.accessToken
+      do {
+        if let accessToken {
+          return try await accessToken()
+        }
+        return try await auth.session.accessToken
+      } catch AuthError.sessionMissing {
+        return nil
       }
     }
   }

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -437,9 +437,20 @@ public final class SupabaseClient: Sendable {
   ///
   /// The returned closure captures the auth dependencies by value instead of `self`. `AuthClient`
   /// holds no reference back to ``SupabaseClient``, so no cycle is formed.
-  private var adaptRequest: @Sendable (_ request: URLRequest) async -> URLRequest {
+  ///
+  /// Only ``AuthError/sessionMissing`` is swallowed here — that's the expected "no signed-in
+  /// user" case, and the request should still go out under the anon key. Any other error
+  /// (a network failure refreshing the session, or one thrown by a configured
+  /// ``SupabaseClientOptions/AuthOptions/accessToken`` third-party auth provider) must fail the
+  /// request instead of silently downgrading it to an anonymous one.
+  private var adaptRequest: @Sendable (_ request: URLRequest) async throws -> URLRequest {
     { [getAccessToken = accessTokenProvider] request in
-      let token = try? await getAccessToken()
+      let token: String?
+      do {
+        token = try await getAccessToken()
+      } catch AuthError.sessionMissing {
+        token = nil
+      }
 
       var request = TraceContext.inject(into: request)
       if let token {

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -291,6 +291,90 @@ struct SupabaseClientTests {
   }
 
   @Test
+  func customAccessTokenErrorPropagatesInsteadOfFallingBackToAnonKey() async {
+    struct TokenProviderError: Error, Equatable {}
+
+    // A URLProtocol that fails any request it receives — proves the request never reaches the
+    // network instead of merely trusting that it didn't. Deliberately not the shared
+    // `RequestCapturingProtocol`: that's also used by `TracingTests` (a `.serialized` suite that
+    // still runs concurrently with this one), so touching its static storage here would race.
+    final class UnreachableProtocol: URLProtocol {
+      override class func canInit(with request: URLRequest) -> Bool { true }
+      override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+      override func startLoading() {
+        client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+      }
+
+      override func stopLoading() {}
+    }
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [UnreachableProtocol.self]
+
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: .init(
+        auth: .init(
+          storage: AuthLocalStorageMock(),
+          accessToken: { throw TokenProviderError() }
+        ),
+        global: .init(session: URLSession(configuration: config))
+      )
+    )
+
+    await #expect(throws: TokenProviderError.self) {
+      try await client.rpc("some_fn").execute()
+    }
+  }
+
+  @Test
+  func missingSessionFallsBackToAnonKeyWithoutCustomAccessToken() async throws {
+    // Single-purpose capturing protocol (not the shared `RequestCapturingProtocol`) so this test
+    // doesn't race with other suites reading/resetting shared static storage.
+    final class CapturingProtocol: URLProtocol {
+      private static let storage = LockIsolated<URLRequest?>(nil)
+      static var capturedRequest: URLRequest? {
+        get { storage.value }
+        set { storage.setValue(newValue) }
+      }
+
+      override class func canInit(with request: URLRequest) -> Bool { true }
+      override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+      override func startLoading() {
+        Self.capturedRequest = request
+        let response = HTTPURLResponse(
+          url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("[]".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+      }
+
+      override func stopLoading() {}
+    }
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [CapturingProtocol.self]
+
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: .init(
+        auth: .init(storage: AuthLocalStorageMock(), autoRefreshToken: false),
+        global: .init(session: URLSession(configuration: config))
+      )
+    )
+
+    try await client.rpc("some_fn").execute()
+
+    let request = try #require(CapturingProtocol.capturedRequest)
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer PUBLISHABLE_KEY")
+  }
+
+  @Test
   func listenForAuthEventsTaskDoesNotRetainClient() async {
     final class WeakBox: @unchecked Sendable {
       weak var client: SupabaseClient?


### PR DESCRIPTION
## Summary

`adaptRequest` (the request adapter shared by REST, Storage, and Functions via `fetchWithAuth`/`uploadWithAuth`) resolved the outgoing access token with:

```swift
let token = try? await getAccessToken()
```

`try?` converts *any* error into `nil`, including one thrown by a configured `options.auth.accessToken` third-party auth provider (see `Examples/Examples/ThirdPartyAuthClerk.swift`). If that provider throws — e.g. a transient failure reaching Clerk — the request silently proceeds under the project's anon key instead of failing, which can expose data/actions that should have required the caller's real identity.

This was flagged by CodeRabbit on [#1233](https://github.com/supabase/supabase-swift/pull/1233#discussion_r3795422433) (against a different, not-yet-merged refactor of the Functions client), but the same `try?` swallowing already exists on `main` today in `adaptRequest`, affecting REST, Storage, and Functions.

## Fix

Only swallow `AuthError.sessionMissing` — the expected "no signed-in user" case — and let everything else propagate:

```swift
let token: String?
do {
  token = try await getAccessToken()
} catch AuthError.sessionMissing {
  token = nil
}
```

This mirrors the existing `catch AuthError.sessionMissing { ... }` convention already used in `Sources/Auth/AuthMFA.swift`, and matches sibling SDK behavior:

- **supabase-js**: `fetchWithAuth` calls `await getAccessToken()` unguarded — a rejecting custom `accessToken` propagates and fails the request.
- **supabase-flutter**: `AuthHttpClient.send()` does the same; `_getAccessToken()` explicitly rethrows session errors with the comment *"Throw the error instead of making an API request with an expired token."*

I've also opened [supabase/sdk#86](https://github.com/supabase/sdk/pull/86) correcting the cross-SDK capability spec for this behavior, so it can serve as the source of truth for other SDKs (and future Swift changes) going forward.

## Test plan

- [x] Added `customAccessTokenErrorPropagatesInsteadOfFallingBackToAnonKey` — a throwing `accessToken` provider fails the call instead of silently sending an anonymous request.
- [x] Added `missingSessionFallsBackToAnonKeyWithoutCustomAccessToken` — the existing "no session, expected" case still falls back to the anon key unchanged.
- [x] `swift test --filter SupabaseTests` and `swift test --filter AuthTests` pass (313 tests, run 3x to rule out flakiness).
- [x] `swift build` succeeds; `./scripts/format.sh` produces no diff.