### PR TITLE
feat(postgrest): add typed writes gated on the writable refinement

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -1,0 +1,103 @@
+//
+//  PostgrestTypedMutation.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+/// A write request against a writable relation.
+///
+/// Obtain one from `insert`, `upsert`, `update` or `delete` on a ``PostgrestTypedSource``. Those
+/// methods exist only where the relation conforms to ``PostgrestWritableRelation``, so a read-only
+/// view cannot be written.
+///
+/// Like the builder it wraps, this is a value type: chaining off the same mutation twice gives
+/// two independent requests.
+public struct PostgrestTypedMutation<R: PostgrestWritableRelation>: PostgrestKeyPathFilterable,
+  Sendable
+{
+  public typealias Relation = R
+  public typealias Phase = PostgrestFilterPhase
+
+  /// The underlying string-based builder.
+  public let builder: PostgrestFilterBuilder
+
+  /// Wraps a builder in the typed mutation surface.
+  ///
+  /// - Parameter builder: The builder to wrap.
+  public init(builder: PostgrestFilterBuilder) {
+    self.builder = builder
+  }
+
+  /// Requests the affected rows back, decoded as `[R]`.
+  ///
+  /// This replaces the `Prefer` header rather than appending to it. The write methods set
+  /// `return=minimal` so a plain ``execute()`` does not transfer rows, and appending would leave
+  /// `Prefer: return=minimal,return=representation`, which is contradictory.
+  /// `return=representation` alone returns every column, so no `select` parameter is needed.
+  ///
+  /// > Note: Because this replaces the whole header, do not combine it with any other `Prefer`
+  /// > preference on a mutation. Slice 0 sets none.
+  ///
+  /// - Returns: A ``PostgrestTypedQuery`` decoding into `[R]`.
+  public func returning() -> PostgrestTypedQuery<R, [R], PostgrestFilterPhase> {
+    PostgrestTypedQuery(
+      builder: builder.setHeader(name: "Prefer", value: "return=representation")
+    )
+  }
+
+  /// Sends the request, discarding the response body.
+  @discardableResult
+  public func execute() async throws -> PostgrestResponse<Void> {
+    try await builder.execute()
+  }
+}
+
+extension PostgrestTypedSource where R: PostgrestWritableRelation {
+  /// Inserts a row.
+  ///
+  /// - Parameter values: The row to insert, in the relation's `Insert` shape. Primary keys and
+  ///   defaulted columns are absent or optional there.
+  /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func insert(_ values: R.Insert) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(builder: try builder.insert(values, returning: .minimal))
+  }
+
+  /// Inserts rows, updating any that conflict.
+  ///
+  /// - Parameters:
+  ///   - values: The rows to upsert.
+  ///   - onConflict: Comma-separated unique columns that determine a duplicate. Defaults to the
+  ///     relation's primary key.
+  /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func upsert(
+    _ values: R.Insert,
+    onConflict: String? = nil
+  ) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(
+      builder: try builder.upsert(values, onConflict: onConflict, returning: .minimal)
+    )
+  }
+
+  /// Updates the rows matched by the filters applied to the returned value.
+  ///
+  /// > Important: With no filter this updates every row in the relation.
+  ///
+  /// - Parameter values: The columns to change, in the relation's `Update` shape.
+  /// - Returns: A ``PostgrestTypedMutation`` to scope, then execute.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func update(_ values: R.Update) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(builder: try builder.update(values, returning: .minimal))
+  }
+
+  /// Deletes the rows matched by the filters applied to the returned value.
+  ///
+  /// > Important: With no filter this deletes every row in the relation.
+  ///
+  /// - Returns: A ``PostgrestTypedMutation`` to scope, then execute.
+  public func delete() -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(builder: builder.delete(returning: .minimal))
+  }
+}

--- a/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
@@ -7,8 +7,9 @@
 
 /// A wrapper that scopes a request by key path.
 ///
