### PR TITLE
fix(ci): fail loudly instead of silently exporting stale coverage

### DIFF
--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -7,14 +7,26 @@ TEMP_COVERAGE_DIR="temp_coverage" # Temporary directory for intermediate coverag
 
 # Step 2: Find the profdata file
 PROFDATA_DIR="$DERIVED_DATA_PATH/Build/ProfileData"
-PROFDATA_FILE=$(find "$PROFDATA_DIR" -name "*.profdata" | head -n 1)
+mkdir -p "$TEMP_COVERAGE_DIR"
+PROFDATA_FILES=()
+while IFS= read -r -d '' file; do
+  PROFDATA_FILES+=("$file")
+done < <(find "$PROFDATA_DIR" -name "*.profdata" -print0)
 
-if [ -z "$PROFDATA_FILE" ]; then
+if [ "${#PROFDATA_FILES[@]}" -eq 0 ]; then
   echo "No profdata file found. Exiting."
   exit 1
+elif [ "${#PROFDATA_FILES[@]}" -eq 1 ]; then
+  PROFDATA_FILE="${PROFDATA_FILES[0]}"
+  echo "Found profdata file: $PROFDATA_FILE"
+else
+  # More than one .profdata under DerivedData (e.g. a leftover from a
+  # restored cache) — merge them instead of picking one arbitrarily.
+  PROFDATA_FILE="$TEMP_COVERAGE_DIR/merged.profdata"
+  echo "Found ${#PROFDATA_FILES[@]} profdata files; merging into $PROFDATA_FILE:"
+  printf '  %s\n' "${PROFDATA_FILES[@]}"
+  xcrun llvm-profdata merge -o "$PROFDATA_FILE" "${PROFDATA_FILES[@]}"
 fi
-
-echo "Found profdata file: $PROFDATA_FILE"
 
 # Step 3: Get all test bundles
 echo "Searching for test bundles in Debug-iphonesimulator..."
@@ -29,7 +41,6 @@ echo "Found test bundles:"
 echo "$TEST_BUNDLES"
 
 # Step 4: Export coverage data for each test bundle
-mkdir -p "$TEMP_COVERAGE_DIR"
 for TEST_BUNDLE in $TEST_BUNDLES; do
   BINARY_NAME=$(basename "$TEST_BUNDLE" .xctest)
   BINARY_PATH="$TEST_BUNDLE/$BINARY_NAME"
@@ -40,15 +51,24 @@ for TEST_BUNDLE in $TEST_BUNDLES; do
   fi
 
   echo "Exporting coverage data for binary: $BINARY_PATH"
+  EXPORT_STDERR="$TEMP_COVERAGE_DIR/$BINARY_NAME.stderr"
   xcrun llvm-cov export \
     -format=lcov \
     -instr-profile "$PROFDATA_FILE" \
     -ignore-filename-regex "Tests/|.build|DerivedData|.derivedData|Deprecated/|Deprecated.swift" \
-    "$BINARY_PATH" > "$TEMP_COVERAGE_DIR/$BINARY_NAME.info"
+    "$BINARY_PATH" > "$TEMP_COVERAGE_DIR/$BINARY_NAME.info" 2> "$EXPORT_STDERR"
+  EXPORT_STATUS=$?
+  cat "$EXPORT_STDERR" >&2
 
-  if [ $? -ne 0 ]; then
+  if [ $EXPORT_STATUS -ne 0 ]; then
     echo "Failed to export coverage for $BINARY_NAME. Skipping..."
     continue
+  fi
+
+  if grep -q "profile data may be out of date" "$EXPORT_STDERR"; then
+    echo "error: $PROFDATA_FILE is stale relative to $BINARY_NAME (llvm-cov reported profile data may be out of date)." >&2
+    echo "Refusing to publish coverage computed against stale profiling data. Re-run the job or clear the DerivedData cache." >&2
+    exit 1
   fi
 done
 


### PR DESCRIPTION
`scripts/generate-coverage.sh` picked an arbitrary `.profdata` file via
`find | head -n1` and never inspected `llvm-cov export`'s stderr, so a
restored DerivedData cache could leave the script silently exporting (and
Coveralls ingesting) coverage computed against stale profiling data —
`llvm-cov` already warns "profile data may be out of date - object is
newer" in this case, but the warning doesn't affect its exit code, and the
script threw it away.

This surfaced as a false -7.4% coverage regression on #1240, including on
a file with zero diff in that PR.

Fix: capture stderr from each `llvm-cov export` and fail the script if it
reports stale profile data, instead of letting wrong numbers reach
Coveralls. Also merge multiple `.profdata` files if more than one is found
under `Build/ProfileData`, rather than picking one arbitrarily.

## Test plan

Verified with fixtures built from real instrumented clang binaries +
`.profdata`, run under `/bin/bash` 3.2 to match the macOS CI runners:
- [x] Stale profdata vs. a rebuilt binary → now exits 1 with a clear error.
- [x] Fresh, correctly-ordered build-then-test data → no false positive.
- [x] Multiple `.profdata` files present → merged instead of picked arbitrarily.
- [x] `bash -n scripts/generate-coverage.sh` passes.
- [x] `./scripts/spell-check.sh` → 0 issues.
- [x] `swift build` succeeds (sanity check; no Swift files touched).

Fixes SDK-1530