### PR TITLE
fix(tests): make request snapshot assertions actually fail

### DIFF
--- a/Sources/TestHelpers/DeferredRequestSnapshots.swift
+++ b/Sources/TestHelpers/DeferredRequestSnapshots.swift
@@ -1,0 +1,108 @@
+//
+//  DeferredRequestSnapshots.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 19/08/26.
+//
+
+package import Foundation
+package import InlineSnapshotTesting
+
+/// A request snapshot whose comparison has to be deferred until the test's own task.
+///
+/// Mocker invokes `onRequestHandler` from the URL-loading queue, not from the task running the
+/// test. Swift Testing resolves the current test from task-local state, so an issue recorded from
+/// that handler has no test to attach to and is silently dropped -- which made every
+/// `Mock.snapshotRequest` assertion in the package pass regardless of the request. Capturing the
+/// request there and comparing it later, inside ``MockerSerializedTrait``, puts the comparison back
+/// in a context where a failure is attributed to the test.
+struct PendingRequestSnapshot {
+  /// The expected snapshot, already evaluated at the call site. `nil` means no snapshot has been
+  /// recorded yet, which `assertInlineSnapshot` treats as a request to record one.
+  var expected: String?
+  var message: String
+  var isRecording: SnapshotTestingConfiguration.Record?
+  var timeout: TimeInterval
+  var syntaxDescriptor: InlineSnapshotSyntaxDescriptor
+  var fileID: StaticString
+  var filePath: StaticString
+  var function: StaticString
+  var line: UInt
+  var column: UInt
+
+  /// Filled in by the Mocker request handler. Stays `nil` if the mock is never matched.
+  var request: URLRequest?
+}
+
+/// Process-global store of snapshots awaiting comparison.
+///
+/// `@unchecked Sendable` with an explicit lock: `PendingRequestSnapshot` holds non-`Sendable`
+/// snapshot-testing values, and every reader and writer is already serialized by
+/// ``MockerSerializedTrait``, which holds a process-wide gate for the whole test.
+final class PendingRequestSnapshotStore: @unchecked Sendable {
+  static let shared = PendingRequestSnapshotStore()
+
+  private let lock = NSLock()
+  private var pending: [Int: PendingRequestSnapshot] = [:]
+  private var nextToken = 0
+
+  /// Registers a snapshot to compare once the test body has finished.
+  ///
+  /// Tokens are monotonic and never reused. Mocker's registry is process-global and a stub can
+  /// outlive the test that registered it, so a handler may fire after its expectation has been
+  /// drained. With a unique token that late arrival finds no entry and is dropped; with array
+  /// indices it would have attached its request to whichever expectation had since taken that
+  /// index, failing an unrelated test at random.
+  func register(_ snapshot: PendingRequestSnapshot) -> Int {
+    lock.lock()
+    defer { lock.unlock() }
+    let token = nextToken
+    nextToken += 1
+    pending[token] = snapshot
+    return token
+  }
+
+  /// Attaches the request Mocker saw to a previously registered snapshot. A token that is no
+  /// longer pending is ignored.
+  func attach(_ request: URLRequest, to token: Int) {
+    lock.lock()
+    defer { lock.unlock() }
+    pending[token]?.request = request
+  }
+
+  /// Removes and returns everything registered so far, oldest first.
+  func drain() -> [PendingRequestSnapshot] {
+    lock.lock()
+    defer { lock.unlock() }
+    let drained = pending.sorted { $0.key < $1.key }.map(\.value)
+    pending = [:]
+    return drained
+  }
+}
+
+/// Compares every deferred snapshot registered during the current test.
+///
+/// Called from ``MockerSerializedTrait`` after the test body returns, so `assertInlineSnapshot`
+/// runs with a current test and a mismatch actually fails.
+///
+/// Snapshots whose mock was never matched are skipped rather than failed: a suite may legitimately
+/// register a mock for a request a given test does not make.
+package func assertDeferredRequestSnapshots() {
+  for snapshot in PendingRequestSnapshotStore.shared.drain() {
+    guard let request = snapshot.request else { continue }
+    assertInlineSnapshot(
+      of: request,
+      as: ._curl,
+      message: snapshot.message,
+      record: snapshot.isRecording,
+      timeout: snapshot.timeout,
+      syntaxDescriptor: snapshot.syntaxDescriptor,
+      matches: snapshot.expected.map { expected in { expected } },
+      fileID: snapshot.fileID,
+      file: snapshot.filePath,
+      function: snapshot.function,
+      line: snapshot.line,
+      column: snapshot.column
+    )
+  }
+}

--- a/Sources/TestHelpers/DeferredRequestSnapshots.swift
+++ b/Sources/TestHelpers/DeferredRequestSnapshots.swift
@@ -8,6 +8,10 @@
 package import Foundation
 package import InlineSnapshotTesting
 
+#if canImport(FoundationNetworking)
+  package import FoundationNetworking
+#endif
+
 /// A request snapshot whose comparison has to be deferred until the test's own task.
 ///
 /// Mocker invokes `onRequestHandler` from the URL-loading queue, not from the task running the

