### PR TITLE
feat(postgrest): add from(_ type:) and a typed whole-row select

### DIFF
--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -9,7 +9,7 @@ public import Logging
 /// The main entry point for interacting with a PostgREST server.
 ///
 /// ``PostgrestClient`` lets you query and mutate data exposed by PostgREST. Start by calling
-/// ``from(_:)`` to target a table or view, or ``rpc(_:params:head:get:count:)`` to invoke a
+/// ``from(_:)->PostgrestQueryBuilder`` to target a table or view, or ``rpc(_:params:head:get:count:)`` to invoke a
 /// stored function.
 ///
 /// ```swift
@@ -37,7 +37,7 @@ public import Logging
 ///
 /// ### Querying and Mutating Data
 ///
-/// - ``from(_:)``
+/// - ``from(_:)->PostgrestQueryBuilder``
 /// - ``rpc(_:params:head:get:count:)``
 /// - ``rpc(_:head:get:count:)``
 ///

--- a/Sources/PostgREST/PostgrestRequestBuilder.swift
+++ b/Sources/PostgREST/PostgrestRequestBuilder.swift
@@ -31,7 +31,7 @@ public protocol PostgrestTransformablePhase: PostgrestExecutablePhase {}
 /// executable.
 public protocol PostgrestFilterablePhase: PostgrestTransformablePhase {}
 
-/// The phase immediately after ``PostgrestClient/from(_:)``, before an operation
+/// The phase immediately after ``PostgrestClient/from(_:)->PostgrestQueryBuilder``, before an operation
 /// (`select`/`insert`/`update`/`upsert`/`delete`) has been chosen.
 ///
 /// This phase conforms to none of the capability protocols: you cannot filter, transform, set
@@ -55,7 +55,7 @@ public enum PostgrestTransformPhase: PostgrestTransformablePhase {}
 /// methods are available: filter methods require ``PostgrestFilterablePhase``, transform methods
 /// require ``PostgrestTransformablePhase``, and `setHeader`/`retry`/`execute` require
 /// ``PostgrestExecutablePhase``. You don't construct this type directly — call
-/// ``PostgrestClient/from(_:)`` or ``PostgrestClient/rpc(_:params:head:get:count:)`` and chain
+/// ``PostgrestClient/from(_:)->PostgrestQueryBuilder`` or ``PostgrestClient/rpc(_:params:head:get:count:)`` and chain
 /// from there.
 ///
 /// ## Topics