-/// ``PostgrestTypedQuery`` conforms, so the key-path filter set is declared once here rather than
-/// repeated on every wrapper that needs it. You do not conform your own types to this.
+/// Both ``PostgrestTypedQuery`` and ``PostgrestTypedMutation`` conform, so the key-path filter set
+/// is declared once here rather than repeated on every wrapper. You do not conform your own types
+/// to this.
 ///
 /// Only filters live here. `order` and `limit` move the request into
 /// ``PostgrestTransformPhase``, so they cannot return `Self` and are declared on

--- a/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
@@ -1,0 +1,110 @@
+//
+//  PostgrestTypedMutationTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestTypedMutationTests {
+  struct Todo: PostgrestWritableRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+    var isDone: Bool
+
+    /// A hand-written conformance has to keep these in step with `columnName(for:)` itself. The
+    /// `@Column` macro generates both from one input so they cannot drift.
+    enum CodingKeys: String, CodingKey {
+      case id
+      case task
+      case isDone = "is_done"
+    }
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.task: "task"
+      case \Self.isDone: "is_done"
+      default: fatalError("unmapped key path")
+      }
+    }
+
+    struct Insert: Encodable, Sendable {
+      var task: String
+      var isDone: Bool?
+    }
+    struct Update: Encodable, Sendable {
+      var task: String?
+      var isDone: Bool?
+    }
+  }
+
+  /// A view: conforms to `PostgrestRelation` only, so the writes must not be offered.
+  struct ActiveTodo: PostgrestRelation {
+    static let relationName = "active_todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  @Test
+  func insertSendsTheInsertShape() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .insert(Todo.Insert(task: "buy milk", isDone: nil)).execute()
+    #expect(capture.httpMethod == "POST")
+    // The Insert shape excludes the primary key, so `id` must not appear in the body.
+    #expect(capture.bodyString?.contains("\"task\":\"buy milk\"") == true)
+    #expect(capture.bodyString?.contains("\"id\"") == false)
+  }
+
+  @Test
+  func preferHeaderIsUnambiguousWhenReturningRows() async throws {
+    let capture = QueryCapture(body: #"[{"id":1,"task":"buy milk","is_done":false}]"#)
+    _ = try await capture.client.from(Todo.self)
+      .insert(Todo.Insert(task: "buy milk", isDone: nil)).returning().execute()
+    let prefer = capture.header("Prefer") ?? ""
+    #expect(prefer.contains("return=representation"))
+    #expect(prefer.contains("return=minimal") == false)
+  }
+
+  @Test
+  func updateScopesByKeyPath() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .update(Todo.Update(task: "done", isDone: true)).eq(\.id, 1).execute()
+    #expect(capture.query?.contains("id=eq.1") == true)
+  }
+
+  @Test
+  func deleteScopesByKeyPath() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).delete().eq(\.id, 1).execute()
+    #expect(capture.query?.contains("id=eq.1") == true)
+  }
+
+  @Test
+  func returningDecodesRows() async throws {
+    let capture = QueryCapture(body: #"[{"id":1,"task":"buy milk","is_done":false}]"#)
+    let rows = try await capture.client.from(Todo.self)
+      .insert(Todo.Insert(task: "buy milk", isDone: nil)).returning().execute().value
+    #expect(rows.first?.task == "buy milk")
+  }
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -60,6 +60,12 @@ supporting_symbols:
   - PostgrestKeyPathFilterable.Relation
   - PostgrestKeyPathFilterable.builder
   - PostgrestKeyPathFilterable.init
+  - PostgrestTypedMutation
+  - PostgrestTypedMutation.Phase
+  - PostgrestTypedMutation.Relation
+  - PostgrestTypedMutation.builder
+  - PostgrestTypedMutation.init
+  - PostgrestTypedMutation.execute
   - PostgrestQueryPhase
   - PostgrestRelation
   - PostgrestRelation.columnName
@@ -576,18 +582,22 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.insert
+      - PostgrestTypedSource.insert
   database.mutate.update:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.update
+      - PostgrestTypedSource.update
   database.mutate.upsert:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.upsert
+      - PostgrestTypedSource.upsert
   database.mutate.delete:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.delete
+      - PostgrestTypedSource.delete
   database.mutate.select_after_mutation:
     status: implemented
     symbols:
@@ -595,6 +605,7 @@ features:
       - PostgrestRequestBuilder.update
       - PostgrestRequestBuilder.upsert
       - PostgrestRequestBuilder.delete
+      - PostgrestTypedMutation.returning
     supporting_symbols:
       - PostgrestReturningOptions
       - PostgrestReturningOptions.init


### PR DESCRIPTION
Stage 1, Task 6 of the [PostgREST v3 plan](https://github.com/supabase/supabase-swift/blob/docs/postgrest-v3-design/docs/design/postgrest-v3-stage-1-plan.md) · SDK-1514

## What

- `PostgrestTypedMutation<R: PostgrestWritableRelation>`, a `Sendable` value type conforming to `PostgrestKeyPathFilterable`, so it inherits the whole key-path filter set from #1254
- `insert`, `upsert`, `update`, `delete` on `extension PostgrestTypedSource where R: PostgrestWritableRelation`
- `returning()` to get the affected rows back as `[R]`

The writes hang off a constrained extension, so writing to a read-only view is *no such member* rather than a runtime 405.

`returning()` **replaces** the `Prefer` header rather than appending to it. The write methods set `return=minimal`, and appending would leave the contradictory `Prefer: return=minimal,return=representation`.

## The read-only gate: verified, but the diagnostic is poor

The plan's Step 5 asked for a manual check that `from(ActiveTodo.self).insert(…)` fails to compile, expecting `has no member 'insert'`. **It is rejected, but the message is misleading.** Because `from(_:)` is overloaded on `String` as well as on relation types, once `insert` is absent Swift backs off to the string overload and reports:

```
error: cannot convert value of type 'ActiveTodo.Type' to expected argument type 'String'
```

Pinning the source type so the overload cannot be re-resolved gives the diagnostic we actually want:

```swift
let view: PostgrestTypedSource<ActiveTodo> = capture.client.from(ActiveTodo.self)
_ = try view.insert(Todo.Insert(task: "x", isDone: nil))
// error: referencing instance method 'insert' on 'PostgrestTypedSource' requires that
//        'ActiveTodo' conform to 'PostgrestWritableRelation'
```

So the compile-time guarantee holds — re-verified against the value-typed builders. The user-facing message when someone writes the natural one-liner does not, and that is worth folding into the macro-diagnostics work (SDK-1518).

## Deviation from the plan: the fixture needs `CodingKeys`

The plan's `Todo` fixture declares `isDone: Bool` and decodes a body containing `"is_done"`, with no `CodingKeys`. That cannot work — `columnName(for:)` maps to snake_case but synthesized `Decodable` uses the property name, so `returning()` failed with `keyNotFound: "isDone"`. Added `CodingKeys` to the fixture.

This is a good demonstration of why decision 11 has `@Column` generate `CodingKeys`: a hand-written conformance has to keep `columnName(for:)` and `CodingKeys` in step by hand, and they silently disagree when it doesn't. Noted in a comment on the fixture.

The plan also says "PASS, 4 tests" for a suite of 5.

## Stack

1. #1238 — nil `eq`/`neq` → `is.null`
2. #1252 — relation and selection protocols
3. #1253 — `from(_ type:)` and typed whole-row select
4. #1254 — key-path filters and modifiers
5. **this PR** — typed writes gated on the writable refinement

## Verification

- `swift test --filter PostgrestTypedMutationTests` — 5 tests pass
- `swift test` — 1227 tests in 125 suites pass
- `./scripts/test-docs.sh` exits 0
- `./scripts/format.sh`, `./scripts/spell-check.sh` clean
- read-only write gate confirmed by hand, as above