### PR TITLE
feat(auth): support concurrent PKCE flows via flow id

### DIFF
--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@63c1ac1d44959bfd02e4fc70a09df287db4a425a # v1.1.1
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@29e402daf432bccac26cfac1280b491b140d6d20 # v1.2.0
     secrets:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@63c1ac1d44959bfd02e4fc70a09df287db4a425a # v1.1.1
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-swift.yml@29e402daf432bccac26cfac1280b491b140d6d20 # v1.2.0

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -98,7 +98,7 @@ private let globalJWKSCache = GlobalJWKSCache()
 /// - ``signInWithOAuth(provider:redirectTo:scopes:queryParams:launchFlow:)``
 ///
 /// ### Session management
-/// - ``exchangeCodeForSession(authCode:)``
+/// - ``exchangeCodeForSession(authCode:flowId:)``
 /// - ``session(from:)``
 /// - ``setSession(accessToken:refreshToken:)``
 /// - ``refreshSession(refreshToken:)``
@@ -376,7 +376,7 @@ public actor AuthClient {
     redirectTo: URL? = nil,
     captchaToken: String? = nil
   ) async throws -> AuthResponse {
-    let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+    let (codeChallenge, codeChallengeMethod, _) = prepareForPKCE()
 
     return try await _signUp(
       request: .init(
@@ -599,7 +599,7 @@ public actor AuthClient {
     data: [String: JSONValue]? = nil,
     captchaToken: String? = nil
   ) async throws {
-    let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+    let (codeChallenge, codeChallengeMethod, _) = prepareForPKCE()
 
     _ = try await api.execute(
       .init(
@@ -672,7 +672,7 @@ public actor AuthClient {
     redirectTo: URL? = nil,
     captchaToken: String? = nil
   ) async throws -> SSOResponse {
-    let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+    let (codeChallenge, codeChallengeMethod, _) = prepareForPKCE()
 
     return try await api.execute(
       HTTPRequest(
@@ -705,7 +705,7 @@ public actor AuthClient {
     redirectTo: URL? = nil,
     captchaToken: String? = nil
   ) async throws -> SSOResponse {
-    let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+    let (codeChallenge, codeChallengeMethod, _) = prepareForPKCE()
 
     return try await api.execute(
       HTTPRequest(
@@ -727,8 +727,17 @@ public actor AuthClient {
   }
 
   /// Log in an existing user by exchanging an Auth Code issued during the PKCE flow.
-  public func exchangeCodeForSession(authCode: String) async throws -> Session {
-    let codeVerifier = codeVerifierStorage.get()
+  /// - Parameters:
+  ///   - authCode: The auth code received from the PKCE callback.
+  ///   - flowId: The id of the flow that generated `authCode`, as returned by
+  /// ``signInWithOAuth(provider:redirectTo:scopes:queryParams:launchFlow:)`` or
+  /// ``getLinkIdentityURL(provider:scopes:redirectTo:queryParams:)``. Pass this when several
+  /// PKCE flows may be pending at once, so the correct code verifier is used. When `nil`, the
+  /// most recently started flow's verifier is used.
+  public func exchangeCodeForSession(authCode: String, flowId: String? = nil) async throws
+    -> Session
+  {
+    let codeVerifier = codeVerifierStorage.get(flowId)
 
     if codeVerifier == nil {
       logger.error(
@@ -751,7 +760,7 @@ public actor AuthClient {
     )
     .decoded(decoder: configuration.resolvedDecoder)
 
-    codeVerifierStorage.set(nil)
+    codeVerifierStorage.remove(flowId)
 
     await sessionManager.update(session)
     eventEmitter.emit(.signedIn, session: session)
@@ -780,7 +789,7 @@ public actor AuthClient {
       scopes: scopes,
       redirectTo: redirectTo,
       queryParams: queryParams
-    )
+    ).url
   }
 
   /// Sign-in an existing user via a third-party provider.
@@ -802,7 +811,8 @@ public actor AuthClient {
     queryParams: [(name: String, value: String?)] = [],
     launchFlow: @MainActor @Sendable (_ url: URL) async throws -> URL
   ) async throws -> Session {
-    let url = try getOAuthSignInURL(
+    let (url, flowId) = try getURLForProvider(
+      url: configuration.url.appendingPathComponent("authorize"),
       provider: provider,
       scopes: scopes,
       redirectTo: redirectTo ?? configuration.redirectToURL,
@@ -811,7 +821,7 @@ public actor AuthClient {
 
     let resultURL = try await launchFlow(url)
 
-    return try await session(from: resultURL)
+    return try await session(from: resultURL, flowId: flowId)
   }
 
   #if canImport(AuthenticationServices)
@@ -950,6 +960,14 @@ public actor AuthClient {
   /// Gets the session data from a OAuth2 callback URL.
   @discardableResult
   public func session(from url: URL) async throws -> Session {
+    try await session(from: url, flowId: nil)
+  }
+
+  /// Gets the session data from a OAuth2 callback URL.
+  /// - Parameter flowId: The id of the PKCE flow that produced this callback, when known ahead
+  /// of time (e.g. the flow that was just launched by ``signInWithOAuth(provider:redirectTo:scopes:queryParams:launchFlow:)``).
+  /// `nil` falls back to the most recently started flow's verifier.
+  private func session(from url: URL, flowId: String?) async throws -> Session {
     logger.debug("Received URL: \(url)")
 
     let params = extractParams(from: url)
@@ -967,7 +985,7 @@ public actor AuthClient {
       guard isPKCEFlow(params: params) else {
         throw AuthError.pkceGrantCodeExchange(message: "Not a valid PKCE flow URL: \(url)")
       }
-      return try await handlePKCEFlow(params: params)
+      return try await handlePKCEFlow(params: params, flowId: flowId)
     }
   }
 
@@ -1020,7 +1038,7 @@ public actor AuthClient {
     return session
   }
 
-  private func handlePKCEFlow(params: [String: String]) async throws -> Session {
+  private func handlePKCEFlow(params: [String: String], flowId: String?) async throws -> Session {
     precondition(configuration.flowType == .pkce, "Method only allowed for PKCE flow.")
 
     if params["error"] != nil || params["error_description"] != nil || params["error_code"] != nil {
@@ -1036,7 +1054,7 @@ public actor AuthClient {
       throw AuthError.pkceGrantCodeExchange(message: "No code detected.")
     }
 
-    return try await exchangeCodeForSession(authCode: code)
+    return try await exchangeCodeForSession(authCode: code, flowId: flowId)
   }
 
   /// Sets the session data from the current session. If the current session is expired, setSession
@@ -1216,7 +1234,7 @@ public actor AuthClient {
     emailRedirectTo: URL? = nil,
     captchaToken: String? = nil
   ) async throws {
-    let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+    let (codeChallenge, codeChallengeMethod, _) = prepareForPKCE()
 
     _ = try await api.execute(
       HTTPRequest(
@@ -1303,7 +1321,7 @@ public actor AuthClient {
     var user = user
 
     if user.email != nil {
-      let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+      let (codeChallenge, codeChallengeMethod, _) = prepareForPKCE()
       user.codeChallenge = codeChallenge
       user.codeChallengeMethod = codeChallengeMethod
     }
@@ -1427,7 +1445,7 @@ public actor AuthClient {
     redirectTo: URL? = nil,
     queryParams: [(name: String, value: String?)] = []
   ) async throws -> OAuthResponse {
-    let url = try getURLForProvider(
+    let (url, flowId) = try getURLForProvider(
       url: configuration.url.appendingPathComponent("user/identities/authorize"),
       provider: provider,
       scopes: scopes,
@@ -1448,7 +1466,7 @@ public actor AuthClient {
     )
     .decoded(as: Response.self, decoder: configuration.resolvedDecoder)
 
-    return OAuthResponse(provider: provider, url: response.url)
+    return OAuthResponse(provider: provider, url: response.url, flowId: flowId)
   }
 
   /// Unlinks an identity from a user by deleting it. The user will no longer be able to sign in
@@ -1468,7 +1486,7 @@ public actor AuthClient {
     redirectTo: URL? = nil,
     captchaToken: String? = nil
   ) async throws {
-    let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+    let (codeChallenge, codeChallengeMethod, _) = prepareForPKCE()
 
     _ = try await api.execute(
       .init(
@@ -1536,19 +1554,20 @@ public actor AuthClient {
   }
 
   nonisolated private func prepareForPKCE() -> (
-    codeChallenge: String?, codeChallengeMethod: String?
+    codeChallenge: String?, codeChallengeMethod: String?, flowId: String?
   ) {
     guard configuration.flowType == .pkce else {
-      return (nil, nil)
+      return (nil, nil, nil)
     }
 
+    let flowId = UUID().uuidString
     let codeVerifier = pkce.generateCodeVerifier()
-    codeVerifierStorage.set(codeVerifier)
+    codeVerifierStorage.set(codeVerifier, flowId)
 
     let codeChallenge = pkce.generateCodeChallenge(codeVerifier)
     let codeChallengeMethod = codeVerifier == codeChallenge ? "plain" : "s256"
 
-    return (codeChallenge, codeChallengeMethod)
+    return (codeChallenge, codeChallengeMethod, flowId)
   }
 
   private func isImplicitGrantFlow(params: [String: String]) -> Bool {
@@ -1556,7 +1575,7 @@ public actor AuthClient {
   }
 
   private func isPKCEFlow(params: [String: String]) -> Bool {
-    let currentCodeVerifier = codeVerifierStorage.get()
+    let currentCodeVerifier = codeVerifierStorage.get(nil)
     return params["code"] != nil || params["error_description"] != nil || params["error"] != nil
       || params["error_code"] != nil && currentCodeVerifier != nil
   }
@@ -1568,7 +1587,7 @@ public actor AuthClient {
     redirectTo: URL? = nil,
     queryParams: [(name: String, value: String?)] = [],
     skipBrowserRedirect: Bool? = nil
-  ) throws -> URL {
+  ) throws -> (url: URL, flowId: String?) {
     guard
       var components = URLComponents(
         url: url,
@@ -1590,7 +1609,7 @@ public actor AuthClient {
       queryItems.append(URLQueryItem(name: "redirect_to", value: redirectTo.absoluteString))
     }
 
-    let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
+    let (codeChallenge, codeChallengeMethod, flowId) = prepareForPKCE()
 
     if let codeChallenge {
       queryItems.append(URLQueryItem(name: "code_challenge", value: codeChallenge))
@@ -1612,7 +1631,7 @@ public actor AuthClient {
       throw URLError(.badURL)
     }
 
-    return url
+    return (url, flowId)
   }
 
   /// Fetches a JWK from the JWKS endpoint with caching

--- a/Sources/Auth/Internal/CodeVerifierStorage.swift
+++ b/Sources/Auth/Internal/CodeVerifierStorage.swift
@@ -30,6 +30,13 @@ extension CodeVerifierStorage {
   static func live(clientID: AuthClientID) -> Self {
     var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
 
+    // Serializes the index read-modify-write in `set`/`remove`/`removeAll`: these are called
+    // `nonisolated`, so concurrent flow starts can genuinely run on different threads, not just
+    // interleave at await points. Without this, two concurrent writers can each read the index
+    // before either writes it back, so one writer's entry is silently dropped, breaking both
+    // eviction and `removeAll`'s cleanup for that flow.
+    let lock = LockIsolated<Void>(())
+
     let baseStorageKey: @Sendable () -> String = {
       configuration.storageKey ?? defaultStorageKey
     }
@@ -90,40 +97,46 @@ extension CodeVerifierStorage {
         return readString(legacyVerifierKey())
       },
       set: { code, flowId in
-        writeString(code, flowSlotKey(flowId))
+        lock.withValue { _ in
+          writeString(code, flowSlotKey(flowId))
 
-        var index = readIndex().filter { $0 != flowId }
-        index.append(flowId)
-        while index.count > maxConcurrentFlows {
-          let evicted = index.removeFirst()
-          removeKey(flowSlotKey(evicted))
+          var index = readIndex().filter { $0 != flowId }
+          index.append(flowId)
+          while index.count > maxConcurrentFlows {
+            let evicted = index.removeFirst()
+            removeKey(flowSlotKey(evicted))
+          }
+          writeIndex(index)
+
+          // Dual write: exchanges with no flow id (older callers, or callers that never
+          // learned this flow's id) fall back to whichever verifier was stored most recently.
+          writeString(code, legacyVerifierKey())
         }
-        writeIndex(index)
-
-        // Dual write: exchanges with no flow id (older callers, or callers that never
-        // learned this flow's id) fall back to whichever verifier was stored most recently.
-        writeString(code, legacyVerifierKey())
       },
       remove: { flowId in
-        guard let flowId else {
-          removeKey(legacyVerifierKey())
-          return
-        }
+        lock.withValue { _ in
+          guard let flowId else {
+            removeKey(legacyVerifierKey())
+            return
+          }
 
-        let slotValue = readString(flowSlotKey(flowId))
-        removeKey(flowSlotKey(flowId))
-        writeIndex(readIndex().filter { $0 != flowId })
+          let slotValue = readString(flowSlotKey(flowId))
+          removeKey(flowSlotKey(flowId))
+          writeIndex(readIndex().filter { $0 != flowId })
 
-        if let slotValue, slotValue == readString(legacyVerifierKey()) {
-          removeKey(legacyVerifierKey())
+          if let slotValue, slotValue == readString(legacyVerifierKey()) {
+            removeKey(legacyVerifierKey())
+          }
         }
       },
       removeAll: {
-        for flowId in readIndex() {
-          removeKey(flowSlotKey(flowId))
+        lock.withValue { _ in
+          for flowId in readIndex() {
+            removeKey(flowSlotKey(flowId))
+          }
+          removeKey(flowIndexKey())
+          removeKey(legacyVerifierKey())
         }
-        removeKey(flowIndexKey())
-        removeKey(legacyVerifierKey())
       }
     )
   }

--- a/Sources/Auth/Internal/CodeVerifierStorage.swift
+++ b/Sources/Auth/Internal/CodeVerifierStorage.swift
@@ -1,4 +1,3 @@
-import ConcurrencyExtras
 import Foundation
 import Logging
 
@@ -35,7 +34,7 @@ extension CodeVerifierStorage {
     // interleave at await points. Without this, two concurrent writers can each read the index
     // before either writes it back, so one writer's entry is silently dropped, breaking both
     // eviction and `removeAll`'s cleanup for that flow.
-    let lock = LockIsolated<Void>(())
+    let lock = NSRecursiveLock()
 
     let baseStorageKey: @Sendable () -> String = {
       configuration.storageKey ?? defaultStorageKey
@@ -97,46 +96,49 @@ extension CodeVerifierStorage {
         return readString(legacyVerifierKey())
       },
       set: { code, flowId in
-        lock.withValue { _ in
-          writeString(code, flowSlotKey(flowId))
+        lock.lock()
+        defer { lock.unlock() }
 
-          var index = readIndex().filter { $0 != flowId }
-          index.append(flowId)
-          while index.count > maxConcurrentFlows {
-            let evicted = index.removeFirst()
-            removeKey(flowSlotKey(evicted))
-          }
-          writeIndex(index)
+        writeString(code, flowSlotKey(flowId))
 
-          // Dual write: exchanges with no flow id (older callers, or callers that never
-          // learned this flow's id) fall back to whichever verifier was stored most recently.
-          writeString(code, legacyVerifierKey())
+        var index = readIndex().filter { $0 != flowId }
+        index.append(flowId)
+        while index.count > maxConcurrentFlows {
+          let evicted = index.removeFirst()
+          removeKey(flowSlotKey(evicted))
         }
+        writeIndex(index)
+
+        // Dual write: exchanges with no flow id (older callers, or callers that never
+        // learned this flow's id) fall back to whichever verifier was stored most recently.
+        writeString(code, legacyVerifierKey())
       },
       remove: { flowId in
-        lock.withValue { _ in
-          guard let flowId else {
-            removeKey(legacyVerifierKey())
-            return
-          }
+        lock.lock()
+        defer { lock.unlock() }
 
-          let slotValue = readString(flowSlotKey(flowId))
-          removeKey(flowSlotKey(flowId))
-          writeIndex(readIndex().filter { $0 != flowId })
+        guard let flowId else {
+          removeKey(legacyVerifierKey())
+          return
+        }
 
-          if let slotValue, slotValue == readString(legacyVerifierKey()) {
-            removeKey(legacyVerifierKey())
-          }
+        let slotValue = readString(flowSlotKey(flowId))
+        removeKey(flowSlotKey(flowId))
+        writeIndex(readIndex().filter { $0 != flowId })
+
+        if let slotValue, slotValue == readString(legacyVerifierKey()) {
+          removeKey(legacyVerifierKey())
         }
       },
       removeAll: {
-        lock.withValue { _ in
-          for flowId in readIndex() {
-            removeKey(flowSlotKey(flowId))
-          }
-          removeKey(flowIndexKey())
-          removeKey(legacyVerifierKey())
+        lock.lock()
+        defer { lock.unlock() }
+
+        for flowId in readIndex() {
+          removeKey(flowSlotKey(flowId))
         }
+        removeKey(flowIndexKey())
+        removeKey(legacyVerifierKey())
       }
     )
   }

--- a/Sources/Auth/Internal/CodeVerifierStorage.swift
+++ b/Sources/Auth/Internal/CodeVerifierStorage.swift
@@ -2,43 +2,128 @@ import ConcurrencyExtras
 import Foundation
 import Logging
 
+/// Stores PKCE code verifiers.
+///
+/// Verifiers are kept in per-flow slots (keyed by a generated flow id) instead of a single
+/// shared slot, so starting several PKCE flows at once — two OAuth sign-ins, or an OAuth flow
+/// started while a password reset is pending — doesn't let one flow's verifier overwrite
+/// another's. At most ``CodeVerifierStorage/maxConcurrentFlows`` flows are kept pending at
+/// once; starting one more evicts the oldest. Every write also updates a legacy fixed-key slot
+/// so callers that don't have a flow id (or predate flow ids) keep working against whichever
+/// verifier was stored most recently.
 struct CodeVerifierStorage: Sendable {
-  var get: @Sendable () -> String?
-  var set: @Sendable (_ code: String?) -> Void
+  /// Returns the verifier for `flowId`, or `nil` if none is stored. With `flowId == nil`,
+  /// returns the most recently stored verifier.
+  var get: @Sendable (_ flowId: String?) -> String?
+  /// Stores `code` under a new slot for `flowId`, evicting the oldest pending flow if the
+  /// ring is full.
+  var set: @Sendable (_ code: String, _ flowId: String) -> Void
+  /// Removes the verifier for `flowId`. With `flowId == nil`, removes the legacy fallback slot.
+  var remove: @Sendable (_ flowId: String?) -> Void
+  /// Removes every pending verifier.
+  var removeAll: @Sendable () -> Void
 }
 
 extension CodeVerifierStorage {
+  static let maxConcurrentFlows = 5
+
   static func live(clientID: AuthClientID) -> Self {
     var configuration: AuthClient.Configuration { Dependencies[clientID].configuration }
-    var key: String { "\(configuration.storageKey ?? defaultStorageKey)-code-verifier" }
 
-    return Self(
-      get: {
-        do {
-          guard let data = try configuration.localStorage.retrieve(key: key) else {
-            configuration.logger.debug("Code verifier not found.")
-            return nil
-          }
-          return String(decoding: data, as: UTF8.self)
-        } catch {
-          configuration.logger.error(
-            "Failure loading code verifier: \(error.localizedDescription)")
+    let baseStorageKey: @Sendable () -> String = {
+      configuration.storageKey ?? defaultStorageKey
+    }
+    let legacyVerifierKey: @Sendable () -> String = { "\(baseStorageKey())-code-verifier" }
+    let flowIndexKey: @Sendable () -> String = { "\(baseStorageKey())-flows-code-verifier" }
+    let flowSlotKey: @Sendable (String) -> String = { flowId in
+      "\(baseStorageKey())-flow-\(flowId)-code-verifier"
+    }
+
+    let readString: @Sendable (String) -> String? = { key in
+      do {
+        guard let data = try configuration.localStorage.retrieve(key: key) else {
           return nil
         }
-      },
-      set: { code in
-        do {
-          if let code, let data = code.data(using: .utf8) {
-            try configuration.localStorage.store(key: key, value: data)
-          } else if code == nil {
-            try configuration.localStorage.remove(key: key)
-          } else {
-            configuration.logger.error("Code verifier is not a valid UTF8 string.")
-          }
-        } catch {
-          configuration.logger.error(
-            "Failure storing code verifier: \(error.localizedDescription)")
+        return String(decoding: data, as: UTF8.self)
+      } catch {
+        configuration.logger.error(
+          "Failure loading code verifier: \(error.localizedDescription)")
+        return nil
+      }
+    }
+
+    let writeString: @Sendable (String, String) -> Void = { value, key in
+      do {
+        try configuration.localStorage.store(key: key, value: Data(value.utf8))
+      } catch {
+        configuration.logger.error(
+          "Failure storing code verifier: \(error.localizedDescription)")
+      }
+    }
+
+    let removeKey: @Sendable (String) -> Void = { key in
+      do {
+        try configuration.localStorage.remove(key: key)
+      } catch {
+        configuration.logger.error(
+          "Failure removing code verifier: \(error.localizedDescription)")
+      }
+    }
+
+    let readIndex: @Sendable () -> [String] = {
+      readString(flowIndexKey())?.split(separator: "\n").map(String.init) ?? []
+    }
+
+    let writeIndex: @Sendable ([String]) -> Void = { index in
+      if index.isEmpty {
+        removeKey(flowIndexKey())
+      } else {
+        writeString(index.joined(separator: "\n"), flowIndexKey())
+      }
+    }
+
+    return Self(
+      get: { flowId in
+        if let flowId {
+          return readString(flowSlotKey(flowId))
         }
+        return readString(legacyVerifierKey())
+      },
+      set: { code, flowId in
+        writeString(code, flowSlotKey(flowId))
+
+        var index = readIndex().filter { $0 != flowId }
+        index.append(flowId)
+        while index.count > maxConcurrentFlows {
+          let evicted = index.removeFirst()
+          removeKey(flowSlotKey(evicted))
+        }
+        writeIndex(index)
+
+        // Dual write: exchanges with no flow id (older callers, or callers that never
+        // learned this flow's id) fall back to whichever verifier was stored most recently.
+        writeString(code, legacyVerifierKey())
+      },
+      remove: { flowId in
+        guard let flowId else {
+          removeKey(legacyVerifierKey())
+          return
+        }
+
+        let slotValue = readString(flowSlotKey(flowId))
+        removeKey(flowSlotKey(flowId))
+        writeIndex(readIndex().filter { $0 != flowId })
+
+        if let slotValue, slotValue == readString(legacyVerifierKey()) {
+          removeKey(legacyVerifierKey())
+        }
+      },
+      removeAll: {
+        for flowId in readIndex() {
+          removeKey(flowSlotKey(flowId))
+        }
+        removeKey(flowIndexKey())
+        removeKey(legacyVerifierKey())
       }
     )
   }

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -1453,14 +1453,22 @@ public struct OAuthResponse: Hashable, Sendable {
   /// The URL to open in order to start the OAuth flow.
   public let url: URL
 
+  /// The id of the PKCE flow this call started, when the client is configured for the PKCE
+  /// flow. Pass it to ``AuthClient/exchangeCodeForSession(authCode:flowId:)`` to select this
+  /// flow's code verifier when multiple PKCE flows may be pending at once. `nil` when not
+  /// using the PKCE flow.
+  public let flowId: String?
+
   /// Creates an ``OAuthResponse``.
   ///
   /// - Parameters:
   ///   - provider: The OAuth provider.
   ///   - url: The URL to open in order to start the OAuth flow.
-  public init(provider: Provider, url: URL) {
+  ///   - flowId: The id of the PKCE flow this call started, if any.
+  public init(provider: Provider, url: URL, flowId: String? = nil) {
     self.provider = provider
     self.url = url
+    self.flowId = flowId
   }
 }
 

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -387,6 +387,97 @@ extension AuthMockerTests {
     }
 
     @Test
+    func exchangeCodeForSessionUsesVerifierForGivenFlowId() async throws {
+      struct ExchangeCodeRequestBody: Decodable, Sendable {
+        let codeVerifier: String?
+
+        enum CodingKeys: String, CodingKey {
+          case codeVerifier = "code_verifier"
+        }
+      }
+
+      try await withMainSerialExecutor {
+        let capturedVerifier = LockIsolated<String?>(nil)
+
+        var mock = Mock(
+          url: clientURL.appendingPathComponent("token").appendingQueryItems([
+            URLQueryItem(name: "grant_type", value: "pkce")
+          ]),
+          statusCode: 200,
+          data: [
+            .post: MockData.session
+          ]
+        )
+        mock.onRequestHandler = OnRequestHandler(httpBodyType: ExchangeCodeRequestBody.self) {
+          _, body in
+          capturedVerifier.setValue(body?.codeVerifier)
+        }
+        mock.register()
+
+        let sut = makeSUT()
+
+        // Two PKCE flows are pending concurrently, each with its own verifier.
+        Dependencies[sut.clientID].codeVerifierStorage.set("verifier-a", "flow-a")
+        Dependencies[sut.clientID].codeVerifierStorage.set("verifier-b", "flow-b")
+
+        _ = try await sut.exchangeCodeForSession(authCode: "12345", flowId: "flow-a")
+
+        expectNoDifference(capturedVerifier.value, "verifier-a")
+
+        // Exchanging "flow-a" must not disturb "flow-b"'s still-pending verifier.
+        #expect(Dependencies[sut.clientID].codeVerifierStorage.get("flow-a") == nil)
+        #expect(Dependencies[sut.clientID].codeVerifierStorage.get("flow-b") == "verifier-b")
+      }
+    }
+
+    @Test
+    func concurrentPKCEFlowsKeepIndependentVerifiers() async throws {
+      try await withMainSerialExecutor {
+        let sut = makeSUT()
+        Dependencies[sut.clientID].sessionStorage.store(.validSession)
+
+        Mock(
+          url: clientURL.appendingPathComponent("user/identities/authorize"),
+          ignoreQuery: true,
+          statusCode: 200,
+          data: [
+            .get: Data(#"{"url": "https://github.com/login/oauth/authorize"}"#.utf8)
+          ]
+        )
+        .register()
+
+        // Flow A starts (e.g. linking a GitHub identity)...
+        let flowA = try await sut.getLinkIdentityURL(provider: .github)
+
+        // ...then flow B starts before flow A's callback arrives (e.g. the user also kicks off
+        // a Google sign-in in another window). Before flow ids, flow B's verifier would have
+        // silently overwritten flow A's in the single shared slot.
+        let flowB = try await sut.getLinkIdentityURL(provider: .google)
+
+        #expect(flowA.flowId != nil)
+        #expect(flowB.flowId != nil)
+        expectNoDifference(flowA.flowId != flowB.flowId, true)
+
+        Mock(
+          url: clientURL.appendingPathComponent("token").appendingQueryItems([
+            URLQueryItem(name: "grant_type", value: "pkce")
+          ]),
+          statusCode: 200,
+          data: [
+            .post: MockData.session
+          ]
+        )
+        .register()
+
+        // Exchanging flow A's code must still resolve flow A's own verifier.
+        _ = try await sut.exchangeCodeForSession(authCode: "code-a", flowId: flowA.flowId)
+
+        // Flow B is still pending, untouched by flow A's exchange.
+        #expect(Dependencies[sut.clientID].codeVerifierStorage.get(flowB.flowId) != nil)
+      }
+    }
+
+    @Test
     func getLinkIdentityURL() async throws {
       try await withMainSerialExecutor {
         let url =
@@ -423,15 +514,9 @@ extension AuthMockerTests {
 
         let response = try await sut.getLinkIdentityURL(provider: .github)
 
-        expectNoDifference(
-          response,
-          OAuthResponse(
-            provider: .github,
-            url: URL(
-              string: url
-            )!
-          )
-        )
+        expectNoDifference(response.provider, .github)
+        expectNoDifference(response.url, URL(string: url)!)
+        #expect(response.flowId != nil)
       }
     }
 
@@ -604,7 +689,7 @@ extension AuthMockerTests {
     func sessionFromURL_withError() async throws {
       let sut = makeSUT()
 
-      Dependencies[sut.clientID].codeVerifierStorage.set("code-verifier")
+      Dependencies[sut.clientID].codeVerifierStorage.set("code-verifier", "test-flow")
 
       let url = URL(
         string:

--- a/Tests/AuthTests/CodeVerifierStorageTests.swift
+++ b/Tests/AuthTests/CodeVerifierStorageTests.swift
@@ -1,0 +1,128 @@
+import ConcurrencyExtras
+import Foundation
+import TestHelpers
+import Testing
+
+@testable import Auth
+
+@Suite
+struct CodeVerifierStorageTests {
+  private func makeSUT() -> (
+    storage: CodeVerifierStorage, localStorage: InMemoryLocalStorage, client: AuthClient
+  ) {
+    let localStorage = InMemoryLocalStorage()
+    let client = AuthClient(
+      configuration: AuthClient.Configuration(
+        url: URL(string: "https://project-id.supabase.com")!,
+        localStorage: localStorage
+      )
+    )
+
+    return (Dependencies[client.clientID].codeVerifierStorage, localStorage, client)
+  }
+
+  @Test
+  func storesAndRetrievesVerifierByFlowId() {
+    let (storage, _, client) = makeSUT()
+    withExtendedLifetime(client) {
+      storage.set("verifier-a", "flow-a")
+      storage.set("verifier-b", "flow-b")
+
+      #expect(storage.get("flow-a") == "verifier-a")
+      #expect(storage.get("flow-b") == "verifier-b")
+    }
+  }
+
+  @Test
+  func getWithNoFlowIdFallsBackToMostRecentlyStoredVerifier() {
+    let (storage, _, client) = makeSUT()
+    withExtendedLifetime(client) {
+      storage.set("verifier-a", "flow-a")
+      storage.set("verifier-b", "flow-b")
+
+      #expect(storage.get(nil) == "verifier-b")
+    }
+  }
+
+  @Test
+  func ringEvictsOldestFlowBeyondMaxConcurrentFlows() {
+    let (storage, _, client) = makeSUT()
+    withExtendedLifetime(client) {
+      for i in 0..<CodeVerifierStorage.maxConcurrentFlows {
+        storage.set("verifier-\(i)", "flow-\(i)")
+      }
+      // All 5 flows are still pending.
+      for i in 0..<CodeVerifierStorage.maxConcurrentFlows {
+        #expect(storage.get("flow-\(i)") == "verifier-\(i)")
+      }
+
+      // A 6th flow evicts the oldest (flow-0).
+      storage.set("verifier-5", "flow-5")
+
+      #expect(storage.get("flow-0") == nil)
+      for i in 1...5 {
+        #expect(storage.get("flow-\(i)") == "verifier-\(i)")
+      }
+    }
+  }
+
+  @Test
+  func removeDeletesOnlyItsOwnFlow() {
+    let (storage, _, client) = makeSUT()
+    withExtendedLifetime(client) {
+      storage.set("verifier-a", "flow-a")
+      storage.set("verifier-b", "flow-b")
+
+      storage.remove("flow-a")
+
+      #expect(storage.get("flow-a") == nil)
+      #expect(storage.get("flow-b") == "verifier-b")
+    }
+  }
+
+  @Test
+  func removeClearsLegacyFallbackOnlyWhenItMatchesTheRemovedFlow() {
+    let (storage, _, client) = makeSUT()
+    withExtendedLifetime(client) {
+      storage.set("verifier-a", "flow-a")
+      storage.set("verifier-b", "flow-b")
+
+      // "flow-a" is no longer the most recent verifier, so removing it must not clear the
+      // legacy fallback slot that "flow-b" owns.
+      storage.remove("flow-a")
+      #expect(storage.get(nil) == "verifier-b")
+
+      storage.remove("flow-b")
+      #expect(storage.get(nil) == nil)
+    }
+  }
+
+  @Test
+  func removeWithNoFlowIdOnlyClearsTheLegacySlot() {
+    let (storage, _, client) = makeSUT()
+    withExtendedLifetime(client) {
+      storage.set("verifier-a", "flow-a")
+
+      storage.remove(nil)
+
+      #expect(storage.get(nil) == nil)
+      #expect(storage.get("flow-a") == "verifier-a")
+    }
+  }
+
+  @Test
+  func removeAllClearsEveryPendingFlowAndTheLegacySlot() {
+    let (storage, localStorage, client) = makeSUT()
+    withExtendedLifetime(client) {
+      storage.set("verifier-a", "flow-a")
+      storage.set("verifier-b", "flow-b")
+
+      storage.removeAll()
+
+      #expect(storage.get("flow-a") == nil)
+      #expect(storage.get("flow-b") == nil)
+      #expect(storage.get(nil) == nil)
+      #expect(localStorage.storage.isEmpty)
+    }
+  }
+}

--- a/Tests/AuthTests/CodeVerifierStorageTests.swift
+++ b/Tests/AuthTests/CodeVerifierStorageTests.swift
@@ -125,4 +125,19 @@ struct CodeVerifierStorageTests {
       #expect(localStorage.storage.isEmpty)
     }
   }
+
+  @Test
+  func concurrentSetsPreserveTheMaxConcurrentFlowsBound() {
+    let (storage, _, client) = makeSUT()
+    withExtendedLifetime(client) {
+      let flowCount = 20
+
+      DispatchQueue.concurrentPerform(iterations: flowCount) { i in
+        storage.set("verifier-\(i)", "flow-\(i)")
+      }
+
+      let pendingFlows = (0..<flowCount).filter { storage.get("flow-\($0)") != nil }
+      #expect(pendingFlows.count == CodeVerifierStorage.maxConcurrentFlows)
+    }
+  }
 }

--- a/Tests/AuthTests/MockHelpers.swift
+++ b/Tests/AuthTests/MockHelpers.swift
@@ -33,11 +33,31 @@ extension Dependencies {
 
 extension CodeVerifierStorage {
   static var mock: CodeVerifierStorage {
-    let code = LockIsolated<String?>(nil)
+    let slots = LockIsolated<[String: String]>([:])
+    let legacy = LockIsolated<String?>(nil)
 
     return Self(
-      get: { code.value },
-      set: { code.setValue($0) }
+      get: { flowId in
+        if let flowId {
+          return slots.value[flowId]
+        }
+        return legacy.value
+      },
+      set: { code, flowId in
+        slots.withValue { $0[flowId] = code }
+        legacy.setValue(code)
+      },
+      remove: { flowId in
+        if let flowId {
+          slots.withValue { _ = $0.removeValue(forKey: flowId) }
+        } else {
+          legacy.setValue(nil)
+        }
+      },
+      removeAll: {
+        slots.setValue([:])
+        legacy.setValue(nil)
+      }
     )
   }
 }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -163,6 +163,11 @@ features:
     status: implemented
     symbols:
       - AuthClient.exchangeCodeForSession
+  auth.sign_in.concurrent_pkce_flows:
+    status: implemented
+    symbols:
+      - AuthClient.exchangeCodeForSession
+      - OAuthResponse.flowId
 
   auth.session.get_session:
     status: implemented


### PR DESCRIPTION
## Summary

* Reworks `CodeVerifierStorage` to key each PKCE code verifier by a generated flow id in a bounded ring (max 5 concurrent flows, oldest evicted), instead of one shared storage slot — so starting several PKCE flows at once (two OAuth sign-ins, or an OAuth flow started while a password reset is pending) no longer lets one flow's verifier silently overwrite another's.
* Adds an optional `flowId` parameter to `exchangeCodeForSession(authCode:flowId:)` to select a specific flow's verifier; omitting it falls back to the most-recently-stored verifier (unchanged behavior).
* Adds `OAuthResponse.flowId`, surfaced by `getLinkIdentityURL`.
* Threads the flow id through `signInWithOAuth(launchFlow:)`'s internal round-trip so two concurrent calls in the same process resolve their own verifier instead of racing on the shared legacy slot.
* All additive — new optional parameter, new optional struct field with a default — no breaking changes.

## Why

Validated against the merged `supabase-js` PR [supabase/supabase-js#2569](<https://github.com/supabase/supabase-js/pull/2569>). The auto-generated parity issue overstated the surface (claimed `signInWithOtp`/`signInWithSSO`/`resend`/`updateUser`/`resetPasswordForEmail` all return a `flowId` — only `signInWithOAuth`/`linkIdentity` actually do in the reference implementation), so this implementation matches the real upstream behavior rather than the issue text. A spec for this capability is being added to `supabase/sdk` in parallel: [supabase/sdk#91](<https://github.com/supabase/sdk/pull/91>).

Fixes supabase/supabase-swift#1168<br>Fixes supabase/supabase-swift#1168

## Test plan

- [X] `swift test` — 1189 tests pass, including new `CodeVerifierStorageTests` (ring eviction, per-flow isolation, legacy fallback, `removeAll`) and two `AuthClientTests` cases proving `exchangeCodeForSession(flowId:)` and concurrent `getLinkIdentityURL` calls don't clobber each other's verifier
- [X] `./scripts/format.sh` — no diff
- [X] `./scripts/spell-check.sh` — clean
- [X] `./scripts/test-docs.sh` — DocC build clean