### PR TITLE
feat(client): add db.retry option to disable PostgREST retries

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -105,7 +105,8 @@ public final class SupabaseClient: Sendable {
       logger: options.global.logger,
       fetch: fetchWithAuth,
       encoder: options.db.encoder,
-      decoder: options.db.decoder
+      decoder: options.db.decoder,
+      retryEnabled: options.db.retry
     )
   }
 

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -35,14 +35,20 @@ public struct SupabaseClientOptions: Sendable {
     /// The JSONDecoder to use when decoding database response objects.
     public let decoder: JSONDecoder
 
+    /// Whether to automatically retry transient (network or 5xx) PostgREST errors.
+    /// Defaults to `true`.
+    public let retry: Bool
+
     public init(
       schema: String? = nil,
       encoder: JSONEncoder = PostgrestClient.Configuration.jsonEncoder,
-      decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder
+      decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder,
+      retry: Bool = true
     ) {
       self.schema = schema
       self.encoder = encoder
       self.decoder = decoder
+      self.retry = retry
     }
   }
 

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -161,6 +161,28 @@ struct SupabaseClientTests {
     #expect(realtimeOptions.logger[metadataKey: "system"] == "realtime")
   }
 
+  @Test
+  func dbRetryOptionForwardsToPostgrestClient() {
+    let defaultClient = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        auth: SupabaseClientOptions.AuthOptions(storage: AuthLocalStorageMock())
+      )
+    )
+    #expect(defaultClient.rest.configuration.retryEnabled == true)
+
+    let noRetryClient = SupabaseClient(
+      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
+      supabaseKey: "PUBLISHABLE_KEY",
+      options: SupabaseClientOptions(
+        db: SupabaseClientOptions.DatabaseOptions(retry: false),
+        auth: SupabaseClientOptions.AuthOptions(storage: AuthLocalStorageMock())
+      )
+    )
+    #expect(noRetryClient.rest.configuration.retryEnabled == false)
+  }
+
   #if !os(Linux) && !os(Android)
     @Test
     func clientInitWithDefaultOptionsShouldBeAvailableInNonLinux() {


### PR DESCRIPTION
## Summary

* Adds `retry: Bool` (default `true`) to `SupabaseClientOptions.DatabaseOptions`, forwarded as `retryEnabled` when `SupabaseClient` builds its PostgREST sub-client.
* Matches supabase-js's `db.retry` option ([supabase-js#2571](<https://github.com/supabase/supabase-js/pull/2571>)) — lets callers disable automatic retries for transient (network/5xx) PostgREST errors at the client level.
* The underlying `PostgrestClient.Configuration.retryEnabled` (and per-request `.retry(enabled:)` override) already existed; `SupabaseClient` just never exposed a way to set it. Additive, no breaking change.

## Test plan

- [X] Added `dbRetryOptionForwardsToPostgrestClient` test asserting both the `true` default and `retry: false` are forwarded to the built `PostgrestClient`'s configuration.
- [X] Full suite: `swift test` — 1181 tests passed, 0 failures.
- [X] `./scripts/format.sh`, `./scripts/spell-check.sh`, `./scripts/test-docs.sh` all clean.

Fixes supabase/supabase-swift#1169<br>Fixes supabase/supabase-swift#1169