### PR TITLE
refactor(storage)!: make Storage client types stateless structs

### DIFF
--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -1,4 +1,3 @@
-import ConcurrencyExtras
 import Foundation
 import HTTPTypes
 
@@ -6,14 +5,11 @@ import HTTPTypes
   import FoundationNetworking
 #endif
 
-/// Base class for Storage API operations.
+/// Base type for Storage API operations.
 ///
-/// ``StorageApi`` holds the ``StorageClientConfiguration`` and manages mutable per-instance HTTP
-/// headers behind a lock. Both ``StorageBucketApi`` and ``StorageFileApi`` inherit from this class.
-///
-/// > Note: This class is `@unchecked Sendable` because all mutable state is protected by
-/// > `LockIsolated`. The ``configuration`` property is immutable (`let`), while mutable headers are
-/// > managed separately.
+/// ``StorageApi`` holds the ``StorageClientConfiguration`` and the underlying HTTP client used to
+/// execute requests. ``SupabaseStorageClient`` and ``StorageFileApi`` each hold a ``StorageApi``
+/// value and delegate to it rather than inheriting from it.
 ///
 /// ## Topics
 ///
@@ -25,20 +21,13 @@ import HTTPTypes
 /// ### Customizing headers
 ///
 /// - ``setHeader(_:forKey:)``
