### PR TITLE
feat(postgrest): add the relation and selection protocols

### DIFF
--- a/Sources/PostgREST/Relations/PostgrestRelation.swift
+++ b/Sources/PostgREST/Relations/PostgrestRelation.swift
@@ -1,0 +1,47 @@
+//
+//  PostgrestRelation.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+/// A shape that can be selected from a relation.
+///
+/// Conformance is normally synthesized by the `@Table` or `@SelectionOf` macro in the
+/// `PostgrestMacros` module, or emitted by the schema generator. Hand-written conformances are
+/// supported and are the escape hatch when neither fits.
+public protocol PostgrestSelection: Decodable, Sendable {
+  /// The PostgREST `select` expression for this shape, for example `"id,task"`.
+  static var selectString: String { get }
+}
+
+/// A queryable source of rows: a table, a view, or a materialized view.
+///
+/// "Relation" is Postgres's own term for that family. Selecting a whole row is the degenerate
+/// selection, which is why this refines ``PostgrestSelection``.
+public protocol PostgrestRelation: PostgrestSelection {
+  /// The relation's name as PostgREST addresses it.
+  static var relationName: String { get }
+
+  /// The Postgres schema the relation belongs to.
+  static var schema: String { get }
+
+  /// The database column name backing a property.
+  ///
+  /// - Parameter keyPath: A key path to one of this type's stored properties.
+  /// - Returns: The column name PostgREST expects in a query string.
+  static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String
+}
+
+/// A relation the database accepts writes for: a table, or a view Postgres reports as updatable.
+///
+/// `Insert` and `Update` have no defaults on purpose. Defaulting them to `Self` would mean sending
+/// the primary key on insert and requiring every column on update.
+public protocol PostgrestWritableRelation: PostgrestRelation {
+  /// The shape accepted by an insert: primary keys excluded, defaulted and nullable columns
+  /// optional.
+  associatedtype Insert: Encodable & Sendable
+
+  /// The shape accepted by an update: every column optional.
+  associatedtype Update: Encodable & Sendable
+}

--- a/Tests/PostgRESTTests/PostgrestRelationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestRelationTests.swift
@@ -1,0 +1,53 @@
+//
+//  PostgrestRelationTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestRelationTests {
+  struct Todo: PostgrestWritableRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+    var isDone: Bool
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.task: "task"
+      case \Self.isDone: "is_done"
+      default: fatalError("unmapped key path")
+      }
+    }
+
+    struct Insert: Encodable, Sendable {
+      var task: String
+      var isDone: Bool?
+    }
+    struct Update: Encodable, Sendable {
+      var task: String?
+      var isDone: Bool?
+    }
+  }
+
+  @Test
+  func columnNameMapsKeyPathToDatabaseColumn() {
+    #expect(Todo.columnName(for: \.id) == "id")
+    #expect(Todo.columnName(for: \.isDone) == "is_done")
+  }
+
+  @Test
+  func aRelationIsAlsoASelection() {
+    func selectString<T: PostgrestSelection>(of type: T.Type) -> String { T.selectString }
+    #expect(selectString(of: Todo.self) == "*")
+  }
+}

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -110,6 +110,7 @@ nosec
 NSEC
 NSPOSIX
 NSURL
+nullable
 nullsfirst
 nullslast
 oauthserver

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -36,6 +36,8 @@ supporting_symbols:
   # feature. Every other filter/modifier method is a 1:1 entry point for
   # exactly one capability and is attributed to that feature's own `symbols:`
   # list instead (see the database.* section below).
+  # The typed-query contracts are in the same category: a relation type is used by
+  # both the read and the write features rather than owned by one capability.
   - PostgrestClient.Configuration.accessToken
   - PostgrestExecutableBuilder
   - PostgrestExecutableBuilder.execute
@@ -54,6 +56,10 @@ supporting_symbols:
   - PostgrestArrayElement.postgrestArrayElement
   - PostgrestFilterValue.postgrestArrayElement
   - PostgrestQueryPhase
+  - PostgrestRelation
+  - PostgrestRelation.columnName
+  - PostgrestRelation.relationName
+  - PostgrestRelation.schema
   - PostgrestRequestBuilder
   - PostgrestRequestBuilder.Operator
   - PostgrestRequestBuilder.execute
@@ -64,8 +70,13 @@ supporting_symbols:
   - PostgrestRequestBuilder.plainToFullTextSearch
   - PostgrestRequestBuilder.setHeader
   - PostgrestRequestBuilder.webFullTextSearch
+  - PostgrestSelection
+  - PostgrestSelection.selectString
   - PostgrestTransformPhase
   - PostgrestTransformablePhase
+  - PostgrestWritableRelation
+  - PostgrestWritableRelation.Insert
+  - PostgrestWritableRelation.Update
 
 features:
 


### PR DESCRIPTION
Stage 1, Task 3 of the [PostgREST v3 plan](https://github.com/supabase/supabase-swift/blob/docs/postgrest-v3-design/docs/design/postgrest-v3-stage-1-plan.md) · spec §4.2 · SDK-1511

## What

Three protocols in `PostgREST`, satisfiable by hand, by a macro, or by the generator:

- `PostgrestSelection: Decodable, Sendable` — `static var selectString: String`
- `PostgrestRelation: PostgrestSelection` — `relationName`, `schema`, `columnName<V>(for:)`
- `PostgrestWritableRelation: PostgrestRelation` — `associatedtype Insert`, `associatedtype Update`

They land in `PostgREST` rather than the macro module. Putting them in the macro module is what made #1036 unmergeable — moving them later touches every file that references them.

`Insert` and `Update` have no defaults on purpose. Defaulting them to `Self` would mean sending the primary key on insert and requiring every column on update.

## Stack

1. #1238 — `fix(postgrest): send is.null for a nil eq/neq filter value` (base)
2. **this PR** — relation and selection protocols
3. `from(_ type:)` and a typed whole-row select
4. key-path filters and modifiers
5. typed writes gated on the writable refinement

## Deviation from the plan

The plan's test helper was spelled `func selectString(of type: some PostgrestSelection.Type)`, which is not valid Swift (`some P.Type` is rejected: *type 'some PostgrestSelection.Type' constrained to non-protocol, non-class type*). Rewritten as a generic `func selectString<T: PostgrestSelection>(of type: T.Type)`, which tests the same thing — that a `PostgrestRelation` is usable where a `PostgrestSelection` is expected.

## Verification

- `swift test --filter PostgrestRelationTests` — 2 tests pass
- `swift test` — 1190 tests in 120 suites pass
- `./scripts/format.sh`, `./scripts/spell-check.sh` clean (`nullable` added to `dictionary.txt`)