### PR TITLE
fix(ci): purge stale Clang module cache in xcodebuild legacy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           path: |
             ~/.derivedData
+            !~/.derivedData/**/ModuleCache.noindex
           key: |
             deriveddata-xcodebuild-${{ matrix.platform }}-${{ matrix.xcode }}-${{ matrix.command }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
@@ -108,6 +109,13 @@ jobs:
         run: defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES
       - name: Update mtime for incremental builds
         uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2.3
+      # This runner class persists local disk state across jobs independent of
+      # actions/cache, so a module cache built against a since-updated Xcode
+      # toolchain can survive even on an actions/cache miss. The module cache
+      # embeds absolute host-header mtimes and is cheap to regenerate, so always
+      # purge it rather than risk "could not build module" errors.
+      - name: Clear stale Clang module cache
+        run: rm -rf ~/.derivedData/*/ModuleCache.noindex
       - name: Debug
         if: matrix.skip_debug != '1'
         run: CONFIG=Debug PLATFORM="${{ matrix.platform }}" XCODEBUILD_ARGUMENT="${{ matrix.command }}" ./scripts/xcodebuild.sh


### PR DESCRIPTION
## Summary

- All `xcodebuild (legacy)` matrix jobs (Xcode 16.4, `blacksmith-6vcpu-macos-15`) started failing with Clang "could not build module" errors caused by a `.pcm` module cache file whose recorded mtime for a toolchain header (`ptrcheck.h`) no longer matched the header's actual mtime.
- `actions/cache` was ruled out as the source for this specific incident (0 of 31 live cache entries matched `deriveddata-xcodebuild-*`). The more likely cause is Blacksmith's own disk-snapshot persistence across job runs surviving an underlying Xcode 16.4 toolchain image update.
- Fix (works regardless of which mechanism reintroduces the stale cache): stop caching `ModuleCache.noindex` via `actions/cache`, and unconditionally purge `~/.derivedData/*/ModuleCache.noindex` before every Debug/Release build in the `macos-legacy` job. The module cache is cheap to regenerate and is exactly the artifact that embeds absolute host-header mtimes.

Fixes SDK-1531

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Watch the next `macos-legacy` CI run on this PR to confirm the module-cache failure is gone (no local Swift test suite change — CI-workflow-only diff)