### PR TITLE
feat(postgrest,realtime)!: standardize per-call encoder/decoder overrides

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -57,6 +57,12 @@ public struct FunctionsClient: Sendable {
   let region: String?
 
   /// The JSON decoder used to decode function response bodies.
+  ///
+  /// Individual calls to ``invoke(_:options:decoder:)`` can override this per call — a
+  /// client-wide default with a per-call override, the same pattern PostgREST's
+  /// `PostgrestClient.Configuration.decoder` uses. ``FunctionsError/httpError(code:data:)``
+  /// carries the response body as raw `Data` rather than decoding it, so this setting never
+  /// affects error handling.
   public let decoder: JSONDecoder
 
   let headers: HTTPFields

--- a/Sources/Helpers/JSONValue/JSONValue+Codable.swift
+++ b/Sources/Helpers/JSONValue/JSONValue+Codable.swift
@@ -17,7 +17,8 @@ extension JSONValue {
 
 extension JSONValue {
   /// Initialize an ``JSONValue`` from an `Encodable` value.
-  public init(_ value: some Encodable) throws {
+  /// - Parameter encoder: The `JSONEncoder` used to serialize `value`. Defaults to ``encoder``.
+  public init(_ value: some Encodable, encoder: JSONEncoder = JSONValue.encoder) throws {
     if let value = value as? JSONValue {
       self = value
     } else if let string = value as? String {
@@ -29,7 +30,7 @@ extension JSONValue {
     } else if let double = value as? Double {
       self = .double(double)
     } else {
-      let data = try JSONValue.encoder.encode(value)
+      let data = try encoder.encode(value)
       self = try JSONValue.decoder.decode(JSONValue.self, from: data)
     }
   }
@@ -64,8 +65,9 @@ extension JSONObject {
   }
 
   /// Initialize JSONObject from an `Encodable` type
-  public init(_ value: some Encodable) throws {
-    guard let object = try JSONValue(value).objectValue else {
+  /// - Parameter encoder: The `JSONEncoder` used to serialize `value`. Defaults to ``JSONValue/encoder``.
+  public init(_ value: some Encodable, encoder: JSONEncoder = JSONValue.encoder) throws {
+    guard let object = try JSONValue(value, encoder: encoder).objectValue else {
       throw DecodingError.typeMismatch(
         JSONObject.self,
         DecodingError.Context(

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -119,12 +119,19 @@ public struct PostgrestClient: Sendable {
     /// The `JSONEncoder` used to serialize request bodies.
     ///
     /// Defaults to ``jsonEncoder``, which is pre-configured with Supabase-compatible settings.
-    public var encoder: JSONEncoder
+    /// Individual calls to ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``,
+    /// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``, and
+    /// ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:encoder:)``
+    /// can override this per call.
+    public let encoder: JSONEncoder
 
     /// The `JSONDecoder` used to deserialize response bodies.
     ///
     /// Defaults to ``jsonDecoder``, which is pre-configured with Supabase-compatible settings.
-    public var decoder: JSONDecoder
+    /// Individual calls to ``PostgrestRequestBuilder/execute(options:decoder:)``
+    /// can override this per call. Never used to decode ``PostgrestError`` — that always uses a
+    /// fixed internal decoder, decoupled from this setting.
+    public let decoder: JSONDecoder
 
     /// Whether the client should automatically retry transient errors.
     ///
@@ -242,9 +249,9 @@ public struct PostgrestClient: Sendable {
   /// Returns a query builder targeting the specified table or view.
   ///
   /// Call ``PostgrestRequestBuilder/select(_:head:count:)`` on the returned builder to begin a
-  /// `SELECT`, or use ``PostgrestRequestBuilder/insert(_:returning:count:)``,
-  /// ``PostgrestRequestBuilder/update(_:returning:count:)``,
-  /// ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``, or
+  /// `SELECT`, or use ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``,
+  /// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``,
+  /// ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:encoder:)``, or
   /// ``PostgrestRequestBuilder/delete(returning:count:)`` for write operations.
   ///
   /// - Parameter table: The name of the table or view to query.

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 import HTTPTypes
 
 // The operation methods available before an operation has been chosen. The overview prose and
@@ -89,14 +89,17 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   ///   - values: An `Encodable` value representing a single row or an array of rows to insert.
   ///   - returning: Controls which rows PostgREST returns. Defaults to `nil` (server decides).
   ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
+  ///   - encoder: The `JSONEncoder` used to serialize `values`. Overrides
+  ///     ``PostgrestClient/Configuration/encoder`` when non-`nil`.
   /// - Returns: A ``PostgrestFilterBuilder`` for applying additional constraints or executing the request.
   /// - Throws: An encoding error if `values` cannot be serialized, or ``PostgrestError`` on server error.
   public func insert(
     _ values: some Encodable,
     returning: PostgrestReturningOptions? = nil,
-    count: CountOption? = nil
+    count: CountOption? = nil,
+    encoder: JSONEncoder? = nil
   ) throws -> PostgrestFilterBuilder {
-    let body = try configuration.encoder.encode(values)
+    let body = try (encoder ?? configuration.encoder).encode(values)
 
     var request = self.request
     request.method = .post
@@ -157,6 +160,8 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
   ///   - ignoreDuplicates: When `true`, conflicting rows are silently ignored. When `false` (the
   ///     default), conflicting rows are merged with the supplied values.
+  ///   - encoder: The `JSONEncoder` used to serialize `values`. Overrides
+  ///     ``PostgrestClient/Configuration/encoder`` when non-`nil`.
   /// - Returns: A ``PostgrestFilterBuilder`` for applying additional constraints or executing the request.
   /// - Throws: An encoding error if `values` cannot be serialized, or ``PostgrestError`` on server error.
   public func upsert(
@@ -164,9 +169,10 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
     onConflict: String? = nil,
     returning: PostgrestReturningOptions = .representation,
     count: CountOption? = nil,
-    ignoreDuplicates: Bool = false
+    ignoreDuplicates: Bool = false,
+    encoder: JSONEncoder? = nil
   ) throws -> PostgrestFilterBuilder {
-    let body = try configuration.encoder.encode(values)
+    let body = try (encoder ?? configuration.encoder).encode(values)
 
     var request = self.request
     request.method = .post
@@ -225,14 +231,17 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   ///   - values: An `Encodable` value with the columns to update.
   ///   - returning: Controls which rows PostgREST returns after the update. Defaults to ``PostgrestReturningOptions/representation``.
   ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
+  ///   - encoder: The `JSONEncoder` used to serialize `values`. Overrides
+  ///     ``PostgrestClient/Configuration/encoder`` when non-`nil`.
   /// - Returns: A ``PostgrestFilterBuilder`` for scoping which rows are affected.
   /// - Throws: An encoding error if `values` cannot be serialized, or ``PostgrestError`` on server error.
   public func update(
     _ values: some Encodable,
     returning: PostgrestReturningOptions = .representation,
-    count: CountOption? = nil
+    count: CountOption? = nil,
+    encoder: JSONEncoder? = nil
   ) throws -> PostgrestFilterBuilder {
-    let body = try configuration.encoder.encode(values)
+    let body = try (encoder ?? configuration.encoder).encode(values)
 
     var request = self.request
     request.method = .patch

--- a/Sources/PostgREST/PostgrestRequestBuilder.swift
+++ b/Sources/PostgREST/PostgrestRequestBuilder.swift
@@ -419,7 +419,7 @@ extension PostgrestRequestBuilder where Phase: PostgrestExecutablePhase {
 
   private func execute<T>(
     options: FetchOptions,
-    decode: @Sendable (Data) throws -> T
+    decode: (Data) throws -> T
   ) async throws -> PostgrestResponse<T> {
     if let message = pendingError {
       throw PostgrestError(message: message)

--- a/Sources/PostgREST/PostgrestRequestBuilder.swift
+++ b/Sources/PostgREST/PostgrestRequestBuilder.swift
@@ -5,7 +5,7 @@
 //  Created by Guilherme Souza on 20/08/26.
 //
 
-import Foundation
+public import Foundation
 import HTTPTypes
 import Logging
 
@@ -71,7 +71,7 @@ public enum PostgrestTransformPhase: PostgrestTransformablePhase {}
 /// ### Executing the Request
 ///
 /// - ``execute(options:)->PostgrestResponse<Void>``
-/// - ``execute(options:)->PostgrestResponse<T>``
+/// - ``execute(options:decoder:)``
 public struct PostgrestRequestBuilder<Phase>: Sendable {
   let configuration: PostgrestClient.Configuration
   let http: any HTTPClientType
@@ -159,15 +159,15 @@ public struct PostgrestRequestBuilder<Phase>: Sendable {
 ///
 /// ### Inserting Rows
 ///
-/// - ``PostgrestRequestBuilder/insert(_:returning:count:)``
+/// - ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``
 ///
 /// ### Updating Rows
 ///
-/// - ``PostgrestRequestBuilder/update(_:returning:count:)``
+/// - ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``
 ///
 /// ### Upsert Rows
 ///
-/// - ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``
+/// - ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:encoder:)``
 ///
 /// ### Deleting Rows
 ///
@@ -180,11 +180,11 @@ public typealias PostgrestQueryBuilder = PostgrestRequestBuilder<PostgrestQueryP
 /// This is ``PostgrestRequestBuilder`` specialized to ``PostgrestFilterPhase``.
 ///
 /// Obtain one from ``PostgrestRequestBuilder/select(_:head:count:)``,
-/// ``PostgrestRequestBuilder/insert(_:returning:count:)``,
-/// ``PostgrestRequestBuilder/update(_:returning:count:)``, or another write method on
+/// ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``,
+/// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``, or another write method on
 /// ``PostgrestQueryBuilder``, or from ``PostgrestClient/rpc(_:params:head:get:count:)``. Chain one
 /// or more filter methods, then call
-/// ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<T>`` to send the request.
+/// ``PostgrestRequestBuilder/execute(options:decoder:)`` to send the request.
 ///
 /// All filter methods return `Self` so they can be freely chained:
 ///
@@ -261,7 +261,7 @@ public typealias PostgrestFilterBuilder = PostgrestRequestBuilder<PostgrestFilte
 ///
 /// This is ``PostgrestRequestBuilder`` specialized to ``PostgrestTransformPhase``. It sits between
 /// ``PostgrestFilterBuilder`` (WHERE clauses) and
-/// ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<T>`` (sending the request). All
+/// ``PostgrestRequestBuilder/execute(options:decoder:)`` (sending the request). All
 /// transformation methods narrow the builder to ``PostgrestTransformPhase``, so once you call one
 /// you can no longer filter — only transform further or execute.
 ///
@@ -320,8 +320,9 @@ public protocol PostgrestExecutableBuilder: Sendable {
   /// See ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<Void>``.
   func execute(options: FetchOptions) async throws -> PostgrestResponse<Void>
 
-  /// See ``PostgrestRequestBuilder/execute(options:)->PostgrestResponse<T>``.
-  func execute<T: Decodable>(options: FetchOptions) async throws -> PostgrestResponse<T>
+  /// See ``PostgrestRequestBuilder/execute(options:decoder:)``.
+  func execute<T: Decodable>(options: FetchOptions, decoder: JSONDecoder?) async throws
+    -> PostgrestResponse<T>
 }
 
 extension PostgrestRequestBuilder: PostgrestExecutableBuilder
@@ -391,18 +392,24 @@ extension PostgrestRequestBuilder where Phase: PostgrestExecutablePhase {
   ///   .value
   /// ```
   ///
-  /// - Parameter options: Options controlling whether to include a row count and whether to
-  ///   use the HEAD method. Defaults to ``FetchOptions/init(head:count:)``.
+  /// - Parameters:
+  ///   - options: Options controlling whether to include a row count and whether to
+  ///     use the HEAD method. Defaults to ``FetchOptions/init(head:count:)``.
+  ///   - decoder: The `JSONDecoder` used to decode the response body into `T`. Overrides
+  ///     ``PostgrestClient/Configuration/decoder`` when non-`nil`. Never used to decode
+  ///     ``PostgrestError`` — that always uses a fixed internal decoder.
   /// - Returns: A ``PostgrestResponse`` whose `value` is the decoded `T`.
   /// - Throws: ``PostgrestError`` if PostgREST returns an error response, a decoding error if
   ///   the response body cannot be decoded as `T`, or any error thrown by the fetch handler.
   @discardableResult
   public func execute<T: Decodable>(
-    options: FetchOptions = FetchOptions()
+    options: FetchOptions = FetchOptions(),
+    decoder: JSONDecoder? = nil
   ) async throws -> PostgrestResponse<T> {
-    try await execute(options: options) { [configuration] data in
+    let decoder = decoder ?? configuration.decoder
+    return try await execute(options: options) { [configuration] data in
       do {
-        return try configuration.decoder.decode(T.self, from: data)
+        return try decoder.decode(T.self, from: data)
       } catch {
         configuration.logger.error("Failed to decode type '\(T.self) with error: \(error)")
         throw error
@@ -490,7 +497,10 @@ extension PostgrestRequestBuilder where Phase: PostgrestExecutablePhase {
         continue
       }
 
-      if let error = try? configuration.decoder.decode(PostgrestError.self, from: response.data) {
+      // `PostgrestError`'s fields match PostgREST's JSON keys exactly, so a plain, fixed
+      // `JSONDecoder` decodes it regardless of any user-supplied key/date strategy on
+      // `configuration.decoder` or a per-call override — those are for user-defined row types.
+      if let error = try? JSONDecoder().decode(PostgrestError.self, from: response.data) {
         // `maybeSingle()` turns the "no rows" variant of PGRST116 into a `nil` value, but
         // rethrows the "multiple rows" variant since that indicates a query that should have
         // been scoped to match at most one row.

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -296,7 +296,7 @@ extension PostgrestRequestBuilder where Phase: PostgrestTransformablePhase {
   /// Requires PostgREST v13 or later. Compatible with PATCH, DELETE, and RPC calls only.
   ///
   /// > Note: This method does not validate the HTTP method. Ensure you only use it with
-  /// > ``PostgrestRequestBuilder/update(_:returning:count:)``,
+  /// > ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``,
   /// > ``PostgrestRequestBuilder/delete(returning:count:)``, or
   /// > ``PostgrestClient/rpc(_:params:head:get:count:)``.
   ///

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -136,8 +136,8 @@ public struct CountOption: RawRepresentable, Hashable, Sendable, ExpressibleBySt
 
 /// Controls which rows PostgREST returns after a write operation.
 ///
-/// Pass a ``PostgrestReturningOptions`` value to ``PostgrestRequestBuilder/insert(_:returning:count:)``,
-/// ``PostgrestRequestBuilder/update(_:returning:count:)``, ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:)``,
+/// Pass a ``PostgrestReturningOptions`` value to ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``,
+/// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``, ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:encoder:)``,
 /// or ``PostgrestRequestBuilder/delete(returning:count:)`` to specify what the server sends back.
 ///
 /// See the [PostgREST documentation](https://postgrest.org/en/v9.0/api.html?highlight=PREFER#insertions-updates)

--- a/Sources/RealtimeV2/RealtimeChannelV2.swift
+++ b/Sources/RealtimeV2/RealtimeChannelV2.swift
@@ -85,7 +85,7 @@ protocol RealtimeChannelProtocol: AnyObject, Sendable {
 /// - ``subscribeWithError()``
 /// - ``unsubscribe()``
 /// ### Broadcasting
-/// - ``broadcast(event:message:)-(_,Codable)``
+/// - ``broadcast(event:message:encoder:)``
 /// - ``broadcast(event:message:)-(_,JSONObject)``
 /// - ``broadcast(event:data:)``
 /// - ``httpSend(event:message:timeout:)-(_,Codable,_)``
@@ -402,8 +402,13 @@ public final class RealtimeChannelV2: Sendable, RealtimeChannelProtocol {
   /// - Parameters:
   ///   - event: The broadcast event name.
   ///   - message: A `Codable` value to send as the message payload.
-  public func broadcast(event: String, message: some Codable) async throws {
-    try await broadcast(event: event, message: JSONObject(message))
+  ///   - encoder: The `JSONEncoder` used to serialize `message`. Defaults to the fixed internal
+  ///     encoder (``JSONValue/encoder``) when `nil`.
+  public func broadcast(
+    event: String, message: some Codable, encoder: JSONEncoder? = nil
+  ) async throws {
+    try await broadcast(
+      event: event, message: JSONObject(message, encoder: encoder ?? JSONValue.encoder))
   }
 
   /// Sends a broadcast message with a raw `JSONObject` payload over WebSocket (or falls back to REST).

--- a/Tests/HelpersTests/JSONValueTests.swift
+++ b/Tests/HelpersTests/JSONValueTests.swift
@@ -390,6 +390,20 @@ struct JSONValueTests {
   }
 
   @Test
+  func jsonObjectInitFromCodableWithCustomEncoder() throws {
+    struct SnakeCasePerson: Encodable {
+      let fullName: String
+    }
+
+    let snakeCaseEncoder = JSONEncoder()
+    snakeCaseEncoder.keyEncodingStrategy = .convertToSnakeCase
+
+    let jsonObject = try JSONObject(SnakeCasePerson(fullName: "John"), encoder: snakeCaseEncoder)
+    #expect(jsonObject["full_name"] == .string("John"))
+    #expect(jsonObject["fullName"] == nil)
+  }
+
+  @Test
   func jsonObjectInitFromCodableFailure() {
     // Test with a simple string, which should fail because it's not an object
     #expect(throws: (any Error).self) {

--- a/Tests/PostgRESTTests/PostgrestBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestBuilderTests.swift
@@ -379,6 +379,141 @@ extension PostgrestMockerTests {
       #expect(query.request.headers[.init("key")!] == "value")
     }
 
+    // MARK: - Encoder/decoder override tests
+
+    @Test
+    func insertPerCallEncoderOverridesClientDefault() async throws {
+      let capturedBody = LockIsolated<Data?>(nil)
+      let sut = makeSUTWithCustomFetch { request in
+        capturedBody.setValue(request.httpBody)
+        return (Data(), self.makeHTTPURLResponse(statusCode: 201))
+      }
+
+      let snakeCaseEncoder = JSONEncoder()
+      snakeCaseEncoder.keyEncodingStrategy = .convertToSnakeCase
+
+      try await sut.from("users")
+        .insert(EncoderOverrideRow(userName: "abc"), encoder: snakeCaseEncoder)
+        .execute()
+
+      let body = try #require(capturedBody.value)
+      let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+      #expect(json["user_name"] as? String == "abc")
+      #expect(json["userName"] == nil)
+    }
+
+    @Test
+    func updatePerCallEncoderOverridesClientDefault() async throws {
+      let capturedBody = LockIsolated<Data?>(nil)
+      let sut = makeSUTWithCustomFetch { request in
+        capturedBody.setValue(request.httpBody)
+        return (Data(), self.makeHTTPURLResponse(statusCode: 200))
+      }
+
+      let snakeCaseEncoder = JSONEncoder()
+      snakeCaseEncoder.keyEncodingStrategy = .convertToSnakeCase
+
+      try await sut.from("users")
+        .update(EncoderOverrideRow(userName: "abc"), encoder: snakeCaseEncoder)
+        .eq("id", value: 1)
+        .execute()
+
+      let body = try #require(capturedBody.value)
+      let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+      #expect(json["user_name"] as? String == "abc")
+      #expect(json["userName"] == nil)
+    }
+
+    @Test
+    func upsertPerCallEncoderOverridesClientDefault() async throws {
+      let capturedBody = LockIsolated<Data?>(nil)
+      let sut = makeSUTWithCustomFetch { request in
+        capturedBody.setValue(request.httpBody)
+        return (Data(), self.makeHTTPURLResponse(statusCode: 201))
+      }
+
+      let snakeCaseEncoder = JSONEncoder()
+      snakeCaseEncoder.keyEncodingStrategy = .convertToSnakeCase
+
+      try await sut.from("users")
+        .upsert(EncoderOverrideRow(userName: "abc"), encoder: snakeCaseEncoder)
+        .execute()
+
+      let body = try #require(capturedBody.value)
+      let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+      #expect(json["user_name"] as? String == "abc")
+      #expect(json["userName"] == nil)
+    }
+
+    @Test
+    func executePerCallDecoderOverridesClientDefault() async throws {
+      struct SnakeCasePayload: Decodable, Sendable {
+        let userId: Int
+      }
+
+      let sut = makeSUTWithCustomFetch { _ in
+        (Data(#"{"user_id": 1}"#.utf8), self.makeHTTPURLResponse(statusCode: 200))
+      }
+
+      // The client's default decoder has no key conversion, so it can't match `user_id` to `userId`.
+      do {
+        let _: SnakeCasePayload = try await sut.from("users").select().execute().value
+        Issue.record("Expected a decoding error without a matching key strategy")
+      } catch is DecodingError {}
+
+      let snakeCaseDecoder = JSONDecoder()
+      snakeCaseDecoder.keyDecodingStrategy = .convertFromSnakeCase
+
+      let result: SnakeCasePayload =
+        try await sut.from("users").select().execute(decoder: snakeCaseDecoder).value
+      #expect(result.userId == 1)
+    }
+
+    @Test
+    func errorDecodingIsUnaffectedByClientDecoderCustomization() async throws {
+      // A decoder aggressive enough to remap every key would prevent `PostgrestError` from ever
+      // finding its required `message` field, if it were used to decode the error response.
+      // Error decoding must use a fixed internal decoder instead, decoupled from this setting.
+      let poisonedDecoder = JSONDecoder()
+      poisonedDecoder.keyDecodingStrategy = .custom { _ in TestCodingKey(stringValue: "unmatched") }
+
+      let sut = makeSUTWithCustomFetch(decoder: poisonedDecoder) { _ in
+        (
+          Data(#"{"code":"PGRST000","message":"Bad Request"}"#.utf8),
+          self.makeHTTPURLResponse(statusCode: 400)
+        )
+      }
+
+      do {
+        try await sut.from("users").select().execute()
+        Issue.record("Expected PostgrestError to be thrown")
+      } catch let error as PostgrestError {
+        #expect(error.message == "Bad Request")
+        #expect(error.code == "PGRST000")
+      }
+    }
+
+    @Test
+    func errorDecodingIsUnaffectedByPerCallDecoderOverride() async throws {
+      let poisonedDecoder = JSONDecoder()
+      poisonedDecoder.keyDecodingStrategy = .custom { _ in TestCodingKey(stringValue: "unmatched") }
+
+      let sut = makeSUTWithCustomFetch { _ in
+        (
+          Data(#"{"code":"PGRST000","message":"Bad Request"}"#.utf8),
+          self.makeHTTPURLResponse(statusCode: 400)
+        )
+      }
+
+      do {
+        let _: [User] = try await sut.from("users").select().execute(decoder: poisonedDecoder).value
+        Issue.record("Expected PostgrestError to be thrown")
+      } catch let error as PostgrestError {
+        #expect(error.message == "Bad Request")
+        #expect(error.code == "PGRST000")
+      }
+    }
+
     // MARK: - Retry tests
 
     @Test
@@ -639,10 +774,11 @@ extension PostgrestMockerTests {
 
     private func makeSUTWithCustomFetch(
       retryEnabled: Bool = true,
+      decoder: JSONDecoder = PostgrestClient.Configuration.jsonDecoder,
       fetch: @escaping PostgrestClient.FetchHandler
     ) -> PostgrestClient {
       PostgrestClient(
-        configuration: .init(url: url, fetch: fetch, retryEnabled: retryEnabled),
+        configuration: .init(url: url, fetch: fetch, decoder: decoder, retryEnabled: retryEnabled),
         clock: ImmediateRetryTestClock()
       )
     }
@@ -659,4 +795,26 @@ struct ImmediateRetryTestClock: Clock {
   var minimumResolution: ContinuousClock.Instant.Duration { ContinuousClock().minimumResolution }
 
   func sleep(until deadline: ContinuousClock.Instant, tolerance: Duration?) async throws {}
+}
+
+/// A row with a camelCase property, used to prove a custom `keyEncodingStrategy` was applied.
+/// `keyEncodingStrategy` only affects keys derived from a type's synthesized `CodingKeys`, not
+/// raw `Dictionary` keys, so this can't be a `[String: String]` literal.
+private struct EncoderOverrideRow: Encodable, Sendable {
+  let userName: String
+}
+
+/// A `CodingKey` that remaps to a fixed, unmatched key — used to simulate a decoder whose key
+/// strategy is aggressive enough to break decoding of any fixed-shape response.
+private struct TestCodingKey: CodingKey {
+  var stringValue: String
+  var intValue: Int? { nil }
+
+  init(stringValue: String) {
+    self.stringValue = stringValue
+  }
+
+  init?(intValue: Int) {
+    nil
+  }
 }

--- a/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
+++ b/Tests/RealtimeTests/RealtimeChannelBroadcastTests.swift
@@ -246,6 +246,46 @@ import Testing
       #expect(payload?["payload"]?.objectValue?["key"]?.stringValue == "value")
     }
 
+    // MARK: - Per-call encoder override
+
+    @Test
+    func broadcast_perCallEncoderOverridesFixedInternalEncoder() async throws {
+      await http.any { _ in
+        HTTPResponse(
+          data: Data(),
+          response: HTTPURLResponse(
+            url: self.url,
+            statusCode: 202,
+            httpVersion: nil,
+            headerFields: nil
+          )!
+        )
+      }
+
+      // Not subscribed, so this falls back to the REST broadcast endpoint. Ack the broadcast so
+      // `broadcast(event:message:encoder:)` awaits the REST call before returning.
+      let channel = sut.channel("test") { config in
+        config.broadcast.acknowledgeBroadcasts = true
+      }
+
+      struct Message: Codable {
+        let userName: String
+      }
+
+      let snakeCaseEncoder = JSONEncoder()
+      snakeCaseEncoder.keyEncodingStrategy = .convertToSnakeCase
+
+      try await channel.broadcast(
+        event: "my_event", message: Message(userName: "abc"), encoder: snakeCaseEncoder
+      )
+
+      let request = await http.receivedRequests.last
+      let body = try #require(request?.body)
+      let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+      #expect(json["user_name"] as? String == "abc")
+      #expect(json["userName"] == nil)
+    }
+
     // MARK: - REST broadcast URL uses the sub-topic (without `realtime:` prefix)
 
     @Test

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1575,3 +1575,84 @@ of the public client types exposed a way to build one from a standalone `Storage
 constructed `StorageApi(configuration:)` directly, construct a `SupabaseStorageClient(configuration:)`
 instead — its public surface (`configuration`, `setHeader(_:forKey:)`, `from(_:)`) is a superset of
 what `StorageApi` exposed.
+
+## `PostgrestClient.Configuration.encoder`/`.decoder` are now `let`, not `var`
+
+`PostgrestClient.Configuration.encoder` and `.decoder` are immutable, matching the `var` → `let`
+direction the rest of `Configuration` already took when `PostgrestClient` became a stateless value
+type. They were the last two settable properties left over from before that change — nothing in
+the SDK ever mutated them after `init`, and the new per-call overrides below (on `insert`/`update`/
+`upsert`/`execute`) cover the case that mutating them after construction was actually used for.
+
+```swift
+// Before
+var configuration = PostgrestClient.Configuration(url: url)
+configuration.decoder = myDecoder
+
+// After — set it at construction time, or pass a per-call override (see below)
+let configuration = PostgrestClient.Configuration(url: url, decoder: myDecoder)
+```
+
+This is a compile error, not a silent behavior change: any assignment to `.encoder`/`.decoder` on a
+`PostgrestClient.Configuration` value no longer builds.
+
+## PostgREST gains per-call `encoder`/`decoder` overrides; `PostgrestError` decoding no longer uses your decoder
+
+`insert`, `update`, and `upsert` now accept a trailing `encoder: JSONEncoder? = nil`, and
+`execute<T: Decodable>(options:)` now accepts a trailing `decoder: JSONDecoder? = nil` — each
+overrides `PostgrestClient.Configuration.encoder`/`.decoder` for that one call. Calling these
+methods without the new argument compiles unchanged.
+
+```swift
+// Encode this one insert with a different key strategy than the client default
+try await client.from("todos")
+  .insert(todo, encoder: mySnakeCaseEncoder)
+  .execute()
+
+// Decode this one response with a different date strategy than the client default
+let todos: [Todo] = try await client.from("todos")
+  .select()
+  .execute(decoder: myCustomDecoder)
+  .value
+```
+
+Separately, decoding a `PostgrestError` from an error response no longer uses
+`Configuration.decoder` or either of these new per-call overrides — it always uses a fixed,
+non-configurable internal decoder. Previously, a decoder with a non-default `keyDecodingStrategy`
+or `dateDecodingStrategy` that didn't match `PostgrestError`'s plain `details`/`hint`/`code`/
+`message` shape could cause a real PostgREST error response to be reported as a generic `HTTPError`
+instead of a `PostgrestError`, since the mismatched decoder failed to parse it. This is a silent
+behavior change, not a compile error: if you `catch`-typed on `PostgrestError` while also
+customizing `Configuration.decoder`'s key or date strategy, error responses that previously fell
+through as `HTTPError` are now caught as `PostgrestError` instead.
+
+## `PostgrestExecutableBuilder.execute<T: Decodable>(options:)` now requires a `decoder:` argument
+
+The generic `execute` requirement on the `any PostgrestExecutableBuilder` protocol gained the same
+`decoder: JSONDecoder?` parameter as the concrete `execute<T: Decodable>(options:decoder:)` above.
+Protocol requirements can't carry a default argument, so calling it through the type-erased
+`any PostgrestExecutableBuilder` — rather than through a concrete builder type, where the parameter
+still defaults to `nil` — now requires passing `decoder:` explicitly:
+
+```swift
+// Before
+let builder: any PostgrestExecutableBuilder = client.from("todos").select()
+let todos: [Todo] = try await builder.execute(options: FetchOptions()).value
+
+// After
+let todos: [Todo] = try await builder.execute(options: FetchOptions(), decoder: nil).value
+```
+
+This is a compile error, not a silent behavior change, and only affects code that calls the
+generic `execute(options:)` through `any`/`some PostgrestExecutableBuilder` rather than through a
+concrete builder type such as `PostgrestFilterBuilder`.
+
+## `RealtimeChannelV2.broadcast(event:message:)` gains a per-call `encoder:` override
+
+`broadcast(event:message:)` now accepts a trailing `encoder: JSONEncoder? = nil`, overriding the
+fixed internal encoder (`JSONValue.encoder`) previously always used to serialize `message`. Calling
+`broadcast` without the new argument compiles unchanged and behaves the same as before.
+
+```swift
+try await channel.broadcast(event: "cursor", message: cursorPosition, encoder: mySnakeCaseEncoder)
+```


### PR DESCRIPTION
## Summary
- Standardize PostgREST and Realtime on the client-wide-default-with-per-call-override pattern Functions already used.
- PostgREST: `Configuration.encoder`/`.decoder` are now `let`; `insert`/`update`/`upsert` gain a per-call `encoder:`; `execute<T: Decodable>` gains a per-call `decoder:`; `PostgrestError` decoding now always uses a fixed internal decoder, decoupled from the client/per-call decoder.
- Realtime: `RealtimeChannelV2.broadcast(event:message:)` gains a per-call `encoder:`.
- Functions: no code change; doc comment now cross-references the same pattern.
- Breaking changes documented in `V3_MIGRATION.md` (the `var`→`let` change, and the `PostgrestExecutableBuilder` protocol requirement picking up the new `decoder:` parameter).

## Test plan
- [x] `swift test` — 1197/1197 tests pass (includes new coverage: per-call override wins over client default for insert/update/upsert/execute/broadcast; error decoding unaffected by a client- or per-call-poisoned decoder)
- [x] `./scripts/format.sh` — no diff
- [x] `./scripts/spell-check.sh` — clean
- [x] `./scripts/test-docs.sh` — DocC builds with no warnings

Fixes SDK-1538