--- a/Sources/TestHelpers/MockExtensions.swift
+++ b/Sources/TestHelpers/MockExtensions.swift
@@ -26,21 +26,29 @@ extension Mock {
       // non-Darwin curl snapshots have a different Content-Length than expected
       return self
     #endif
-    var copy = self
-    copy.onRequestHandler = OnRequestHandler {
-      assertInlineSnapshot(
-        of: $0,
-        as: ._curl,
-        record: isRecording,
+    // The comparison cannot happen in the handler below: Mocker calls it from the URL-loading
+    // queue, where Swift Testing has no current test, so a recorded issue is dropped and the
+    // assertion silently passes whatever the request was. Register the expectation here -- on the
+    // test's task -- and let `MockerSerializedTrait` compare it once the body returns.
+    let token = PendingRequestSnapshotStore.shared.register(
+      PendingRequestSnapshot(
+        expected: expected?(),
+        message: message(),
+        isRecording: isRecording,
         timeout: timeout,
         syntaxDescriptor: syntaxDescriptor,
-        matches: expected,
         fileID: fileID,
-        file: filePath,
+        filePath: filePath,
         function: function,
         line: line,
-        column: column
+        column: column,
+        request: nil
       )
+    )
+
+    var copy = self
+    copy.onRequestHandler = OnRequestHandler {
+      PendingRequestSnapshotStore.shared.attach($0, to: token)
     }
     return copy
   }

--- a/Sources/TestHelpers/MockerSerialization.swift
+++ b/Sources/TestHelpers/MockerSerialization.swift
@@ -58,6 +58,14 @@ package struct MockerSerializedTrait: SuiteTrait, TestScoping {
     performing function: @Sendable () async throws -> Void
   ) async throws {
     try await MockerGate.shared.withLock {
+      // Discard anything left over from a suite that does not use this trait, so a stale
+      // expectation cannot be blamed on this one.
+      _ = PendingRequestSnapshotStore.shared.drain()
+      // `Mock.snapshotRequest` cannot compare inside Mocker's request handler: that runs on the
+      // URL-loading queue, where Swift Testing has no current test, so a recorded issue is dropped
+      // and the assertion passes whatever the request was. Comparing here instead puts it back on
+      // the task running the suite, where a mismatch is reported.
+      defer { assertDeferredRequestSnapshots() }
       try await function()
     }
   }

--- a/Tests/PostgRESTTests/DeferredRequestSnapshotTests.swift
+++ b/Tests/PostgRESTTests/DeferredRequestSnapshotTests.swift
@@ -1,0 +1,43 @@
+//
+//  DeferredRequestSnapshotTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 19/08/26.
+//
+
+import Foundation
+import Mocker
+import PostgREST
+import TestHelpers
+import Testing
+
+extension PostgrestMockerTests {
+  /// Guards the fix for SDK-1520.
+  ///
+  /// `Mock.snapshotRequest` used to compare inside Mocker's request handler, which runs on the
+  /// URL-loading queue where Swift Testing has no current test. The recorded issue was dropped, so
+  /// every request snapshot in the package passed regardless of the request. If that regresses,
+  /// this test fails because the expected mismatch never gets reported.
+  @Suite(.mockerSerialized)
+  struct DeferredRequestSnapshotTests {
+    let fixture = PostgrestQueryFixture()
+
+    @Test
+    func mismatchedRequestSnapshotIsReported() async throws {
+      Mock(
+        url: fixture.url.appendingPathComponent("users"),
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [.get: Data("[]".utf8)]
+      )
+      .snapshotRequest(matches: { "a curl command this request cannot possibly produce" })
+      .register()
+
+      _ = try await fixture.sut.from("users").select().execute()
+
+      withKnownIssue("the snapshot above is deliberately wrong, so comparing it must report") {
+        assertDeferredRequestSnapshots()
+      }
+    }
+  }
+}

--- a/Tests/PostgRESTTests/DeferredRequestSnapshotTests.swift
+++ b/Tests/PostgRESTTests/DeferredRequestSnapshotTests.swift
@@ -11,33 +11,39 @@ import PostgREST
 import TestHelpers
 import Testing
 
-extension PostgrestMockerTests {
-  /// Guards the fix for SDK-1520.
-  ///
-  /// `Mock.snapshotRequest` used to compare inside Mocker's request handler, which runs on the
-  /// URL-loading queue where Swift Testing has no current test. The recorded issue was dropped, so
-  /// every request snapshot in the package passed regardless of the request. If that regresses,
-  /// this test fails because the expected mismatch never gets reported.
-  @Suite(.mockerSerialized)
-  struct DeferredRequestSnapshotTests {
-    let fixture = PostgrestQueryFixture()
+#if os(Linux) || os(Android)
+  // `Mock.snapshotRequest` no-ops on Linux/Android (see `MockExtensions.swift`), so there is
+  // nothing for this guard to observe on those platforms.
+#else
 
-    @Test
-    func mismatchedRequestSnapshotIsReported() async throws {
-      Mock(
-        url: fixture.url.appendingPathComponent("users"),
-        ignoreQuery: true,
-        statusCode: 200,
-        data: [.get: Data("[]".utf8)]
-      )
-      .snapshotRequest(matches: { "a curl command this request cannot possibly produce" })
-      .register()
+  extension PostgrestMockerTests {
+    /// Guards the fix for SDK-1520.
+    ///
+    /// `Mock.snapshotRequest` used to compare inside Mocker's request handler, which runs on the
+    /// URL-loading queue where Swift Testing has no current test. The recorded issue was dropped,
+    /// so every request snapshot in the package passed regardless of the request. If that
+    /// regresses, this test fails because the expected mismatch never gets reported.
+    @Suite(.mockerSerialized)
+    struct DeferredRequestSnapshotTests {
+      let fixture = PostgrestQueryFixture()
 
-      _ = try await fixture.sut.from("users").select().execute()
+      @Test
+      func mismatchedRequestSnapshotIsReported() async throws {
+        Mock(
+          url: fixture.url.appendingPathComponent("users"),
+          ignoreQuery: true,
+          statusCode: 200,
+          data: [.get: Data("[]".utf8)]
+        )
+        .snapshotRequest(matches: { "a curl command this request cannot possibly produce" })
+        .register()
 
-      withKnownIssue("the snapshot above is deliberately wrong, so comparing it must report") {
-        assertDeferredRequestSnapshots()
+        _ = try await fixture.sut.from("users").select().execute()
+
+        withKnownIssue("the snapshot above is deliberately wrong, so comparing it must report") {
+          assertDeferredRequestSnapshots()
+        }
       }
     }
   }
-}
+#endif


### PR DESCRIPTION
Closes SDK-1520

## What

`Mock.snapshotRequest` never failed a test. Every request snapshot in the package — 196 live call sites across Auth, PostgREST, Storage and Functions — was asserting nothing.

## Why it happened

The comparison ran inside Mocker's `onRequestHandler`. Mocker invokes that from the URL-loading queue, not from the task running the test. Swift Testing resolves the current test from task-local state, so the issue `assertInlineSnapshot` recorded had no test to attach to and was dropped.

## How it was found

Three tests written for SDK-1509 against not-yet-implemented behaviour passed on the first run. Corrupting snapshots confirmed the scope:

| Change | Result |
|---|---|
| Bogus URL in PostgREST `notFilter` | 32 tests passed |
| Bogus URL in `AuthClientTests` | 295 tests passed |
| Bogus value in a plain `#expect` (control) | Failed, as expected |

Two probes isolated the cause: `Test.current` is nil inside the handler, and an explicitly-labelled wrong `matches:` argument also passed — ruling out a trailing-closure binding problem.

## How it's fixed

The handler now only captures the request. `MockerSerializedTrait.provideScope` runs on the task performing the suite, so it compares the captured requests after the body returns, where a mismatch is attributed and reported.

**No call sites change.** The trait is already applied to every suite that uses `snapshotRequest`.

## Look at this first

**Monotonic tokens, and why they matter.** An earlier attempt keyed pending snapshots by array index. Mocker's registry is process-global and a stub can outlive the test that registered it, so a late handler fired after its expectation had been drained and attached its request to whichever expectation had since taken that index. That produced failures that moved between runs — 23, then 15, then 23. Tokens are now monotonic and never reused, so a late arrival finds no entry and is dropped. Three consecutive full runs are now identical.

**Suite-scoped, not test-scoped.** Making the trait `isRecursive` would give per-test attribution instead of per-suite, and I tried it. It changes which scopes hold `MockerGate` and produced widespread unmatched-mock failures. Not worth it: a failure still names the exact file and line of the snapshot, which is enough to locate it. Left as is deliberately.

## Result

All 196 live snapshots are now genuinely asserted, **and all of them pass**. The expectations were correct all along; they simply were not being checked. Nothing was re-recorded.

## Testing

- `Tests/PostgRESTTests/DeferredRequestSnapshotTests.swift` asserts a deliberately mismatched snapshot is reported. Verified load-bearing by stubbing the comparison back out, which makes it fail with `Known issue was not recorded`.
- Corruption now fails in both PostgREST and Auth, in filtered and full-suite runs.
- Full suite: 1174 tests in 116 suites passed, 10 known issues (9 pre-existing plus the intentional one in the new guard).
- `./scripts/format.sh` and `./scripts/spell-check.sh` clean.

## Risks

- Test-infrastructure only; no production code touched.
- A snapshot whose mock is never matched is skipped rather than failed, since a suite may legitimately register a mock a given test does not use. In this run 0 were skipped, so it is not currently masking anything.
- `./scripts/build-for-library-evolution.sh` fails on `main` under the local Swift 6.3.3 toolchain inside `swift-log`'s own source, unrelated to this change. Noted on PR #1238 as well.