### PR TITLE
fix(docs): match DocC's current warning phrasing and fix stale symbol links

### DIFF
--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -29,10 +29,6 @@ import HTTPTypes
 ///
 /// ### OAuth 2.1 clients
 /// - ``oauth``
-///
-/// ### Passkeys
-/// - ``listPasskeys(userId:)``
-/// - ``deletePasskey(userId:passkeyId:)``
 public struct AuthAdmin: Sendable {
   let clientID: AuthClientID
 

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -815,7 +815,7 @@ public actor AuthClient {
   }
 
   #if canImport(AuthenticationServices)
-    /// Sign-in an existing user via a third-party provider using ``ASWebAuthenticationSession``.
+    /// Sign-in an existing user via a third-party provider using `ASWebAuthenticationSession`.
     ///
     /// - Parameters:
     ///   - provider: The third-party provider.
@@ -823,7 +823,7 @@ public actor AuthClient {
     ///   - scopes: A space-separated list of scopes granted to the OAuth application.
     ///   - queryParams: Additional query params.
     ///   - configure: A configuration closure that you can use to customize the internal
-    /// ``ASWebAuthenticationSession`` object.
+    /// `ASWebAuthenticationSession` object.
     ///
     /// - Note: This method support the PKCE flow.
     /// - Warning: Do not call `start()` on the `ASWebAuthenticationSession` object inside the

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1145,7 +1145,7 @@ public struct MFAVerifyParams: Encodable, Hashable {
   public let challengeId: String
 
   /// Verification code provided by the user. Used for `totp` and `phone` factors; empty for
-  /// `webauthn` factors (which use ``credentialResponse`` instead).
+  /// `webauthn` factors (which use `credentialResponse` instead).
   public let code: String
 
   /// The W3C credential (assertion) response produced by the authenticator. Used for `webauthn`
@@ -2140,7 +2140,7 @@ public struct JWTClaims: Decodable, Hashable, Sendable {
   /// User metadata.
   public let userMetadata: [String: JSONValue]?
 
-  /// Any claims not recognized by the standard set of ``CodingKeys``.
+  /// Any claims not recognized by the standard set of `CodingKeys`.
   public var additionalClaims: [String: JSONValue] = [:]
 
   enum CodingKeys: String, CodingKey {

--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -11,7 +11,7 @@ let version = Helpers.version
 
 /// A client for invoking Supabase Edge Functions.
 ///
-/// Obtain an instance from ``SupabaseClient/functions`` rather than creating one directly.
+/// Obtain an instance from `SupabaseClient.functions` rather than creating one directly.
 ///
 /// ```swift
 /// // Invoke and decode a response
@@ -27,14 +27,13 @@ let version = Helpers.version
 /// ## Topics
 ///
 /// ### Creating a Client
-/// - ``init(url:headers:region:logger:fetch:decoder:accessToken:)``
+/// - ``init(url:headers:region:logger:fetch:decoder:accessToken:)-(_,_,FunctionRegion?,_,_,_,_)``
 /// - ``FetchHandler``
 ///
 /// ### Invoking Functions
 /// - ``invoke(_:options:decode:)``
 /// - ``invoke(_:options:decoder:)``
 /// - ``invoke(_:options:)``
-/// - ``_invokeWithStreamedResponse(_:options:)``
 ///
 /// ### Configuration
 /// - ``decoder``
@@ -48,7 +47,7 @@ public struct FunctionsClient: Sendable {
 
   /// The maximum time an Edge Function may run before the gateway returns a 504 error (150 seconds).
   ///
-  /// Can be overridden per-invocation via ``FunctionInvokeOptions/timeoutInterval``.
+  /// Can be overridden per-invocation via ``FunctionInvokeOptions/init(method:headers:region:timeoutInterval:)``.
   public static let requestIdleTimeout: TimeInterval = 150
 
   /// The base URL for the functions.

--- a/Sources/Helpers/JSONValue/JSONValue+Codable.swift
+++ b/Sources/Helpers/JSONValue/JSONValue+Codable.swift
@@ -16,7 +16,7 @@ extension JSONValue {
 }
 
 extension JSONValue {
-  /// Initialize an ``JSONValue`` from an ``Encodable`` value.
+  /// Initialize an ``JSONValue`` from an `Encodable` value.
   public init(_ value: some Encodable) throws {
     if let value = value as? JSONValue {
       self = value

--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -9,7 +9,7 @@ import Logging
 
 /// The base builder class for all PostgREST requests.
 ///
-/// ``PostgrestBuilder`` holds the shared HTTP request state and provides the ``execute(options:)-96tpd``
+/// ``PostgrestBuilder`` holds the shared HTTP request state and provides the ``execute(options:)->PostgrestResponse<Void>``
 /// methods that send the request to the PostgREST server. You typically interact with one of its
 /// subclasses — ``PostgrestQueryBuilder``, ``PostgrestFilterBuilder``, or
 /// ``PostgrestTransformBuilder`` — rather than instantiating ``PostgrestBuilder`` directly.
@@ -32,8 +32,8 @@ import Logging
 ///
 /// ### Executing the Request
 ///
-/// - ``execute(options:)-96tpd``
-/// - ``execute(options:)-6mk2u``
+/// - ``execute(options:)->PostgrestResponse<Void>``
+/// - ``execute(options:)->PostgrestResponse<T>``
 public class PostgrestBuilder: @unchecked Sendable {
   /// The configuration for the PostgREST client.
   let configuration: PostgrestClient.Configuration

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -81,7 +81,7 @@ public final class PostgrestClient: Sendable {
   ///
   /// Create a ``Configuration`` value and pass it to ``PostgrestClient/init(configuration:)`` when
   /// you need fine-grained control over the client, such as supplying a custom ``FetchHandler`` or
-  /// ``JSONEncoder``/``JSONDecoder``.
+  /// ``jsonEncoder``/``jsonDecoder``.
   ///
   /// ## Topics
   ///

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -7,7 +7,7 @@ import Helpers
 /// Obtain a ``PostgrestFilterBuilder`` from ``PostgrestQueryBuilder/select(_:head:count:)``,
 /// ``PostgrestQueryBuilder/insert(_:returning:count:)``, ``PostgrestQueryBuilder/update(_:returning:count:)``,
 /// or other write methods. Chain one or more filter methods, then call
-/// ``PostgrestBuilder/execute(options:)-96tpd`` to send the request.
+/// ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>`` to send the request.
 ///
 /// All filter methods return `self` so they can be freely chained:
 ///
@@ -36,7 +36,7 @@ import Helpers
 /// - ``isDistinct(_:value:)``
 /// - ``in(_:values:)``
 /// - ``notIn(_:values:)``
-/// - ``match(_:)-6h9ou``
+/// - ``match(_:)``
 ///
 /// ### Comparison Filters
 ///
@@ -53,7 +53,7 @@ import Helpers
 /// - ``ilike(_:pattern:)``
 /// - ``iLikeAllOf(_:patterns:)``
 /// - ``iLikeAnyOf(_:patterns:)``
-/// - ``match(_:pattern:)-9qlv5``
+/// - ``match(_:pattern:)``
 /// - ``imatch(_:pattern:)``
 ///
 /// ### Array and Range Filters

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -256,7 +256,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   /// suppress this, pass `.minimal` as `returning`.
   ///
   /// > Important: Omitting a filter will update **all rows** in the table. Always chain
-  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestBuilder/execute(options:)-96tpd``.
+  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>``.
   ///
   /// ```swift
   /// try await client
@@ -301,7 +301,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder, @unchecked Sendable 
   /// suppress this, pass `.minimal` as `returning`.
   ///
   /// > Important: Omitting a filter will delete **all rows** in the table. Always chain
-  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestBuilder/execute(options:)-96tpd``.
+  /// > a filter such as ``PostgrestFilterBuilder/eq(_:value:)`` before calling ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>``.
   ///
   /// ```swift
   /// try await client

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -5,7 +5,7 @@ import HTTPTypes
 /// Builder for applying result transformations such as ordering, pagination, and response format.
 ///
 /// ``PostgrestTransformBuilder`` sits between ``PostgrestFilterBuilder`` (WHERE clauses) and
-/// ``PostgrestBuilder/execute(options:)-96tpd`` (sending the request). All transformation methods
+/// ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>`` (sending the request). All transformation methods
 /// return `self` so they can be chained freely.
 ///
 /// > Note: Thread Safety: Inherits thread-safe mutable state management from ``PostgrestBuilder``.

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -248,7 +248,7 @@ public struct ExplainFormat: RawRepresentable, Hashable, Sendable {
 
 /// Options for controlling whether the response body is returned and how rows are counted.
 ///
-/// Pass a ``FetchOptions`` value to ``PostgrestBuilder/execute(options:)-96tpd`` (or the typed
+/// Pass a ``FetchOptions`` value to ``PostgrestBuilder/execute(options:)->PostgrestResponse<Void>`` (or the typed
 /// overload) to request a count without fetching data, or to fetch data and a count simultaneously.
 ///
 /// ```swift

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -20,7 +20,6 @@ import Logging
   }
 #endif
 
-// cspell:ignore pvzp hhoc cnrp
 /// Configuration for a ``RealtimeChannelV2``.
 ///
 /// Pass a builder closure to ``RealtimeClientV2/channel(_:options:)`` to customize
@@ -86,11 +85,11 @@ protocol RealtimeChannelProtocol: AnyObject, Sendable {
 /// - ``subscribeWithError()``
 /// - ``unsubscribe()``
 /// ### Broadcasting
-/// - ``broadcast(event:message:)-7xyf5``
-/// - ``broadcast(event:message:)-2pvzp``
+/// - ``broadcast(event:message:)-(_,Codable)``
+/// - ``broadcast(event:message:)-(_,JSONObject)``
 /// - ``broadcast(event:data:)``
-/// - ``httpSend(event:message:timeout:)-8v03n``
-/// - ``httpSend(event:message:timeout:)-5hhoc``
+/// - ``httpSend(event:message:timeout:)-(_,Codable,_)``
+/// - ``httpSend(event:message:timeout:)-(_,JSONObject,_)``
 /// - ``httpSend(event:data:timeout:)``
 /// ### Presence
 /// - ``track(_:)``
@@ -98,16 +97,16 @@ protocol RealtimeChannelProtocol: AnyObject, Sendable {
 /// - ``untrack()``
 /// - ``onPresenceChange(_:)``
 /// ### Postgres Changes
-/// - ``onPostgresChange(_:schema:table:filter:callback:)-8kn76``
-/// - ``onPostgresChange(_:schema:table:filter:callback:)-1j0l6``
-/// - ``onPostgresChange(_:schema:table:filter:callback:)-9c5h2``
-/// - ``onPostgresChange(_:schema:table:filter:callback:)-7srl6``
+/// - ``onPostgresChange(_:schema:table:filter:select:callback:)-(AnyAction.Type,_,_,RealtimePostgresFilter?,_,_)``
+/// - ``onPostgresChange(_:schema:table:filter:select:callback:)-(InsertAction.Type,_,_,RealtimePostgresFilter?,_,_)``
+/// - ``onPostgresChange(_:schema:table:filter:select:callback:)-(UpdateAction.Type,_,_,RealtimePostgresFilter?,_,_)``
+/// - ``onPostgresChange(_:schema:table:filter:select:callback:)-(DeleteAction.Type,_,_,RealtimePostgresFilter?,_,_)``
 /// ### Broadcast Events
 /// - ``onBroadcast(event:callback:)``
 /// - ``onBroadcastData(event:callback:)``
 /// ### System Events
-/// - ``onSystem(callback:)-7cnrp``
-/// - ``onSystem(callback:)-7cno3``
+/// - ``onSystem(callback:)-((RealtimeMessageV2)->Void)``
+/// - ``onSystem(callback:)-(()->Void)``
 public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// The fully-qualified topic string sent to the Realtime server (e.g. `"realtime:room:lobby"`).
   public let topic: String
@@ -220,7 +219,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// All callbacks (broadcast, presence, postgres changes) must be registered before calling
   /// this method. Calling it more than once on an already-subscribed channel is a no-op.
   ///
-  /// - Throws: A ``RealtimeError`` if the subscribe attempt fails or times out.
+  /// - Throws: A `RealtimeError` if the subscribe attempt fails or times out.
   public func subscribeWithError() async throws {
     logger.debug("Subscribe requested for channel '\(topic)'")
     try await stateManager.subscribe()
@@ -278,7 +277,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   ///   - event: The broadcast event name.
   ///   - message: A `Codable` value to send as the message payload.
   ///   - timeout: An optional timeout in seconds. Defaults to the socket's configured timeout.
-  /// - Throws: A ``RealtimeError`` if the access token is missing or the request fails.
+  /// - Throws: A `RealtimeError` if the access token is missing or the request fails.
   public func httpSend(
     event: String,
     message: some Codable,
@@ -300,7 +299,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   ///   - event: The broadcast event name.
   ///   - message: A ``JSONObject`` to send as the message payload.
   ///   - timeout: An optional timeout in seconds. Defaults to the socket's configured timeout.
-  /// - Throws: A ``RealtimeError`` if the access token is missing or the request fails.
+  /// - Throws: A `RealtimeError` if the access token is missing or the request fails.
   public func httpSend(
     event: String,
     message: JSONObject,
@@ -349,7 +348,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   ///   - event: The broadcast event name.
   ///   - data: Raw binary data to send as the request body.
   ///   - timeout: An optional timeout in seconds. Defaults to the socket's configured timeout.
-  /// - Throws: A ``RealtimeError`` if the access token is missing or the request fails.
+  /// - Throws: A `RealtimeError` if the access token is missing or the request fails.
   public func httpSend(
     event: String,
     data: Data,
@@ -398,7 +397,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   ///
   /// When the channel is subscribed, the message is sent over the existing WebSocket connection.
   /// If not subscribed, the call falls back to the REST broadcast endpoint with a deprecation notice.
-  /// Prefer ``httpSend(event:message:timeout:)-8v03n`` for an explicit REST call.
+  /// Prefer ``httpSend(event:message:timeout:)-(_,Codable,_)`` for an explicit REST call.
   ///
   /// - Parameters:
   ///   - event: The broadcast event name.
@@ -411,7 +410,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   ///
   /// When the channel is subscribed, the message is sent over the existing WebSocket connection.
   /// If not subscribed, the call falls back to the REST broadcast endpoint with a deprecation notice.
-  /// Prefer ``httpSend(event:message:timeout:)-5hhoc`` for an explicit REST call.
+  /// Prefer ``httpSend(event:message:timeout:)-(_,JSONObject,_)`` for an explicit REST call.
   ///
   /// - Parameters:
   ///   - event: The broadcast event name.
@@ -776,7 +775,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// }
   /// ```
   ///
-  /// > Note: Use ``postgresChange(_:schema:table:filter:)`` if you prefer async iteration over closures.
+  /// > Note: Use ``postgresChange(_:schema:table:filter:select:)->AsyncStream<AnyAction>`` if you prefer async iteration over closures.
   ///
   /// - Parameters:
   ///   - type: Pass `AnyAction.self` to match all change types.
@@ -836,7 +835,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// }
   /// ```
   ///
-  /// > Note: Use ``postgresChange(_:schema:table:filter:)`` if you prefer async iteration over closures.
+  /// > Note: Use ``postgresChange(_:schema:table:filter:select:)->AsyncStream<InsertAction>`` if you prefer async iteration over closures.
   ///
   /// - Parameters:
   ///   - type: Pass `InsertAction.self`.
@@ -898,7 +897,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// }
   /// ```
   ///
-  /// > Note: Use ``postgresChange(_:schema:table:filter:)`` if you prefer async iteration over closures.
+  /// > Note: Use ``postgresChange(_:schema:table:filter:select:)->AsyncStream<UpdateAction>`` if you prefer async iteration over closures.
   ///
   /// - Parameters:
   ///   - type: Pass `UpdateAction.self`.
@@ -960,7 +959,7 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// }
   /// ```
   ///
-  /// > Note: Use ``postgresChange(_:schema:table:filter:)`` if you prefer async iteration over closures.
+  /// > Note: Use ``postgresChange(_:schema:table:filter:select:)->AsyncStream<DeleteAction>`` if you prefer async iteration over closures.
   ///
   /// - Parameters:
   ///   - type: Pass `DeleteAction.self`.

--- a/Sources/RealtimeV2/RealtimeClientV2.swift
+++ b/Sources/RealtimeV2/RealtimeClientV2.swift
@@ -329,7 +329,7 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
 
   /// Opens the WebSocket connection and suspends until it is established.
   ///
-  /// Calling this method when already connected is a no-op. If ``RealtimeClientOptions/connectOnSubscribe``
+  /// Calling this method when already connected is a no-op. If ``RealtimeClientOptions/defaultConnectOnSubscribe``
   /// is `true` (the default), this is called automatically when a channel is subscribed to.
   ///
   /// ```swift
@@ -695,10 +695,10 @@ public final class RealtimeClientV2: Sendable, RealtimeClientProtocol {
   /// Updates the JWT access token used for channel authorization and Realtime RLS.
   ///
   /// When called, the token is propagated to all currently-subscribed channels. If `token`
-  /// is `nil`, the value is fetched from ``RealtimeClientOptions/accessToken`` if provided,
-  /// or the token already stored on the client is used.
+  /// is `nil`, the value is fetched from the `accessToken` callback configured on
+  /// ``RealtimeClientOptions`` if provided, or the token already stored on the client is used.
   ///
-  /// If ``RealtimeClientOptions/accessToken`` throws, the client keeps the current token and no update is sent to channels.
+  /// If the `accessToken` callback throws, the client keeps the current token and no update is sent to channels.
   /// - Parameter token: A JWT string, or `nil` to refresh from the configured `accessToken` callback.
   public func setAuth(_ token: String? = nil) async {
     var tokenToSend = token

--- a/Sources/RealtimeV2/RealtimeJoinConfig.swift
+++ b/Sources/RealtimeV2/RealtimeJoinConfig.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-// cspell:ignore pvzp
 struct RealtimeJoinPayload: Encodable {
   var config: RealtimeJoinConfig
   var accessToken: String?
@@ -73,11 +72,11 @@ public struct ReplayOption: Encodable, Hashable, Sendable {
 /// - ``receiveOwnBroadcasts``
 /// - ``replay``
 /// ### Initialization
-/// - ``init(acknowledgeBroadcasts:receiveOwnBroadcasts:replay:)``
+/// - ``init(acknowledgeBroadcasts:receiveOwnBroadcasts:replay:replicationReady:)``
 public struct BroadcastJoinConfig: Encodable, Hashable, Sendable {
   /// When `true`, the server acknowledges each broadcast message before delivering it.
   ///
-  /// Useful in combination with ``RealtimeChannelV2/broadcast(event:message:)-2pvzp``
+  /// Useful in combination with ``RealtimeChannelV2/broadcast(event:message:)-(_,JSONObject)``
   /// to ensure delivery before continuing.
   public var acknowledgeBroadcasts: Bool = false
 
@@ -91,7 +90,7 @@ public struct BroadcastJoinConfig: Encodable, Hashable, Sendable {
   /// Instructs the server to emit a `system` event once the Postgres replication
   /// connection backing this channel is established and ready to stream changes.
   ///
-  /// Listen for it with ``RealtimeChannelV2/onSystem(callback:)-(_)`` (or the
+  /// Listen for it with ``RealtimeChannelV2/onSystem(callback:)-((RealtimeMessageV2)->Void)`` (or the
   /// ``RealtimeChannelV2/system()`` async stream): the message's `status` is
   /// `.ok` (message `"Replication connection established"`) on success, or
   /// `.error` if the connection is not ready in time.

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -74,7 +74,7 @@ enum FileUpload {
 /// let url = try await fileApi.createSignedURL(path: "user123.png", expiresIn: 60)
 /// ```
 ///
-/// > Note: This class is `@unchecked Sendable`. The ``bucketId`` property is immutable (`let`), and
+/// > Note: This class is `@unchecked Sendable`. The `bucketId` property is immutable (`let`), and
 /// > all mutable header state is protected by the lock inherited from ``StorageApi``.
 ///
 /// ## Topics
@@ -95,7 +95,7 @@ enum FileUpload {
 /// ### Downloading files
 ///
 /// - ``download(path:options:query:cacheNonce:)``
-/// - ``getPublicURL(path:download:options:cacheNonce:)``
+/// - ``getPublicURL(path:download:options:cacheNonce:)-(_,DownloadBehavior?,_,_)``
 ///
 /// ### Managing files
 ///
@@ -108,8 +108,8 @@ enum FileUpload {
 ///
 /// ### Creating signed URLs
 ///
-/// - ``createSignedURL(path:expiresIn:download:transform:cacheNonce:)``
-/// - ``createSignedURLs(paths:expiresIn:download:cacheNonce:)``
+/// - ``createSignedURL(path:expiresIn:download:transform:cacheNonce:)-(_,_,DownloadBehavior?,_,_)``
+/// - ``createSignedURLs(paths:expiresIn:download:cacheNonce:)-(_,_,DownloadBehavior?,_)``
 public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// The identifier of the bucket this instance operates on.
   let bucketId: String
@@ -644,7 +644,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// Downloads a file from a private bucket and returns its raw bytes.
   ///
   /// For public buckets, prefer requesting the URL returned by
-  /// ``getPublicURL(path:download:options:cacheNonce:)`` directly.
+  /// ``getPublicURL(path:download:options:cacheNonce:)-(_,DownloadBehavior?,_,_)`` directly.
   ///
   /// ```swift
   /// let data = try await storage.from("avatars").download(path: "user123.png")

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -108,7 +108,6 @@ public struct StorageClientConfiguration: Sendable {
 /// ### Accessing buckets
 ///
 /// - ``from(_:)``
-/// - ``vectors``
 ///
 /// ### Bucket management
 ///

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -172,7 +172,7 @@ public struct FileOptions: Sendable {
 
 /// A single signed URL returned as part of a batch sign operation.
 ///
-/// Returned by ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)-5lkmo`` // cspell:ignore lkmo
+/// Returned by ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)-(_,_,DownloadBehavior?,_)``
 /// (the legacy `[SignedURL]` overload). Prefer the ``SignedURLResult`` overload for new code.
 ///
 /// ## Topics
@@ -205,7 +205,7 @@ public struct SignedURL: Decodable, Sendable {
   }
 }
 
-/// Represents the per-item result of a ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)`` call.
+/// Represents the per-item result of a ``StorageFileApi/createSignedURLs(paths:expiresIn:download:cacheNonce:)-(_,_,DownloadBehavior?,_)`` call.
 ///
 /// It is guaranteed that exactly one case applies per item: either the URL was signed
 /// successfully, or the path did not exist or was inaccessible.
@@ -975,8 +975,8 @@ public struct BucketOptions: Sendable {
 /// Options for server-side image transformation applied before the asset is served to the client.
 ///
 /// Pass a ``TransformOptions`` value to ``StorageFileApi/download(path:options:query:cacheNonce:)``,
-/// ``StorageFileApi/getPublicURL(path:download:options:cacheNonce:)``, or
-/// ``StorageFileApi/createSignedURL(path:expiresIn:download:transform:cacheNonce:)`` to resize,
+/// ``StorageFileApi/getPublicURL(path:download:options:cacheNonce:)-(_,DownloadBehavior?,_,_)``, or
+/// ``StorageFileApi/createSignedURL(path:expiresIn:download:transform:cacheNonce:)-(_,_,DownloadBehavior?,_,_)`` to resize,
 /// reformat, or adjust the quality of images on the fly.
 ///
 /// ```swift

--- a/scripts/test-docs.sh
+++ b/scripts/test-docs.sh
@@ -5,7 +5,7 @@ warnings=$(xcodebuild clean docbuild \
   -scheme Supabase \
   -destination 'platform=macOS' \
   -quiet \
-  2>&1 | grep "couldn't be resolved to known documentation" | sed "s|$PWD|.|g" || true)
+  2>&1 | grep -E "doesn't exist at |isn't a disambiguation for | is ambiguous at " | grep -v "SourcePackages/checkouts" | sed "s|$PWD|.|g" || true)
 
 if [[ -n "$warnings" ]]; then
   echo "xcodebuild docbuild failed:"


### PR DESCRIPTION
## Summary

`scripts/test-docs.sh` greps `xcodebuild docbuild` output for the phrase `"couldn't be resolved to known documentation"` to detect broken DocC symbol links. Current DocC no longer emits that phrase — it now says `doesn't exist at`, `isn't a disambiguation for`, or `is ambiguous at` — so the grep matched zero lines and the check could never fail, giving zero real protection against doc-link rot.

- Fixed the grep pattern to match DocC's current warning phrasing.
- Scoped the check to exclude warnings from vendored third-party dependencies under `SourcePackages/checkouts` (swift-concurrency-extras, xctest-dynamic-overlay, swift-clocks all have their own unrelated broken doc links we don't control and can't fix).
- Fixing the grep immediately surfaced 59 pre-existing broken doc-comment links across `Auth`, `Functions`, `Helpers`, `PostgREST`, `RealtimeV2`, and `Storage`. Fixed all of them in this PR rather than gating the check behind an allowlist, mostly using DocC's own fix-it suggestions:
  - Stale disambiguator suffixes left behind by overload changes (e.g. `Storage`'s new `cacheNonce` parameter, `RealtimeV2`'s `select:` parameter additions).
  - Links to symbols that became `@_spi(Experimental)` or otherwise non-public since the docs were written (can't resolve in a standard docbuild) — converted to plain code spans or removed the topic entry.
  - A handful of outright renames/removals (`connectOnSubscribe` → `defaultConnectOnSubscribe`, `_invokeWithStreamedResponse` → removed, `JSONEncoder`/`JSONDecoder` → `jsonEncoder`/`jsonDecoder`).

No behavior or public API changes — doc-comment text only, plus the script fix.

## Test plan

- [x] `./scripts/test-docs.sh` passes (previously always passed vacuously; now genuinely validates 0 broken links in our own sources)
- [x] `swift build` — succeeds, no new warnings
- [x] `swift test` — full suite passes (1180 tests, 9 known issues, all pre-existing)
- [x] `./scripts/format.sh` — no changes needed
- [x] `./scripts/spell-check.sh` — 0 issues