### PR TITLE
feat(postgrest): add key-path filters and modifiers to the typed query

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
@@ -1,0 +1,108 @@
+//
+//  PostgrestTypedQuery+Filters.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+/// A wrapper that scopes a request by key path.
+///
+/// ``PostgrestTypedQuery`` conforms, so the key-path filter set is declared once here rather than
+/// repeated on every wrapper that needs it. You do not conform your own types to this.
+///
+/// Only filters live here. `order` and `limit` move the request into
+/// ``PostgrestTransformPhase``, so they cannot return `Self` and are declared on
+/// ``PostgrestTypedQuery`` instead.
+public protocol PostgrestKeyPathFilterable {
+  /// The relation whose key paths this wrapper accepts.
+  associatedtype Relation: PostgrestRelation
+
+  /// The phase of the underlying request. Filters require a filterable phase.
+  associatedtype Phase: PostgrestFilterablePhase
+
+  /// The underlying string-based builder.
+  var builder: PostgrestRequestBuilder<Phase> { get }
+
+  /// Wraps a builder, preserving the wrapper's type.
+  init(builder: PostgrestRequestBuilder<Phase>)
+}
+
+extension PostgrestTypedQuery: PostgrestKeyPathFilterable
+where Phase: PostgrestFilterablePhase {
+  public typealias Relation = R
+}
+
+extension PostgrestKeyPathFilterable {
+  /// Matches rows where the column at `column` equals `value`.
+  public func eq<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.eq(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is not equal to `value`.
+  public func neq<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.neq(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is greater than `value`.
+  public func gt<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.gt(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is greater than or equal to `value`.
+  public func gte<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.gte(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is less than `value`.
+  public func lt<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.lt(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is less than or equal to `value`.
+  public func lte<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.lte(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is one of `values`.
+  public func `in`<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ values: [V]) -> Self {
+    Self(builder: builder.in(Relation.columnName(for: column), values: values))
+  }
+
+  /// Matches rows where the optional column at `column` is SQL `NULL`.
+  public func isNull<V>(_ column: KeyPath<Relation, V?>) -> Self {
+    Self(builder: builder.filter(Relation.columnName(for: column), operator: "is", value: "null"))
+  }
+
+  /// Matches rows where the optional column at `column` is not SQL `NULL`.
+  public func isNotNull<V>(_ column: KeyPath<Relation, V?>) -> Self {
+    Self(
+      builder: builder.filter(Relation.columnName(for: column), operator: "not.is", value: "null")
+    )
+  }
+}
+
+extension PostgrestTypedQuery where Phase: PostgrestTransformablePhase {
+  /// Sorts the result by the column at `column`.
+  ///
+  /// Ordering moves the request into ``PostgrestTransformPhase``, so no further filter can be
+  /// applied after it — the same rule the string-based builders follow.
+  public func order<V>(
+    _ column: KeyPath<R, V>,
+    ascending: Bool = true,
+    nullsFirst: Bool = false
+  ) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> {
+    PostgrestTypedQuery<R, Output, PostgrestTransformPhase>(
+      builder: builder.order(
+        R.columnName(for: column), ascending: ascending, nullsFirst: nullsFirst
+      )
+    )
+  }
+
+  /// Limits the number of rows returned.
+  ///
+  /// Like ``order(_:ascending:nullsFirst:)`` this moves the request into
+  /// ``PostgrestTransformPhase``.
+  public func limit(_ count: Int) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> {
+    PostgrestTypedQuery<R, Output, PostgrestTransformPhase>(builder: builder.limit(count))
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestTypedQueryFilterTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedQueryFilterTests.swift
@@ -1,0 +1,93 @@
+//
+//  PostgrestTypedQueryFilterTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestTypedQueryFilterTests {
+  struct Todo: PostgrestRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+    var isDone: Bool
+    var dueDate: Date?
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.task: "task"
+      case \Self.isDone: "is_done"
+      case \Self.dueDate: "due_date"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  @Test
+  func eqUsesTheMappedColumnName() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().eq(\.isDone, false).execute()
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+  }
+
+  @Test
+  func comparisonOperatorsRenderTheirPrefix() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().gt(\.id, 10).lte(\.id, 20).execute()
+    #expect(capture.query?.contains("id=gt.10") == true)
+    #expect(capture.query?.contains("id=lte.20") == true)
+  }
+
+  @Test
+  func inRendersAParenthesisedList() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().in(\.task, ["a", "b"]).execute()
+    #expect(capture.query?.contains("task=in.(a,b)") == true)
+  }
+
+  @Test
+  func isNullAndIsNotNullRenderCorrectly() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().isNull(\.dueDate).execute()
+    #expect(capture.query?.contains("due_date=is.null") == true)
+
+    let other = QueryCapture()
+    _ = try await other.client.from(Todo.self).select().isNotNull(\.dueDate).execute()
+    #expect(other.query?.contains("due_date=not.is.null") == true)
+  }
+
+  /// The typed wrappers hold value-typed builders, so two chains branched off one query are
+  /// independent. Under the old class-based builders the second request also carried the first
+  /// chain's filter.
+  @Test
+  func branchingTwoChainsOffOneQueryDoesNotAlias() async throws {
+    let capture = QueryCapture()
+    let base = capture.client.from(Todo.self).select()
+
+    _ = try await base.eq(\.isDone, true).execute()
+    #expect(capture.query?.contains("is_done=eq.true") == true)
+
+    _ = try await base.gt(\.id, 5).execute()
+    #expect(capture.query?.contains("id=gt.5") == true)
+    #expect(capture.query?.contains("is_done") == false)
+  }
+
+  @Test
+  func orderAndLimitUseTheMappedColumnName() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select().order(\.dueDate, ascending: false).limit(5).execute()
+    #expect(capture.query?.contains("order=due_date.desc") == true)
+    #expect(capture.query?.contains("limit=5") == true)
+  }
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -55,6 +55,11 @@ supporting_symbols:
   - PostgrestArrayElement
   - PostgrestArrayElement.postgrestArrayElement
   - PostgrestFilterValue.postgrestArrayElement
+  - PostgrestKeyPathFilterable
+  - PostgrestKeyPathFilterable.Phase
+  - PostgrestKeyPathFilterable.Relation
+  - PostgrestKeyPathFilterable.builder
+  - PostgrestKeyPathFilterable.init
   - PostgrestQueryPhase
   - PostgrestRelation
   - PostgrestRelation.columnName
@@ -74,6 +79,7 @@ supporting_symbols:
   - PostgrestSelection.selectString
   - PostgrestTransformPhase
   - PostgrestTransformablePhase
+  - PostgrestTypedQuery.Relation
   - PostgrestWritableRelation
   - PostgrestWritableRelation.Insert
   - PostgrestWritableRelation.Update
@@ -601,31 +607,37 @@ features:
     symbols:
       - PostgrestRequestBuilder.eq
       - PostgrestRequestBuilder.equals
+      - PostgrestKeyPathFilterable.eq
   database.using_filters.neq:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.neq
       - PostgrestRequestBuilder.notEquals
+      - PostgrestKeyPathFilterable.neq
   database.using_filters.gt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.gt
       - PostgrestRequestBuilder.greaterThan
+      - PostgrestKeyPathFilterable.gt
   database.using_filters.gte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.gte
       - PostgrestRequestBuilder.greaterThanOrEquals
+      - PostgrestKeyPathFilterable.gte
   database.using_filters.lt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.lt
       - PostgrestRequestBuilder.lowerThan
+      - PostgrestKeyPathFilterable.lt
   database.using_filters.lte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.lte
       - PostgrestRequestBuilder.lowerThanOrEquals
+      - PostgrestKeyPathFilterable.lte
   database.using_filters.like:
     status: implemented
     symbols:
@@ -638,10 +650,13 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.is
+      - PostgrestKeyPathFilterable.isNull
+      - PostgrestKeyPathFilterable.isNotNull
   database.using_filters.in:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.in
+      - PostgrestKeyPathFilterable.in
   database.using_filters.contains:
     status: implemented
     symbols:
@@ -773,10 +788,12 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.order
+      - PostgrestTypedQuery.order
   database.using_modifiers.limit:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.limit
+      - PostgrestTypedQuery.limit
   database.using_modifiers.range:
     status: implemented
     symbols:


### PR DESCRIPTION
Stage 1, Task 5 of the [PostgREST v3 plan](https://github.com/supabase/supabase-swift/blob/docs/postgrest-v3-design/docs/design/postgrest-v3-stage-1-plan.md) · SDK-1513

## What

`PostgrestKeyPathFilterable` carrying `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `isNull`, `isNotNull` — each taking a `KeyPath<Relation, V>` and returning `Self`. Declared once on the protocol so the next PR's mutation type inherits all of it.

`order` and `limit` are declared on `PostgrestTypedQuery` instead. A mistyped column is now a compile error instead of a runtime 400.

`isNull`/`isNotNull` take `KeyPath<Relation, V?>`, so they only apply to optional columns.

## The force casts are gone — replaced by real phase safety

The plan anticipated two `as!` casts, because `order`/`limit` were declared on `PostgrestTransformBuilder` while the receiver was a `PostgrestFilterBuilder` subclass. **On the value-typed builders now on `main` that cast would not compile**: `order` returns `PostgrestRequestBuilder<PostgrestTransformPhase>`, an unrelated struct instantiation rather than a superclass.

That is the correct design, not an obstacle — a transform genuinely ends the filtering phase. So:

- Filters stay on the protocol and return `Self`.
- `order`/`limit` move to `PostgrestTypedQuery` and return `PostgrestTypedQuery<R, Output, PostgrestTransformPhase>`.

The typed surface now enforces the same rule the string builders do: no filter after a transform. No casts anywhere.

## New test: value semantics

`branchingTwoChainsOffOneQueryDoesNotAlias` builds one query, branches two filter chains off it, and asserts the second request does not carry the first chain's filter. **Under the old class-based builders this test would have failed** — that aliasing bug was the RFC's opening complaint, and the stack no longer inherits it.

## Stack

1. #1238 — nil `eq`/`neq` → `is.null`
2. #1252 — relation and selection protocols
3. #1253 — `from(_ type:)` and typed whole-row select
4. **this PR** — key-path filters and modifiers
5. #1255 — typed writes gated on the writable refinement

## Verification

- `swift test --filter PostgrestTypedQueryFilterTests` — 6 tests pass
- `swift test` — 1227 tests in 125 suites pass
- `./scripts/test-docs.sh` exits 0
- `./scripts/format.sh`, `./scripts/spell-check.sh` clean