### PR TITLE
ci: bump supabase/sdk reusable workflows to v1.1.1

### DIFF
--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@93b52588ffda761e61b22cebfc3e5e29aa3cb3f4 # v1.0.0
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@63c1ac1d44959bfd02e4fc70a09df287db4a425a # v1.1.1
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@93b52588ffda761e61b22cebfc3e5e29aa3cb3f4 # v1.0.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@63c1ac1d44959bfd02e4fc70a09df287db4a425a # v1.1.1


### PR DESCRIPTION
## What

Bumps both `supabase/sdk` reusable workflow pins from v1.0.0 (`93b52588`) to v1.1.1 (`63c1ac1d`):

- `.github/workflows/sync-compliance.yml` → `sync-sdk-compliance.yml`
- `.github/workflows/validate-capabilities.yml` → `validate-sdk-compliance-swift.yml`

## Why

v1.0.0 of the sync workflow read the capability spec from a hardcoded commit, `faba359a` from 2026-07-20. Every weekly run therefore re-inserted capability IDs that had since been renamed, split, or removed upstream, and the validate check then rejected them as unknown feature IDs. Capabilities added after that date were never synced at all.

supabase/sdk#87 fixed this by checking the spec out at `job.workflow_sha`, the commit of the reusable workflow as pinned here, so the spec now tracks this pin. The fix only takes effect once the pin is bumped, which is what this PR does.

## Notes

Verified on supabase-flutter first: after the same bump, the sync run resolved the spec checkout to `63c1ac1d` rather than `main`, and the resulting sync PR contained only canonical IDs, with the compliance validation passing.

The only change to `.github/` between v1.0.0 and v1.1.1 is that sync workflow fix, so the `validate-sdk-compliance-swift.yml` bump is a no-op in behavior and just keeps both pins on the same version.

Any currently open sync pull request here carrying stale IDs should be closed and the sync re-run after this lands.