### PR TITLE
feat(postgrest): add the PostgrestMacros targets

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e02e24d410edd1a54b0cc6c1b179cf93c6fab7b27de683761e1eb6b27f8e8b8c",
+  "originHash" : "66fc84e1d93fc7d8e6e79e85cb1c6583c07ea159d66325d0329cfeba57a7a06a",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -83,6 +83,15 @@
       }
     },
     {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
+      }
+    },
+    {
       "identity" : "swift-secp256k1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/21-DOT-DEV/swift-secp256k1.git",
@@ -105,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version:6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import CompilerPluginSupport
 import Foundation
 import PackageDescription
 
@@ -17,6 +18,9 @@ let package = Package(
     .library(name: "Auth", targets: ["Auth"]),
     .library(name: "Functions", targets: ["Functions"]),
     .library(name: "PostgREST", targets: ["PostgREST"]),
+    // Opt-in. `Supabase` deliberately does not re-export this, so swift-syntax is compiled
+    // only for users who write `import PostgrestMacros`.
+    .library(name: "PostgrestMacros", targets: ["PostgrestMacros"]),
     .library(name: "Realtime", targets: ["Realtime"]),
     .library(name: "Storage", targets: ["Storage"]),
     .library(name: "Supabase", targets: ["Supabase"]),
@@ -28,6 +32,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
     .package(url: "https://github.com/apple/swift-http-types.git", from: "1.3.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "601.0.0"..<"605.0.0"),
     // Pinned below 1.11.0: that version requires swift-tools-version 6.2, above this
     // package's current floor (Xcode 16.4+ / Swift 6.1). Widening this range raises
     // the effective minimum toolchain for every consumer — see SDK-1412.
@@ -36,6 +41,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
     .package(url: "https://github.com/WeTransfer/Mocker", from: "3.0.0"),
@@ -173,6 +179,28 @@ let package = Package(
         "__Snapshots__"
       ]
     ),
+    .macro(
+      name: "PostgrestMacrosPlugin",
+      dependencies: [
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      ]
+    ),
+    .target(
+      name: "PostgrestMacros",
+      dependencies: [
+        "PostgREST",
+        "PostgrestMacrosPlugin",
+      ]
+    ),
+    .testTarget(
+      name: "PostgrestMacrosTests",
+      dependencies: [
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+        "PostgrestMacros",
+        "PostgrestMacrosPlugin",
+      ]
+    ),
     .target(
       name: "RealtimeV2",
       dependencies: [
@@ -281,9 +309,16 @@ for target in package.targets {
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ImmutableWeakCaptures"),
     .enableUpcomingFeature("InferIsolatedConformances"),
-    .enableUpcomingFeature("InternalImportsByDefault"),
-    .enableUpcomingFeature("MemberImportVisibility"),
   ]
+
+  // The compiler-plugin target must declare its macro types `public` to satisfy SwiftSyntax's
+  // `CompilerPlugin` protocol, and `InternalImportsByDefault` rejects a public conformance to a
+  // protocol from an internally-imported module. Plugins run at build time and ship no
+  // distributable API, so the two import-visibility features gain nothing there.
+  if target.name != "PostgrestMacrosPlugin" {
+    swiftSettings.append(.enableUpcomingFeature("InternalImportsByDefault"))
+    swiftSettings.append(.enableUpcomingFeature("MemberImportVisibility"))
+  }
 
   target.swiftSettings = swiftSettings
 }

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -1,0 +1,10 @@
+//
+//  Macros.swift
+//  PostgrestMacros
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+// Re-exported so a single `import PostgrestMacros` is enough: the macros synthesize conformances to
+// protocols that live in `PostgREST`, and a user should not have to import both.
+@_exported public import PostgREST

--- a/Sources/PostgrestMacrosPlugin/Plugin.swift
+++ b/Sources/PostgrestMacrosPlugin/Plugin.swift
@@ -1,0 +1,14 @@
+//
+//  Plugin.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct PostgrestMacrosPlugin: CompilerPlugin {
+  let providingMacros: [any Macro.Type] = []
+}

--- a/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5e68a3cf2de6edf2abec2dfb983a8393d24cb9fc0b0786db3b5f16fa4672d712",
+  "originHash" : "9d9f6b0fc1bc72b8bfc309542e450e769d50124b550f98600e5d16cb59f23a43",
   "pins" : [
     {
       "identity" : "appauth-ios",
@@ -215,6 +215,24 @@
       "state" : {
         "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
       }
     },
     {

--- a/Tests/PostgrestMacrosTests/PluginTests.swift
+++ b/Tests/PostgrestMacrosTests/PluginTests.swift
@@ -1,0 +1,20 @@
+//
+//  PluginTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Testing
+
+@testable import PostgrestMacros
+
+@Suite
+struct PluginTests {
+  @Test
+  func macroModuleReExportsPostgREST() {
+    // Compiles only if PostgrestMacros re-exports PostgREST, which is what lets a user write a
+    // single `import PostgrestMacros`.
+    #expect(PostgrestClient.Configuration.defaultHeaders["X-Client-Info"] != nil)
+  }
+}


### PR DESCRIPTION
Closes SDK-1515. First PR of M3 (macros), stacked on #1255.

## What

Macro infrastructure, and proof of the module boundary, before any macro logic exists.

- `PostgrestMacrosPlugin` — a `.macro` target on swift-syntax
- `PostgrestMacros` — a thin library re-exporting `PostgREST`
- `PostgrestMacrosTests` — with `MacroTesting`

Neither `PostgREST` nor `Supabase` depends on either, so swift-syntax is compiled only for users who write `import PostgrestMacros`. That is what makes the macro layer architecturally optional rather than optional by promise.

## Why the swift-syntax floor is 601

swift-syntax majors track a toolchain, and 600.x targets Swift 6.0 — below this package's Swift 6.1 minimum. The floor is 601.0.0 so the range cannot resolve to a version built for an older toolchain than we support. Thanks @grdsdev.

## Two build gotchas, both recorded in `Package.swift`

The plugin target is exempt from `InternalImportsByDefault` and `MemberImportVisibility`, which reject the public conformances SwiftSyntax's `CompilerPlugin` protocol requires. The other three upcoming features stay on for it — they cost nothing there.

`PostgrestMacros` is *not* exempt, so the re-export needs `@_exported public import PostgREST`. A bare `@_exported import` is not enough.

## Verification

| Check | Result |
| --- | --- |
| `swift package resolve` | swift-syntax **603.0.2** from the `601..<605` range, on Swift 6.3.3 / Xcode 26.6. A fresh resolve with no `Package.resolved` picks the same version. |
| `swift build` | passes |
| `import PostgrestMacros` reaches `PostgREST` | `PluginTests.macroModuleReExportsPostgREST` |
| `swift build --target PostgREST` | 117 compile steps, **0** swift-syntax |
| `./scripts/spell-check.sh` | clean |

The dependency-boundary check becomes permanent CI in SDK-1519.

## Review order

1. **#1258** ← this PR
2. #1259 — `@Table` and its markers
3. #1260 — `@SelectionOf`
4. #1261 — macro diagnostics

