### PR TITLE
fix(postgrest)!: reject nil filter operands at compile time

### DIFF
--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -469,7 +469,8 @@ extension PostgrestRequestBuilder where Phase: PostgrestFilterablePhase {
     _ column: String,
     value: Bool?
   ) -> Self {
-    let queryValue = value.rawValue
+    // `Optional` is not a `PostgrestFilterValue`, so spell the NULL case out here.
+    let queryValue = value.map(\.rawValue) ?? "NULL"
     var copy = self
     copy.request.query.append(URLQueryItem(name: column, value: "is.\(queryValue)"))
     return copy

--- a/Sources/PostgREST/PostgrestFilterValue.swift
+++ b/Sources/PostgREST/PostgrestFilterValue.swift
@@ -1,11 +1,33 @@
 public import Foundation
 import Helpers
 
+/// A value that can appear as an element of a Postgres array literal, including SQL `NULL`.
+///
+/// This is the weaker of the two filter protocols, and the reason it exists separately from
+/// ``PostgrestFilterValue`` is `nil`. A `NULL` is a perfectly good *array member* — `{1,NULL}` is a
+/// real Postgres array — but it is not a value you can compare against, because `column = NULL` is
+/// never true in SQL. So `Optional` conforms to this and deliberately **not** to
+/// ``PostgrestFilterValue``, which is what makes `eq("col", value: nil)` fail to compile.
+///
+/// Every ``PostgrestFilterValue`` is automatically a `PostgrestArrayElement`, so a custom filter
+/// value works inside an array with no extra conformance.
+public protocol PostgrestArrayElement {
+  /// This value's encoding when embedded inside a Postgres array literal.
+  ///
+  /// Distinct from ``PostgrestFilterValue/rawValue`` because a plain raw string cannot tell a real
+  /// SQL `NULL` apart from the string `"NULL"`, nor a nested array literal from a `String` that
+  /// merely looks like one (e.g. `"{a,b}"`).
+  var postgrestArrayElement: String { get }
+}
+
 /// A value that can be used as a filter operand in PostgREST queries.
 ///
 /// Types conforming to ``PostgrestFilterValue`` provide a ``rawValue`` string that is appended
 /// directly to the PostgREST query string. The SDK ships with conformances for the most common
-/// Swift types; you can add your own by conforming any `Encodable` type to this protocol.
+/// Swift types; you can add your own by conforming any type to this protocol.
+///
+/// > Important: `Optional` does **not** conform. To test for `NULL`, use ``PostgrestRequestBuilder/is(_:value:)``
+/// > rather than an equality filter — see ``PostgrestArrayElement`` for why.
 ///
 /// ## Built-in Conformances
 ///
@@ -18,10 +40,16 @@ import Helpers
 /// | `UUID` | `"123e4567-e89b-..."` |
 /// | `Date` | `"2024-01-15T12:00:00.000Z"` |
 /// | `[Element]` | `"{a,b,c}"` |
-/// | `Optional<Wrapped>` | `"NULL"` when `nil` |
-public protocol PostgrestFilterValue {
+public protocol PostgrestFilterValue: PostgrestArrayElement {
   /// The string representation sent to PostgREST as the filter value.
   var rawValue: String { get }
+}
+
+extension PostgrestFilterValue {
+  /// Escaping the raw value as a scalar is always correct for a non-`nil`, non-array value.
+  public var postgrestArrayElement: String {
+    escapePostgRESTArrayLiteralElement(rawValue)
+  }
 }
 
 /// `String` can be used directly as a PostgREST filter value.
@@ -58,26 +86,21 @@ extension Date: PostgrestFilterValue {
   }
 }
 
-/// An array of ``PostgrestFilterValue`` elements is itself a ``PostgrestFilterValue``.
+/// An array of ``PostgrestArrayElement`` values is itself a ``PostgrestFilterValue``.
 ///
-/// The raw value is a PostgreSQL array literal, e.g. `{a,b,c}`.
-extension Array: PostgrestFilterValue where Element: PostgrestFilterValue {
+/// The raw value is a Postgres array literal, e.g. `{a,b,c}`. Because the element only needs to be
+/// a ``PostgrestArrayElement``, an array may contain `nil` — `{1,NULL}` — even though `nil` cannot
+/// be used as a filter operand on its own.
+extension Array: PostgrestFilterValue where Element: PostgrestArrayElement {
   public var rawValue: String {
-    let elements = map { element -> String in
-      if let element = element as? any PostgrestArrayLiteralElementEncodable {
-        return element.postgrestArrayLiteralElement
-      }
-      return escapePostgRESTArrayLiteralElement(element.rawValue)
-    }
-    return "{\(elements.joined(separator: ","))}"
+    "{\(map(\.postgrestArrayElement).joined(separator: ","))}"
   }
 }
 
-/// An array of ``PostgrestFilterValue`` elements is itself a nested array literal
-/// (e.g. `{1,2}`) when it appears as an element of another array, so it's passed
-/// through unescaped rather than quoted as a scalar string.
-extension Array: PostgrestArrayLiteralElementEncodable where Element: PostgrestFilterValue {
-  package var postgrestArrayLiteralElement: String { rawValue }
+/// A nested array is already an array literal, so it is passed through unescaped rather than
+/// quoted as a scalar string.
+extension Array: PostgrestArrayElement where Element: PostgrestArrayElement {
+  public var postgrestArrayElement: String { rawValue }
 }
 
 /// `JSONValue` can be used directly as a PostgREST filter value.
@@ -93,45 +116,32 @@ extension JSONValue: PostgrestFilterValue {
     case .null: "NULL"
     }
   }
-}
 
-/// `.null` is an actual SQL `NULL` array member, not the string `"NULL"`, and
-/// `.array` is a nested array literal, not a scalar string — both are passed
-/// through unescaped rather than quoted as a scalar.
-extension JSONValue: PostgrestArrayLiteralElementEncodable {
-  package var postgrestArrayLiteralElement: String {
+  /// `.null` is an actual SQL `NULL` array member, not the string `"NULL"`, and `.array` is a
+  /// nested array literal, not a scalar string — both are passed through unescaped.
+  public var postgrestArrayElement: String {
     switch self {
-    case .array(let array): array.postgrestArrayLiteralElement
+    case .array(let array): array.postgrestArrayElement
     case .null: "NULL"
-    case .object, .string, .double, .integer, .bool: escapePostgRESTArrayLiteralElement(rawValue)
+    case .object, .string, .double, .integer, .bool:
+      escapePostgRESTArrayLiteralElement(rawValue)
     }
   }
 }
 
-/// An optional ``PostgrestFilterValue`` is itself a ``PostgrestFilterValue``.
+/// An optional value is a Postgres array member, but **not** a filter operand.
 ///
-/// When the optional is `nil`, the raw value is `"NULL"`.
-extension Optional: PostgrestFilterValue where Wrapped: PostgrestFilterValue {
-  public var rawValue: String {
-    if let value = self {
-      return value.rawValue
-    }
-
-    return "NULL"
+/// `nil` encodes as `NULL` inside an array literal. It conforms to ``PostgrestArrayElement`` only,
+/// so passing it to `eq`, `neq`, `gt` and friends is a compile error rather than a query that
+/// silently matches the wrong rows.
+extension Optional: PostgrestArrayElement where Wrapped: PostgrestArrayElement {
+  public var postgrestArrayElement: String {
+    guard let self else { return "NULL" }
+    return self.postgrestArrayElement
   }
 }
 
-/// A `nil` optional is an actual SQL `NULL` array member, not the string
-/// `"NULL"`, so it's passed through unescaped rather than quoted as a scalar.
-extension Optional: PostgrestArrayLiteralElementEncodable where Wrapped: PostgrestFilterValue {
-  package var postgrestArrayLiteralElement: String {
-    guard let value = self else { return "NULL" }
-    if let value = value as? any PostgrestArrayLiteralElementEncodable {
-      return value.postgrestArrayLiteralElement
-    }
-    return escapePostgRESTArrayLiteralElement(value.rawValue)
-  }
-}
+extension JSONObject: PostgrestArrayElement {}
 
 /// `JSONObject` can be used directly as a PostgREST filter value.
 extension JSONObject: PostgrestFilterValue {

--- a/Tests/PostgRESTTests/PostgrestFilterValueTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterValueTests.swift
@@ -79,10 +79,12 @@ struct PostgrestFilterValueTests {
     #expect(JSONValue.null.rawValue == "NULL")
   }
 
+  /// `Optional` is a ``PostgrestArrayElement`` but deliberately not a ``PostgrestFilterValue``,
+  /// so it encodes for an array literal and has no `rawValue` to pass to a comparison filter.
   @Test
-  func optional() {
-    #expect(Optional.some([1, 2]).rawValue == "{1,2}")
-    #expect(Optional<[Int]>.none.rawValue == "NULL")
+  func optionalIsAnArrayElementNotAFilterValue() {
+    #expect(Optional.some([1, 2]).postgrestArrayElement == "{1,2}")
+    #expect(Optional<[Int]>.none.postgrestArrayElement == "NULL")
   }
 
   @Test

--- a/Tests/PostgRESTTests/PostgrestNilFilterValueTests.swift
+++ b/Tests/PostgRESTTests/PostgrestNilFilterValueTests.swift
@@ -1,0 +1,69 @@
+//
+//  PostgrestNilFilterValueTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 19/08/26.
+//
+
+import Testing
+
+@testable import PostgREST
+
+/// `NULL` is not a comparable value in SQL: `column = NULL` is never true, and PostgREST makes that
+/// worse than a no-op. Spec §9.3 measured it against a live server — on an `integer` column
+/// `column=eq.null` is an HTTP 400, and on a `text` column it returns **HTTP 200 with the row whose
+/// value is the literal string** `'null'`. A silently wrong row, not an empty result.
+///
+/// So the SDK does not translate a `nil` operand into `is.null`, and does not send it either. It
+/// refuses to compile: `Optional` conforms to ``PostgrestArrayElement`` but not to
+/// ``PostgrestFilterValue``, so there is nothing to pass to `eq`.
+///
+/// Swift Testing cannot assert that code fails to compile, so the negative cases are recorded here
+/// as commented call sites and verified by hand. Each one is `error: argument type 'String?' does
+/// not conform to expected type 'PostgrestFilterValue'`.
+///
+/// ```swift
+/// let email: String? = nil
+/// client.from("users").select().eq("email", value: email)   // does not compile
+/// client.from("users").select().eq("email", value: nil)     // does not compile
+/// client.from("users").select().neq("email", value: email)  // does not compile
+/// client.from("users").select().gt("age", value: Int?.none) // does not compile
+/// client.from("users").select().in("id", values: [1, nil])  // does not compile
+/// ```
+@Suite
+struct PostgrestNilFilterValueTests {
+  /// The supported way to test for `NULL`, and the reason `eq` does not need to guess.
+  @Test
+  func isNullSendsIsNull() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().is("email", value: nil).execute()
+    #expect(capture.query?.contains("email=is.NULL") == true)
+  }
+
+  /// The counterpart, via `not`.
+  @Test
+  func notIsNullSendsNotIsNull() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select()
+      .not("email", operator: .is, value: "null").execute()
+    #expect(capture.query?.contains("email=not.is.null") == true)
+  }
+
+  /// A non-optional value is unaffected — the point is to reject `nil`, not to narrow the API.
+  @Test
+  func presentValueStillUsesEq() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().eq("email", value: "a@b.co").execute()
+    #expect(capture.query?.contains("email=eq.a@b.co") == true)
+  }
+
+  /// A real Postgres array column may legitimately contain `NULL`, which is why `Optional` keeps
+  /// its ``PostgrestArrayElement`` conformance.
+  @Test
+  func arrayColumnStillAcceptsNullMembers() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select()
+      .contains("tags", value: [Optional("a"), nil]).execute()
+    #expect(capture.query?.contains("tags=cs.{a,NULL}") == true)
+  }
+}

--- a/Tests/PostgRESTTests/QueryCapture.swift
+++ b/Tests/PostgRESTTests/QueryCapture.swift
@@ -1,0 +1,63 @@
+//
+//  QueryCapture.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 19/08/26.
+//
+
+import ConcurrencyExtras
+import Foundation
+import PostgREST
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// Captures the `URLRequest` a builder produces, so a test can assert on it in its own context.
+///
+/// The `Mock.snapshotRequest` helper asserts from inside Mocker's request handler, which runs
+/// outside the test's task, so Swift Testing drops the recorded issue and the assertion never
+/// fails (SDK-1520). This captures the request instead and leaves the assertion to the test body,
+/// where a failure is attributed correctly.
+struct QueryCapture {
+  let client: PostgrestClient
+  private let captured = LockIsolated(URLRequest?.none)
+
+  init(body: String = "[]") {
+    let captured = self.captured
+    client = PostgrestClient(
+      url: URL(string: "https://example.supabase.co")!,
+      headers: ["X-Client-Info": "postgrest-swift/test"],
+      fetch: { request in
+        captured.setValue(request)
+        let response = HTTPURLResponse(
+          url: request.url!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: ["Content-Type": "application/json"]
+        )!
+        return (Data(body.utf8), response)
+      }
+    )
+  }
+
+  /// The query string of the captured request, percent-decoded so assertions can be written in
+  /// the spelling PostgREST documents rather than in escaped form.
+  var query: String? {
+    guard let query = captured.value?.url?.query else { return nil }
+    return query.removingPercentEncoding ?? query
+  }
+
+  /// The HTTP method of the captured request.
+  var httpMethod: String? { captured.value?.httpMethod }
+
+  /// The captured request body decoded as UTF-8.
+  var bodyString: String? {
+    captured.value?.httpBody.map { String(decoding: $0, as: UTF8.self) }
+  }
+
+  /// A header field of the captured request.
+  func header(_ name: String) -> String? {
+    captured.value?.value(forHTTPHeaderField: name)
+  }
+}

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1656,3 +1656,57 @@ fixed internal encoder (`JSONValue.encoder`) previously always used to serialize
 ```swift
 try await channel.broadcast(event: "cursor", message: cursorPosition, encoder: mySnakeCaseEncoder)
 ```
+
+## `Optional` no longer conforms to `PostgrestFilterValue`; `nil` cannot be a comparison operand
+
+`Optional` used to conform to `PostgrestFilterValue`, rendering `nil` as the literal text `NULL`.
+It now conforms only to the new `PostgrestArrayElement` protocol, so passing `nil` (or any
+optional) to `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `in` or `notIn` no longer
+compiles.
+
+The old conformance produced silently wrong results rather than an error. Verified against a live
+PostgREST 14.15: on an `integer` column `column=eq.null` is an HTTP 400, but on a `text` column it
+returns **HTTP 200 with the row whose value is the literal string** `'null'` — a wrong row, not an
+empty result. `column = NULL` is never true in SQL, so there is no correct query to send here and
+the SDK does not guess one.
+
+```swift
+// Before — compiled, sent `email=eq.NULL`, matched the wrong rows
+let email: String? = nil
+try await client.from("users").select().eq("email", value: email).execute()
+
+// After — use the NULL-aware filter
+try await client.from("users").select().is("email", value: nil).execute()
+
+// ...and its negation
+try await client.from("users").select()
+  .not("email", operator: .is, value: "null").execute()
+```
+
+**This is a compile error**, so the compiler lists every affected call site:
+`argument type 'String?' does not conform to expected type 'PostgrestFilterValue'`. If the value is
+optional only because of how you obtained it, unwrap it and branch:
+
+```swift
+let query = client.from("users").select()
+let scoped = email.map { query.eq("email", value: $0) } ?? query.is("email", value: nil)
+```
+
+There is no escape hatch, and that is deliberate — the previous behavior had no correct use.
+
+### Array columns still accept `NULL` members
+
+A real Postgres array may legitimately contain `NULL`, so `Optional` keeps that capability through
+`PostgrestArrayElement`:
+
+```swift
+// Still compiles, still sends `tags=cs.{a,NULL}`
+try await client.from("users").select().contains("tags", value: [Optional("a"), nil]).execute()
+```
+
+### If you wrote your own `PostgrestFilterValue`
+
+`PostgrestFilterValue` now refines `PostgrestArrayElement`, which has a default implementation for
+every conforming type. Existing custom conformances keep compiling unchanged and gain array-element
+support for free. Only declare `postgrestArrayElement` yourself if your type is a nested array
+literal or a real `NULL`, where escaping the raw value as a scalar would be wrong.

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -26,6 +26,7 @@ chan
 checkmark
 Cloudflare
 cloudflare
+conformances
 confirmer
 corelibs
 CREDENTIALW

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -42,6 +42,17 @@ supporting_symbols:
   - PostgrestExecutablePhase
   - PostgrestFilterPhase
   - PostgrestFilterablePhase
+  # Array-literal encoding. `PostgrestArrayElement` is the weaker of the two
+  # filter protocols: a value that may appear inside a Postgres array literal,
+  # including SQL NULL. It underpins every filter that takes an array
+  # (contains/containedBy/overlaps) rather than belonging to one of them, and
+  # it is what keeps `nil` out of the scalar comparison filters.
+  - Array.postgrestArrayElement
+  - JSONValue.postgrestArrayElement
+  - Optional.postgrestArrayElement
+  - PostgrestArrayElement
+  - PostgrestArrayElement.postgrestArrayElement
+  - PostgrestFilterValue.postgrestArrayElement
   - PostgrestQueryPhase
   - PostgrestRequestBuilder
   - PostgrestRequestBuilder.Operator


### PR DESCRIPTION
Stage 1, Task 1 of the [PostgREST v3 plan](https://github.com/supabase/supabase-swift/blob/docs/postgrest-v3-design/docs/design/postgrest-v3-stage-1-plan.md) · SDK-1509

## The bug

`Optional` conformed to `PostgrestFilterValue` and rendered `nil` as the literal text `NULL`, so this compiled:

```swift
let email: String? = nil
try await client.from("users").select().eq("email", value: email).execute()  // email=eq.NULL
```

Verified against a live PostgREST 14.15, that is worse than a no-op:

| Column type | `column=eq.null` |
| --- | --- |
| `integer` | HTTP 400 |
| `text` | **HTTP 200 with the row whose value is the string `'null'`** |

A silently wrong row, not an empty result.

## The fix: make it unrepresentable, not translated

`column = NULL` is never true in SQL, so there is no correct query to send. An earlier revision of this PR translated a `nil` operand into `is.null`; that was rejected as guessing on the caller's behalf.

Instead the type system now says what is true — **`nil` is not a filter operand**:

- New `PostgrestArrayElement`: a value that can appear in a Postgres array literal, *including* `NULL`.
- `PostgrestFilterValue` now refines it, with a default implementation — so every existing conformance, including custom ones, keeps compiling untouched and gains array-element support for free.
- `Optional` conforms to `PostgrestArrayElement` **only**.

Passing an optional to `eq`/`neq`/`gt`/`gte`/`lt`/`lte`/`like`/`ilike`/`in`/`notIn` is now a compile error:

```
argument type 'String?' does not conform to expected type 'PostgrestFilterValue'
```

`in` is included deliberately: `IN (NULL)` never matches in SQL either.

## What still works

Real array columns legitimately contain `NULL`, and that is exactly the distinction the split encodes:

```swift
try await client.from("users").select().contains("tags", value: [Optional("a"), nil]).execute()
// tags=cs.{a,NULL}
```

And the supported NULL test is unchanged:

```swift
try await client.from("users").select().is("email", value: nil).execute()          // email=is.NULL
try await client.from("users").select().not("email", operator: .is, value: "null") // email=not.is.null
```

## Breaking change

`V3_MIGRATION.md` gains a section covering the before/after, the exact compiler error, the unwrap-and-branch pattern for genuinely-optional values, and the note that array members are unaffected. There is no escape hatch, deliberately — the old behavior had no correct use.

## Notes

- Rebased onto `main`, which has since landed the value-typed `PostgrestRequestBuilder<Phase>`. The one merge conflict was doc wording (`builder instance` → `builder value`).
- `is(_:value:)` no longer relies on `Optional.rawValue`; it spells the NULL case out directly.
- Because there is only one `eq`/`neq` overload again, the DocC disambiguation an earlier revision needed is gone — `Sources/PostgREST/PostgrestQueryBuilder.swift` and `PostgrestRequestBuilder.swift` are untouched by this PR now.
- `QueryCapture` (new test helper) percent-decodes the captured query, so assertions read in the spelling PostgREST documents.

## Verification

- `swift build` clean; `swift test` — 1213 tests in 121 suites pass
- `./scripts/test-docs.sh` exits 0
- `./scripts/format.sh`, `./scripts/spell-check.sh` clean
- The negative cases are recorded as commented call sites in `PostgrestNilFilterValueTests` and verified by hand, since Swift Testing cannot assert that code fails to compile