-public class StorageApi: @unchecked Sendable {
+public struct StorageApi: Sendable {
   /// The configuration used to initialize this client instance.
   public let configuration: StorageClientConfiguration
 
-  private struct MutableState {
-    var headers: [String: String]
-  }
-
-  private let mutableState: LockIsolated<MutableState>
   private let http: any HTTPClientType
 
   /// Creates a ``StorageApi`` with the given configuration.
-  ///
-  /// Subclasses call this initializer via `super.init(configuration:)`.
   ///
   /// - Parameter configuration: The configuration that controls the endpoint URL, authentication
   ///   headers, JSON codecs, and HTTP session.
@@ -70,9 +59,7 @@ public class StorageApi: @unchecked Sendable {
       configuration.url = components.url!
     }
 
-    let initialHeaders = configuration.headers
     self.configuration = configuration
-    self.mutableState = LockIsolated(MutableState(headers: initialHeaders))
 
     let interceptors: [any HTTPClientInterceptor] = [
       LoggerInterceptor(logger: configuration.logger)
@@ -84,30 +71,32 @@ public class StorageApi: @unchecked Sendable {
     )
   }
 
-  /// Sets an HTTP header that will be included in all subsequent requests made by this instance.
+  /// Returns a new ``StorageApi`` with an additional HTTP header merged into
+  /// ``configuration``'s headers, included in all requests made by the returned instance.
   ///
-  /// This method is thread-safe. The header key is normalized to lowercase before being stored.
+  /// Because ``StorageApi`` is an immutable value type, this method does not mutate `self` — it
+  /// returns a new instance. Discarding the return value is a no-op, so always use the result:
   ///
   /// ```swift
   /// storage.from("avatars")
   ///   .setHeader("x-custom-header", forKey: "X-Custom-Header")
+  ///   .list()
   /// ```
   ///
   /// - Parameters:
   ///   - value: The value of the header field.
   ///   - key: The name of the header field. The key is case-insensitively stored as lowercase.
-  /// - Returns: `self`, enabling method chaining.
-  @discardableResult
+  /// - Returns: A new ``StorageApi`` with the header merged into ``configuration``'s headers.
   public func setHeader(_ value: String, forKey key: String) -> Self {
-    mutableState.withValue { $0.headers[key.lowercased()] = value }
-    return self
+    var configuration = configuration
+    configuration.headers[key.lowercased()] = value
+    return StorageApi(configuration: configuration)
   }
 
   @discardableResult
   func execute(_ request: Helpers.HTTPRequest) async throws -> Helpers.HTTPResponse {
     var request = request
-    let headers = mutableState.headers
-    request.headers = HTTPFields(headers).merging(with: request.headers)
+    request.headers = HTTPFields(configuration.headers).merging(with: request.headers)
 
     let response = try await http.send(request)
 

--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -5,25 +5,15 @@ import HTTPTypes
   import FoundationNetworking
 #endif
 
-/// Base type for Storage API operations.
+/// Internal implementation detail shared by ``SupabaseStorageClient``, ``StorageFileApi``, and the
+/// Vectors trio (``StorageVectorsClient``, ``VectorBucketClient``, ``VectorIndexClient``).
 ///
-/// ``StorageApi`` holds the ``StorageClientConfiguration`` and the underlying HTTP client used to
-/// execute requests. ``SupabaseStorageClient`` and ``StorageFileApi`` each hold a ``StorageApi``
-/// value and delegate to it rather than inheriting from it.
-///
-/// ## Topics
-///
-/// ### Configuration
-///
-/// - ``configuration``
-/// - ``init(configuration:)``
-///
-/// ### Customizing headers
-///
-/// - ``setHeader(_:forKey:)``
-public struct StorageApi: Sendable {
+/// Holds the ``StorageClientConfiguration`` and the underlying HTTP client used to execute
+/// requests. Each of the types above holds a ``StorageApi`` value and delegates to it rather than
+/// inheriting from it.
+struct StorageApi: Sendable {
   /// The configuration used to initialize this client instance.
-  public let configuration: StorageClientConfiguration
+  let configuration: StorageClientConfiguration
 
   private let http: any HTTPClientType
 
@@ -31,7 +21,7 @@ public struct StorageApi: Sendable {
   ///
   /// - Parameter configuration: The configuration that controls the endpoint URL, authentication
   ///   headers, JSON codecs, and HTTP session.
-  public init(configuration: StorageClientConfiguration) {
+  init(configuration: StorageClientConfiguration) {
     var configuration = configuration
     if configuration.headers["X-Client-Info"] == nil {
       configuration.headers["X-Client-Info"] = "storage-swift/\(version)"
@@ -87,7 +77,7 @@ public struct StorageApi: Sendable {
   ///   - value: The value of the header field.
   ///   - key: The name of the header field. The key is case-insensitively stored as lowercase.
   /// - Returns: A new ``StorageApi`` with the header merged into ``configuration``'s headers.
-  public func setHeader(_ value: String, forKey key: String) -> Self {
+  func setHeader(_ value: String, forKey key: String) -> Self {
     var configuration = configuration
     configuration.headers[key.lowercased()] = value
     return StorageApi(configuration: configuration)

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -74,9 +74,6 @@ enum FileUpload {
 /// let url = try await fileApi.createSignedURL(path: "user123.png", expiresIn: 60)
 /// ```
 ///
-/// > Note: This class is `@unchecked Sendable`. The `bucketId` property is immutable (`let`), and
-/// > all mutable header state is protected by the lock inherited from ``StorageApi``.
-///
 /// ## Topics
 ///
 /// ### Uploading files
@@ -110,13 +107,39 @@ enum FileUpload {
 ///
 /// - ``createSignedURL(path:expiresIn:download:transform:cacheNonce:)-(_,_,DownloadBehavior?,_,_)``
 /// - ``createSignedURLs(paths:expiresIn:download:cacheNonce:)-(_,_,DownloadBehavior?,_)``
-public class StorageFileApi: StorageApi, @unchecked Sendable {
+///
+/// ### Customizing headers
+///
+/// - ``setHeader(_:forKey:)``
+public struct StorageFileApi: Sendable {
   /// The identifier of the bucket this instance operates on.
   let bucketId: String
 
-  init(bucketId: String, configuration: StorageClientConfiguration) {
+  let api: StorageApi
+
+  init(bucketId: String, api: StorageApi) {
     self.bucketId = bucketId
-    super.init(configuration: configuration)
+    self.api = api
+  }
+
+  /// Returns a new ``StorageFileApi`` with an additional HTTP header merged into the underlying
+  /// ``StorageApi``'s configuration, included in all requests made by the returned instance.
+  ///
+  /// Because ``StorageFileApi`` is an immutable value type, this method does not mutate `self` —
+  /// it returns a new instance. Discarding the return value is a no-op, so always use the result:
+  ///
+  /// ```swift
+  /// storage.from("avatars")
+  ///   .setHeader("x-custom-header", forKey: "X-Custom-Header")
+  ///   .list()
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - value: The value of the header field.
+  ///   - key: The name of the header field. The key is case-insensitively stored as lowercase.
+  /// - Returns: A new ``StorageFileApi`` with the header merged into the configuration's headers.
+  public func setHeader(_ value: String, forKey key: String) -> Self {
+    StorageFileApi(bucketId: bucketId, api: api.setHeader(value, forKey: key))
   }
 
   private struct MoveResponse: Decodable {
@@ -163,9 +186,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     let cleanPath = _removeEmptyFolders(path)
     let _path = _getFinalPath(cleanPath)
 
-    let response = try await execute(
+    let response = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/\(_path)"),
+        url: api.configuration.url.appendingPathComponent("object/\(_path)"),
         method: method,
         query: [],
         formData: formData,
@@ -173,7 +196,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
         headers: headers
       )
     )
-    .decoded(as: UploadResponse.self, decoder: configuration.decoder)
+    .decoded(as: UploadResponse.self, decoder: api.configuration.decoder)
 
     return FileUploadResponse(
       id: response.Id,
@@ -306,11 +329,11 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     to destination: String,
     options: DestinationOptions? = nil
   ) async throws {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/move"),
+        url: api.configuration.url.appendingPathComponent("object/move"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: api.configuration.encoder.encode(
           [
             "bucketId": bucketId,
             "sourceKey": source,
@@ -345,11 +368,11 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
       let Key: String
     }
 
-    return try await execute(
+    return try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/copy"),
+        url: api.configuration.url.appendingPathComponent("object/copy"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: api.configuration.encoder.encode(
           [
             "bucketId": bucketId,
             "sourceKey": source,
@@ -359,7 +382,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
         )
       )
     )
-    .decoded(as: UploadResponse.self, decoder: configuration.decoder)
+    .decoded(as: UploadResponse.self, decoder: api.configuration.decoder)
     .Key
   }
 
@@ -390,16 +413,16 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
 
     let encoder = JSONEncoder.unconfiguredEncoder
 
-    let response = try await execute(
+    let response = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/sign/\(_getFinalPath(path))"),
+        url: api.configuration.url.appendingPathComponent("object/sign/\(_getFinalPath(path))"),
         method: .post,
         body: encoder.encode(
           Body(expiresIn: expiresIn, transform: transform)
         )
       )
     )
-    .decoded(as: SignedURLAPIResponse.self, decoder: configuration.decoder)
+    .decoded(as: SignedURLAPIResponse.self, decoder: api.configuration.decoder)
 
     return try makeSignedURL(response.signedURL, download: download, cacheNonce: cacheNonce)
   }
@@ -475,16 +498,16 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
 
     let encoder = JSONEncoder.unconfiguredEncoder
 
-    let response = try await execute(
+    let response = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/sign/\(bucketId)"),
+        url: api.configuration.url.appendingPathComponent("object/sign/\(bucketId)"),
         method: .post,
         body: encoder.encode(
           Params(expiresIn: expiresIn, paths: paths)
         )
       )
     )
-    .decoded(as: [SignedURLsAPIResponse].self, decoder: configuration.decoder)
+    .decoded(as: [SignedURLsAPIResponse].self, decoder: api.configuration.decoder)
 
     return try response.map { item in
       if let signedURLString = item.signedURL {
@@ -554,7 +577,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   {
     guard let signedURLComponents = URLComponents(string: signedURL),
       var baseComponents = URLComponents(
-        url: configuration.url, resolvingAgainstBaseURL: false)
+        url: api.configuration.url, resolvingAgainstBaseURL: false)
     else {
       throw URLError(.badURL)
     }
@@ -593,14 +616,14 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   @discardableResult
   public func remove(paths: [String]) async throws -> [FileObject] {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/\(bucketId)"),
+        url: api.configuration.url.appendingPathComponent("object/\(bucketId)"),
         method: .delete,
-        body: configuration.encoder.encode(["prefixes": paths])
+        body: api.configuration.encoder.encode(["prefixes": paths])
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: api.configuration.decoder)
   }
 
   /// Lists all files within a bucket folder.
@@ -631,14 +654,14 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
     sortBy.order = sortBy.order ?? defaultSearchOptions.sortBy?.order
     options.sortBy = sortBy
 
-    return try await execute(
+    return try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/list/\(bucketId)"),
+        url: api.configuration.url.appendingPathComponent("object/list/\(bucketId)"),
         method: .post,
         body: encoder.encode(options)
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: api.configuration.decoder)
   }
 
   /// Downloads a file from a private bucket and returns its raw bytes.
@@ -678,9 +701,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
       queryItems.append(URLQueryItem(name: "cacheNonce", value: cacheNonce))
     }
 
-    return try await execute(
+    return try await api.execute(
       HTTPRequest(
-        url: configuration.url
+        url: api.configuration.url
           .appendingPathComponent("\(renderPath)/\(_path)"),
         method: .get,
         query: queryItems
@@ -697,13 +720,13 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   public func info(path: String) async throws -> FileObjectV2 {
     let _path = _getFinalPath(path)
 
-    return try await execute(
+    return try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("object/info/\(_path)"),
+        url: api.configuration.url.appendingPathComponent("object/info/\(_path)"),
         method: .get
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: api.configuration.decoder)
   }
 
   /// Checks whether a file exists in the bucket without downloading it.
@@ -716,9 +739,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ///   authorization errors).
   public func exists(path: String) async throws -> Bool {
     do {
-      try await execute(
+      try await api.execute(
         HTTPRequest(
-          url: configuration.url.appendingPathComponent("object/\(_getFinalPath(path))"),
+          url: api.configuration.url.appendingPathComponent("object/\(_getFinalPath(path))"),
           method: .head
         )
       )
@@ -762,7 +785,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
   ) throws -> URL {
     var queryItems: [URLQueryItem] = []
 
-    guard var components = URLComponents(url: configuration.url, resolvingAgainstBaseURL: true)
+    guard var components = URLComponents(url: api.configuration.url, resolvingAgainstBaseURL: true)
     else {
       throw URLError(.badURL)
     }
@@ -862,15 +885,15 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
 
     let cleanPath = _removeEmptyFolders(path)
 
-    let response = try await execute(
+    let response = try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent(
+        url: api.configuration.url.appendingPathComponent(
           "object/upload/sign/\(bucketId)/\(cleanPath)"),
         method: .post,
         headers: headers
       )
     )
-    .decoded(as: Response.self, decoder: configuration.decoder)
+    .decoded(as: Response.self, decoder: api.configuration.decoder)
 
     let signedURL = try makeSignedURL(response.url, download: nil)
 
@@ -974,9 +997,9 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
 
     let cleanPath = _removeEmptyFolders(path)
 
-    let fullPath = try await execute(
+    let fullPath = try await api.execute(
       HTTPRequest(
-        url: configuration.url
+        url: api.configuration.url
           .appendingPathComponent("object/upload/sign/\(bucketId)/\(cleanPath)"),
         method: .put,
         query: [URLQueryItem(name: "token", value: token)],
@@ -985,7 +1008,7 @@ public class StorageFileApi: StorageApi, @unchecked Sendable {
         headers: headers
       )
     )
-    .decoded(as: UploadResponse.self, decoder: configuration.decoder)
+    .decoded(as: UploadResponse.self, decoder: api.configuration.decoder)
     .Key
 
     return SignedURLUploadResponse(path: cleanPath, fullPath: fullPath)

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -130,7 +130,7 @@ public struct StorageFileApi: Sendable {
   }
 
   /// Returns a new ``StorageFileApi`` with an additional HTTP header merged into the underlying
-  /// ``StorageApi``'s configuration, included in all requests made by the returned instance.
+  /// configuration, included in all requests made by the returned instance.
   ///
   /// Because ``StorageFileApi`` is an immutable value type, this method does not mutate `self` —
   /// it returns a new instance. Discarding the return value is a no-op, so always use the result:

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -111,11 +111,18 @@ enum FileUpload {
 /// ### Customizing headers
 ///
 /// - ``setHeader(_:forKey:)``
+///
+/// ### Configuration
+///
+/// - ``configuration``
 public struct StorageFileApi: Sendable {
   /// The identifier of the bucket this instance operates on.
   let bucketId: String
 
   let api: StorageApi
+
+  /// The configuration used to initialize this client instance.
+  public var configuration: StorageClientConfiguration { api.configuration }
 
   init(bucketId: String, api: StorageApi) {
     self.bucketId = bucketId

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -87,8 +87,8 @@ public struct StorageClientConfiguration: Sendable {
 
 /// The top-level Supabase Storage client for managing buckets and files.
 ///
-/// ``SupabaseStorageClient`` inherits all bucket-management operations from ``StorageBucketApi``
-/// and provides a ``from(_:)`` method to obtain a ``StorageFileApi`` scoped to a specific bucket.
+/// ``SupabaseStorageClient`` provides bucket-management operations directly and a ``from(_:)``
+/// method to obtain a ``StorageFileApi`` scoped to a specific bucket.
 ///
 /// Typically you obtain an instance via the main `SupabaseClient`:
 ///
@@ -105,19 +105,33 @@ public struct StorageClientConfiguration: Sendable {
 ///
 /// ## Topics
 ///
+/// ### Creating a client
+///
+/// - ``init(configuration:)``
+///
 /// ### Accessing buckets
 ///
 /// - ``from(_:)``
 ///
 /// ### Bucket management
 ///
-/// - ``StorageBucketApi/listBuckets()``
-/// - ``StorageBucketApi/getBucket(_:)``
-/// - ``StorageBucketApi/createBucket(_:options:)``
-/// - ``StorageBucketApi/updateBucket(_:options:)``
-/// - ``StorageBucketApi/emptyBucket(_:)``
-/// - ``StorageBucketApi/deleteBucket(_:)``
-public class SupabaseStorageClient: StorageBucketApi, @unchecked Sendable {
+/// - ``listBuckets()``
+/// - ``getBucket(_:)``
+/// - ``createBucket(_:options:)``
+/// - ``updateBucket(_:options:)``
+/// - ``emptyBucket(_:)``
+/// - ``deleteBucket(_:)``
+public struct SupabaseStorageClient: Sendable {
+  let api: StorageApi
+
+  /// Creates a ``SupabaseStorageClient`` with the given configuration.
+  ///
+  /// - Parameter configuration: The configuration that controls the endpoint URL, authentication
+  ///   headers, JSON codecs, and HTTP session.
+  public init(configuration: StorageClientConfiguration) {
+    api = StorageApi(configuration: configuration)
+  }
+
   /// Returns a ``StorageFileApi`` scoped to the given bucket.
   ///
   /// Use the returned object to upload, download, list, move, copy, or delete files within the
@@ -126,7 +140,7 @@ public class SupabaseStorageClient: StorageBucketApi, @unchecked Sendable {
   /// - Parameter id: The unique identifier of the bucket to operate on.
   /// - Returns: A ``StorageFileApi`` configured for the given bucket.
   public func from(_ id: String) -> StorageFileApi {
-    StorageFileApi(bucketId: id, configuration: configuration)
+    StorageFileApi(bucketId: id, api: api)
   }
 
   /// A client for managing vector buckets.
@@ -139,6 +153,6 @@ public class SupabaseStorageClient: StorageBucketApi, @unchecked Sendable {
   /// - Warning: Experimental. See ``StorageVectorsClient``.
   @_spi(Experimental)
   public var vectors: StorageVectorsClient {
-    StorageVectorsClient(api: self)
+    StorageVectorsClient(api: api)
   }
 }

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -109,6 +109,10 @@ public struct StorageClientConfiguration: Sendable {
 ///
 /// - ``init(configuration:)``
 ///
+/// ### Configuration
+///
+/// - ``configuration``
+///
 /// ### Accessing buckets
 ///
 /// - ``from(_:)``
@@ -123,6 +127,9 @@ public struct StorageClientConfiguration: Sendable {
 /// - ``deleteBucket(_:)``
 public struct SupabaseStorageClient: Sendable {
   let api: StorageApi
+
+  /// The configuration used to initialize this client instance.
+  public var configuration: StorageClientConfiguration { api.configuration }
 
   /// Creates a ``SupabaseStorageClient`` with the given configuration.
   ///

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -113,6 +113,10 @@ public struct StorageClientConfiguration: Sendable {
 ///
 /// - ``configuration``
 ///
+/// ### Customizing headers
+///
+/// - ``setHeader(_:forKey:)``
+///
 /// ### Accessing buckets
 ///
 /// - ``from(_:)``
@@ -137,6 +141,31 @@ public struct SupabaseStorageClient: Sendable {
   ///   headers, JSON codecs, and HTTP session.
   public init(configuration: StorageClientConfiguration) {
     api = StorageApi(configuration: configuration)
+  }
+
+  init(api: StorageApi) {
+    self.api = api
+  }
+
+  /// Returns a new ``SupabaseStorageClient`` with an additional HTTP header merged into the
+  /// underlying ``StorageApi``'s configuration, included in all requests made by the returned
+  /// instance (and by ``StorageFileApi`` instances subsequently obtained via ``from(_:)``).
+  ///
+  /// Because ``SupabaseStorageClient`` is an immutable value type, this method does not mutate
+  /// `self` — it returns a new instance. Discarding the return value is a no-op, so always use
+  /// the result:
+  ///
+  /// ```swift
+  /// let storage = client.storage.setHeader("x-custom-header", forKey: "X-Custom-Header")
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - value: The value of the header field.
+  ///   - key: The name of the header field. The key is case-insensitively stored as lowercase.
+  /// - Returns: A new ``SupabaseStorageClient`` with the header merged into the configuration's
+  ///   headers.
+  public func setHeader(_ value: String, forKey key: String) -> Self {
+    SupabaseStorageClient(api: api.setHeader(value, forKey: key))
   }
 
   /// Returns a ``StorageFileApi`` scoped to the given bucket.

--- a/Sources/Storage/SupabaseStorage.swift
+++ b/Sources/Storage/SupabaseStorage.swift
@@ -148,8 +148,8 @@ public struct SupabaseStorageClient: Sendable {
   }
 
   /// Returns a new ``SupabaseStorageClient`` with an additional HTTP header merged into the
-  /// underlying ``StorageApi``'s configuration, included in all requests made by the returned
-  /// instance (and by ``StorageFileApi`` instances subsequently obtained via ``from(_:)``).
+  /// underlying configuration, included in all requests made by the returned instance (and by
+  /// ``StorageFileApi`` instances subsequently obtained via ``from(_:)``).
   ///
   /// Because ``SupabaseStorageClient`` is an immutable value type, this method does not mutate
   /// `self` — it returns a new instance. Discarding the return value is a no-op, so always use

--- a/Sources/Storage/SupabaseStorageClient+Buckets.swift
+++ b/Sources/Storage/SupabaseStorageClient+Buckets.swift
@@ -5,43 +5,37 @@ import HTTPTypes
   import FoundationNetworking
 #endif
 
-/// Storage API for bucket management operations.
-///
-/// ``StorageBucketApi`` provides methods to list, create, update, empty, and delete Storage
-/// buckets. It is the superclass of ``SupabaseStorageClient``.
-///
-/// > Note: This class is `@unchecked Sendable` and inherits the thread-safe design of
-/// > ``StorageApi``. No additional mutable state is introduced.
+/// Bucket-management operations for ``SupabaseStorageClient``.
 ///
 /// ## Topics
 ///
 /// ### Listing and inspecting buckets
 ///
-/// - ``listBuckets()``
-/// - ``getBucket(_:)``
+/// - ``SupabaseStorageClient/listBuckets()``
+/// - ``SupabaseStorageClient/getBucket(_:)``
 ///
 /// ### Creating and updating buckets
 ///
-/// - ``createBucket(_:options:)``
-/// - ``updateBucket(_:options:)``
+/// - ``SupabaseStorageClient/createBucket(_:options:)``
+/// - ``SupabaseStorageClient/updateBucket(_:options:)``
 ///
 /// ### Removing buckets
 ///
-/// - ``emptyBucket(_:)``
-/// - ``deleteBucket(_:)``
-public class StorageBucketApi: StorageApi, @unchecked Sendable {
+/// - ``SupabaseStorageClient/emptyBucket(_:)``
+/// - ``SupabaseStorageClient/deleteBucket(_:)``
+extension SupabaseStorageClient {
   /// Retrieves the details of all Storage buckets within the project.
   ///
   /// - Returns: An array of ``Bucket`` objects, one for each bucket in the project.
   /// - Throws: ``StorageError`` if the request fails or the caller is not authorized.
   public func listBuckets() async throws -> [Bucket] {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("bucket"),
+        url: api.configuration.url.appendingPathComponent("bucket"),
         method: .get
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: api.configuration.decoder)
   }
 
   /// Retrieves the details of an existing Storage bucket.
@@ -50,13 +44,13 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// - Returns: The ``Bucket`` with the given identifier.
   /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func getBucket(_ id: String) async throws -> Bucket {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("bucket/\(id)"),
+        url: api.configuration.url.appendingPathComponent("bucket/\(id)"),
         method: .get
       )
     )
-    .decoded(decoder: configuration.decoder)
+    .decoded(decoder: api.configuration.decoder)
   }
 
   struct BucketParameters: Encodable {
@@ -85,11 +79,11 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   public func createBucket(_ id: String, options: BucketOptions = BucketOptions(isPublic: false))
     async throws
   {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("bucket"),
+        url: api.configuration.url.appendingPathComponent("bucket"),
         method: .post,
-        body: configuration.encoder.encode(
+        body: api.configuration.encoder.encode(
           BucketParameters(
             id: id,
             name: id,
@@ -116,11 +110,11 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   ///   - options: The new options to apply to the bucket.
   /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func updateBucket(_ id: String, options: BucketOptions) async throws {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("bucket/\(id)"),
+        url: api.configuration.url.appendingPathComponent("bucket/\(id)"),
         method: .put,
-        body: configuration.encoder.encode(
+        body: api.configuration.encoder.encode(
           BucketParameters(
             id: id,
             name: id,
@@ -141,9 +135,9 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// - Parameter id: The unique identifier of the bucket to empty.
   /// - Throws: ``StorageError`` if the bucket does not exist or the caller is not authorized.
   public func emptyBucket(_ id: String) async throws {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("bucket/\(id)/empty"),
+        url: api.configuration.url.appendingPathComponent("bucket/\(id)/empty"),
         method: .post
       )
     )
@@ -158,9 +152,9 @@ public class StorageBucketApi: StorageApi, @unchecked Sendable {
   /// - Throws: ``StorageError`` if the bucket is not empty, does not exist, or the caller is not
   ///   authorized.
   public func deleteBucket(_ id: String) async throws {
-    try await execute(
+    try await api.execute(
       HTTPRequest(
-        url: configuration.url.appendingPathComponent("bucket/\(id)"),
+        url: api.configuration.url.appendingPathComponent("bucket/\(id)"),
         method: .delete
       )
     )

--- a/Sources/Storage/SupabaseStorageClient+Buckets.swift
+++ b/Sources/Storage/SupabaseStorageClient+Buckets.swift
@@ -5,24 +5,8 @@ import HTTPTypes
   import FoundationNetworking
 #endif
 
-/// Bucket-management operations for ``SupabaseStorageClient``.
-///
-/// ## Topics
-///
-/// ### Listing and inspecting buckets
-///
-/// - ``SupabaseStorageClient/listBuckets()``
-/// - ``SupabaseStorageClient/getBucket(_:)``
-///
-/// ### Creating and updating buckets
-///
-/// - ``SupabaseStorageClient/createBucket(_:options:)``
-/// - ``SupabaseStorageClient/updateBucket(_:options:)``
-///
-/// ### Removing buckets
-///
-/// - ``SupabaseStorageClient/emptyBucket(_:)``
-/// - ``SupabaseStorageClient/deleteBucket(_:)``
+/// Bucket-management operations (listing, creating, updating, emptying, and deleting) for
+/// ``SupabaseStorageClient``.
 extension SupabaseStorageClient {
   /// Retrieves the details of all Storage buckets within the project.
   ///

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -561,7 +561,7 @@ public struct FileObjectV2: Identifiable, Hashable, Decodable, Sendable {
 /// A Supabase Storage bucket.
 ///
 /// Buckets are the top-level containers for files. Retrieve bucket details with
-/// ``StorageBucketApi/getBucket(_:)`` or ``StorageBucketApi/listBuckets()``.
+/// ``SupabaseStorageClient/getBucket(_:)`` or ``SupabaseStorageClient/listBuckets()``.
 ///
 /// ## Topics
 ///

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -111,21 +111,15 @@ public final class SupabaseClient: Sendable {
 
   /// The Storage client for uploading, downloading, and managing files.
   public var storage: SupabaseStorageClient {
-    mutableState.withValue {
-      if $0.storage == nil {
-        $0.storage = SupabaseStorageClient(
-          configuration: StorageClientConfiguration(
-            url: storageURL,
-            headers: headers,
-            session: StorageHTTPSession(fetch: fetchWithAuth, upload: uploadWithAuth),
-            logger: options.global.logger,
-            useNewHostname: options.storage.useNewHostname
-          )
-        )
-      }
-
-      return $0.storage!
-    }
+    SupabaseStorageClient(
+      configuration: StorageClientConfiguration(
+        url: storageURL,
+        headers: headers,
+        session: StorageHTTPSession(fetch: fetchWithAuth, upload: uploadWithAuth),
+        logger: options.global.logger,
+        useNewHostname: options.storage.useNewHostname
+      )
+    )
   }
 
   /// The Realtime client for subscribing to database changes and broadcasting presence events.
@@ -170,7 +164,6 @@ public final class SupabaseClient: Sendable {
 
   struct MutableState {
     var listenForAuthEventsTask: Task<Void, Never>?
-    var storage: SupabaseStorageClient?
     var realtime: RealtimeClientV2?
 
     var changedAccessToken: String?

--- a/Tests/StorageTests/StorageBucketAPITests.swift
+++ b/Tests/StorageTests/StorageBucketAPITests.swift
@@ -93,7 +93,7 @@ extension StorageMockerTests {
         )
       )
       #expect(
-        storage.api.configuration.url.absoluteString == expected,
+        storage.configuration.url.absoluteString == expected,
         "should \(description) if useNewHostname is true"
       )
     }
@@ -115,7 +115,7 @@ extension StorageMockerTests {
           useNewHostname: false
         )
       )
-      #expect(storage.api.configuration.url.absoluteString == input)
+      #expect(storage.configuration.url.absoluteString == input)
     }
 
     @Test

--- a/Tests/StorageTests/StorageBucketAPITests.swift
+++ b/Tests/StorageTests/StorageBucketAPITests.swift
@@ -93,7 +93,7 @@ extension StorageMockerTests {
         )
       )
       #expect(
-        storage.configuration.url.absoluteString == expected,
+        storage.api.configuration.url.absoluteString == expected,
         "should \(description) if useNewHostname is true"
       )
     }
@@ -115,7 +115,7 @@ extension StorageMockerTests {
           useNewHostname: false
         )
       )
-      #expect(storage.configuration.url.absoluteString == input)
+      #expect(storage.api.configuration.url.absoluteString == input)
     }
 
     @Test

--- a/Tests/StorageTests/StorageFileAPITests.swift
+++ b/Tests/StorageTests/StorageFileAPITests.swift
@@ -75,6 +75,12 @@ extension StorageMockerTests {
     }
 
     @Test
+    func configuration() {
+      let storage = makeSUT()
+      #expect(storage.from("bucket").configuration.url == url)
+    }
+
+    @Test
     func listFiles() async throws {
       let storage = makeSUT()
 

--- a/Tests/StorageTests/SupabaseStorageTests.swift
+++ b/Tests/StorageTests/SupabaseStorageTests.swift
@@ -419,4 +419,46 @@ struct SupabaseStorageTests {
     // The new StorageFileApi instance should NOT have the previous instance's header
     #expect(capturedRequests[1].value(forHTTPHeaderField: "X-Child-Header") == nil)
   }
+
+  @Test
+  func setHeader_onTopLevelClientPropagatesToFileApi() async throws {
+    let capturedRequest = LockIsolated(URLRequest?.none)
+    let sessionMock = StorageHTTPSession(
+      fetch: { request in
+        capturedRequest.setValue(request)
+        return (
+          """
+          [
+            {
+              "name": "test.txt",
+              "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
+              "updatedAt": "2024-01-01T00:00:00Z",
+              "createdAt": "2024-01-01T00:00:00Z",
+              "lastAccessedAt": "2024-01-01T00:00:00Z",
+              "metadata": {}
+            }
+          ]
+          """.data(using: .utf8)!,
+          HTTPURLResponse(
+            url: self.supabaseURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      },
+      upload: unimplemented("StorageHTTPSession.upload")
+    )
+
+    let sut = makeSUT(session: sessionMock)
+
+    _ =
+      try await sut
+      .setHeader("client-value", forKey: "X-Client-Header")
+      .from(bucketId)
+      .list()
+
+    #expect(
+      capturedRequest.value?.value(forHTTPHeaderField: "X-Client-Header") == "client-value")
+  }
 }

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -11,6 +11,7 @@ import Testing
 @testable import Functions
 @testable import Realtime
 @testable import RealtimeV2
+@testable import Storage
 @testable import Supabase
 
 #if canImport(FoundationNetworking)
@@ -114,7 +115,7 @@ struct SupabaseClientTests {
     }
     expectNoDifference(client.headers, client.auth.configuration.headers)
     expectNoDifference(client.headers, client.functions.headers.dictionary)
-    expectNoDifference(client.headers, client.storage.configuration.headers)
+    expectNoDifference(client.headers, client.storage.api.configuration.headers)
     expectNoDifference(client.headers, client.rest.configuration.headers)
 
     #expect(client.functions.region == "ap-northeast-1")

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -11,7 +11,6 @@ import Testing
 @testable import Functions
 @testable import Realtime
 @testable import RealtimeV2
-@testable import Storage
 @testable import Supabase
 
 #if canImport(FoundationNetworking)
@@ -115,7 +114,7 @@ struct SupabaseClientTests {
     }
     expectNoDifference(client.headers, client.auth.configuration.headers)
     expectNoDifference(client.headers, client.functions.headers.dictionary)
-    expectNoDifference(client.headers, client.storage.api.configuration.headers)
+    expectNoDifference(client.headers, client.storage.configuration.headers)
     expectNoDifference(client.headers, client.rest.configuration.headers)
 
     #expect(client.functions.region == "ap-northeast-1")

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -432,12 +432,18 @@ struct SupabaseClientTests {
       )
       box.client = client
 
-      // Materialize every lazily-built sub-client: each one caches the `fetch`/`upload` closures
-      // in `mutableState`, so a `self` capture there would form a retain cycle.
+      // Materialize every sub-client cached in `mutableState`: each one captures the
+      // `fetch`/`upload` closures there, so a `self` capture in one of those closures would
+      // form a retain cycle (client -> mutableState -> cached sub-client -> closure -> client).
       _ = client.rest
-      _ = client.storage
       _ = client.functions
       _ = client.realtimeV2
+
+      // `storage` builds a fresh, uncached `SupabaseStorageClient` on every access (see
+      // `SupabaseClient.storage`), so discarding the result here can't exercise the same
+      // detection: nothing keeps the closures it captures alive past this statement, so this
+      // arm can't prove `storage` is cycle-free the way the cached sub-clients above can.
+      _ = client.storage
     }
     scope()
 

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1463,3 +1463,65 @@ unused` warning instead of an error, and at runtime the header (or the `retry(en
 simply not applied. Search your codebase for `setHeader(` and `retry(enabled:` on a PostgREST
 builder and make sure every call site consumes the returned value — either by chaining directly onto
 it or by reassigning, as above.
+## `StorageApi`, `SupabaseStorageClient`, and `StorageFileApi` are now `struct`s instead of `class`es; `StorageBucketApi` is removed
+
+These types no longer hold any mutable state — the only mutable state they had was the header
+dictionary `setHeader(_:forKey:)` wrote to, which is now handled by returning a new value instead
+(see below) — so every stored property is now an immutable `let`, and the types themselves are now
+`struct`s.
+
+`StorageBucketApi` is removed entirely. It was never constructed directly; it existed only so
+`SupabaseStorageClient` could inherit its bucket-management methods (`listBuckets()`,
+`getBucket(_:)`, `createBucket(_:options:)`, `updateBucket(_:options:)`, `emptyBucket(_:)`,
+`deleteBucket(_:)`). Those methods are now declared directly on `SupabaseStorageClient` — call
+sites that only ever called them through `SupabaseStorageClient` (e.g. `client.storage.listBuckets()`)
+compile unchanged.
+
+Calling methods (`from(_:)`, `upload`, `download`, `list`, and friends) compiles unchanged; this
+only breaks code that depended on these types being reference types: a `weak var` holding one, an
+`AnyObject` constraint, or an identity check with `===`. None of those compile against a struct.
+
+```swift
+// Before
+weak var storage: SupabaseStorageClient?
+
+// After
+// Structs have no identity to hold weakly — keep a strong reference, or drop the field if it only
+// existed to avoid a retain cycle.
+var storage: SupabaseStorageClient?
+```
+
+This is a compile error, not a silent behavior change. Search your codebase for `weak`, `unowned`,
+`AnyObject`, or `===` next to a `StorageApi`, `SupabaseStorageClient`, or `StorageFileApi` variable
+to find affected call sites.
+
+## `StorageApi.setHeader(_:forKey:)` no longer mutates in place
+
+`setHeader(_:forKey:)` used to mutate a lock-protected header dictionary on the instance and return
+`self` for chaining, marked `@discardableResult`. Now that `StorageApi` (and `SupabaseStorageClient`
+/ `StorageFileApi`, which hold one) is an immutable value type, `setHeader` instead builds and
+returns a **new** value with the header merged in, and `@discardableResult` is removed.
+
+This is a silent behavior change, not a compile error, if you call `setHeader` and discard the
+result — removing `@discardableResult` turns that into an "unused result" compiler warning rather
+than a build failure, so it's easy to miss if warnings aren't treated as errors:
+
+```swift
+// Before: mutated the instance in place; the extra header applied to every later request.
+storage.from("avatars").setHeader("x-custom-header", forKey: "X-Custom-Header")
+try await storage.from("avatars").upload(...) // included the header
+
+// After: returns a new value; the statement above is now a no-op, and the header is
+// lost by the next line unless you capture and reuse the returned value.
+let avatars = storage.from("avatars").setHeader("x-custom-header", forKey: "X-Custom-Header")
+try await avatars.upload(...) // includes the header
+
+// Or chain directly:
+try await storage.from("avatars")
+  .setHeader("x-custom-header", forKey: "X-Custom-Header")
+  .upload(...)
+```
+
+Search your codebase for `.setHeader(` on a `StorageApi`/`SupabaseStorageClient`/`StorageFileApi`
+value to find affected call sites, and check that each one uses the returned value rather than
+discarding it.

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1535,12 +1535,12 @@ let storage = client.storage.setHeader("v", forKey: "X-Foo")
 try await storage.from("bucket").list() // X-Foo is sent
 ```
 
-## `StorageApi.setHeader(_:forKey:)` no longer mutates in place
+## `setHeader(_:forKey:)` on `SupabaseStorageClient`/`StorageFileApi` no longer mutates in place
 
 `setHeader(_:forKey:)` used to mutate a lock-protected header dictionary on the instance and return
-`self` for chaining, marked `@discardableResult`. Now that `StorageApi` (and `SupabaseStorageClient`
-/ `StorageFileApi`, which hold one) is an immutable value type, `setHeader` instead builds and
-returns a **new** value with the header merged in, and `@discardableResult` is removed.
+`self` for chaining, marked `@discardableResult`. Now that these are immutable value types,
+`setHeader` instead builds and returns a **new** value with the header merged in, and
+`@discardableResult` is removed.
 
 This is a silent behavior change, not a compile error, if you call `setHeader` and discard the
 result — removing `@discardableResult` turns that into an "unused result" compiler warning rather
@@ -1562,6 +1562,16 @@ try await storage.from("avatars")
   .upload(...)
 ```
 
-Search your codebase for `.setHeader(` on a `StorageApi`/`SupabaseStorageClient`/`StorageFileApi`
-value to find affected call sites, and check that each one uses the returned value rather than
-discarding it.
+Search your codebase for `.setHeader(` on a `SupabaseStorageClient`/`StorageFileApi` value to find
+affected call sites, and check that each one uses the returned value rather than discarding it.
+
+## `StorageApi` is now internal
+
+`StorageApi` is removed from the public API. It was the shared implementation type
+`SupabaseStorageClient`, `StorageFileApi`, and the Vectors trio each held internally and delegated
+to — nothing in the public API ever accepted or returned one, so a directly-constructed
+`StorageApi` value had no productive use: its `execute(_:)` method was already internal, and none
+of the public client types exposed a way to build one from a standalone `StorageApi`. If your code
+constructed `StorageApi(configuration:)` directly, construct a `SupabaseStorageClient(configuration:)`
+instead — its public surface (`configuration`, `setHeader(_:forKey:)`, `from(_:)`) is a superset of
+what `StorageApi` exposed.

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1470,12 +1470,33 @@ dictionary `setHeader(_:forKey:)` wrote to, which is now handled by returning a 
 (see below) — so every stored property is now an immutable `let`, and the types themselves are now
 `struct`s.
 
-`StorageBucketApi` is removed entirely. It was never constructed directly; it existed only so
-`SupabaseStorageClient` could inherit its bucket-management methods (`listBuckets()`,
-`getBucket(_:)`, `createBucket(_:options:)`, `updateBucket(_:options:)`, `emptyBucket(_:)`,
-`deleteBucket(_:)`). Those methods are now declared directly on `SupabaseStorageClient` — call
-sites that only ever called them through `SupabaseStorageClient` (e.g. `client.storage.listBuckets()`)
-compile unchanged.
+**Why**: beyond removing the lock, this is a real bug fix. `SupabaseStorageClient` used to store
+its mutable header dictionary separately from its immutable `configuration`, and `from(_:)` built
+each `StorageFileApi` from `configuration` alone — never from the live header state:
+
+```swift
+// Before, inside SupabaseStorageClient.from(_:):
+public func from(_ id: String) -> StorageFileApi {
+  StorageFileApi(bucketId: id, configuration: configuration)  // not the mutated headers
+}
+```
+
+So `storage.setHeader("v", forKey: "X-Foo")` followed by `storage.from("bucket").list()` silently
+dropped `X-Foo` — the new `StorageFileApi` never saw it. Meanwhile the same header *did* reach
+`storage.vectors` calls, since `vectors` passed `self` (the live instance, headers and all) through
+instead of rebuilding from `configuration`. This composition-based rewrite passes the whole `api`
+value — which now carries the header state, since there's no separate mutable copy to drop —
+through both `from(_:)` and `vectors`, so `setHeader` propagates consistently to both call paths.
+
+`StorageBucketApi` is removed entirely. Nothing in this codebase ever constructed it directly; it
+existed only so `SupabaseStorageClient` could inherit its bucket-management methods
+(`listBuckets()`, `getBucket(_:)`, `createBucket(_:options:)`, `updateBucket(_:options:)`,
+`emptyBucket(_:)`, `deleteBucket(_:)`). Those methods are now declared directly on
+`SupabaseStorageClient` — call sites that only ever called them through `SupabaseStorageClient`
+(e.g. `client.storage.listBuckets()`) compile unchanged. If your code constructed
+`StorageBucketApi` directly — it was a public class with an inherited public initializer, so this
+was possible even though nothing here did it — switch to constructing/using
+`SupabaseStorageClient` instead; its methods are a superset, since the bucket methods moved there.
 
 Calling methods (`from(_:)`, `upload`, `download`, `list`, and friends) compiles unchanged; this
 only breaks code that depended on these types being reference types: a `weak var` holding one, an
@@ -1494,6 +1515,25 @@ var storage: SupabaseStorageClient?
 This is a compile error, not a silent behavior change. Search your codebase for `weak`, `unowned`,
 `AnyObject`, or `===` next to a `StorageApi`, `SupabaseStorageClient`, or `StorageFileApi` variable
 to find affected call sites.
+
+`SupabaseClient.storage` also stopped memoizing its result as a side effect of this rewrite: it
+used to cache the `SupabaseStorageClient` it built and return that same instance on every access,
+so a header set via `client.storage.setHeader(...)` (before `setHeader` even required using its
+result, back when it mutated in place) stuck around across later `client.storage` accesses. Now
+every `client.storage` access builds a fresh value, so nothing is around to remember a header
+across accesses even if you do capture and reuse `setHeader`'s result:
+
+```swift
+// This does not persist the header on `client.storage` — the next access builds a new,
+// unmodified instance from `client`'s own configuration.
+_ = client.storage.setHeader("v", forKey: "X-Foo")
+try await client.storage.from("bucket").list() // X-Foo is not sent
+
+// Hold the returned value instead, and use it directly rather than going through
+// `client.storage` again.
+let storage = client.storage.setHeader("v", forKey: "X-Foo")
+try await storage.from("bucket").list() // X-Foo is sent
+```
 
 ## `StorageApi.setHeader(_:forKey:)` no longer mutates in place
 


### PR DESCRIPTION
## Summary

Converts `Sources/Storage`'s public client types (`StorageApi`, `StorageBucketApi`, `StorageFileApi`, `SupabaseStorageClient`) from `LockIsolated`-backed classes to immutable structs, mirroring the `FunctionsClient` conversion in #1233. Part of the "supabase-swift v3" migration (tracked in [SDK-1533](https://linear.app/supabase/issue/SDK-1533)).

- `StorageApi` becomes a plain immutable struct (drops `LockIsolated`/`@unchecked Sendable`), and is now `internal` — nothing public ever accepted or returned one, so it was dead public surface ([SDK-1534](https://linear.app/supabase/issue/SDK-1534)).
- `StorageBucketApi` is removed; its methods move onto `SupabaseStorageClient` directly (`SupabaseStorageClient+Buckets.swift`).
- `SupabaseStorageClient` and `StorageFileApi` become structs composing `StorageApi`, matching the shape already used by the Vectors trio (`StorageVectorsClient`/`VectorBucketClient`/`VectorIndexClient`, untouched).
- `setHeader(_:forKey:)` is now non-mutating (returns a new value) and drops `@discardableResult`.
- `SupabaseClient.storage` stops being memoized, mirroring the existing `functions` property.
- Along the way, this fixes a real bug: `SupabaseStorageClient.from(_:)` used to silently drop headers set via `setHeader` on the top-level client (it only passed the stored `configuration`, not the live header state) — the composition-based rewrite fixes this asymmetry.
- `V3_MIGRATION.md` documents all of the above as breaking changes.
- Filed as follow-ups rather than scope-creeped into this PR: [SDK-1536](https://linear.app/supabase/issue/SDK-1536) (whether `setHeader`'s name should change now that it's non-mutating).

## Test plan

- [x] `swift test` — 1182/1182 passing, 9 known pre-existing issues, no new failures
- [x] `./scripts/test-docs.sh` — clean, no DocC warnings
- [x] `./scripts/spell-check.sh` — clean on all shipped files
- [x] `./scripts/format.sh` — no changes
- [x] Examples Xcode workspace build (`Supabase.xcworkspace`, `Examples` scheme) — builds successfully
- [x] Full whole-branch code review completed, all Critical/Important findings addressed