### PR TITLE
refactor(postgrest)!: make client and builders stateless value types

### DIFF
--- a/Examples/Examples/Database/FilteringView.swift
+++ b/Examples/Examples/Database/FilteringView.swift
@@ -113,26 +113,27 @@ struct FilteringView: View {
     do {
       error = nil
 
-      var query = supabase.from("todos").select()
+      var filtered = supabase.from("todos").select()
 
       // Apply filter
       switch filterComplete {
       case .all:
         break
       case .complete:
-        query = query.eq("is_complete", value: true)
+        filtered = filtered.eq("is_complete", value: true)
       case .incomplete:
-        query = query.eq("is_complete", value: false)
+        filtered = filtered.eq("is_complete", value: false)
       }
 
       // Apply sorting
+      let query: PostgrestTransformBuilder
       switch sortOrder {
       case .newest:
-        query = query.order("created_at", ascending: false) as! PostgrestFilterBuilder
+        query = filtered.order("created_at", ascending: false)
       case .oldest:
-        query = query.order("created_at", ascending: true) as! PostgrestFilterBuilder
+        query = filtered.order("created_at", ascending: true)
       case .alphabetical:
-        query = query.order("description", ascending: true) as! PostgrestFilterBuilder
+        query = filtered.order("description", ascending: true)
       }
 
       todos = try await IdentifiedArrayOf(

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -1,5 +1,5 @@
 public import Foundation
-public import HTTPTypes
+import HTTPTypes
 public import Logging
 
 #if canImport(FoundationNetworking)

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -241,11 +241,11 @@ public struct PostgrestClient: Sendable {
 
   /// Returns a query builder targeting the specified table or view.
   ///
-  /// Call ``PostgrestQueryBuilder/select(_:head:count:)`` on the returned builder to begin a
-  /// `SELECT`, or use ``PostgrestQueryBuilder/insert(_:returning:count:)``,
-  /// ``PostgrestQueryBuilder/update(_:returning:count:)``,
-  /// ``PostgrestQueryBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``, or
-  /// ``PostgrestQueryBuilder/delete(returning:count:)`` for write operations.
+  /// Call ``PostgrestRequestBuilder/select(_:head:count:)`` on the returned builder to begin a
+  /// `SELECT`, or use ``PostgrestRequestBuilder/insert(_:returning:count:)``,
+  /// ``PostgrestRequestBuilder/update(_:returning:count:)``,
+  /// ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``, or
+  /// ``PostgrestRequestBuilder/delete(returning:count:)`` for write operations.
   ///
   /// - Parameter table: The name of the table or view to query.
   /// - Returns: A ``PostgrestQueryBuilder`` for the specified table or view.

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -1,4 +1,3 @@
-import ConcurrencyExtras
 public import Foundation
 public import HTTPTypes
 public import Logging
@@ -32,7 +31,7 @@ public import Logging
 /// ### Creating a Client
 ///
 /// - ``init(configuration:)``
-/// - ``init(url:schema:headers:logger:fetch:encoder:decoder:retryEnabled:)``
+/// - ``init(url:schema:headers:logger:fetch:encoder:decoder:retryEnabled:accessToken:)``
 /// - ``Configuration``
 /// - ``FetchHandler``
 ///
@@ -42,10 +41,6 @@ public import Logging
 /// - ``rpc(_:params:head:get:count:)``
 /// - ``rpc(_:head:get:count:)``
 ///
-/// ### Managing Authentication
-///
-/// - ``setAuth(_:)``
-///
 /// ### Switching the Schema
 ///
 /// - ``schema(_:)``
@@ -53,7 +48,7 @@ public import Logging
 /// ### Inspecting Configuration
 ///
 /// - ``configuration``
-public final class PostgrestClient: Sendable {
+public struct PostgrestClient: Sendable {
   /// A closure that performs an HTTP request and returns the raw response data and metadata.
   ///
   /// Provide a custom ``FetchHandler`` through ``Configuration`` when you need to intercept,
@@ -87,7 +82,7 @@ public final class PostgrestClient: Sendable {
   ///
   /// ### Creating Configuration
   ///
-  /// - ``init(url:schema:headers:logger:fetch:encoder:decoder:retryEnabled:)``
+  /// - ``init(url:schema:headers:logger:fetch:encoder:decoder:retryEnabled:accessToken:)``
   ///
   /// ### Configuration Properties
   ///
@@ -98,6 +93,7 @@ public final class PostgrestClient: Sendable {
   /// - ``encoder``
   /// - ``decoder``
   /// - ``retryEnabled``
+  /// - ``accessToken``
   ///
   /// ### Defaults
   ///
@@ -135,8 +131,15 @@ public final class PostgrestClient: Sendable {
     /// When `true` (the default), GET and HEAD requests that receive an HTTP 503 or 520
     /// response, or encounter a network error, are retried up to three times with
     /// exponential back-off. Set to `false` to disable retries globally; individual
-    /// requests can also override this via ``PostgrestBuilder/retry(enabled:)``.
+    /// requests can also override this via ``PostgrestRequestBuilder/retry(enabled:)``.
     public var retryEnabled: Bool
+
+    /// An async closure returning the current access token, resolved fresh for every request and
+    /// sent as `Authorization: Bearer <token>`. `nil` (the default) sends no bearer token from this
+    /// closure. An `Authorization` header already present on the request — from `headers` above, or
+    /// from an explicit `PostgrestRequestBuilder.setHeader("Authorization", ...)` call — always
+    /// takes precedence over this closure's result.
+    public var accessToken: (@Sendable () async throws -> String?)?
 
     let logger: Logging.Logger
 
@@ -151,6 +154,7 @@ public final class PostgrestClient: Sendable {
     ///   - encoder: The `JSONEncoder` used for request bodies. Defaults to ``jsonEncoder``.
     ///   - decoder: The `JSONDecoder` used for response bodies. Defaults to ``jsonDecoder``.
     ///   - retryEnabled: Whether to retry transient errors. Defaults to `true`.
+    ///   - accessToken: An async closure returning the current access token. Defaults to `nil`.
     public init(
       url: URL,
       schema: String? = nil,
@@ -159,7 +163,8 @@ public final class PostgrestClient: Sendable {
       fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
       encoder: JSONEncoder = PostgrestClient.Configuration.jsonEncoder,
       decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder,
-      retryEnabled: Bool = true
+      retryEnabled: Bool = true,
+      accessToken: (@Sendable () async throws -> String?)? = nil
     ) {
       self.url = url
       self.schema = schema
@@ -171,31 +176,25 @@ public final class PostgrestClient: Sendable {
       self.encoder = encoder
       self.decoder = decoder
       self.retryEnabled = retryEnabled
+      self.accessToken = accessToken
     }
   }
 
-  private let _configuration: LockIsolated<Configuration>
+  /// The configuration this client was created with.
+  public let configuration: Configuration
   let clock: any Clock<Duration>
-
-  /// The current configuration of this client.
-  ///
-  /// The configuration may change at runtime — for example, when ``setAuth(_:)`` updates the
-  /// `Authorization` header. Always read this property rather than caching a copy if you need
-  /// the most up-to-date values.
-  public var configuration: Configuration { _configuration.value }
 
   /// Creates a ``PostgrestClient`` from an existing ``Configuration``.
   ///
   /// - Parameter configuration: The configuration to use.
-  public convenience init(configuration: Configuration) {
+  public init(configuration: Configuration) {
     self.init(configuration: configuration, clock: ContinuousClock())
   }
 
   init(configuration: Configuration, clock: any Clock<Duration>) {
-    _configuration = LockIsolated(configuration)
-    _configuration.withValue {
-      $0.headers.merge(Configuration.defaultHeaders) { l, _ in l }
-    }
+    var configuration = configuration
+    configuration.headers.merge(Configuration.defaultHeaders) { l, _ in l }
+    self.configuration = configuration
     self.clock = clock
   }
 
@@ -213,7 +212,8 @@ public final class PostgrestClient: Sendable {
   ///   - encoder: The `JSONEncoder` used for request bodies. Defaults to ``Configuration/jsonEncoder``.
   ///   - decoder: The `JSONDecoder` used for response bodies. Defaults to ``Configuration/jsonDecoder``.
   ///   - retryEnabled: Whether to retry transient errors. Defaults to `true`.
-  public convenience init(
+  ///   - accessToken: An async closure returning the current access token. Defaults to `nil`.
+  public init(
     url: URL,
     schema: String? = nil,
     headers: [String: String] = [:],
@@ -221,7 +221,8 @@ public final class PostgrestClient: Sendable {
     fetch: @escaping FetchHandler = { try await URLSession.shared.data(for: $0) },
     encoder: JSONEncoder = PostgrestClient.Configuration.jsonEncoder,
     decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder,
-    retryEnabled: Bool = true
+    retryEnabled: Bool = true,
+    accessToken: (@Sendable () async throws -> String?)? = nil
   ) {
     self.init(
       configuration: Configuration(
@@ -232,26 +233,10 @@ public final class PostgrestClient: Sendable {
         fetch: fetch,
         encoder: encoder,
         decoder: decoder,
-        retryEnabled: retryEnabled
+        retryEnabled: retryEnabled,
+        accessToken: accessToken
       )
     )
-  }
-
-  /// Sets or clears the JWT used for row-level security.
-  ///
-  /// When `token` is non-`nil`, the client adds an `Authorization: Bearer <token>` header to all
-  /// subsequent requests. Passing `nil` removes the header.
-  ///
-  /// - Parameter token: A JWT string, or `nil` to remove the authorization header.
-  /// - Returns: The same ``PostgrestClient`` instance so calls can be chained.
-  @discardableResult
-  public func setAuth(_ token: String?) -> PostgrestClient {
-    if let token {
-      _configuration.withValue { $0.headers["Authorization"] = "Bearer \(token)" }
-    } else {
-      _ = _configuration.withValue { $0.headers.removeValue(forKey: "Authorization") }
-    }
-    return self
   }
 
   /// Returns a query builder targeting the specified table or view.

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -2,83 +2,87 @@ import ConcurrencyExtras
 import Foundation
 import Helpers
 
-extension PostgrestRequestBuilder {
-  /// The set of PostgREST comparison operators available for use with
-  /// ``PostgrestFilterBuilder/not(_:operator:value:)`` and
-  /// ``PostgrestFilterBuilder/filter(_:operator:value:)``.
-  ///
-  /// Most operators have dedicated convenience methods (e.g., ``PostgrestFilterBuilder/eq(_:value:)``,
-  /// ``PostgrestFilterBuilder/gt(_:value:)``). Use ``Operator`` directly only when you need
-  /// `not(_:operator:value:)` or the raw `filter(_:operator:value:)` escape hatch.
-  ///
-  /// > Note: `Operator` is declared in an unconstrained extension of ``PostgrestRequestBuilder``
-  /// > (rather than one constrained to `Phase: PostgrestFilterablePhase`) purely so its nested-type
-  /// > declaration doesn't depend on unclear compiler support for nested types in conditional
-  /// > extensions — it's still only meaningfully used from filterable phases.
-  public struct Operator: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
-    public let rawValue: String
+/// The set of PostgREST comparison operators available for use with
+/// ``PostgrestFilterBuilder/not(_:operator:value:)`` and
+/// ``PostgrestFilterBuilder/filter(_:operator:value:)``.
+///
+/// Most operators have dedicated convenience methods (e.g., ``PostgrestFilterBuilder/eq(_:value:)``,
+/// ``PostgrestFilterBuilder/gt(_:value:)``). Use ``PostgrestOperator`` directly only when you need
+/// `not(_:operator:value:)` or the raw `filter(_:operator:value:)` escape hatch.
+///
+/// > Note: This is a top-level type aliased onto ``PostgrestRequestBuilder`` as `Operator` (see
+/// > below) rather than declared as a nested type there — a struct nested inside an extension of a
+/// > generic type is a distinct type per generic specialization, which would make
+/// > `PostgrestQueryBuilder.Operator`, `PostgrestFilterBuilder.Operator`, and
+/// > `PostgrestTransformBuilder.Operator` three unrelated types instead of one shared type.
+public struct PostgrestOperator: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
+  public let rawValue: String
 
-    /// Creates an ``Operator`` from a raw string value.
-    public init(rawValue: String) {
-      self.rawValue = rawValue
-    }
-
-    /// Creates an ``Operator`` from a string literal.
-    public init(stringLiteral value: String) {
-      self.init(rawValue: value)
-    }
-
-    /// Equals (`=`).
-    public static var eq: Operator { "eq" }
-    /// Not equals (`!=`).
-    public static var neq: Operator { "neq" }
-    /// Greater than (`>`).
-    public static var gt: Operator { "gt" }
-    /// Greater than or equal (`>=`).
-    public static var gte: Operator { "gte" }
-    /// Less than (`<`).
-    public static var lt: Operator { "lt" }
-    /// Less than or equal (`<=`).
-    public static var lte: Operator { "lte" }
-    /// Case-sensitive LIKE pattern match.
-    public static var like: Operator { "like" }
-    /// Case-insensitive ILIKE pattern match.
-    public static var ilike: Operator { "ilike" }
-    /// Case-sensitive regex match.
-    public static var match: Operator { "match" }
-    /// Case-insensitive regex match.
-    public static var imatch: Operator { "imatch" }
-    /// IS (for NULL / boolean checks).
-    public static var `is`: Operator { "is" }
-    /// IS DISTINCT FROM.
-    public static var isdistinct: Operator { "isdistinct" }
-    /// IN — value is in a list.
-    public static var `in`: Operator { "in" }
-    /// Contains (`@>`).
-    public static var cs: Operator { "cs" }
-    /// Contained by (`<@`).
-    public static var cd: Operator { "cd" }
-    /// Range strictly left of (`<<`).
-    public static var sl: Operator { "sl" }
-    /// Range strictly right of (`>>`).
-    public static var sr: Operator { "sr" }
-    /// Range does not extend to the left (`&>`).
-    public static var nxl: Operator { "nxl" }
-    /// Range does not extend to the right (`&<`).
-    public static var nxr: Operator { "nxr" }
-    /// Range is adjacent (`-|-`).
-    public static var adj: Operator { "adj" }
-    /// Overlaps (`&&`).
-    public static var ov: Operator { "ov" }
-    /// Full-text search using `to_tsquery`.
-    public static var fts: Operator { "fts" }
-    /// Full-text search using `plainto_tsquery`.
-    public static var plfts: Operator { "plfts" }
-    /// Full-text search using `phraseto_tsquery`.
-    public static var phfts: Operator { "phfts" }
-    /// Full-text search using `websearch_to_tsquery`.
-    public static var wfts: Operator { "wfts" }
+  /// Creates a ``PostgrestOperator`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
   }
+
+  /// Creates a ``PostgrestOperator`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
+  /// Equals (`=`).
+  public static let eq: PostgrestOperator = "eq"
+  /// Not equals (`!=`).
+  public static let neq: PostgrestOperator = "neq"
+  /// Greater than (`>`).
+  public static let gt: PostgrestOperator = "gt"
+  /// Greater than or equal (`>=`).
+  public static let gte: PostgrestOperator = "gte"
+  /// Less than (`<`).
+  public static let lt: PostgrestOperator = "lt"
+  /// Less than or equal (`<=`).
+  public static let lte: PostgrestOperator = "lte"
+  /// Case-sensitive LIKE pattern match.
+  public static let like: PostgrestOperator = "like"
+  /// Case-insensitive ILIKE pattern match.
+  public static let ilike: PostgrestOperator = "ilike"
+  /// Case-sensitive regex match.
+  public static let match: PostgrestOperator = "match"
+  /// Case-insensitive regex match.
+  public static let imatch: PostgrestOperator = "imatch"
+  /// IS (for NULL / boolean checks).
+  public static let `is`: PostgrestOperator = "is"
+  /// IS DISTINCT FROM.
+  public static let isdistinct: PostgrestOperator = "isdistinct"
+  /// IN — value is in a list.
+  public static let `in`: PostgrestOperator = "in"
+  /// Contains (`@>`).
+  public static let cs: PostgrestOperator = "cs"
+  /// Contained by (`<@`).
+  public static let cd: PostgrestOperator = "cd"
+  /// Range strictly left of (`<<`).
+  public static let sl: PostgrestOperator = "sl"
+  /// Range strictly right of (`>>`).
+  public static let sr: PostgrestOperator = "sr"
+  /// Range does not extend to the left (`&>`).
+  public static let nxl: PostgrestOperator = "nxl"
+  /// Range does not extend to the right (`&<`).
+  public static let nxr: PostgrestOperator = "nxr"
+  /// Range is adjacent (`-|-`).
+  public static let adj: PostgrestOperator = "adj"
+  /// Overlaps (`&&`).
+  public static let ov: PostgrestOperator = "ov"
+  /// Full-text search using `to_tsquery`.
+  public static let fts: PostgrestOperator = "fts"
+  /// Full-text search using `plainto_tsquery`.
+  public static let plfts: PostgrestOperator = "plfts"
+  /// Full-text search using `phraseto_tsquery`.
+  public static let phfts: PostgrestOperator = "phfts"
+  /// Full-text search using `websearch_to_tsquery`.
+  public static let wfts: PostgrestOperator = "wfts"
+}
+
+extension PostgrestRequestBuilder {
+  /// See ``PostgrestOperator``.
+  public typealias Operator = PostgrestOperator
 }
 
 /// Filter methods for applying WHERE-clause filters to a PostgREST query.

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -2,14 +2,93 @@ import ConcurrencyExtras
 import Foundation
 import Helpers
 
-/// Builder for applying WHERE-clause filters to a PostgREST query.
+extension PostgrestRequestBuilder {
+  /// The set of PostgREST comparison operators available for use with
+  /// ``PostgrestFilterBuilder/not(_:operator:value:)`` and
+  /// ``PostgrestFilterBuilder/filter(_:operator:value:)``.
+  ///
+  /// Most operators have dedicated convenience methods (e.g., ``PostgrestFilterBuilder/eq(_:value:)``,
+  /// ``PostgrestFilterBuilder/gt(_:value:)``). Use ``Operator`` directly only when you need
+  /// `not(_:operator:value:)` or the raw `filter(_:operator:value:)` escape hatch.
+  ///
+  /// > Note: `Operator` is declared in an unconstrained extension of ``PostgrestRequestBuilder``
+  /// > (rather than one constrained to `Phase: PostgrestFilterablePhase`) purely so its nested-type
+  /// > declaration doesn't depend on unclear compiler support for nested types in conditional
+  /// > extensions — it's still only meaningfully used from filterable phases.
+  public struct Operator: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
+    public let rawValue: String
+
+    /// Creates an ``Operator`` from a raw string value.
+    public init(rawValue: String) {
+      self.rawValue = rawValue
+    }
+
+    /// Creates an ``Operator`` from a string literal.
+    public init(stringLiteral value: String) {
+      self.init(rawValue: value)
+    }
+
+    /// Equals (`=`).
+    public static var eq: Operator { "eq" }
+    /// Not equals (`!=`).
+    public static var neq: Operator { "neq" }
+    /// Greater than (`>`).
+    public static var gt: Operator { "gt" }
+    /// Greater than or equal (`>=`).
+    public static var gte: Operator { "gte" }
+    /// Less than (`<`).
+    public static var lt: Operator { "lt" }
+    /// Less than or equal (`<=`).
+    public static var lte: Operator { "lte" }
+    /// Case-sensitive LIKE pattern match.
+    public static var like: Operator { "like" }
+    /// Case-insensitive ILIKE pattern match.
+    public static var ilike: Operator { "ilike" }
+    /// Case-sensitive regex match.
+    public static var match: Operator { "match" }
+    /// Case-insensitive regex match.
+    public static var imatch: Operator { "imatch" }
+    /// IS (for NULL / boolean checks).
+    public static var `is`: Operator { "is" }
+    /// IS DISTINCT FROM.
+    public static var isdistinct: Operator { "isdistinct" }
+    /// IN — value is in a list.
+    public static var `in`: Operator { "in" }
+    /// Contains (`@>`).
+    public static var cs: Operator { "cs" }
+    /// Contained by (`<@`).
+    public static var cd: Operator { "cd" }
+    /// Range strictly left of (`<<`).
+    public static var sl: Operator { "sl" }
+    /// Range strictly right of (`>>`).
+    public static var sr: Operator { "sr" }
+    /// Range does not extend to the left (`&>`).
+    public static var nxl: Operator { "nxl" }
+    /// Range does not extend to the right (`&<`).
+    public static var nxr: Operator { "nxr" }
+    /// Range is adjacent (`-|-`).
+    public static var adj: Operator { "adj" }
+    /// Overlaps (`&&`).
+    public static var ov: Operator { "ov" }
+    /// Full-text search using `to_tsquery`.
+    public static var fts: Operator { "fts" }
+    /// Full-text search using `plainto_tsquery`.
+    public static var plfts: Operator { "plfts" }
+    /// Full-text search using `phraseto_tsquery`.
+    public static var phfts: Operator { "phfts" }
+    /// Full-text search using `websearch_to_tsquery`.
+    public static var wfts: Operator { "wfts" }
+  }
+}
+
+/// Filter methods for applying WHERE-clause filters to a PostgREST query.
 ///
 /// Obtain a ``PostgrestFilterBuilder`` from ``PostgrestQueryBuilder/select(_:head:count:)``,
 /// ``PostgrestQueryBuilder/insert(_:returning:count:)``, ``PostgrestQueryBuilder/update(_:returning:count:)``,
 /// or other write methods. Chain one or more filter methods, then call
-/// ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>`` to send the request.
+/// ``PostgrestRequestBuilder/execute(options:)-96tpd`` to send the request.
 ///
-/// All filter methods return `self` so they can be freely chained:
+/// All filter methods return `Self` so they can be freely chained:
 ///
 /// ```swift
 /// let results: [Todo] = try await client
@@ -22,10 +101,6 @@ import Helpers
 ///   .value
 /// ```
 ///
-/// > Note: Thread Safety: Inherits thread-safe mutable state management from ``PostgrestBuilder``.
-///
-/// > Important: Do not modify the same builder instance from multiple concurrent tasks.
-///
 /// ## Topics
 ///
 /// ### Equality Filters
@@ -36,7 +111,7 @@ import Helpers
 /// - ``isDistinct(_:value:)``
 /// - ``in(_:values:)``
 /// - ``notIn(_:values:)``
-/// - ``match(_:)``
+/// - ``match(_:)-6h9ou``
 ///
 /// ### Comparison Filters
 ///
@@ -53,7 +128,7 @@ import Helpers
 /// - ``ilike(_:pattern:)``
 /// - ``iLikeAllOf(_:patterns:)``
 /// - ``iLikeAnyOf(_:patterns:)``
-/// - ``match(_:pattern:)``
+/// - ``match(_:pattern:)-9qlv5``
 /// - ``imatch(_:pattern:)``
 ///
 /// ### Array and Range Filters
@@ -81,78 +156,7 @@ import Helpers
 /// ### Operators
 ///
 /// - ``Operator``
-public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Sendable {
-  /// The set of PostgREST comparison operators available for use with ``not(_:operator:value:)``
-  /// and ``filter(_:operator:value:)``.
-  ///
-  /// Most operators have dedicated convenience methods (e.g., ``eq(_:value:)``, ``gt(_:value:)``).
-  /// Use ``Operator`` directly only when you need ``not(_:operator:value:)`` or the raw
-  /// ``filter(_:operator:value:)`` escape hatch.
-  public struct Operator: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
-    public let rawValue: String
-
-    /// Creates an ``Operator`` from a raw string value.
-    public init(rawValue: String) {
-      self.rawValue = rawValue
-    }
-
-    /// Creates an ``Operator`` from a string literal.
-    public init(stringLiteral value: String) {
-      self.init(rawValue: value)
-    }
-
-    /// Equals (`=`).
-    public static let eq: Operator = "eq"
-    /// Not equals (`!=`).
-    public static let neq: Operator = "neq"
-    /// Greater than (`>`).
-    public static let gt: Operator = "gt"
-    /// Greater than or equal (`>=`).
-    public static let gte: Operator = "gte"
-    /// Less than (`<`).
-    public static let lt: Operator = "lt"
-    /// Less than or equal (`<=`).
-    public static let lte: Operator = "lte"
-    /// Case-sensitive LIKE pattern match.
-    public static let like: Operator = "like"
-    /// Case-insensitive ILIKE pattern match.
-    public static let ilike: Operator = "ilike"
-    /// Case-sensitive regex match.
-    public static let match: Operator = "match"
-    /// Case-insensitive regex match.
-    public static let imatch: Operator = "imatch"
-    /// IS (for NULL / boolean checks).
-    public static let `is`: Operator = "is"
-    /// IS DISTINCT FROM.
-    public static let isdistinct: Operator = "isdistinct"
-    /// IN — value is in a list.
-    public static let `in`: Operator = "in"
-    /// Contains (`@>`).
-    public static let cs: Operator = "cs"
-    /// Contained by (`<@`).
-    public static let cd: Operator = "cd"
-    /// Range strictly left of (`<<`).
-    public static let sl: Operator = "sl"
-    /// Range strictly right of (`>>`).
-    public static let sr: Operator = "sr"
-    /// Range does not extend to the left (`&>`).
-    public static let nxl: Operator = "nxl"
-    /// Range does not extend to the right (`&<`).
-    public static let nxr: Operator = "nxr"
-    /// Range is adjacent (`-|-`).
-    public static let adj: Operator = "adj"
-    /// Overlaps (`&&`).
-    public static let ov: Operator = "ov"
-    /// Full-text search using `to_tsquery`.
-    public static let fts: Operator = "fts"
-    /// Full-text search using `plainto_tsquery`.
-    public static let plfts: Operator = "plfts"
-    /// Full-text search using `phraseto_tsquery`.
-    public static let phfts: Operator = "phfts"
-    /// Full-text search using `websearch_to_tsquery`.
-    public static let wfts: Operator = "wfts"
-  }
-
+extension PostgrestRequestBuilder where Phase: PostgrestFilterablePhase {
   // MARK: - Filters
 
   /// Negates the specified filter using the PostgREST `not.<operator>` syntax.
@@ -168,23 +172,18 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///   - column: The column to filter on.
   ///   - op: The ``Operator`` to negate.
   ///   - value: The filter value.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func not(
     _ column: String,
     operator op: Operator,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-
-    mutableState.withValue {
-      $0.request.query.append(
-        URLQueryItem(
-          name: column,
-          value: "not.\(op.rawValue).\(queryValue)"
-        ))
-    }
-
-    return self
+    var copy = self
+    copy.request.query.append(
+      URLQueryItem(name: column, value: "not.\(op.rawValue).\(queryValue)")
+    )
+    return copy
   }
 
   /// Combines multiple filters with an OR condition.
@@ -201,17 +200,16 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - filters: A comma-separated list of PostgREST filter expressions combined with OR logic.
   ///   - referencedTable: The name of an embedded table to apply the OR filter on. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func or(
     _ filters: any PostgrestFilterValue,
     referencedTable: String? = nil
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let key = referencedTable.map { "\($0).or" } ?? "or"
     let queryValue = filters.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: key, value: "(\(queryValue))"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: key, value: "(\(queryValue))"))
+    return copy
   }
 
   /// Matches only rows where `column` equals `value`.
@@ -226,16 +224,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func eq(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "eq.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "eq.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` is not equal to `value`.
@@ -248,16 +245,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func neq(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "neq.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "neq.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` is greater than `value`.
@@ -270,16 +266,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func gt(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "gt.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "gt.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` is greater than or equal to `value`.
@@ -292,16 +287,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func gte(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "gte.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "gte.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` is less than `value`.
@@ -314,16 +308,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func lt(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "lt.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "lt.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` is less than or equal to `value`.
@@ -336,16 +329,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func lte(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "lte.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "lte.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches `pattern` case-sensitively using SQL LIKE.
@@ -360,16 +352,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - pattern: The LIKE pattern to match against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func like(
     _ column: String,
     pattern: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = pattern.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "like.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "like.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches **all** of the supplied LIKE `patterns` case-sensitively.
@@ -382,16 +373,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - patterns: The LIKE patterns that must all match.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func likeAllOf(
     _ column: String,
     patterns: [some PostgrestFilterValue]
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = patterns.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "like(all).\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "like(all).\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches **any** of the supplied LIKE `patterns` case-sensitively.
@@ -404,16 +394,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - patterns: The LIKE patterns, at least one of which must match.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func likeAnyOf(
     _ column: String,
     patterns: [some PostgrestFilterValue]
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = patterns.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "like(any).\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "like(any).\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches `pattern` case-insensitively using SQL ILIKE.
@@ -428,16 +417,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - pattern: The ILIKE pattern to match against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func ilike(
     _ column: String,
     pattern: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = pattern.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "ilike.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "ilike.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches **all** of the supplied ILIKE `patterns` case-insensitively.
@@ -450,16 +438,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - patterns: The ILIKE patterns that must all match.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func iLikeAllOf(
     _ column: String,
     patterns: [some PostgrestFilterValue]
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = patterns.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "ilike(all).\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "ilike(all).\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches **any** of the supplied ILIKE `patterns` case-insensitively.
@@ -472,16 +459,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - patterns: The ILIKE patterns, at least one of which must match.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func iLikeAnyOf(
     _ column: String,
     patterns: [some PostgrestFilterValue]
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = patterns.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "ilike(any).\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "ilike(any).\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches the regular expression `pattern` case-sensitively.
@@ -496,16 +482,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - pattern: The POSIX regular expression to match against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func match(
     _ column: String,
     pattern: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = pattern.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "match.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "match.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches the regular expression `pattern` case-insensitively.
@@ -520,16 +505,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - pattern: The POSIX regular expression to match against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func imatch(
     _ column: String,
     pattern: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = pattern.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "imatch.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "imatch.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` IS `value`.
@@ -548,16 +532,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: `true`, `false`, or `nil` (for NULL).
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func `is`(
     _ column: String,
     value: Bool?
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "is.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "is.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` IS DISTINCT FROM `value`.
@@ -573,16 +556,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against using IS DISTINCT FROM.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func isDistinct(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "isdistinct.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "isdistinct.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` is one of the values in `values`.
@@ -597,21 +579,20 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - values: The list of acceptable values.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func `in`(
     _ column: String,
     values: [any PostgrestFilterValue]
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValues = values.map { escapePostgRESTFilterValue($0.rawValue) }
-    mutableState.withValue {
-      $0.request.query.append(
-        URLQueryItem(
-          name: column,
-          value: "in.(\(queryValues.joined(separator: ",")))"
-        )
+    var copy = self
+    copy.request.query.append(
+      URLQueryItem(
+        name: column,
+        value: "in.(\(queryValues.joined(separator: ",")))"
       )
-    }
-    return self
+    )
+    return copy
   }
 
   /// Matches only rows where `column` is not one of the values in `values`.
@@ -626,21 +607,20 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - values: The list of values to exclude.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func notIn(
     _ column: String,
     values: [any PostgrestFilterValue]
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValues = values.map { escapePostgRESTFilterValue($0.rawValue) }
-    mutableState.withValue {
-      $0.request.query.append(
-        URLQueryItem(
-          name: column,
-          value: "not.in.(\(queryValues.joined(separator: ",")))"
-        )
+    var copy = self
+    copy.request.query.append(
+      URLQueryItem(
+        name: column,
+        value: "not.in.(\(queryValues.joined(separator: ",")))"
       )
-    }
-    return self
+    )
+    return copy
   }
 
   /// Matches only rows where `column` contains every element in `value`.
@@ -655,16 +635,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The `jsonb`, array, or range column to filter on.
   ///   - value: The `jsonb`, array, or range value that `column` must contain.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func contains(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "cs.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "cs.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` is contained by `value`.
@@ -679,16 +658,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The `jsonb`, array, or range column to filter on.
   ///   - value: The `jsonb`, array, or range value that must contain every element in `column`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func containedBy(
     _ column: String,
     value: some PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "cd.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "cd.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where every element in `column` is strictly less than every element in `range`.
@@ -703,16 +681,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - range: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeLt(
     _ column: String,
     range: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = range.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "sl.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "sl.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where every element in `column` is strictly greater than every element in `range`.
@@ -727,16 +704,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - range: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeGt(
     _ column: String,
     range: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = range.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "sr.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "sr.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` does not extend to the left of `range`.
@@ -751,16 +727,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - range: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeGte(
     _ column: String,
     range: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = range.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "nxl.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "nxl.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` does not extend to the right of `range`.
@@ -775,16 +750,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - range: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeLte(
     _ column: String,
     range: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = range.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "nxr.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "nxr.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` and `range` are adjacent (no gap between them).
@@ -800,16 +774,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - range: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeAdjacent(
     _ column: String,
     range: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = range.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "adj.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "adj.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` and `value` share at least one element.
@@ -824,16 +797,15 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The array or range column to filter on.
   ///   - value: The array or range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func overlaps(
     _ column: String,
     value: any PostgrestFilterValue
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = value.rawValue
-    mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: column, value: "ov.\(queryValue)"))
-    }
-    return self
+    var copy = self
+    copy.request.query.append(URLQueryItem(name: column, value: "ov.\(queryValue)"))
+    return copy
   }
 
   /// Matches only rows where `column` matches the full-text search `query`.
@@ -855,24 +827,23 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///   - query: The search query text.
   ///   - config: The text search configuration name (e.g., `"english"`). Defaults to `nil`.
   ///   - type: The query conversion strategy. See ``TextSearchType``. Defaults to `nil` (uses `to_tsquery`).
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func textSearch(
     _ column: String,
     query: any PostgrestFilterValue,
     config: String? = nil,
     type: TextSearchType? = nil
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let queryValue = query.rawValue
     let configPart = config.map { "(\($0))" }
 
-    mutableState.withValue {
-      $0.request.query.append(
-        URLQueryItem(
-          name: column, value: "\(type?.rawValue ?? "")fts\(configPart ?? "").\(queryValue)"
-        )
+    var copy = self
+    copy.request.query.append(
+      URLQueryItem(
+        name: column, value: "\(type?.rawValue ?? "")fts\(configPart ?? "").\(queryValue)"
       )
-    }
-    return self
+    )
+    return copy
   }
 
   /// Matches only rows where `column` matches the full-text search `query` using `to_tsquery`.
@@ -888,12 +859,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///   - column: The `text` or `tsvector` column to search.
   ///   - query: The search query text.
   ///   - config: The text search configuration name. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func fts(
     _ column: String,
     query: any PostgrestFilterValue,
     config: String? = nil
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     textSearch(column, query: query, config: config, type: nil)
   }
 
@@ -913,20 +884,19 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///   - column: The column to filter on.
   ///   - operator: The PostgREST operator string (e.g., `"eq"`, `"gt"`, `"cs"`).
   ///   - value: The filter value string, already formatted for PostgREST.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func filter(
     _ column: String,
     operator: String,
     value: String
-  ) -> PostgrestFilterBuilder {
-    mutableState.withValue {
-      $0.request.query.append(
-        URLQueryItem(
-          name: column,
-          value: "\(`operator`).\(value)"
-        ))
-    }
-    return self
+  ) -> Self {
+    var copy = self
+    copy.request.query.append(
+      URLQueryItem(
+        name: column,
+        value: "\(`operator`).\(value)"
+      ))
+    return copy
   }
 
   /// Matches only rows where each key in `query` equals its associated value.
@@ -939,21 +909,20 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// ```
   ///
   /// - Parameter query: A dictionary mapping column names to filter values.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func match(
     _ query: [String: any PostgrestFilterValue]
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     let query = query.mapValues(\.rawValue)
-    mutableState.withValue { mutableState in
-      for (key, value) in query {
-        mutableState.request.query.append(
-          URLQueryItem(
-            name: key,
-            value: "eq.\(value.rawValue)"
-          ))
-      }
+    var copy = self
+    for (key, value) in query {
+      copy.request.query.append(
+        URLQueryItem(
+          name: key,
+          value: "eq.\(value.rawValue)"
+        ))
     }
-    return self
+    return copy
   }
 
   // MARK: - Filter Semantic Improvements
@@ -965,11 +934,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func equals(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     eq(column, value: value)
   }
 
@@ -980,11 +949,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func notEquals(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     neq(column, value: value)
   }
 
@@ -995,11 +964,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func greaterThan(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     gt(column, value: value)
   }
 
@@ -1010,11 +979,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func greaterThanOrEquals(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     gte(column, value: value)
   }
 
@@ -1025,11 +994,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func lowerThan(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     lt(column, value: value)
   }
 
@@ -1040,11 +1009,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The column to filter on.
   ///   - value: The value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func lowerThanOrEquals(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     lte(column, value: value)
   }
 
@@ -1055,11 +1024,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - range: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeLowerThan(
     _ column: String,
     range: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     rangeLt(column, range: range)
   }
 
@@ -1070,11 +1039,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - value: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeGreaterThan(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     rangeGt(column, range: value)
   }
 
@@ -1085,11 +1054,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - value: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeGreaterThanOrEquals(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     rangeGte(column, range: value)
   }
 
@@ -1100,11 +1069,11 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   /// - Parameters:
   ///   - column: The range column to filter on.
   ///   - value: The range value to compare against.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func rangeLowerThanOrEquals(
     _ column: String,
     value: String
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     rangeLte(column, range: value)
   }
 
@@ -1116,12 +1085,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///   - column: The `text` or `tsvector` column to search.
   ///   - query: The search query text.
   ///   - config: The text search configuration name. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func fullTextSearch(
     _ column: String,
     query: String,
     config: String? = nil
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     fts(column, query: query, config: config)
   }
 
@@ -1133,12 +1102,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///   - column: The `text` or `tsvector` column to search.
   ///   - query: The search query text.
   ///   - config: The text search configuration name. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func plainToFullTextSearch(
     _ column: String,
     query: String,
     config: String? = nil
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     textSearch(column, query: query, config: config, type: .plain)
   }
 
@@ -1150,12 +1119,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///   - column: The `text` or `tsvector` column to search.
   ///   - query: The search query text.
   ///   - config: The text search configuration name. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func phraseToFullTextSearch(
     _ column: String,
     query: String,
     config: String? = nil
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     textSearch(column, query: query, config: config, type: .phrase)
   }
 
@@ -1167,12 +1136,12 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder, @unchecked Senda
   ///   - column: The `text` or `tsvector` column to search.
   ///   - query: The search query text.
   ///   - config: The text search configuration name. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: The same builder value so calls can be chained.
   public func webFullTextSearch(
     _ column: String,
     query: String,
     config: String? = nil
-  ) -> PostgrestFilterBuilder {
+  ) -> Self {
     textSearch(column, query: query, config: config, type: .websearch)
   }
 }

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -1,13 +1,12 @@
-import ConcurrencyExtras
 import Foundation
 import Helpers
 
 /// The set of PostgREST comparison operators available for use with
-/// ``PostgrestFilterBuilder/not(_:operator:value:)`` and
-/// ``PostgrestFilterBuilder/filter(_:operator:value:)``.
+/// ``PostgrestRequestBuilder/not(_:operator:value:)`` and
+/// ``PostgrestRequestBuilder/filter(_:operator:value:)``.
 ///
-/// Most operators have dedicated convenience methods (e.g., ``PostgrestFilterBuilder/eq(_:value:)``,
-/// ``PostgrestFilterBuilder/gt(_:value:)``). Use ``PostgrestOperator`` directly only when you need
+/// Most operators have dedicated convenience methods (e.g., ``PostgrestRequestBuilder/eq(_:value:)``,
+/// ``PostgrestRequestBuilder/gt(_:value:)``). Use ``PostgrestOperator`` directly only when you need
 /// `not(_:operator:value:)` or the raw `filter(_:operator:value:)` escape hatch.
 ///
 /// > Note: This is a top-level type aliased onto ``PostgrestRequestBuilder`` as `Operator` (see
@@ -85,81 +84,10 @@ extension PostgrestRequestBuilder {
   public typealias Operator = PostgrestOperator
 }
 
-/// Filter methods for applying WHERE-clause filters to a PostgREST query.
-///
-/// Obtain a ``PostgrestFilterBuilder`` from ``PostgrestQueryBuilder/select(_:head:count:)``,
-/// ``PostgrestQueryBuilder/insert(_:returning:count:)``, ``PostgrestQueryBuilder/update(_:returning:count:)``,
-/// or other write methods. Chain one or more filter methods, then call
-/// ``PostgrestRequestBuilder/execute(options:)-96tpd`` to send the request.
-///
-/// All filter methods return `Self` so they can be freely chained:
-///
-/// ```swift
-/// let results: [Todo] = try await client
-///   .from("todos")
-///   .select()
-///   .eq("done", value: false)
-///   .order("created_at", ascending: false)
-///   .limit(20)
-///   .execute()
-///   .value
-/// ```
-///
-/// ## Topics
-///
-/// ### Equality Filters
-///
-/// - ``eq(_:value:)``
-/// - ``neq(_:value:)``
-/// - ``is(_:value:)``
-/// - ``isDistinct(_:value:)``
-/// - ``in(_:values:)``
-/// - ``notIn(_:values:)``
-/// - ``match(_:)-6h9ou``
-///
-/// ### Comparison Filters
-///
-/// - ``gt(_:value:)``
-/// - ``gte(_:value:)``
-/// - ``lt(_:value:)``
-/// - ``lte(_:value:)``
-///
-/// ### Pattern Matching Filters
-///
-/// - ``like(_:pattern:)``
-/// - ``likeAllOf(_:patterns:)``
-/// - ``likeAnyOf(_:patterns:)``
-/// - ``ilike(_:pattern:)``
-/// - ``iLikeAllOf(_:patterns:)``
-/// - ``iLikeAnyOf(_:patterns:)``
-/// - ``match(_:pattern:)-9qlv5``
-/// - ``imatch(_:pattern:)``
-///
-/// ### Array and Range Filters
-///
-/// - ``contains(_:value:)``
-/// - ``containedBy(_:value:)``
-/// - ``overlaps(_:value:)``
-/// - ``rangeLt(_:range:)``
-/// - ``rangeGt(_:range:)``
-/// - ``rangeGte(_:range:)``
-/// - ``rangeLte(_:range:)``
-/// - ``rangeAdjacent(_:range:)``
-///
-/// ### Full-Text Search
-///
-/// - ``textSearch(_:query:config:type:)``
-/// - ``fts(_:query:config:)``
-///
-/// ### Logical Operators
-///
-/// - ``not(_:operator:value:)``
-/// - ``or(_:referencedTable:)``
-/// - ``filter(_:operator:value:)``
-///
-/// ### Operators
-///
-/// - ``Operator``
+// The filter methods available while the request is still in a filterable phase. The overview
+// prose and curated `## Topics` groups for these live on the ``PostgrestFilterBuilder`` type alias
+// in `PostgrestRequestBuilder.swift` — DocC discards doc comments written on `extension` blocks,
+// so a `///` comment here would never be rendered.
 extension PostgrestRequestBuilder where Phase: PostgrestFilterablePhase {
   // MARK: - Filters
 

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -24,10 +24,6 @@ import HTTPTypes
 ///   .value
 /// ```
 ///
-/// > Note: Thread Safety: Inherits thread-safe mutable state management from ``PostgrestBuilder``.
-///
-/// > Important: Do not modify the same builder instance from multiple concurrent tasks.
-///
 /// ## Topics
 ///
 /// ### Querying Rows
@@ -49,7 +45,7 @@ import HTTPTypes
 /// ### Deleting Rows
 ///
 /// - ``delete(returning:count:)``
-public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable {
+extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   /// Performs a SELECT query on the table or view.
   ///
   /// By default all columns are returned (`*`). You can request specific columns, rename them,
@@ -81,32 +77,31 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
     head: Bool = false,
     count: CountOption? = nil
   ) -> PostgrestFilterBuilder {
-    mutableState.withValue {
-      $0.request.method = .get
-      // remove whitespaces except when quoted.
-      var quoted = false
-      let cleanedColumns = columns.compactMap { char -> String? in
-        if char.isWhitespace, !quoted {
-          return nil
-        }
-        if char == "\"" {
-          quoted = !quoted
-        }
-        return String(char)
+    var request = self.request
+    request.method = .get
+    // remove whitespaces except when quoted.
+    var quoted = false
+    let cleanedColumns = columns.compactMap { char -> String? in
+      if char.isWhitespace, !quoted {
+        return nil
       }
-      .joined(separator: "")
+      if char == "\"" {
+        quoted = !quoted
+      }
+      return String(char)
+    }
+    .joined(separator: "")
 
-      $0.request.query.appendOrUpdate(URLQueryItem(name: "select", value: cleanedColumns))
+    request.query.appendOrUpdate(URLQueryItem(name: "select", value: cleanedColumns))
 
-      if let count {
-        $0.request.headers.appendOrUpdate(.prefer, value: "count=\(count.rawValue)")
-      }
-      if head {
-        $0.request.method = .head
-      }
+    if let count {
+      request.headers.appendOrUpdate(.prefer, value: "count=\(count.rawValue)")
+    }
+    if head {
+      request.method = .head
     }
 
-    return PostgrestFilterBuilder(self)
+    return PostgrestFilterBuilder(carryingFrom: self, request: request)
   }
 
   /// Inserts one or more rows into the table or view.
@@ -143,37 +138,36 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   ) throws -> PostgrestFilterBuilder {
     let body = try configuration.encoder.encode(values)
 
-    try mutableState.withValue {
-      $0.request.method = .post
-      var prefersHeaders: [String] = []
-      if let returning {
-        prefersHeaders.append("return=\(returning.rawValue)")
-      }
-      $0.request.body = body
-      if let count {
-        prefersHeaders.append("count=\(count.rawValue)")
-      }
-      if let prefer = $0.request.headers[.prefer] {
-        prefersHeaders.insert(prefer, at: 0)
-      }
-      if !prefersHeaders.isEmpty {
-        $0.request.headers[.prefer] = prefersHeaders.joined(separator: ",")
-      }
-      if let body = $0.request.body,
-        let jsonObject = try JSONSerialization.jsonObject(with: body) as? [[String: Any]]
-      {
-        let allKeys = jsonObject.flatMap(\.keys)
-        let uniqueKeys = Set(allKeys).sorted()
-        $0.request.query.appendOrUpdate(
-          URLQueryItem(
-            name: "columns",
-            value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
-          )
+    var request = self.request
+    request.method = .post
+    var prefersHeaders: [String] = []
+    if let returning {
+      prefersHeaders.append("return=\(returning.rawValue)")
+    }
+    request.body = body
+    if let count {
+      prefersHeaders.append("count=\(count.rawValue)")
+    }
+    if let prefer = request.headers[.prefer] {
+      prefersHeaders.insert(prefer, at: 0)
+    }
+    if !prefersHeaders.isEmpty {
+      request.headers[.prefer] = prefersHeaders.joined(separator: ",")
+    }
+    if let body = request.body,
+      let jsonObject = try JSONSerialization.jsonObject(with: body) as? [[String: Any]]
+    {
+      let allKeys = jsonObject.flatMap(\.keys)
+      let uniqueKeys = Set(allKeys).sorted()
+      request.query.appendOrUpdate(
+        URLQueryItem(
+          name: "columns",
+          value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
         )
-      }
+      )
     }
 
-    return PostgrestFilterBuilder(self)
+    return PostgrestFilterBuilder(carryingFrom: self, request: request)
   }
 
   /// Inserts rows, updating existing rows on conflict (upsert).
@@ -214,40 +208,40 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   ) throws -> PostgrestFilterBuilder {
     let body = try configuration.encoder.encode(values)
 
-    try mutableState.withValue {
-      $0.request.method = .post
-      var prefersHeaders = [
-        "resolution=\(ignoreDuplicates ? "ignore" : "merge")-duplicates",
-        "return=\(returning.rawValue)",
-      ]
-      if let onConflict {
-        $0.request.query.appendOrUpdate(URLQueryItem(name: "on_conflict", value: onConflict))
-      }
-      $0.request.body = body
-      if let count {
-        prefersHeaders.append("count=\(count.rawValue)")
-      }
-      if let prefer = $0.request.headers[.prefer] {
-        prefersHeaders.insert(prefer, at: 0)
-      }
-      if !prefersHeaders.isEmpty {
-        $0.request.headers[.prefer] = prefersHeaders.joined(separator: ",")
-      }
-
-      if let body = $0.request.body,
-        let jsonObject = try JSONSerialization.jsonObject(with: body) as? [[String: Any]]
-      {
-        let allKeys = jsonObject.flatMap(\.keys)
-        let uniqueKeys = Set(allKeys).sorted()
-        $0.request.query.appendOrUpdate(
-          URLQueryItem(
-            name: "columns",
-            value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
-          )
-        )
-      }
+    var request = self.request
+    request.method = .post
+    var prefersHeaders = [
+      "resolution=\(ignoreDuplicates ? "ignore" : "merge")-duplicates",
+      "return=\(returning.rawValue)",
+    ]
+    if let onConflict {
+      request.query.appendOrUpdate(URLQueryItem(name: "on_conflict", value: onConflict))
     }
-    return PostgrestFilterBuilder(self)
+    request.body = body
+    if let count {
+      prefersHeaders.append("count=\(count.rawValue)")
+    }
+    if let prefer = request.headers[.prefer] {
+      prefersHeaders.insert(prefer, at: 0)
+    }
+    if !prefersHeaders.isEmpty {
+      request.headers[.prefer] = prefersHeaders.joined(separator: ",")
+    }
+
+    if let body = request.body,
+      let jsonObject = try JSONSerialization.jsonObject(with: body) as? [[String: Any]]
+    {
+      let allKeys = jsonObject.flatMap(\.keys)
+      let uniqueKeys = Set(allKeys).sorted()
+      request.query.appendOrUpdate(
+        URLQueryItem(
+          name: "columns",
+          value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
+        )
+      )
+    }
+
+    return PostgrestFilterBuilder(carryingFrom: self, request: request)
   }
 
   /// Performs a partial UPDATE on rows that match subsequent filters.
@@ -256,7 +250,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   /// suppress this, pass `.minimal` as `returning`.
   ///
   /// > Important: Omitting a filter will update **all rows** in the table. Always chain
-  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>``.
+  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestRequestBuilder/execute(options:)-96tpd``.
   ///
   /// ```swift
   /// try await client
@@ -278,21 +272,22 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
     count: CountOption? = nil
   ) throws -> PostgrestFilterBuilder {
     let body = try configuration.encoder.encode(values)
-    mutableState.withValue {
-      $0.request.method = .patch
-      var preferHeaders = ["return=\(returning.rawValue)"]
-      $0.request.body = body
-      if let count {
-        preferHeaders.append("count=\(count.rawValue)")
-      }
-      if let prefer = $0.request.headers[.prefer] {
-        preferHeaders.insert(prefer, at: 0)
-      }
-      if !preferHeaders.isEmpty {
-        $0.request.headers[.prefer] = preferHeaders.joined(separator: ",")
-      }
+
+    var request = self.request
+    request.method = .patch
+    var preferHeaders = ["return=\(returning.rawValue)"]
+    request.body = body
+    if let count {
+      preferHeaders.append("count=\(count.rawValue)")
     }
-    return PostgrestFilterBuilder(self)
+    if let prefer = request.headers[.prefer] {
+      preferHeaders.insert(prefer, at: 0)
+    }
+    if !preferHeaders.isEmpty {
+      request.headers[.prefer] = preferHeaders.joined(separator: ",")
+    }
+
+    return PostgrestFilterBuilder(carryingFrom: self, request: request)
   }
 
   /// Performs a DELETE on rows that match subsequent filters.
@@ -301,7 +296,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   /// suppress this, pass `.minimal` as `returning`.
   ///
   /// > Important: Omitting a filter will delete **all rows** in the table. Always chain
-  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>``.
+  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestRequestBuilder/execute(options:)-96tpd``.
   ///
   /// ```swift
   /// try await client
@@ -319,19 +314,19 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
     returning: PostgrestReturningOptions = .representation,
     count: CountOption? = nil
   ) -> PostgrestFilterBuilder {
-    mutableState.withValue {
-      $0.request.method = .delete
-      var preferHeaders = ["return=\(returning.rawValue)"]
-      if let count {
-        preferHeaders.append("count=\(count.rawValue)")
-      }
-      if let prefer = $0.request.headers[.prefer] {
-        preferHeaders.insert(prefer, at: 0)
-      }
-      if !preferHeaders.isEmpty {
-        $0.request.headers[.prefer] = preferHeaders.joined(separator: ",")
-      }
+    var request = self.request
+    request.method = .delete
+    var preferHeaders = ["return=\(returning.rawValue)"]
+    if let count {
+      preferHeaders.append("count=\(count.rawValue)")
     }
-    return PostgrestFilterBuilder(self)
+    if let prefer = request.headers[.prefer] {
+      preferHeaders.insert(prefer, at: 0)
+    }
+    if !preferHeaders.isEmpty {
+      request.headers[.prefer] = preferHeaders.joined(separator: ",")
+    }
+
+    return PostgrestFilterBuilder(carryingFrom: self, request: request)
   }
 }

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -1,50 +1,10 @@
-import ConcurrencyExtras
 import Foundation
 import HTTPTypes
 
-/// Builder for SELECT, INSERT, UPDATE, UPSERT, and DELETE operations on a table or view.
-///
-/// Obtain a ``PostgrestQueryBuilder`` by calling ``PostgrestClient/from(_:)`` and then chain one
-/// of the operation methods. Most methods return a ``PostgrestFilterBuilder`` so you can narrow the
-/// affected rows with WHERE clauses before executing.
-///
-/// ```swift
-/// // INSERT a single row
-/// try await client
-///   .from("todos")
-///   .insert(["task": "Buy milk", "done": false])
-///   .execute()
-///
-/// // SELECT with a filter
-/// let todos: [Todo] = try await client
-///   .from("todos")
-///   .select()
-///   .eq("done", value: false)
-///   .execute()
-///   .value
-/// ```
-///
-/// ## Topics
-///
-/// ### Querying Rows
-///
-/// - ``select(_:head:count:)``
-///
-/// ### Inserting Rows
-///
-/// - ``insert(_:returning:count:)``
-///
-/// ### Updating Rows
-///
-/// - ``update(_:returning:count:)``
-///
-/// ### Upsert Rows
-///
-/// - ``upsert(_:onConflict:returning:count:ignoreDuplicates:)``
-///
-/// ### Deleting Rows
-///
-/// - ``delete(returning:count:)``
+// The operation methods available before an operation has been chosen. The overview prose and
+// curated `## Topics` groups for these live on the ``PostgrestQueryBuilder`` type alias in
+// `PostgrestRequestBuilder.swift` — DocC discards doc comments written on `extension` blocks, so a
+// `///` comment here would never be rendered.
 extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   /// Performs a SELECT query on the table or view.
   ///
@@ -107,7 +67,7 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   /// Inserts one or more rows into the table or view.
   ///
   /// By default, inserted rows are not returned. To receive the inserted data, chain with
-  /// ``PostgrestTransformBuilder/select(_:)`` after calling this method.
+  /// ``PostgrestRequestBuilder/select(_:)`` after calling this method.
   ///
   /// ```swift
   /// // Insert a single row
@@ -250,7 +210,8 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   /// suppress this, pass `.minimal` as `returning`.
   ///
   /// > Important: Omitting a filter will update **all rows** in the table. Always chain
-  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestRequestBuilder/execute(options:)-96tpd``.
+  /// > a filter such as ``PostgrestRequestBuilder/eq(_:value:)`` before calling
+  /// > ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<Void>``.
   ///
   /// ```swift
   /// try await client
@@ -296,7 +257,8 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   /// suppress this, pass `.minimal` as `returning`.
   ///
   /// > Important: Omitting a filter will delete **all rows** in the table. Always chain
-  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestRequestBuilder/execute(options:)-96tpd``.
+  /// > a filter such as ``PostgrestRequestBuilder/eq(_:value:)`` before calling
+  /// > ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<Void>``.
   ///
   /// ```swift
   /// try await client

--- a/Sources/PostgREST/PostgrestRequestBuilder.swift
+++ b/Sources/PostgREST/PostgrestRequestBuilder.swift
@@ -70,8 +70,8 @@ public enum PostgrestTransformPhase: PostgrestTransformablePhase {}
 ///
 /// ### Executing the Request
 ///
-/// - ``execute(options:)-96tpd``
-/// - ``execute(options:)-6mk2u``
+/// - ``execute(options:)->PostgrestResponse<Void>``
+/// - ``execute(options:)->PostgrestResponse<T>``
 public struct PostgrestRequestBuilder<Phase>: Sendable {
   let configuration: PostgrestClient.Configuration
   let http: any HTTPClientType
@@ -126,8 +126,186 @@ public struct PostgrestRequestBuilder<Phase>: Sendable {
   }
 }
 
+/// Builder for SELECT, INSERT, UPDATE, UPSERT, and DELETE operations on a table or view.
+///
+/// This is ``PostgrestRequestBuilder`` specialized to ``PostgrestQueryPhase``, the phase a request
+/// starts in before an operation has been chosen.
+///
+/// Obtain one by calling ``PostgrestClient/from(_:)`` and then chain one of the operation methods.
+/// Most methods return a ``PostgrestFilterBuilder`` so you can narrow the affected rows with WHERE
+/// clauses before executing.
+///
+/// ```swift
+/// // INSERT a single row
+/// try await client
+///   .from("todos")
+///   .insert(["task": "Buy milk", "done": false])
+///   .execute()
+///
+/// // SELECT with a filter
+/// let todos: [Todo] = try await client
+///   .from("todos")
+///   .select()
+///   .eq("done", value: false)
+///   .execute()
+///   .value
+/// ```
+///
+/// ## Topics
+///
+/// ### Querying Rows
+///
+/// - ``PostgrestRequestBuilder/select(_:head:count:)``
+///
+/// ### Inserting Rows
+///
+/// - ``PostgrestRequestBuilder/insert(_:returning:count:)``
+///
+/// ### Updating Rows
+///
+/// - ``PostgrestRequestBuilder/update(_:returning:count:)``
+///
+/// ### Upsert Rows
+///
+/// - ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``
+///
+/// ### Deleting Rows
+///
+/// - ``PostgrestRequestBuilder/delete(returning:count:)``
 public typealias PostgrestQueryBuilder = PostgrestRequestBuilder<PostgrestQueryPhase>
+
+/// Builder for applying WHERE-clause filters to a PostgREST query, before transforming or
+/// executing it.
+///
+/// This is ``PostgrestRequestBuilder`` specialized to ``PostgrestFilterPhase``.
+///
+/// Obtain one from ``PostgrestRequestBuilder/select(_:head:count:)``,
+/// ``PostgrestRequestBuilder/insert(_:returning:count:)``,
+/// ``PostgrestRequestBuilder/update(_:returning:count:)``, or another write method on
+/// ``PostgrestQueryBuilder``, or from ``PostgrestClient/rpc(_:params:head:get:count:)``. Chain one
+/// or more filter methods, then call
+/// ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<T>`` to send the request.
+///
+/// All filter methods return `Self` so they can be freely chained:
+///
+/// ```swift
+/// let results: [Todo] = try await client
+///   .from("todos")
+///   .select()
+///   .eq("done", value: false)
+///   .order("created_at", ascending: false)
+///   .limit(20)
+///   .execute()
+///   .value
+/// ```
+///
+/// ## Topics
+///
+/// ### Equality Filters
+///
+/// - ``PostgrestRequestBuilder/eq(_:value:)``
+/// - ``PostgrestRequestBuilder/neq(_:value:)``
+/// - ``PostgrestRequestBuilder/is(_:value:)``
+/// - ``PostgrestRequestBuilder/isDistinct(_:value:)``
+/// - ``PostgrestRequestBuilder/in(_:values:)``
+/// - ``PostgrestRequestBuilder/notIn(_:values:)``
+/// - ``PostgrestRequestBuilder/match(_:)``
+///
+/// ### Comparison Filters
+///
+/// - ``PostgrestRequestBuilder/gt(_:value:)``
+/// - ``PostgrestRequestBuilder/gte(_:value:)``
+/// - ``PostgrestRequestBuilder/lt(_:value:)``
+/// - ``PostgrestRequestBuilder/lte(_:value:)``
+///
+/// ### Pattern Matching Filters
+///
+/// - ``PostgrestRequestBuilder/like(_:pattern:)``
+/// - ``PostgrestRequestBuilder/likeAllOf(_:patterns:)``
+/// - ``PostgrestRequestBuilder/likeAnyOf(_:patterns:)``
+/// - ``PostgrestRequestBuilder/ilike(_:pattern:)``
+/// - ``PostgrestRequestBuilder/iLikeAllOf(_:patterns:)``
+/// - ``PostgrestRequestBuilder/iLikeAnyOf(_:patterns:)``
+/// - ``PostgrestRequestBuilder/match(_:pattern:)``
+/// - ``PostgrestRequestBuilder/imatch(_:pattern:)``
+///
+/// ### Array and Range Filters
+///
+/// - ``PostgrestRequestBuilder/contains(_:value:)``
+/// - ``PostgrestRequestBuilder/containedBy(_:value:)``
+/// - ``PostgrestRequestBuilder/overlaps(_:value:)``
+/// - ``PostgrestRequestBuilder/rangeLt(_:range:)``
+/// - ``PostgrestRequestBuilder/rangeGt(_:range:)``
+/// - ``PostgrestRequestBuilder/rangeGte(_:range:)``
+/// - ``PostgrestRequestBuilder/rangeLte(_:range:)``
+/// - ``PostgrestRequestBuilder/rangeAdjacent(_:range:)``
+///
+/// ### Full-Text Search
+///
+/// - ``PostgrestRequestBuilder/textSearch(_:query:config:type:)``
+/// - ``PostgrestRequestBuilder/fts(_:query:config:)``
+///
+/// ### Logical Operators
+///
+/// - ``PostgrestRequestBuilder/not(_:operator:value:)``
+/// - ``PostgrestRequestBuilder/or(_:referencedTable:)``
+/// - ``PostgrestRequestBuilder/filter(_:operator:value:)``
+///
+/// ### Operators
+///
+/// - ``PostgrestOperator``
 public typealias PostgrestFilterBuilder = PostgrestRequestBuilder<PostgrestFilterPhase>
+
+/// Builder for ordering, pagination, and response-format transformations, before executing a
+/// PostgREST request.
+///
+/// This is ``PostgrestRequestBuilder`` specialized to ``PostgrestTransformPhase``. It sits between
+/// ``PostgrestFilterBuilder`` (WHERE clauses) and
+/// ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<T>`` (sending the request). All
+/// transformation methods narrow the builder to ``PostgrestTransformPhase``, so once you call one
+/// you can no longer filter — only transform further or execute.
+///
+/// ```swift
+/// let page: [Todo] = try await client
+///   .from("todos")
+///   .select()
+///   .order("created_at", ascending: false)
+///   .range(from: 0, to: 9)
+///   .execute()
+///   .value
+/// ```
+///
+/// ## Topics
+///
+/// ### Returning Modified Rows
+///
+/// - ``PostgrestRequestBuilder/select(_:)``
+///
+/// ### Ordering and Pagination
+///
+/// - ``PostgrestRequestBuilder/order(_:ascending:nullsFirst:referencedTable:)``
+/// - ``PostgrestRequestBuilder/limit(_:referencedTable:)``
+/// - ``PostgrestRequestBuilder/range(from:to:referencedTable:)``
+///
+/// ### Response Format
+///
+/// - ``PostgrestRequestBuilder/single()``
+/// - ``PostgrestRequestBuilder/maybeSingle()``
+/// - ``PostgrestRequestBuilder/csv()``
+/// - ``PostgrestRequestBuilder/geojson()``
+/// - ``PostgrestRequestBuilder/stripNulls()``
+///
+/// ### Query Analysis
+///
+/// - ``PostgrestRequestBuilder/explain(analyze:verbose:settings:buffers:wal:format:)``
+///
+/// ### Limiting Affected Rows
+///
+/// - ``PostgrestRequestBuilder/maxAffected(_:)``
+///
+/// ### Testing Mutations
+///
+/// - ``PostgrestRequestBuilder/dryRun()``
 public typealias PostgrestTransformBuilder = PostgrestRequestBuilder<PostgrestTransformPhase>
 
 /// A type-erased PostgREST builder that can execute a request and set per-request
@@ -139,10 +317,10 @@ public typealias PostgrestTransformBuilder = PostgrestRequestBuilder<PostgrestTr
 /// "any executable PostgREST builder" regardless of which filter/transform methods were chained
 /// to produce it.
 public protocol PostgrestExecutableBuilder: Sendable {
-  /// See ``PostgrestRequestBuilder/execute(options:)-96tpd``.
+  /// See ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<Void>``.
   func execute(options: FetchOptions) async throws -> PostgrestResponse<Void>
 
-  /// See ``PostgrestRequestBuilder/execute(options:)-6mk2u``.
+  /// See ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<T>``.
   func execute<T: Decodable>(options: FetchOptions) async throws -> PostgrestResponse<T>
 }
 
@@ -188,7 +366,7 @@ extension PostgrestRequestBuilder where Phase: PostgrestExecutablePhase {
   /// Executes the request and discards the response body.
   ///
   /// Use this overload for mutations (INSERT, UPDATE, DELETE) when you do not need the
-  /// affected rows, or when you have already called ``PostgrestTransformBuilder/csv()`` or
+  /// affected rows, or when you have already called ``PostgrestRequestBuilder/csv()`` or
   /// a similar method that changes the response format.
   ///
   /// - Parameter options: Options controlling whether to include a row count and whether to

--- a/Sources/PostgREST/PostgrestRequestBuilder.swift
+++ b/Sources/PostgREST/PostgrestRequestBuilder.swift
@@ -1,4 +1,10 @@
-import ConcurrencyExtras
+//
+//  PostgrestRequestBuilder.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 20/08/24.
+//
+
 import Foundation
 import HTTPTypes
 import Logging
@@ -7,18 +13,50 @@ import Logging
   import FoundationNetworking
 #endif
 
-/// The base builder class for all PostgREST requests.
+/// A marker protocol conformed to by every phase whose builder can execute a request and set
+/// per-request headers/retry behavior.
 ///
-/// ``PostgrestBuilder`` holds the shared HTTP request state and provides the ``execute(options:)->PostgrestResponse<Void>``
-/// methods that send the request to the PostgREST server. You typically interact with one of its
-/// subclasses — ``PostgrestQueryBuilder``, ``PostgrestFilterBuilder``, or
-/// ``PostgrestTransformBuilder`` — rather than instantiating ``PostgrestBuilder`` directly.
+/// Conform a phase type to this — or, more commonly, to ``PostgrestTransformablePhase`` or
+/// ``PostgrestFilterablePhase``, both of which refine it — to grant `setHeader`/`retry`/`execute`
+/// on ``PostgrestRequestBuilder`` when `Phase` is that type.
+public protocol PostgrestExecutablePhase {}
+
+/// A marker protocol for phases that can still apply ordering, pagination, and response-format
+/// transformations. Refines ``PostgrestExecutablePhase``, so every transformable phase is also
+/// executable.
+public protocol PostgrestTransformablePhase: PostgrestExecutablePhase {}
+
+/// A marker protocol for phases that can still apply WHERE-clause filters. Refines
+/// ``PostgrestTransformablePhase``, so every filterable phase is also transformable and
+/// executable.
+public protocol PostgrestFilterablePhase: PostgrestTransformablePhase {}
+
+/// The phase immediately after ``PostgrestClient/from(_:)``, before an operation
+/// (`select`/`insert`/`update`/`upsert`/`delete`) has been chosen.
 ///
-/// > Note: Thread Safety: This class is `@unchecked Sendable` because all mutable state
-/// > is protected by `LockIsolated`. Access to `mutableState` is always through its `withValue` API.
+/// This phase conforms to none of the capability protocols: you cannot filter, transform, set
+/// headers, or execute until you pick an operation.
+public enum PostgrestQueryPhase {}
+
+/// The phase after a filterable operation has been chosen (or after
+/// ``PostgrestClient/rpc(_:params:head:get:count:)``). Supports filtering, transforming, and
+/// executing.
+public enum PostgrestFilterPhase: PostgrestFilterablePhase {}
+
+/// The phase after any transformation (`order`, `limit`, `single`, ...) has been applied.
+/// Supports further transformations and executing, but no longer filtering.
+public enum PostgrestTransformPhase: PostgrestTransformablePhase {}
+
+/// Builder for all PostgREST requests, parameterized by the request's current phase.
 ///
-/// > Important: While this class is `Sendable`, individual builder instances should not be
-/// > modified concurrently from multiple tasks. Create separate builder chains for concurrent operations.
+/// Don't reference this generic type directly — use the phase-specific type aliases instead:
+/// ``PostgrestQueryBuilder``, ``PostgrestFilterBuilder``, and ``PostgrestTransformBuilder``. The
+/// `Phase` parameter is a compile-time-only marker (never constructed) that determines which
+/// methods are available: filter methods require ``PostgrestFilterablePhase``, transform methods
+/// require ``PostgrestTransformablePhase``, and `setHeader`/`retry`/`execute` require
+/// ``PostgrestExecutablePhase``. You don't construct this type directly — call
+/// ``PostgrestClient/from(_:)`` or ``PostgrestClient/rpc(_:params:head:get:count:)`` and chain
+/// from there.
 ///
 /// ## Topics
 ///
@@ -32,28 +70,24 @@ import Logging
 ///
 /// ### Executing the Request
 ///
-/// - ``execute(options:)->PostgrestResponse<Void>``
-/// - ``execute(options:)->PostgrestResponse<T>``
-public class PostgrestBuilder: @unchecked Sendable {
-  /// The configuration for the PostgREST client.
+/// - ``execute(options:)-96tpd``
+/// - ``execute(options:)-6mk2u``
+public struct PostgrestRequestBuilder<Phase>: Sendable {
   let configuration: PostgrestClient.Configuration
   let http: any HTTPClientType
   let clock: any Clock<Duration>
 
-  struct MutableState {
-    var request: Helpers.HTTPRequest
+  var request: Helpers.HTTPRequest
 
-    /// Whether automatic retries are enabled for this request.
-    var retryEnabled: Bool
+  /// Whether automatic retries are enabled for this request.
+  var retryEnabled: Bool
 
-    /// An error to throw when execute() is called, set when an invalid method combination is detected.
-    var pendingError: String?
+  /// An error to throw when execute() is called, set when an invalid method combination is
+  /// detected.
+  var pendingError: String?
 
-    /// Whether a `PGRST116` error should be returned as a `nil` value instead of being thrown.
-    var isMaybeSingle: Bool = false
-  }
-
-  let mutableState: LockIsolated<MutableState>
+  /// Whether a `PGRST116` error should be returned as a `nil` value instead of being thrown.
+  var isMaybeSingle: Bool = false
 
   init(
     configuration: PostgrestClient.Configuration,
@@ -66,26 +100,56 @@ public class PostgrestBuilder: @unchecked Sendable {
     let interceptors: [any HTTPClientInterceptor] = [
       LoggerInterceptor(logger: configuration.logger)
     ]
+    self.http = HTTPClient(fetch: configuration.fetch, interceptors: interceptors)
 
-    http = HTTPClient(fetch: configuration.fetch, interceptors: interceptors)
-
-    mutableState = LockIsolated(
-      MutableState(
-        request: request,
-        retryEnabled: configuration.retryEnabled
-      )
-    )
+    self.request = request
+    self.retryEnabled = configuration.retryEnabled
+    self.pendingError = nil
+    self.isMaybeSingle = false
   }
 
-  convenience init(_ other: PostgrestBuilder) {
-    self.init(
-      configuration: other.configuration,
-      request: other.mutableState.value.request,
-      clock: other.clock
-    )
-    mutableState.withValue { $0.retryEnabled = other.mutableState.value.retryEnabled }
+  /// Recasts an existing builder to a different phase, preserving every field except `request`.
+  ///
+  /// Every method that changes phase (e.g. `select`/`insert` moving from ``PostgrestQueryPhase``
+  /// to ``PostgrestFilterPhase``, or any transform method moving to ``PostgrestTransformPhase``)
+  /// goes through this initializer instead of resetting state, because `pendingError` and
+  /// `isMaybeSingle` must survive a phase change — e.g. `.maybeSingle().order(...)` must not lose
+  /// the `isMaybeSingle` flag just because `order` also changes the phase.
+  init<From>(carryingFrom other: PostgrestRequestBuilder<From>, request: Helpers.HTTPRequest) {
+    self.configuration = other.configuration
+    self.http = other.http
+    self.clock = other.clock
+    self.request = request
+    self.retryEnabled = other.retryEnabled
+    self.pendingError = other.pendingError
+    self.isMaybeSingle = other.isMaybeSingle
   }
+}
 
+public typealias PostgrestQueryBuilder = PostgrestRequestBuilder<PostgrestQueryPhase>
+public typealias PostgrestFilterBuilder = PostgrestRequestBuilder<PostgrestFilterPhase>
+public typealias PostgrestTransformBuilder = PostgrestRequestBuilder<PostgrestTransformPhase>
+
+/// A type-erased PostgREST builder that can execute a request and set per-request
+/// headers/retry behavior, regardless of its concrete phase.
+///
+/// ``PostgrestFilterBuilder`` and ``PostgrestTransformBuilder`` both conform to this
+/// automatically; ``PostgrestQueryBuilder`` does not, since it hasn't had an operation
+/// (`select`/`insert`/`update`/`upsert`/`delete`) applied yet. Use this when you need to accept
+/// "any executable PostgREST builder" regardless of which filter/transform methods were chained
+/// to produce it.
+public protocol PostgrestExecutableBuilder: Sendable {
+  /// See ``PostgrestRequestBuilder/execute(options:)-96tpd``.
+  func execute(options: FetchOptions) async throws -> PostgrestResponse<Void>
+
+  /// See ``PostgrestRequestBuilder/execute(options:)-6mk2u``.
+  func execute<T: Decodable>(options: FetchOptions) async throws -> PostgrestResponse<T>
+}
+
+extension PostgrestRequestBuilder: PostgrestExecutableBuilder
+where Phase: PostgrestExecutablePhase {}
+
+extension PostgrestRequestBuilder where Phase: PostgrestExecutablePhase {
   /// Adds or replaces a custom HTTP header on the request.
   ///
   /// Use this method to attach arbitrary headers — for example, to pass custom PostgREST
@@ -94,33 +158,31 @@ public class PostgrestBuilder: @unchecked Sendable {
   /// - Parameters:
   ///   - name: The header field name.
   ///   - value: The header field value.
-  /// - Returns: The same builder instance so calls can be chained.
-  @discardableResult
+  /// - Returns: The same builder value so calls can be chained.
   public func setHeader(name: String, value: String) -> Self {
-    return self.setHeader(name: .init(name)!, value: value)
+    setHeader(name: .init(name)!, value: value)
   }
 
   /// Set a HTTP header for the request.
-  @discardableResult
-  internal func setHeader(name: HTTPField.Name, value: String) -> Self {
-    mutableState.withValue {
-      $0.request.headers[name] = value
-    }
-    return self
+  func setHeader(name: HTTPField.Name, value: String) -> Self {
+    var copy = self
+    copy.request.headers[name] = value
+    return copy
   }
 
   /// Controls whether automatic retries are enabled for this specific request.
   ///
-  /// When enabled, GET and HEAD requests that receive an HTTP 503 or 520 response, or encounter a
-  /// network error, are retried up to three times with exponential back-off. The global default is
-  /// set via ``PostgrestClient/Configuration/retryEnabled``; this method overrides it per request.
+  /// When enabled, GET and HEAD requests that receive an HTTP 503 or 520 response, or encounter
+  /// a network error, are retried up to three times with exponential back-off. The global
+  /// default is set via ``PostgrestClient/Configuration/retryEnabled``; this method overrides it
+  /// per request.
   ///
   /// - Parameter enabled: Pass `false` to disable retries for this request.
-  /// - Returns: The same builder instance so calls can be chained.
-  @discardableResult
+  /// - Returns: The same builder value so calls can be chained.
   public func retry(enabled: Bool) -> Self {
-    mutableState.withValue { $0.retryEnabled = enabled }
-    return self
+    var copy = self
+    copy.retryEnabled = enabled
+    return copy
   }
 
   /// Executes the request and discards the response body.
@@ -132,7 +194,8 @@ public class PostgrestBuilder: @unchecked Sendable {
   /// - Parameter options: Options controlling whether to include a row count and whether to
   ///   use the HEAD method. Defaults to ``FetchOptions/init(head:count:)``.
   /// - Returns: A ``PostgrestResponse`` whose `value` is `Void`.
-  /// - Throws: ``PostgrestError`` if PostgREST returns an error response, or any error thrown by the fetch handler.
+  /// - Throws: ``PostgrestError`` if PostgREST returns an error response, or any error thrown by
+  ///   the fetch handler.
   @discardableResult
   public func execute(
     options: FetchOptions = FetchOptions()
@@ -153,8 +216,8 @@ public class PostgrestBuilder: @unchecked Sendable {
   /// - Parameter options: Options controlling whether to include a row count and whether to
   ///   use the HEAD method. Defaults to ``FetchOptions/init(head:count:)``.
   /// - Returns: A ``PostgrestResponse`` whose `value` is the decoded `T`.
-  /// - Throws: ``PostgrestError`` if PostgREST returns an error response, a decoding error if the
-  ///   response body cannot be decoded as `T`, or any error thrown by the fetch handler.
+  /// - Throws: ``PostgrestError`` if PostgREST returns an error response, a decoding error if
+  ///   the response body cannot be decoded as `T`, or any error thrown by the fetch handler.
   @discardableResult
   public func execute<T: Decodable>(
     options: FetchOptions = FetchOptions()
@@ -173,13 +236,20 @@ public class PostgrestBuilder: @unchecked Sendable {
     options: FetchOptions,
     decode: @Sendable (Data) throws -> T
   ) async throws -> PostgrestResponse<T> {
-    let (baseRequest, retryEnabled, isMaybeSingle) = try mutableState.withValue {
-      if let message = $0.pendingError {
-        throw PostgrestError(message: message)
-      }
-      return ($0.request, $0.retryEnabled, $0.isMaybeSingle)
+    if let message = pendingError {
+      throw PostgrestError(message: message)
     }
-    var request = baseRequest
+
+    var request = self.request
+
+    // Resolve the access token fresh for every request. An `Authorization` header already set
+    // on the request — whether from `PostgrestClient.Configuration.headers` or from an explicit
+    // `.setHeader("Authorization", ...)` call — always wins over the resolved token.
+    if let accessToken = configuration.accessToken, request.headers[.authorization] == nil {
+      if let token = try await accessToken() {
+        request.headers[.authorization] = "Bearer \(token)"
+      }
+    }
 
     if options.head {
       request.method = .head
@@ -257,10 +327,10 @@ public class PostgrestBuilder: @unchecked Sendable {
     }
   }
 
-  private static let maxDelay = 30.0
-  private static let maxRetries = 3
-  private static let retryableMethods: Set<HTTPTypes.HTTPRequest.Method> = [.get, .head]
-  private static let retryableStatusCodes: Set<Int> = [503, 520]
+  private static var maxDelay: Double { 30.0 }
+  private static var maxRetries: Int { 3 }
+  private static var retryableMethods: Set<HTTPTypes.HTTPRequest.Method> { [.get, .head] }
+  private static var retryableStatusCodes: Set<Int> { [503, 520] }
 
   /// Check if a request should be retried based on method, status code, and error type.
   private func shouldRetry(
@@ -284,7 +354,6 @@ public class PostgrestBuilder: @unchecked Sendable {
   private func retryDelay(attempt: Int) -> TimeInterval {
     min(pow(2.0, Double(attempt)), Self.maxDelay)
   }
-
 }
 
 extension HTTPField.Name {

--- a/Sources/PostgREST/PostgrestRequestBuilder.swift
+++ b/Sources/PostgREST/PostgrestRequestBuilder.swift
@@ -2,7 +2,7 @@
 //  PostgrestRequestBuilder.swift
 //  PostgREST
 //
-//  Created by Guilherme Souza on 20/08/24.
+//  Created by Guilherme Souza on 20/08/26.
 //
 
 import Foundation

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -1,45 +1,10 @@
-import ConcurrencyExtras
 import Foundation
 import HTTPTypes
 
-/// Transformation methods for ordering, pagination, and response format.
-///
-/// ``PostgrestTransformBuilder`` sits between ``PostgrestFilterBuilder`` (WHERE clauses) and
-/// ``PostgrestRequestBuilder/execute(options:)-96tpd`` (sending the request). All transformation
-/// methods narrow the builder to ``PostgrestTransformPhase``, so once you call one you can no
-/// longer filter — only transform further or execute.
-///
-/// ## Topics
-///
-/// ### Returning Modified Rows
-///
-/// - ``select(_:)``
-///
-/// ### Ordering and Pagination
-///
-/// - ``order(_:ascending:nullsFirst:referencedTable:)``
-/// - ``limit(_:referencedTable:)``
-/// - ``range(from:to:referencedTable:)``
-///
-/// ### Response Format
-///
-/// - ``single()``
-/// - ``maybeSingle()``
-/// - ``csv()``
-/// - ``geojson()``
-/// - ``stripNulls()``
-///
-/// ### Query Analysis
-///
-/// - ``explain(analyze:verbose:settings:buffers:wal:format:)``
-///
-/// ### Limiting Affected Rows
-///
-/// - ``maxAffected(_:)``
-///
-/// ### Testing Mutations
-///
-/// - ``dryRun()``
+// The ordering, pagination, and response-format methods available while the request is still in a
+// transformable phase. The overview prose and curated `## Topics` groups for these live on the
+// ``PostgrestTransformBuilder`` type alias in `PostgrestRequestBuilder.swift` — DocC discards doc
+// comments written on `extension` blocks, so a `///` comment here would never be rendered.
 extension PostgrestRequestBuilder where Phase: PostgrestTransformablePhase {
   /// Requests that the server return the modified rows from a write operation.
   ///
@@ -331,8 +296,8 @@ extension PostgrestRequestBuilder where Phase: PostgrestTransformablePhase {
   /// Requires PostgREST v13 or later. Compatible with PATCH, DELETE, and RPC calls only.
   ///
   /// > Note: This method does not validate the HTTP method. Ensure you only use it with
-  /// > ``PostgrestQueryBuilder/update(_:returning:count:)``,
-  /// > ``PostgrestQueryBuilder/delete(returning:count:)``, or
+  /// > ``PostgrestRequestBuilder/update(_:returning:count:)``,
+  /// > ``PostgrestRequestBuilder/delete(returning:count:)``, or
   /// > ``PostgrestClient/rpc(_:params:head:get:count:)``.
   ///
   /// - Parameter value: The maximum number of rows that the operation may affect.

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -2,15 +2,12 @@ import ConcurrencyExtras
 import Foundation
 import HTTPTypes
 
-/// Builder for applying result transformations such as ordering, pagination, and response format.
+/// Transformation methods for ordering, pagination, and response format.
 ///
 /// ``PostgrestTransformBuilder`` sits between ``PostgrestFilterBuilder`` (WHERE clauses) and
-/// ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>`` (sending the request). All transformation methods
-/// return `self` so they can be chained freely.
-///
-/// > Note: Thread Safety: Inherits thread-safe mutable state management from ``PostgrestBuilder``.
-///
-/// > Important: Do not modify the same builder instance from multiple concurrent tasks.
+/// ``PostgrestRequestBuilder/execute(options:)-96tpd`` (sending the request). All transformation
+/// methods narrow the builder to ``PostgrestTransformPhase``, so once you call one you can no
+/// longer filter — only transform further or execute.
 ///
 /// ## Topics
 ///
@@ -43,7 +40,7 @@ import HTTPTypes
 /// ### Testing Mutations
 ///
 /// - ``dryRun()``
-public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
+extension PostgrestRequestBuilder where Phase: PostgrestTransformablePhase {
   /// Requests that the server return the modified rows from a write operation.
   ///
   /// By default, INSERT, UPDATE, UPSERT, and DELETE operations do not return the affected rows.
@@ -61,7 +58,7 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   /// ```
   ///
   /// - Parameter columns: A comma-separated list of columns to retrieve. Defaults to `"*"` (all columns).
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func select(_ columns: String = "*") -> PostgrestTransformBuilder {
     // remove whitespaces except when quoted.
     var quoted = false
@@ -75,11 +72,12 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
       return String(char)
     }
     .joined(separator: "")
-    mutableState.withValue {
-      $0.request.query.appendOrUpdate(URLQueryItem(name: "select", value: cleanedColumns))
-      $0.request.headers.appendOrUpdate(.prefer, value: "return=representation")
-    }
-    return self
+
+    var request = self.request
+    request.query.appendOrUpdate(URLQueryItem(name: "select", value: cleanedColumns))
+    request.headers.appendOrUpdate(.prefer, value: "return=representation")
+
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 
   /// Sorts the query result by the specified column.
@@ -99,32 +97,31 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   ///   - ascending: When `true` (the default), results are sorted ascending (`ASC`).
   ///   - nullsFirst: When `true`, `NULL` values appear before non-null values. Defaults to `false`.
   ///   - referencedTable: The name of an embedded table to order by its columns. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func order(
     _ column: String,
     ascending: Bool = true,
     nullsFirst: Bool = false,
     referencedTable: String? = nil
   ) -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      let key = referencedTable.map { "\($0).order" } ?? "order"
-      let existingOrderIndex = $0.request.query.firstIndex { $0.name == key }
-      let value =
-        "\(column).\(ascending ? "asc" : "desc").\(nullsFirst ? "nullsfirst" : "nullslast")"
+    var request = self.request
+    let key = referencedTable.map { "\($0).order" } ?? "order"
+    let existingOrderIndex = request.query.firstIndex { $0.name == key }
+    let value =
+      "\(column).\(ascending ? "asc" : "desc").\(nullsFirst ? "nullsfirst" : "nullslast")"
 
-      if let existingOrderIndex,
-        let currentValue = $0.request.query[existingOrderIndex].value
-      {
-        $0.request.query[existingOrderIndex] = URLQueryItem(
-          name: key,
-          value: "\(currentValue),\(value)"
-        )
-      } else {
-        $0.request.query.append(URLQueryItem(name: key, value: value))
-      }
+    if let existingOrderIndex,
+      let currentValue = request.query[existingOrderIndex].value
+    {
+      request.query[existingOrderIndex] = URLQueryItem(
+        name: key,
+        value: "\(currentValue),\(value)"
+      )
+    } else {
+      request.query.append(URLQueryItem(name: key, value: value))
     }
 
-    return self
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 
   /// Limits the number of rows returned by the query.
@@ -132,13 +129,12 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   /// - Parameters:
   ///   - count: The maximum number of rows to return.
   ///   - referencedTable: The name of an embedded table to limit instead of the parent table. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func limit(_ count: Int, referencedTable: String? = nil) -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      let key = referencedTable.map { "\($0).limit" } ?? "limit"
-      $0.request.query.appendOrUpdate(URLQueryItem(name: key, value: "\(count)"))
-    }
-    return self
+    var request = self.request
+    let key = referencedTable.map { "\($0).limit" } ?? "limit"
+    request.query.appendOrUpdate(URLQueryItem(name: key, value: "\(count)"))
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 
   /// Returns only the rows within the specified zero-based, inclusive index range.
@@ -160,7 +156,7 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   ///   - from: The zero-based index of the first row to return.
   ///   - to: The zero-based index of the last row to return (inclusive).
   ///   - referencedTable: The name of an embedded table to paginate instead of the parent table. Defaults to `nil`.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func range(
     from: Int,
     to: Int,
@@ -169,14 +165,12 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     let keyOffset = referencedTable.map { "\($0).offset" } ?? "offset"
     let keyLimit = referencedTable.map { "\($0).limit" } ?? "limit"
 
-    mutableState.withValue {
-      $0.request.query.appendOrUpdate(URLQueryItem(name: keyOffset, value: "\(from)"))
+    var request = self.request
+    request.query.appendOrUpdate(URLQueryItem(name: keyOffset, value: "\(from)"))
+    // Range is inclusive, so add 1
+    request.query.appendOrUpdate(URLQueryItem(name: keyLimit, value: "\(to - from + 1)"))
 
-      // Range is inclusive, so add 1
-      $0.request.query.appendOrUpdate(URLQueryItem(name: keyLimit, value: "\(to - from + 1)"))
-    }
-
-    return self
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 
   /// Instructs PostgREST to return a single JSON object instead of an array.
@@ -194,12 +188,11 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   ///   .value
   /// ```
   ///
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func single() -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      $0.request.headers[.accept] = "application/vnd.pgrst.object+json"
-    }
-    return self
+    var request = self.request
+    request.headers[.accept] = "application/vnd.pgrst.object+json"
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 
   /// Instructs PostgREST to return a single JSON object, returning `nil` when no row matches.
@@ -225,13 +218,13 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   ///   .value
   /// ```
   ///
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func maybeSingle() -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      $0.request.headers[.accept] = "application/vnd.pgrst.object+json"
-      $0.isMaybeSingle = true
-    }
-    return self
+    var request = self.request
+    request.headers[.accept] = "application/vnd.pgrst.object+json"
+    var copy = PostgrestTransformBuilder(carryingFrom: self, request: request)
+    copy.isMaybeSingle = true
+    return copy
   }
 
   /// Sets the response format to CSV.
@@ -241,16 +234,15 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   ///
   /// > Note: ``csv()`` cannot be combined with ``stripNulls()``.
   ///
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func csv() -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      let preferComponents = $0.request.headers[.prefer]?.components(separatedBy: ",") ?? []
-      if preferComponents.contains("return=stripped-nulls") {
-        $0.pendingError = "`.csv()` cannot be combined with `.stripNulls()`"
-      }
-      $0.request.headers[.accept] = "text/csv"
+    var copy = PostgrestTransformBuilder(carryingFrom: self, request: self.request)
+    let preferComponents = copy.request.headers[.prefer]?.components(separatedBy: ",") ?? []
+    if preferComponents.contains("return=stripped-nulls") {
+      copy.pendingError = "`.csv()` cannot be combined with `.stripNulls()`"
     }
-    return self
+    copy.request.headers[.accept] = "text/csv"
+    return copy
   }
 
   /// Instructs PostgREST to omit `null` values from the JSON response.
@@ -259,15 +251,14 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   ///
   /// > Note: ``stripNulls()`` cannot be combined with ``csv()``.
   ///
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func stripNulls() -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      if $0.request.headers[.accept] == "text/csv" {
-        $0.pendingError = "`.stripNulls()` cannot be combined with `.csv()`"
-      }
-      $0.request.headers.appendOrUpdate(.prefer, value: "return=stripped-nulls")
+    var copy = PostgrestTransformBuilder(carryingFrom: self, request: self.request)
+    if copy.request.headers[.accept] == "text/csv" {
+      copy.pendingError = "`.stripNulls()` cannot be combined with `.csv()`"
     }
-    return self
+    copy.request.headers.appendOrUpdate(.prefer, value: "return=stripped-nulls")
+    return copy
   }
 
   /// Sets the response format to [GeoJSON](https://geojson.org).
@@ -275,12 +266,11 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   /// Use this when querying geometry or geography columns from a PostGIS-enabled table.
   /// The response is a GeoJSON `FeatureCollection`.
   ///
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func geojson() -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      $0.request.headers[.accept] = "application/geo+json"
-    }
-    return self
+    var request = self.request
+    request.headers[.accept] = "application/geo+json"
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 
   /// Returns the PostgreSQL EXPLAIN plan for the query instead of the query results.
@@ -305,7 +295,7 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   ///   - buffers: When `true`, buffer usage statistics are included (requires `analyze: true`).
   ///   - wal: When `true`, WAL record generation statistics are included (requires `analyze: true`).
   ///   - format: The output format. See ``ExplainFormat``. Defaults to ``ExplainFormat/text``.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func explain(
     analyze: Bool = false,
     verbose: Bool = false,
@@ -314,22 +304,22 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
     wal: Bool = false,
     format: ExplainFormat = .text
   ) -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      let options = [
-        analyze ? "analyze" : nil,
-        verbose ? "verbose" : nil,
-        settings ? "settings" : nil,
-        buffers ? "buffers" : nil,
-        wal ? "wal" : nil,
-      ]
-      .compactMap { $0 }
-      .joined(separator: "|")
-      let forMediaType = $0.request.headers[.accept] ?? "application/json"
-      $0.request.headers[.accept] =
-        "application/vnd.pgrst.plan+\(format.rawValue); for=\"\(forMediaType)\"; options=\(options);"
-    }
+    let options = [
+      analyze ? "analyze" : nil,
+      verbose ? "verbose" : nil,
+      settings ? "settings" : nil,
+      buffers ? "buffers" : nil,
+      wal ? "wal" : nil,
+    ]
+    .compactMap { $0 }
+    .joined(separator: "|")
 
-    return self
+    var request = self.request
+    let forMediaType = request.headers[.accept] ?? "application/json"
+    request.headers[.accept] =
+      "application/vnd.pgrst.plan+\(format.rawValue); for=\"\(forMediaType)\"; options=\(options);"
+
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 
   /// Limits the maximum number of rows that a write operation may affect.
@@ -346,13 +336,12 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   /// > ``PostgrestClient/rpc(_:params:head:get:count:)``.
   ///
   /// - Parameter value: The maximum number of rows that the operation may affect.
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func maxAffected(_ value: Int) -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      $0.request.headers.appendOrUpdate(.prefer, value: "handling=strict")
-      $0.request.headers.appendOrUpdate(.prefer, value: "max-affected=\(value)")
-    }
-    return self
+    var request = self.request
+    request.headers.appendOrUpdate(.prefer, value: "handling=strict")
+    request.headers.appendOrUpdate(.prefer, value: "max-affected=\(value)")
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 
   /// Executes the query but rolls back the transaction instead of committing it.
@@ -375,11 +364,10 @@ public class PostgrestTransformBuilder: PostgrestBuilder, @unchecked Sendable {
   /// // Row is not actually updated in the database.
   /// ```
   ///
-  /// - Returns: The same builder instance so calls can be chained.
+  /// - Returns: A ``PostgrestTransformBuilder`` so calls can be chained.
   public func dryRun() -> PostgrestTransformBuilder {
-    mutableState.withValue {
-      $0.request.headers.appendOrUpdate(.prefer, value: "tx=rollback")
-    }
-    return self
+    var request = self.request
+    request.headers.appendOrUpdate(.prefer, value: "tx=rollback")
+    return PostgrestTransformBuilder(carryingFrom: self, request: request)
   }
 }

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -92,7 +92,7 @@ public struct PostgrestResponse<T> {
 
 /// The algorithm PostgREST uses to count the total number of rows matching a query.
 ///
-/// Pass a ``CountOption`` to query methods such as ``PostgrestQueryBuilder/select(_:head:count:)``
+/// Pass a ``CountOption`` to query methods such as ``PostgrestRequestBuilder/select(_:head:count:)``
 /// or ``PostgrestClient/rpc(_:params:head:get:count:)`` to include a row count in the response.
 ///
 /// The chosen algorithm determines the accuracy vs. performance trade-off:
@@ -136,9 +136,9 @@ public struct CountOption: RawRepresentable, Hashable, Sendable, ExpressibleBySt
 
 /// Controls which rows PostgREST returns after a write operation.
 ///
-/// Pass a ``PostgrestReturningOptions`` value to ``PostgrestQueryBuilder/insert(_:returning:count:)``,
-/// ``PostgrestQueryBuilder/update(_:returning:count:)``, ``PostgrestQueryBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``,
-/// or ``PostgrestQueryBuilder/delete(returning:count:)`` to specify what the server sends back.
+/// Pass a ``PostgrestReturningOptions`` value to ``PostgrestRequestBuilder/insert(_:returning:count:)``,
+/// ``PostgrestRequestBuilder/update(_:returning:count:)``, ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``,
+/// or ``PostgrestRequestBuilder/delete(returning:count:)`` to specify what the server sends back.
 ///
 /// See the [PostgREST documentation](https://postgrest.org/en/v9.0/api.html?highlight=PREFER#insertions-updates)
 /// for more detail.
@@ -172,7 +172,7 @@ public struct PostgrestReturningOptions: RawRepresentable, Hashable, Sendable,
 
 /// The conversion strategy used to turn a plain-text search query into a `tsquery` expression.
 ///
-/// Pass a ``TextSearchType`` to ``PostgrestFilterBuilder/textSearch(_:query:config:type:)`` to
+/// Pass a ``TextSearchType`` to ``PostgrestRequestBuilder/textSearch(_:query:config:type:)`` to
 /// control how user-supplied text is interpreted by PostgreSQL's full-text search engine.
 public struct TextSearchType: RawRepresentable, Hashable, Sendable, ExpressibleByStringLiteral {
   public let rawValue: String
@@ -209,7 +209,7 @@ public struct TextSearchType: RawRepresentable, Hashable, Sendable, ExpressibleB
 
 /// The output format of a PostgREST EXPLAIN plan.
 ///
-/// Pass an ``ExplainFormat`` value to ``PostgrestTransformBuilder/explain(analyze:verbose:settings:buffers:wal:format:)``
+/// Pass an ``ExplainFormat`` value to ``PostgrestRequestBuilder/explain(analyze:verbose:settings:buffers:wal:format:)``
 /// to choose how the query plan is serialized in the response.
 ///
 /// ## Topics
@@ -248,7 +248,7 @@ public struct ExplainFormat: RawRepresentable, Hashable, Sendable {
 
 /// Options for controlling whether the response body is returned and how rows are counted.
 ///
-/// Pass a ``FetchOptions`` value to ``PostgrestRequestBuilder/execute(options:)-96tpd`` (or the
+/// Pass a ``FetchOptions`` value to ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<Void>`` (or the
 /// typed overload) to request a count without fetching data, or to fetch data and a count
 /// simultaneously.
 ///

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -248,8 +248,9 @@ public struct ExplainFormat: RawRepresentable, Hashable, Sendable {
 
 /// Options for controlling whether the response body is returned and how rows are counted.
 ///
-/// Pass a ``FetchOptions`` value to ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>`` (or the typed
-/// overload) to request a count without fetching data, or to fetch data and a count simultaneously.
+/// Pass a ``FetchOptions`` value to ``PostgrestRequestBuilder/execute(options:)-96tpd`` (or the
+/// typed overload) to request a count without fetching data, or to fetch data and a count
+/// simultaneously.
 ///
 /// ```swift
 /// // Fetch only the count, no rows

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -403,9 +403,11 @@ public final class SupabaseClient: Sendable {
   /// A `fetch` closure handed to the REST, Storage and Functions sub-clients.
   ///
   /// Captures only the dependencies it needs — never `self` — because each sub-client stores this
-  /// closure for its whole lifetime while being cached in ``mutableState``. Capturing `self` here
-  /// would form a `self -> mutableState -> sub-client -> closure -> self` retain cycle that keeps
-  /// ``deinit`` from ever running.
+  /// closure for its whole lifetime, and the cached sub-clients (`storage`, `realtimeV2`) are held
+  /// in ``mutableState`` for the lifetime of the client. Capturing `self` here would form a
+  /// `self -> mutableState -> sub-client -> closure -> self` retain cycle that keeps ``deinit`` from
+  /// ever running. `rest` is rebuilt per access and not cached, but it gets the same closure, so the
+  /// no-`self`-capture rule applies uniformly.
   private var fetchWithAuth: @Sendable (_ request: URLRequest) async throws -> (Data, URLResponse) {
     { [session = options.global.session, adapt = adaptRequest] request in
       try await session.data(for: adapt(request))

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -98,21 +98,15 @@ public final class SupabaseClient: Sendable {
   }
 
   var rest: PostgrestClient {
-    mutableState.withValue {
-      if $0.rest == nil {
-        $0.rest = PostgrestClient(
-          url: databaseURL,
-          schema: options.db.schema,
-          headers: headers,
-          logger: options.global.logger,
-          fetch: fetchWithAuth,
-          encoder: options.db.encoder,
-          decoder: options.db.decoder
-        )
-      }
-
-      return $0.rest!
-    }
+    PostgrestClient(
+      url: databaseURL,
+      schema: options.db.schema,
+      headers: headers,
+      logger: options.global.logger,
+      fetch: fetchWithAuth,
+      encoder: options.db.encoder,
+      decoder: options.db.decoder
+    )
   }
 
   /// The Storage client for uploading, downloading, and managing files.
@@ -177,7 +171,6 @@ public final class SupabaseClient: Sendable {
   struct MutableState {
     var listenForAuthEventsTask: Task<Void, Never>?
     var storage: SupabaseStorageClient?
-    var rest: PostgrestClient?
     var realtime: RealtimeClientV2?
 
     var changedAccessToken: String?

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -23,14 +23,14 @@ struct BuildURLRequestTests {
     let record: Bool
     let file: StaticString
     let line: UInt
-    let build: @Sendable (PostgrestClient) async throws -> PostgrestBuilder
+    let build: @Sendable (PostgrestClient) async throws -> any PostgrestExecutableBuilder
 
     init(
       name: String,
       record: Bool = false,
       file: StaticString = #filePath,
       line: UInt = #line,
-      build: @escaping @Sendable (PostgrestClient) async throws -> PostgrestBuilder
+      build: @escaping @Sendable (PostgrestClient) async throws -> any PostgrestExecutableBuilder
     ) {
       self.name = name
       self.record = record
@@ -250,7 +250,7 @@ struct BuildURLRequestTests {
     for testCase in testCases {
       runningTestCase.withValue { $0 = testCase }
       let builder = try await testCase.build(client)
-      _ = try? await builder.execute()
+      _ = try? await builder.execute(options: FetchOptions())
     }
   }
 

--- a/Tests/PostgRESTTests/PostgrestBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestBuilderTests.swift
@@ -35,9 +35,9 @@ extension PostgrestMockerTests {
 
       // Original client object isn't affected
       #expect(
-        postgrest1.from("users").select().mutableState.request.headers[.init("apikey")!] == "foo")
+        postgrest1.from("users").select().request.headers[.init("apikey")!] == "foo")
       // Derived client object uses new header value
-      #expect(postgrest2.mutableState.request.headers[.init("apikey")!] == "bar")
+      #expect(postgrest2.request.headers[.init("apikey")!] == "bar")
     }
 
     @Test
@@ -373,9 +373,10 @@ extension PostgrestMockerTests {
     @Test
     func setHeader() {
       let query = sut.from("users")
+        .select()
         .setHeader(name: "key", value: "value")
 
-      #expect(query.mutableState.request.headers[.init("key")!] == "value")
+      #expect(query.request.headers[.init("key")!] == "value")
     }
 
     // MARK: - Retry tests

--- a/Tests/PostgRESTTests/PostgrestClientAccessTokenTests.swift
+++ b/Tests/PostgRESTTests/PostgrestClientAccessTokenTests.swift
@@ -1,0 +1,125 @@
+//
+//  PostgrestClientAccessTokenTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 19/08/26.
+//
+
+import ConcurrencyExtras
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+@Suite
+struct PostgrestClientAccessTokenTests {
+  let url = URL(string: "http://localhost:54321/rest/v1")!
+
+  private func okResponse(for request: URLRequest) -> (Data, URLResponse) {
+    (
+      Data("[]".utf8),
+      HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    )
+  }
+
+  @Test
+  func accessTokenSetsAuthorizationHeader() async throws {
+    let capturedHeaders = LockIsolated([String: String]())
+
+    let sut = PostgrestClient(
+      url: url,
+      fetch: { request in
+        capturedHeaders.withValue { $0 = request.allHTTPHeaderFields ?? [:] }
+        return self.okResponse(for: request)
+      },
+      accessToken: { "access.token" }
+    )
+
+    try await sut.from("todos").select().execute()
+
+    #expect(capturedHeaders.value["Authorization"] == "Bearer access.token")
+  }
+
+  @Test
+  func accessTokenIsResolvedPerRequest() async throws {
+    let token = LockIsolated("first.token")
+    let capturedAuthorizationHeaders = LockIsolated([String]())
+
+    let sut = PostgrestClient(
+      url: url,
+      fetch: { request in
+        capturedAuthorizationHeaders.withValue {
+          $0.append(request.value(forHTTPHeaderField: "Authorization") ?? "")
+        }
+        return self.okResponse(for: request)
+      },
+      accessToken: { token.value }
+    )
+
+    try await sut.from("todos").select().execute()
+    token.withValue { $0 = "second.token" }
+    try await sut.from("todos").select().execute()
+
+    #expect(capturedAuthorizationHeaders.value == ["Bearer first.token", "Bearer second.token"])
+  }
+
+  @Test
+  func explicitAuthorizationHeaderOverridesAccessToken() async throws {
+    let capturedHeaders = LockIsolated([String: String]())
+
+    let sut = PostgrestClient(
+      url: url,
+      fetch: { request in
+        capturedHeaders.withValue { $0 = request.allHTTPHeaderFields ?? [:] }
+        return self.okResponse(for: request)
+      },
+      accessToken: { "access.token" }
+    )
+
+    try await sut.from("todos")
+      .select()
+      .setHeader(name: "Authorization", value: "Bearer explicit")
+      .execute()
+
+    #expect(capturedHeaders.value["Authorization"] == "Bearer explicit")
+  }
+
+  @Test
+  func accessTokenErrorPropagatesToExecute() async throws {
+    struct TokenError: Error, Equatable {}
+
+    let sut = PostgrestClient(
+      url: url,
+      fetch: { request in
+        Issue.record("fetch should not be called when the access token provider throws")
+        return self.okResponse(for: request)
+      },
+      accessToken: { throw TokenError() }
+    )
+
+    await #expect(throws: TokenError.self) {
+      try await sut.from("todos").select().execute()
+    }
+  }
+
+  @Test
+  func noAccessTokenSendsNoAuthorizationHeader() async throws {
+    let capturedHeaders = LockIsolated([String: String]())
+
+    let sut = PostgrestClient(
+      url: url,
+      fetch: { request in
+        capturedHeaders.withValue { $0 = request.allHTTPHeaderFields ?? [:] }
+        return self.okResponse(for: request)
+      }
+    )
+
+    try await sut.from("todos").select().execute()
+
+    #expect(capturedHeaders.value["Authorization"] == nil)
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
@@ -18,14 +18,14 @@ extension PostgrestMockerTests {
     var url: URL { fixture.url }
     var sut: PostgrestClient { fixture.sut }
 
-    @Test
-    func setAuth() {
-      #expect(sut.configuration.headers["Authorization"] == nil)
-      sut.setAuth("token")
-      #expect(sut.configuration.headers["Authorization"] == "Bearer token")
-
-      sut.setAuth(nil)
-      #expect(sut.configuration.headers["Authorization"] == nil)
+    /// A client whose `Prefer` header is pre-set to `value`, for tests that verify an
+    /// already-present `Prefer` header is merged with the one the query builder adds. Setting it
+    /// this way (instead of `.setHeader(...)` on the query builder before choosing an operation)
+    /// is required now that `PostgrestQueryPhase` doesn't conform to `PostgrestExecutablePhase`.
+    private func sut(withPreferHeader value: String) -> PostgrestClient {
+      var configuration = sut.configuration
+      configuration.headers["Prefer"] = value
+      return PostgrestClient(configuration: configuration)
     }
 
     @Test
@@ -191,9 +191,8 @@ extension PostgrestMockerTests {
       .register()
 
       let count =
-        try await sut
+        try await sut(withPreferHeader: "existing=value")
         .from("users")
-        .setHeader(name: "Prefer", value: "existing=value")
         .select(head: true, count: .exact)
         .execute()
         .count
@@ -297,9 +296,8 @@ extension PostgrestMockerTests {
       }
       .register()
 
-      try await sut
+      try await sut(withPreferHeader: "existing=value")
         .from("users")
-        .setHeader(name: "Prefer", value: "existing=value")
         .insert(User(id: 1, username: "supabase"), returning: .minimal)
         .execute()
     }
@@ -330,9 +328,8 @@ extension PostgrestMockerTests {
       }
       .register()
 
-      try await sut
+      try await sut(withPreferHeader: "existing=value")
         .from("users")
-        .setHeader(name: "Prefer", value: "existing=value")
         .update(["username": "supabase2"], returning: .minimal, count: .planned)
         .eq("id", value: 1)
         .execute()
@@ -364,9 +361,8 @@ extension PostgrestMockerTests {
       }
       .register()
 
-      try await sut
+      try await sut(withPreferHeader: "existing=value")
         .from("users")
-        .setHeader(name: "Prefer", value: "existing=value")
         .upsert(
           [
             User(id: 1, username: "admin"),
@@ -435,9 +431,8 @@ extension PostgrestMockerTests {
       }
       .register()
 
-      try await sut
+      try await sut(withPreferHeader: "existing=value")
         .from("users")
-        .setHeader(name: "Prefer", value: "existing=value")
         .delete(count: .estimated)
         .eq("username", value: "supabase")
         .execute()

--- a/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTransformBuilderTests.swift
@@ -786,5 +786,37 @@ extension PostgrestMockerTests {
         .dryRun()
         .execute()
     }
+
+    @Test
+    func maybeSingleFlagSurvivesALaterTransformCall() async throws {
+      Mock(
+        url: url.appendingPathComponent("users"),
+        ignoreQuery: true,
+        statusCode: 406,
+        data: [
+          .get: Data(
+            """
+            {
+              "code": "PGRST116",
+              "details": "Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row",
+              "message": "JSON object requested, multiple (or no) rows returned"
+            }
+            """.utf8
+          )
+        ]
+      )
+      .register()
+
+      let user: User? =
+        try await sut
+        .from("users")
+        .select()
+        .maybeSingle()
+        .order("id")
+        .execute()
+        .value
+
+      #expect(user == nil)
+    }
   }
 }

--- a/Tests/SupabaseTests/SupabaseClientPostgrestAuthTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientPostgrestAuthTests.swift
@@ -1,0 +1,99 @@
+import ConcurrencyExtras
+import Foundation
+import Testing
+
+@testable import Supabase
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// Single-purpose capturing protocol, deliberately not the shared `RequestCapturingProtocol`:
+/// that's also used by `TracingTests` (a `.serialized` suite that still runs concurrently with
+/// this one), so touching its static storage here would race.
+private final class PostgrestAuthCapturingProtocol: URLProtocol {
+  private static let storage = LockIsolated<URLRequest?>(nil)
+  static var capturedRequest: URLRequest? {
+    get { storage.value }
+    set { storage.setValue(newValue) }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    Self.capturedRequest = request
+    let response = HTTPURLResponse(
+      url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+      headerFields: ["Content-Type": "application/json"]
+    )!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: Data("[]".utf8))
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
+private func makePostgrestAuthCapturingSession() -> URLSession {
+  let config = URLSessionConfiguration.ephemeral
+  config.protocolClasses = [PostgrestAuthCapturingProtocol.self]
+  return URLSession(configuration: config)
+}
+
+/// `.serialized`: the tests below share `PostgrestAuthCapturingProtocol`'s static request log, which
+/// would otherwise race against itself under Swift Testing's default parallel execution. That
+/// storage is private to this file, so — unlike the shared `RequestCapturingProtocol` — no other
+/// suite can race against it.
+///
+/// These pin the design decision in ``SupabaseClient/rest``: it deliberately does *not* pass an
+/// `accessToken` closure into `PostgrestClient.Configuration`, and relies on `fetchWithAuth` to
+/// resolve and inject the live session token on every request instead. Without a test, dropping that
+/// transport-level injection (or adding a stale `Authorization` header to `Configuration.headers`)
+/// would silently send requests as the anon/publishable key.
+@Suite(.serialized)
+struct SupabaseClientPostgrestAuthTests {
+  @Test
+  func restRequestUsesLiveAccessToken() async throws {
+    PostgrestAuthCapturingProtocol.capturedRequest = nil
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        // A custom `accessToken` closure stands in for a real signed-in session, without needing to
+        // drive the full sign-in flow.
+        auth: SupabaseClientOptions.AuthOptions(
+          storage: AuthLocalStorageMock(),
+          accessToken: { "live-session-token" }
+        ),
+        global: SupabaseClientOptions.GlobalOptions(session: makePostgrestAuthCapturingSession())
+      )
+    )
+
+    _ = try await client.from("todos").select().execute()
+
+    let request = try #require(PostgrestAuthCapturingProtocol.capturedRequest)
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer live-session-token")
+  }
+
+  @Test
+  func restRequestWithoutSessionFallsBackToSupabaseKey() async throws {
+    PostgrestAuthCapturingProtocol.capturedRequest = nil
+    let client = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        auth: SupabaseClientOptions.AuthOptions(
+          storage: AuthLocalStorageMock(),
+          autoRefreshToken: false
+        ),
+        global: SupabaseClientOptions.GlobalOptions(session: makePostgrestAuthCapturingSession())
+      )
+    )
+
+    _ = try await client.from("todos").select().execute()
+
+    let request = try #require(PostgrestAuthCapturingProtocol.capturedRequest)
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer PUBLISHABLE_KEY")
+  }
+}

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1281,3 +1281,147 @@ var client: FunctionsClient?
 
 This is a compile error, not a silent behavior change. Search your codebase for `weak`, `unowned`,
 `AnyObject`, or `===` next to a `FunctionsClient` variable to find affected call sites.
+
+## `PostgrestClient.setAuth(_:)` is removed; pass an `accessToken` closure instead
+
+`PostgrestClient.setAuth(_:)` is removed. Every initializer now takes an optional
+`accessToken: (@Sendable () async throws -> String?)?` closure instead. `PostgrestClient` calls it
+fresh before each request and sends the result as `Authorization: Bearer <token>`.
+
+`setAuth` mutated a lock-protected `Authorization` header stored on the client, the same pattern
+`FunctionsClient.setAuth(token:)` went through earlier (see above). Moving to a pull-based closure
+removes that lock and lets a token that expires and refreshes — e.g. one paired with Supabase
+Auth — stay current without a separate setter call on every refresh.
+
+```swift
+// Before
+let client = PostgrestClient(url: url)
+client.setAuth(token)
+
+// After — static token
+let client = PostgrestClient(url: url, accessToken: { token })
+
+// After — refreshable token, e.g. paired with Supabase Auth
+let client = PostgrestClient(url: url, accessToken: { try await auth.session?.accessToken })
+```
+
+This is a compile error, not a silent behavior change: any call site using `setAuth` fails to
+build.
+
+An `Authorization` header already set via `Configuration.headers`, or via an explicit
+`.setHeader("Authorization", ...)` call on a builder, always takes precedence over the
+`accessToken` closure's result.
+
+## `PostgrestClient` and its builders are now structs, not classes
+
+`PostgrestClient`, `PostgrestBuilder`, `PostgrestQueryBuilder`, `PostgrestFilterBuilder`, and
+`PostgrestTransformBuilder` are structs instead of classes. The `setAuth` removal above took away
+`PostgrestClient`'s only mutable, lock-protected state, and the builder types held their own
+per-request state (headers, retry flag, pending-error tracking) the same way. With neither type
+holding mutable shared state anymore, every stored property is now an immutable `let`, and both
+are value types.
+
+Under the hood, `PostgrestBuilder`, `PostgrestQueryBuilder`, `PostgrestFilterBuilder`, and
+`PostgrestTransformBuilder` are now `typealias`es of a single generic `PostgrestRequestBuilder<Phase>`
+type, where `Phase` is a compile-time-only marker that determines which methods are available (see
+the next two sections for what that means for your code).
+
+Calling methods (`from`, `select`, `eq`, `execute`, and friends) compiles unchanged; this only
+breaks code that depended on these types being reference types: a `weak var` holding one, an
+`AnyObject` constraint, or an identity check with `===`. None of those compile against a struct.
+Subclassing any of the builder types is also no longer possible, since none of them are classes
+anymore — this was previously possible because none of the builder classes were `final`.
+
+```swift
+// Before
+weak var client: PostgrestClient?
+
+// After
+// Structs have no identity to hold weakly — keep a strong reference, or drop the field if it only
+// existed to avoid a retain cycle.
+var client: PostgrestClient?
+```
+
+This is a compile error, not a silent behavior change. Search your codebase for `weak`, `unowned`,
+`AnyObject`, `===`, or a subclass declaration next to `PostgrestClient`, `PostgrestBuilder`,
+`PostgrestQueryBuilder`, `PostgrestFilterBuilder`, or `PostgrestTransformBuilder` to find affected
+call sites.
+
+## `PostgrestBuilder` is no longer a nameable, non-generic type
+
+Code that spells out `PostgrestBuilder` as a type — a stored property, a function parameter or
+return type — no longer compiles, since it's now a generic type alias
+(`PostgrestRequestBuilder<Phase>`) without a non-generic supertype. Use the new
+`any PostgrestExecutableBuilder` protocol for "any executable PostgREST builder regardless of
+phase," or name one of the concrete phase-specific type aliases (`PostgrestFilterBuilder`,
+`PostgrestTransformBuilder`) directly:
+
+```swift
+// Before
+func makeUsersQuery(_ client: PostgrestClient) -> PostgrestBuilder {
+  client.from("users").select()
+}
+
+// After
+func makeUsersQuery(_ client: PostgrestClient) -> any PostgrestExecutableBuilder {
+  client.from("users").select()
+}
+
+try await makeUsersQuery(client).execute(options: FetchOptions())
+```
+
+`any PostgrestExecutableBuilder` only exposes `execute(options:)` — it doesn't carry
+`setHeader`/`retry`, since those are declared directly on `PostgrestRequestBuilder<Phase>` and
+constrained to phases conforming to `PostgrestExecutablePhase`, not on the protocol itself. Code
+that needs to call `setHeader`/`retry` generically must keep the concrete phase type instead of
+erasing to `any PostgrestExecutableBuilder`.
+
+This is a compile error, not a silent behavior change.
+
+## `PostgrestQueryBuilder` no longer supports `execute()`/`setHeader(...)`/`retry(...)` before an operation
+
+`client.from("table").execute()` — calling `execute()` (or `setHeader`/`retry`) without first
+calling `select`/`insert`/`update`/`upsert`/`delete` — no longer compiles. This closes a
+previously-compiling but apparently-unused capability; the fix is to call one of those operations
+first:
+
+```swift
+// Before (compiled, but sent an implicit "select *")
+try await client.from("todos").execute()
+
+// After
+try await client.from("todos").select().execute()
+```
+
+This also removes `setHeader(...)` from the builder `from(_:)` returns, before an operation is
+chosen. If you relied on setting a header there — the operation methods (`select`/`insert`/
+`update`/`upsert`/`delete`) merge their own `Prefer` value with whatever the request already
+carries — set it via `PostgrestClient.Configuration.headers` instead. A client-level header
+applies to every request from that client, and the operation methods still merge with it the same
+way:
+
+```swift
+// Before — a Prefer header set on the query-phase builder, merged by select(count:) into
+// "params=single-object,count=exact"
+let client = PostgrestClient(url: url)
+let todos: [Todo] = try await client
+  .from("todos")
+  .setHeader(name: "Prefer", value: "params=single-object")
+  .select(count: .exact)
+  .execute()
+  .value
+
+// After — set the Prefer header at the client level; select(count:) still merges it
+let client = PostgrestClient(
+  url: url,
+  headers: ["Prefer": "params=single-object"]
+)
+let todos: [Todo] = try await client
+  .from("todos")
+  .select(count: .exact)
+  .execute()
+  .value
+```
+
+This is a compile error, not a silent behavior change: any call site chaining `execute`/
+`setHeader`/`retry` directly onto `from(_:)` fails to build.

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1302,7 +1302,7 @@ client.setAuth(token)
 let client = PostgrestClient(url: url, accessToken: { token })
 
 // After — refreshable token, e.g. paired with Supabase Auth
-let client = PostgrestClient(url: url, accessToken: { try await auth.session?.accessToken })
+let client = PostgrestClient(url: url, accessToken: { try await auth.session.accessToken })
 ```
 
 This is a compile error, not a silent behavior change: any call site using `setAuth` fails to
@@ -1316,10 +1316,11 @@ An `Authorization` header already set via `Configuration.headers`, or via an exp
 
 `PostgrestClient`, `PostgrestBuilder`, `PostgrestQueryBuilder`, `PostgrestFilterBuilder`, and
 `PostgrestTransformBuilder` are structs instead of classes. The `setAuth` removal above took away
-`PostgrestClient`'s only mutable, lock-protected state, and the builder types held their own
-per-request state (headers, retry flag, pending-error tracking) the same way. With neither type
-holding mutable shared state anymore, every stored property is now an immutable `let`, and both
-are value types.
+`PostgrestClient`'s only mutable, lock-protected state, so every one of its stored properties is
+now an immutable `let`. The builder types held their own per-request state (headers, retry flag,
+pending-error tracking) the same lock-protected way; removing that lock made them structs too, but
+they still have `var` stored properties — each chained call (`select`, `eq`, `setHeader`, ...)
+copies `self`, mutates the copy, and returns it, rather than mutating shared state in place.
 
 Under the hood, `PostgrestBuilder`, `PostgrestQueryBuilder`, `PostgrestFilterBuilder`, and
 `PostgrestTransformBuilder` are now `typealias`es of a single generic `PostgrestRequestBuilder<Phase>`

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1048,6 +1048,11 @@ it now prints the struct's default description (`PostgrestFilterBuilder.Operator
 If you log, build a URL, or send analytics using direct interpolation of a
 `PostgrestFilterBuilder.Operator` value, use `.rawValue` explicitly to get the bare string back.
 
+The operator type is now declared at the top level as `PostgrestOperator`, with
+`PostgrestFilterBuilder.Operator` kept as a type alias for it — so every spelling above keeps
+working, and diagnostics that mention `PostgrestOperator` are referring to the same type. Nothing to
+change; this is additive.
+
 ## `CountOption` is now a struct, not an enum
 
 `CountOption` (passed to query methods like `select(_:head:count:)`) is a `RawRepresentable`
@@ -1314,7 +1319,7 @@ An `Authorization` header already set via `Configuration.headers`, or via an exp
 
 ## `PostgrestClient` and its builders are now structs, not classes
 
-`PostgrestClient`, `PostgrestBuilder`, `PostgrestQueryBuilder`, `PostgrestFilterBuilder`, and
+`PostgrestClient`, `PostgrestQueryBuilder`, `PostgrestFilterBuilder`, and
 `PostgrestTransformBuilder` are structs instead of classes. The `setAuth` removal above took away
 `PostgrestClient`'s only mutable, lock-protected state, so every one of its stored properties is
 now an immutable `let`. The builder types held their own per-request state (headers, retry flag,
@@ -1322,10 +1327,11 @@ pending-error tracking) the same lock-protected way; removing that lock made the
 they still have `var` stored properties — each chained call (`select`, `eq`, `setHeader`, ...)
 copies `self`, mutates the copy, and returns it, rather than mutating shared state in place.
 
-Under the hood, `PostgrestBuilder`, `PostgrestQueryBuilder`, `PostgrestFilterBuilder`, and
-`PostgrestTransformBuilder` are now `typealias`es of a single generic `PostgrestRequestBuilder<Phase>`
-type, where `Phase` is a compile-time-only marker that determines which methods are available (see
-the next two sections for what that means for your code).
+Under the hood, `PostgrestQueryBuilder`, `PostgrestFilterBuilder`, and `PostgrestTransformBuilder`
+are now `typealias`es of a single generic `PostgrestRequestBuilder<Phase>` type, where `Phase` is a
+compile-time-only marker that determines which methods are available. `PostgrestBuilder` has no
+replacement name at all — it was removed outright (see the next two sections for what that means for
+your code).
 
 Calling methods (`from`, `select`, `eq`, `execute`, and friends) compiles unchanged; this only
 breaks code that depended on these types being reference types: a `weak var` holding one, an
@@ -1351,8 +1357,8 @@ call sites.
 ## `PostgrestBuilder` is no longer a nameable, non-generic type
 
 Code that spells out `PostgrestBuilder` as a type — a stored property, a function parameter or
-return type — no longer compiles, since it's now a generic type alias
-(`PostgrestRequestBuilder<Phase>`) without a non-generic supertype. Use the new
+return type — no longer compiles. The type was removed outright: there is no `PostgrestBuilder`
+type alias, and no non-generic supertype shared by the phase-specific builders. Use the new
 `any PostgrestExecutableBuilder` protocol for "any executable PostgREST builder regardless of
 phase," or name one of the concrete phase-specific type aliases (`PostgrestFilterBuilder`,
 `PostgrestTransformBuilder`) directly:
@@ -1368,7 +1374,9 @@ func makeUsersQuery(_ client: PostgrestClient) -> any PostgrestExecutableBuilder
   client.from("users").select()
 }
 
-try await makeUsersQuery(client).execute(options: FetchOptions())
+// `PostgrestExecutableBuilder.execute(options:)` is a protocol requirement, so it can't carry
+// `@discardableResult` — bind or use the result to avoid an "unused result" warning.
+_ = try await makeUsersQuery(client).execute(options: FetchOptions())
 ```
 
 `any PostgrestExecutableBuilder` only exposes `execute(options:)` — it doesn't carry
@@ -1426,3 +1434,32 @@ let todos: [Todo] = try await client
 
 This is a compile error, not a silent behavior change: any call site chaining `execute`/
 `setHeader`/`retry` directly onto `from(_:)` fails to build.
+
+## `setHeader(name:value:)` and `retry(enabled:)` no longer carry `@discardableResult`
+
+> Warning: This is the one PostgREST item on this page that is **not** a compile error. It is a
+> warning you can miss.
+
+When the builders were classes, `setHeader(name:value:)` and `retry(enabled:)` mutated the receiver
+in place and returned `self` only for chaining convenience, so both were marked
+`@discardableResult`. Now that the builders are structs, both methods return a **new** value and
+leave the receiver untouched. `@discardableResult` was therefore removed: dropping the return value
+would silently drop the header or the retry setting.
+
+```swift
+// Before — mutated `q` in place, chained call not required
+let q = client.from("todos").select()
+q.setHeader(name: "X-Foo", value: "1")
+try await q.execute()
+
+// After — setHeader/retry return a NEW value; you must use the result
+var q = client.from("todos").select()
+q = q.setHeader(name: "X-Foo", value: "1")
+try await q.execute()
+```
+
+The "before" spelling still compiles. It produces a `result of call to 'setHeader(name:value:)' is
+unused` warning instead of an error, and at runtime the header (or the `retry(enabled:)` setting) is
+simply not applied. Search your codebase for `setHeader(` and `retry(enabled:` on a PostgREST
+builder and make sure every call site consumes the returned value — either by chaining directly onto
+it or by reassigning, as above.

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -30,6 +30,77 @@ supporting_symbols:
   - JSONValue.description
   - JSONValue.rawValue
 
+  # PostgrestBuilder/PostgrestQueryBuilder/PostgrestFilterBuilder/PostgrestTransformBuilder
+  # were replaced by a single generic PostgrestRequestBuilder<Phase> (see the stateless
+  # PostgREST client/builders refactor, PR #1240). Its members implement several already-
+  # `implemented` database.* capabilities above simultaneously (filtering, transforming,
+  # executing), so they're listed here rather than attributed to one feature.
+  - PostgrestClient.Configuration.accessToken
+  - PostgrestExecutableBuilder
+  - PostgrestExecutableBuilder.execute
+  - PostgrestExecutablePhase
+  - PostgrestFilterPhase
+  - PostgrestFilterablePhase
+  - PostgrestQueryPhase
+  - PostgrestRequestBuilder
+  - PostgrestRequestBuilder.Operator
+  - PostgrestRequestBuilder.containedBy
+  - PostgrestRequestBuilder.contains
+  - PostgrestRequestBuilder.csv
+  - PostgrestRequestBuilder.eq
+  - PostgrestRequestBuilder.equals
+  - PostgrestRequestBuilder.execute
+  - PostgrestRequestBuilder.explain
+  - PostgrestRequestBuilder.filter
+  - PostgrestRequestBuilder.fts
+  - PostgrestRequestBuilder.fullTextSearch
+  - PostgrestRequestBuilder.geojson
+  - PostgrestRequestBuilder.greaterThan
+  - PostgrestRequestBuilder.greaterThanOrEquals
+  - PostgrestRequestBuilder.gt
+  - PostgrestRequestBuilder.gte
+  - PostgrestRequestBuilder.iLikeAllOf
+  - PostgrestRequestBuilder.iLikeAnyOf
+  - PostgrestRequestBuilder.ilike
+  - PostgrestRequestBuilder.imatch
+  - PostgrestRequestBuilder.in
+  - PostgrestRequestBuilder.is
+  - PostgrestRequestBuilder.isDistinct
+  - PostgrestRequestBuilder.like
+  - PostgrestRequestBuilder.likeAllOf
+  - PostgrestRequestBuilder.likeAnyOf
+  - PostgrestRequestBuilder.limit
+  - PostgrestRequestBuilder.lowerThan
+  - PostgrestRequestBuilder.lowerThanOrEquals
+  - PostgrestRequestBuilder.lt
+  - PostgrestRequestBuilder.lte
+  - PostgrestRequestBuilder.match
+  - PostgrestRequestBuilder.maxAffected
+  - PostgrestRequestBuilder.neq
+  - PostgrestRequestBuilder.notEquals
+  - PostgrestRequestBuilder.or
+  - PostgrestRequestBuilder.order
+  - PostgrestRequestBuilder.overlaps
+  - PostgrestRequestBuilder.phraseToFullTextSearch
+  - PostgrestRequestBuilder.plainToFullTextSearch
+  - PostgrestRequestBuilder.range
+  - PostgrestRequestBuilder.rangeAdjacent
+  - PostgrestRequestBuilder.rangeGreaterThan
+  - PostgrestRequestBuilder.rangeGreaterThanOrEquals
+  - PostgrestRequestBuilder.rangeGt
+  - PostgrestRequestBuilder.rangeGte
+  - PostgrestRequestBuilder.rangeLowerThan
+  - PostgrestRequestBuilder.rangeLowerThanOrEquals
+  - PostgrestRequestBuilder.rangeLt
+  - PostgrestRequestBuilder.rangeLte
+  - PostgrestRequestBuilder.retry
+  - PostgrestRequestBuilder.setHeader
+  - PostgrestRequestBuilder.single
+  - PostgrestRequestBuilder.stripNulls
+  - PostgrestRequestBuilder.webFullTextSearch
+  - PostgrestTransformPhase
+  - PostgrestTransformablePhase
+
 features:
 
   # ── Auth ───────────────────────────────────────────────────────────────────
@@ -452,7 +523,7 @@ features:
   database.query.select:
     status: implemented
     symbols:
-      - PostgrestQueryBuilder.select
+      - PostgrestRequestBuilder.select
     supporting_symbols:
       - CountOption
       - CountOption.init
@@ -470,10 +541,10 @@ features:
   database.mutate.select_after_mutation:
     status: implemented
     symbols:
-      - PostgrestQueryBuilder.insert
-      - PostgrestQueryBuilder.update
-      - PostgrestQueryBuilder.upsert
-      - PostgrestQueryBuilder.delete
+      - PostgrestRequestBuilder.insert
+      - PostgrestRequestBuilder.update
+      - PostgrestRequestBuilder.upsert
+      - PostgrestRequestBuilder.delete
     supporting_symbols:
       - PostgrestReturningOptions
       - PostgrestReturningOptions.init
@@ -502,7 +573,7 @@ features:
   database.using_filters.text_search:
     status: implemented
     symbols:
-      - PostgrestFilterBuilder.textSearch
+      - PostgrestRequestBuilder.textSearch
     supporting_symbols:
       - TextSearchType
       - TextSearchType.init
@@ -514,36 +585,36 @@ features:
   database.using_filters.not:
     status: implemented
     symbols:
-      - PostgrestFilterBuilder.not
+      - PostgrestRequestBuilder.not
     supporting_symbols:
-      - PostgrestFilterBuilder.Operator
-      - PostgrestFilterBuilder.Operator.init
-      - PostgrestFilterBuilder.Operator.rawValue
-      - PostgrestFilterBuilder.Operator.eq
-      - PostgrestFilterBuilder.Operator.neq
-      - PostgrestFilterBuilder.Operator.gt
-      - PostgrestFilterBuilder.Operator.gte
-      - PostgrestFilterBuilder.Operator.lt
-      - PostgrestFilterBuilder.Operator.lte
-      - PostgrestFilterBuilder.Operator.like
-      - PostgrestFilterBuilder.Operator.ilike
-      - PostgrestFilterBuilder.Operator.match
-      - PostgrestFilterBuilder.Operator.imatch
-      - PostgrestFilterBuilder.Operator.is
-      - PostgrestFilterBuilder.Operator.isdistinct
-      - PostgrestFilterBuilder.Operator.in
-      - PostgrestFilterBuilder.Operator.cs
-      - PostgrestFilterBuilder.Operator.cd
-      - PostgrestFilterBuilder.Operator.sl
-      - PostgrestFilterBuilder.Operator.sr
-      - PostgrestFilterBuilder.Operator.nxl
-      - PostgrestFilterBuilder.Operator.nxr
-      - PostgrestFilterBuilder.Operator.adj
-      - PostgrestFilterBuilder.Operator.ov
-      - PostgrestFilterBuilder.Operator.fts
-      - PostgrestFilterBuilder.Operator.plfts
-      - PostgrestFilterBuilder.Operator.phfts
-      - PostgrestFilterBuilder.Operator.wfts
+      - PostgrestOperator
+      - PostgrestOperator.init
+      - PostgrestOperator.rawValue
+      - PostgrestOperator.eq
+      - PostgrestOperator.neq
+      - PostgrestOperator.gt
+      - PostgrestOperator.gte
+      - PostgrestOperator.lt
+      - PostgrestOperator.lte
+      - PostgrestOperator.like
+      - PostgrestOperator.ilike
+      - PostgrestOperator.match
+      - PostgrestOperator.imatch
+      - PostgrestOperator.is
+      - PostgrestOperator.isdistinct
+      - PostgrestOperator.in
+      - PostgrestOperator.cs
+      - PostgrestOperator.cd
+      - PostgrestOperator.sl
+      - PostgrestOperator.sr
+      - PostgrestOperator.nxl
+      - PostgrestOperator.nxr
+      - PostgrestOperator.adj
+      - PostgrestOperator.ov
+      - PostgrestOperator.fts
+      - PostgrestOperator.plfts
+      - PostgrestOperator.phfts
+      - PostgrestOperator.wfts
   database.using_filters.or: implemented
   database.using_filters.raw: implemented
   database.using_filters.regex: implemented
@@ -552,7 +623,7 @@ features:
   database.using_filters.not_in:
     status: implemented
     symbols:
-      - PostgrestFilterBuilder.notIn
+      - PostgrestRequestBuilder.notIn
   database.using_filters.like_all: implemented
   database.using_filters.like_any: implemented
   database.using_filters.ilike_all: implemented
@@ -565,7 +636,7 @@ features:
   database.using_modifiers.maybe_single_row:
     status: implemented
     symbols:
-      - PostgrestTransformBuilder.maybeSingle
+      - PostgrestRequestBuilder.maybeSingle
   database.using_modifiers.strip_nulls: implemented
   database.using_modifiers.format_csv: implemented
   database.using_modifiers.format_geojson: implemented
@@ -581,7 +652,7 @@ features:
   database.using_modifiers.dry_run:
     status: implemented
     symbols:
-      - PostgrestTransformBuilder.dryRun
+      - PostgrestRequestBuilder.dryRun
 
   database.configuration.auto_retry: implemented
   database.configuration.request_timeout: not_implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -30,11 +30,9 @@ supporting_symbols:
   - JSONValue.description
   - JSONValue.rawValue
 
-  # PostgrestBuilder/PostgrestQueryBuilder/PostgrestFilterBuilder/PostgrestTransformBuilder
-  # were replaced by a single generic PostgrestRequestBuilder<Phase> (see the stateless
-  # PostgREST client/builders refactor, PR #1240). Its members implement several already-
-  # `implemented` database.* capabilities above simultaneously (filtering, transforming,
-  # executing), so they're listed here rather than attributed to one feature.
+  # PostgrestRequestBuilder<Phase>'s members implement several already-`implemented`
+  # database.* capabilities above simultaneously (filtering, transforming, executing),
+  # rather than owned by a single feature.
   - PostgrestClient.Configuration.accessToken
   - PostgrestExecutableBuilder
   - PostgrestExecutableBuilder.execute


### PR DESCRIPTION
## Summary

- Replaces `PostgrestClient` and the `PostgrestBuilder`/`PostgrestQueryBuilder`/`PostgrestFilterBuilder`/`PostgrestTransformBuilder` class hierarchy with stateless value types: a single generic `PostgrestRequestBuilder<Phase>` struct, with phantom-typed phases (`PostgrestQueryPhase`/`PostgrestFilterPhase`/`PostgrestTransformPhase`) and protocol-refinement-based conditional conformance (`PostgrestExecutablePhase` ⊂ `PostgrestTransformablePhase` ⊂ `PostgrestFilterablePhase`) encoding the builder phase graph at compile time. `PostgrestQueryBuilder`/`PostgrestFilterBuilder`/`PostgrestTransformBuilder` remain directly nameable via `typealias`.
- `PostgrestClient.setAuth(_:)` is removed in favor of a constructor-injected `accessToken` closure resolved fresh per request, mirroring the `FunctionsClient` stateless refactor (#1233).
- `SupabaseClient.rest` no longer memoizes a `PostgrestClient` (nothing left to cache once it holds no mutable state), mirroring `.functions`.
- Closes a previously-compiling loophole: `.from(table).execute()`/`.setHeader(...)`/`.retry(...)` without first choosing an operation (`select`/`insert`/`update`/`upsert`/`delete`) no longer compiles.
- `V3_MIGRATION.md` documents all breaking changes with before/after examples.

Design spec and implementation plan (brainstormed, planned, and executed via subagent-driven-development — 5 tasks, each individually reviewed, plus a final whole-branch review that found and fixed a DocC regression and a couple of migration-doc inaccuracies) are not included in this PR — they lived under the repo's gitignored `docs/superpowers/` scratch directory.

## Test plan

- [x] `swift build` — clean, no new warnings
- [x] `swift test` — full suite green: 1187 tests, 118 suites, 9 pre-existing known issues (unchanged)
- [x] `PLATFORM=IOS ./scripts/xcodebuild.sh` (Examples target) — green, 157 tests
- [x] `xcodebuild clean docbuild -scheme Supabase` — verified 0 branch-introduced unresolved doc links (was 29 mid-review), all builder typealiases render real DocC pages
- [x] `./scripts/spell-check.sh` — clean
- [x] `./scripts/format.sh` — clean