@@ -131,7 +131,7 @@ public struct PostgrestRequestBuilder<Phase>: Sendable {
 /// This is ``PostgrestRequestBuilder`` specialized to ``PostgrestQueryPhase``, the phase a request
 /// starts in before an operation has been chosen.
 ///
-/// Obtain one by calling ``PostgrestClient/from(_:)`` and then chain one of the operation methods.
+/// Obtain one by calling ``PostgrestClient/from(_:)->PostgrestQueryBuilder`` and then chain one of the operation methods.
 /// Most methods return a ``PostgrestFilterBuilder`` so you can narrow the affected rows with WHERE
 /// clauses before executing.
 ///

--- a/Sources/PostgREST/Query/PostgrestTypedQuery.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery.swift
@@ -1,0 +1,42 @@
+//
+//  PostgrestTypedQuery.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+/// A read request against a relation, with filters and modifiers applied by key path.
+///
+/// `Phase` mirrors the phase parameter on ``PostgrestRequestBuilder``: it is a compile-time-only
+/// marker that decides which methods are available. Filters need a
+/// ``PostgrestFilterablePhase``, `order`/`limit` need a ``PostgrestTransformablePhase``, and
+/// ``execute()`` needs a ``PostgrestExecutablePhase``. You never spell it out — it is inferred
+/// from the chain.
+///
+/// Like the builder it wraps, this is a value type: chaining off the same query twice gives two
+/// independent requests.
+public struct PostgrestTypedQuery<
+  R: PostgrestRelation,
+  Output: Decodable & Sendable,
+  Phase
+>: Sendable {
+  /// The underlying string-based builder.
+  public let builder: PostgrestRequestBuilder<Phase>
+
+  /// Wraps a builder in the typed query surface.
+  ///
+  /// - Parameter builder: The builder to wrap.
+  public init(builder: PostgrestRequestBuilder<Phase>) {
+    self.builder = builder
+  }
+}
+
+extension PostgrestTypedQuery where Phase: PostgrestExecutablePhase {
+  /// Sends the request and decodes the response.
+  ///
+  /// - Returns: A ``PostgrestResponse`` whose `value` is the decoded `Output`.
+  @discardableResult
+  public func execute() async throws -> PostgrestResponse<Output> {
+    try await builder.execute()
+  }
+}

--- a/Sources/PostgREST/Query/PostgrestTypedSource.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedSource.swift
@@ -1,0 +1,40 @@
+//
+//  PostgrestTypedSource.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+extension PostgrestClient {
+  /// Returns a typed source for a relation, so column and relation names are checked by the
+  /// compiler instead of being spelled as strings.
+  ///
+  /// ```swift
+  /// let todos = try await client.from(Todo.self).select().execute().value
+  /// ```
+  ///
+  /// - Parameter relation: The relation type to query.
+  /// - Returns: A ``PostgrestTypedSource`` for that relation.
+  public func from<R: PostgrestRelation>(_ relation: R.Type) -> PostgrestTypedSource<R> {
+    PostgrestTypedSource(builder: from(R.relationName))
+  }
+}
+
+/// A relation that has been chosen but for which no operation has been picked yet.
+///
+/// It is called a *source* rather than a table because it may be a view, and rather than a query
+/// because no operation has been chosen. Obtain one by passing a relation type to
+/// `PostgrestClient.from(_:)`.
+///
+/// Like the builder it wraps, this is a value type: chaining off the same source twice gives two
+/// independent requests.
+public struct PostgrestTypedSource<R: PostgrestRelation>: Sendable {
+  let builder: PostgrestQueryBuilder
+
+  /// Selects every column of the relation.
+  ///
+  /// - Returns: A ``PostgrestTypedQuery`` decoding into `[R]`.
+  public func select() -> PostgrestTypedQuery<R, [R], PostgrestFilterPhase> {
+    PostgrestTypedQuery(builder: builder.select(R.selectString))
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestTypedSourceTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedSourceTests.swift
@@ -1,0 +1,47 @@
+//
+//  PostgrestTypedSourceTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestTypedSourceTests {
+  struct Todo: PostgrestRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.task: "task"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  @Test
+  func fromUsesTheRelationName() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().execute()
+    #expect(capture.path?.hasSuffix("/todos") == true)
+    #expect(capture.query?.contains("select=*") == true)
+  }
+
+  @Test
+  func selectDecodesIntoTheRelationType() async throws {
+    let capture = QueryCapture(body: #"[{"id":1,"task":"buy milk"}]"#)
+    let todos = try await capture.client.from(Todo.self).select().execute().value
+    #expect(todos.count == 1)
+    #expect(todos.first?.task == "buy milk")
+  }
+}

--- a/Tests/PostgRESTTests/QueryCapture.swift
+++ b/Tests/PostgRESTTests/QueryCapture.swift
@@ -48,6 +48,9 @@ struct QueryCapture {
     return query.removingPercentEncoding ?? query
   }
 
+  /// The path of the captured request's URL, which ends in the relation name.
+  var path: String? { captured.value?.url?.path }
+
   /// The HTTP method of the captured request.
   var httpMethod: String? { captured.value?.httpMethod }
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -535,11 +535,20 @@ features:
     status: implemented
     symbols:
       - PostgrestError.details
+    supporting_symbols:
+      # The value `from(_ type:)` returns once a relation has been chosen but
+      # no operation has been picked yet.
+      - PostgrestTypedSource
   database.query.select:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.select
+      - PostgrestTypedSource.select
     supporting_symbols:
+      - PostgrestTypedQuery
+      - PostgrestTypedQuery.builder
+      - PostgrestTypedQuery.init
+      - PostgrestTypedQuery.execute
       - CountOption
       - CountOption.init
       - CountOption.rawValue


### PR DESCRIPTION
Stage 1, Task 4 of the [PostgREST v3 plan](https://github.com/supabase/supabase-swift/blob/docs/postgrest-v3-design/docs/design/postgrest-v3-stage-1-plan.md) · SDK-1512

## What

- `PostgrestClient.from<R: PostgrestRelation>(_:)` returning `PostgrestTypedSource<R>`
- `PostgrestTypedSource.select()` returning `PostgrestTypedQuery<R, [R], PostgrestFilterPhase>`
- `PostgrestTypedQuery.execute()`, available where `Phase: PostgrestExecutablePhase`

Both wrappers hold the phase-generic `PostgrestRequestBuilder` rather than reimplementing request building, so the typed surface ships before the value-typed core.

## Rebased onto the value-typed builders

This was originally written against the class-based builders and has been reworked for the `PostgrestRequestBuilder<Phase>` struct now on `main`. Two consequences:

- **Both wrappers are `Sendable` value types.** The plan's `> Note` warning not to branch two chains off one value is gone, because that hazard no longer exists.
- **`PostgrestTypedQuery` carries a `Phase` parameter**, mirroring the builder. It is a compile-time-only marker, never spelled by callers — `execute()` requires `PostgrestExecutablePhase`, and the next PR's `order`/`limit` use it to move into `PostgrestTransformPhase`.

## Stack

1. #1238 — nil `eq`/`neq` → `is.null`
2. #1252 — relation and selection protocols
3. **this PR** — `from(_ type:)` and typed whole-row select
4. #1254 — key-path filters and modifiers
5. #1255 — typed writes gated on the writable refinement

## Deviations from the plan

**`QueryCapture.query` now percent-decodes fully.** It previously decoded only `%22`. The plan's assertions are written in PostgREST's documented spelling (`select=*`), which could never match a partially-decoded query string — `*` arrives as `%2A`. Full decoding makes the plan's spellings correct and leaves every existing assertion in `PostgrestNilFilterValueTests` passing unchanged. This edits a file introduced by #1238.

**Added a `path` accessor and an assertion on it.** The plan's `fromUsesTheRelationName` asserted only `select=*`, which does not exercise the relation name at all. It now also asserts the request path ends in `/todos`.

**DocC disambiguation.** Adding a `from` overload makes the five existing `` ``from(_:)`` `` links ambiguous; they now carry `->PostgrestQueryBuilder`. `PostgrestTypedSource`'s own doc comment refers to the typed overload in plain code rather than as a link, because DocC offers no return-type disambiguator for it and the only one it suggests points at the string overload.

## Verification

- `swift test --filter PostgrestTypedSourceTests` — 2 tests pass
- `swift test` — 1227 tests in 125 suites pass
- `./scripts/test-docs.sh` exits 0
- `./scripts/format.sh`, `./scripts/spell-check.sh` clean