### PR TITLE
feat(postgrest): add the @Table macro and its marker attributes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -197,6 +197,7 @@ let package = Package(
       name: "PostgrestMacrosTests",
       dependencies: [
         .product(name: "MacroTesting", package: "swift-macro-testing"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
         "PostgrestMacros",
         "PostgrestMacrosPlugin",
       ]

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -8,3 +8,66 @@
 // Re-exported so a single `import PostgrestMacros` is enough: the macros synthesize conformances to
 // protocols that live in `PostgREST`, and a user should not have to import both.
 @_exported public import PostgREST
+
+/// Synthesizes ``PostgrestRelation`` conformance for a struct that maps to a relation.
+///
+/// ```swift
+/// @Table("todos")
+/// struct Todo {
+///   @PrimaryKey var id: Int
+///   var task: String
+///   @Default var isDone: Bool
+///   @Column("due_at") var dueDate: Date?
+/// }
+/// ```
+///
+/// Property names convert camelCase to snake_case; ``Column(_:)`` overrides a single name. The
+/// generated `CodingKeys` and the generated column mapping come from the same input, so an insert
+/// body and a filter can never disagree about a column.
+///
+/// The annotated type must be declared at file scope. The macro attaches an extension, and Swift
+/// does not allow an extension of a type nested inside another type.
+///
+/// - Parameters:
+///   - name: The relation's name as PostgREST addresses it.
+///   - schema: The Postgres schema. Defaults to `"public"`.
+///   - readOnly: Pass `true` for a view. The type then conforms to ``PostgREST/PostgrestRelation``
+///     only, and the write methods are not available on it.
+@attached(
+  extension,
+  conformances: Decodable, Sendable, PostgrestRelation, PostgrestWritableRelation,
+  names: named(relationName), named(schema), named(selectString), named(columnName(for:)),
+  named(CodingKeys), named(Insert), named(Update)
+)
+public macro Table(
+  _ name: String,
+  schema: String = "public",
+  readOnly: Bool = false
+) = #externalMacro(module: "PostgrestMacrosPlugin", type: "TableMacro")
+
+/// Overrides the database column name for a property.
+///
+/// Use it for any name the camelCase-to-snake_case convention cannot produce.
+///
+/// - Parameter name: The column name PostgREST expects.
+@attached(peer)
+public macro Column(_ name: String) =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "MarkerMacro"
+  )
+
+/// Marks a property as the relation's primary key, excluding it from the generated `Insert`.
+@attached(peer)
+public macro PrimaryKey() =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "MarkerMacro"
+  )
+
+/// Marks a property as having a database default, making it optional in the generated `Insert`.
+///
+/// Leaving it `nil` omits the column from the request body, so the database fills it in.
+@attached(peer)
+public macro Default() =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "MarkerMacro"
+  )

--- a/Sources/PostgrestMacrosPlugin/MarkerMacros.swift
+++ b/Sources/PostgrestMacrosPlugin/MarkerMacros.swift
@@ -1,0 +1,20 @@
+//
+//  MarkerMacros.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// The marker attributes carry no expansion of their own — `@Table` reads them off the properties.
+public struct MarkerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    []
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/Plugin.swift
+++ b/Sources/PostgrestMacrosPlugin/Plugin.swift
@@ -10,5 +10,8 @@ import SwiftSyntaxMacros
 
 @main
 struct PostgrestMacrosPlugin: CompilerPlugin {
-  let providingMacros: [any Macro.Type] = []
+  let providingMacros: [any Macro.Type] = [
+    MarkerMacro.self,
+    TableMacro.self,
+  ]
 }

--- a/Sources/PostgrestMacrosPlugin/Support/CamelToSnake.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/CamelToSnake.swift
@@ -1,0 +1,30 @@
+//
+//  CamelToSnake.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+/// Converts a Swift property name to its snake_case database column name.
+///
+/// `isDone` becomes `is_done`; `dueDate` becomes `due_date`; an already-lowercase name is unchanged.
+/// A run of capitals is one word, so `htmlURL` becomes `html_url` and `urlSession` stays
+/// `url_session`.
+func camelToSnakeCase(_ name: String) -> String {
+  var out = ""
+  var previousWasUpper = false
+  for (index, character) in name.enumerated() {
+    if character.isUppercase {
+      let nextIsLower = name.dropFirst(index + 1).first?.isLowercase ?? false
+      if index > 0, !previousWasUpper || nextIsLower {
+        out.append("_")
+      }
+      out.append(Character(character.lowercased()))
+      previousWasUpper = true
+    } else {
+      out.append(character)
+      previousWasUpper = false
+    }
+  }
+  return out
+}

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -1,0 +1,80 @@
+//
+//  StoredProperty.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+
+/// One stored property of an annotated type, with the marker attributes that affect it.
+struct StoredProperty {
+  var name: String
+  var type: String
+  var isOptional: Bool
+  var isPrimaryKey: Bool
+  var hasDefault: Bool
+  var explicitColumn: String?
+
+  /// The database column name: an explicit `@Column`, otherwise the snake_case form.
+  var columnName: String { explicitColumn ?? camelToSnakeCase(name) }
+
+  /// The property's type made optional, or left alone if it already is.
+  var optionalType: String { isOptional ? type : "\(type)?" }
+}
+
+extension DeclGroupSyntax {
+  /// Reads the stored properties, skipping computed properties and static members.
+  ///
+  /// A key path to a skipped property therefore maps to no column, which is what the generated
+  /// `columnName(for:)` traps on.
+  func postgrestStoredProperties() -> [StoredProperty] {
+    memberBlock.members.compactMap { member -> StoredProperty? in
+      guard
+        let variable = member.decl.as(VariableDeclSyntax.self),
+        !variable.modifiers.contains(where: { $0.name.text == "static" }),
+        let binding = variable.bindings.first,
+        let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+        let annotation = binding.typeAnnotation?.type,
+        binding.accessorBlock == nil
+      else { return nil }
+
+      let attributes = variable.attributes.compactMap { $0.as(AttributeSyntax.self) }
+      func attribute(_ name: String) -> AttributeSyntax? {
+        attributes.first { $0.attributeName.trimmedDescription == name }
+      }
+
+      let column =
+        attribute("Column")?
+        .arguments?.as(LabeledExprListSyntax.self)?.first?
+        .expression.as(StringLiteralExprSyntax.self)?
+        .representedLiteralValue
+
+      let typeText = annotation.trimmedDescription
+      return StoredProperty(
+        name: identifier.identifier.text,
+        type: typeText,
+        isOptional: typeText.hasSuffix("?") || typeText.hasPrefix("Optional<"),
+        isPrimaryKey: attribute("PrimaryKey") != nil,
+        hasDefault: attribute("Default") != nil,
+        explicitColumn: column
+      )
+    }
+  }
+
+  /// The access level to repeat on generated members, with a trailing space, or `""`.
+  ///
+  /// Only `public` and `package` are propagated. A protocol witness must be at least as accessible
+  /// as the conformance, and an internal witness already satisfies a `fileprivate` or `private`
+  /// one.
+  var postgrestAccessLevel: String {
+    for modifier in modifiers {
+      switch modifier.name.tokenKind {
+      case .keyword(.public): return "public "
+      case .keyword(.package): return "package "
+      default: continue
+      }
+    }
+    return ""
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -28,17 +28,31 @@ extension DeclGroupSyntax {
   ///
   /// A key path to a skipped property therefore maps to no column, which is what the generated
   /// `columnName(for:)` traps on.
+  ///
+  /// Three shapes are easy to get wrong, so each is spelled out:
+  ///
+  /// - **Every binding counts.** `var task: String, note: String` is one `VariableDeclSyntax` with
+  ///   two bindings. Reading only the first silently drops `note` from `CodingKeys`, the column
+  ///   map, `Insert` and `Update`.
+  /// - **A shared annotation sits on the last binding.** In `var draft, review: String` only
+  ///   `review` carries the type, so a binding without one takes the next annotation forward —
+  ///   but only when it has no initializer of its own. In `var a = 1, b: String`, `a` is an `Int`
+  ///   inferred from its initializer, and borrowing `b`'s annotation would type it `String`.
+  /// - **Observers keep a property stored.** `var task: String = "" { didSet { … } }` has an
+  ///   accessor block, so testing `accessorBlock == nil` excludes it as though it were computed.
+  ///
+  /// A property whose type is inferred from an initializer (`var isDone = false`) is still
+  /// skipped: a macro sees syntax, not types, so there is no annotation to read. That is a real
+  /// gap — the property silently gets no column — and it wants a diagnostic rather than a guess.
   func postgrestStoredProperties() -> [StoredProperty] {
-    memberBlock.members.compactMap { member -> StoredProperty? in
+    memberBlock.members.flatMap { member -> [StoredProperty] in
       guard
         let variable = member.decl.as(VariableDeclSyntax.self),
-        !variable.modifiers.contains(where: { $0.name.text == "static" }),
-        let binding = variable.bindings.first,
-        let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
-        let annotation = binding.typeAnnotation?.type,
-        binding.accessorBlock == nil
-      else { return nil }
+        !variable.modifiers.contains(where: { $0.name.text == "static" })
+      else { return [] }
 
+      // Marker attributes sit on the declaration, not the binding, so every binding in
+      // `@Default var a, b: Bool` carries them.
       let attributes = variable.attributes.compactMap { $0.as(AttributeSyntax.self) }
       func attribute(_ name: String) -> AttributeSyntax? {
         attributes.first { $0.attributeName.trimmedDescription == name }
@@ -50,15 +64,25 @@ extension DeclGroupSyntax {
         .expression.as(StringLiteralExprSyntax.self)?
         .representedLiteralValue
 
-      let typeText = annotation.trimmedDescription
-      return StoredProperty(
-        name: identifier.identifier.text,
-        type: typeText,
-        isOptional: typeText.hasSuffix("?") || typeText.hasPrefix("Optional<"),
-        isPrimaryKey: attribute("PrimaryKey") != nil,
-        hasDefault: attribute("Default") != nil,
-        explicitColumn: column
-      )
+      let bindings = Array(variable.bindings)
+      return bindings.indices.compactMap { index -> StoredProperty? in
+        let binding = bindings[index]
+        guard
+          let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+          binding.isPostgrestStored,
+          let annotation = bindings.postgrestType(at: index)
+        else { return nil }
+
+        let typeText = annotation.trimmedDescription
+        return StoredProperty(
+          name: identifier.identifier.text,
+          type: typeText,
+          isOptional: typeText.hasSuffix("?") || typeText.hasPrefix("Optional<"),
+          isPrimaryKey: attribute("PrimaryKey") != nil,
+          hasDefault: attribute("Default") != nil,
+          explicitColumn: column
+        )
+      }
     }
   }
 
@@ -76,5 +100,43 @@ extension DeclGroupSyntax {
       }
     }
     return ""
+  }
+}
+
+extension PatternBindingSyntax {
+  /// Whether this binding is stored rather than computed.
+  ///
+  /// No accessor block means stored. An accessor block holding only `willSet`/`didSet` is a
+  /// stored property with observers, which still has storage and still round-trips to a column.
+  /// Anything else — an explicit `get`, or the implicit getter of `var x: Int { 1 }` — is
+  /// computed and has no column.
+  var isPostgrestStored: Bool {
+    guard let accessorBlock else { return true }
+
+    switch accessorBlock.accessors {
+    case .accessors(let accessors):
+      return accessors.allSatisfy { accessor in
+        switch accessor.accessorSpecifier.tokenKind {
+        case .keyword(.willSet), .keyword(.didSet): true
+        default: false
+        }
+      }
+    case .getter:
+      // `var x: Int { 1 }` — an implicit getter, so computed.
+      return false
+    }
+  }
+}
+
+extension [PatternBindingSyntax] {
+  /// The type of the binding at `index`, resolving a shared annotation.
+  ///
+  /// `var draft, review: String` puts the annotation on `review` alone, so an unannotated binding
+  /// looks forward for one. A binding with its own initializer does not: in `var a = 1, b: String`
+  /// the initializer is what types `a`, and it is not the macro's to read.
+  func postgrestType(at index: Int) -> TypeSyntax? {
+    if let annotation = self[index].typeAnnotation?.type { return annotation }
+    guard self[index].initializer == nil else { return nil }
+    return self[index...].lazy.compactMap { $0.typeAnnotation?.type }.first
   }
 }

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -1,0 +1,202 @@
+//
+//  TableMacro.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Expands `@Table` into a relation conformance.
+///
+/// Everything is emitted from the extension role, and none of it from a member role. Two rules
+/// force that shape, and both fail confusingly if you get them wrong:
+///
+/// - A macro-generated extension cannot witness a requirement with a member added by a *member*
+///   role of the same attribute. Splitting the witnesses across the two roles compiles as
+///   hand-written source and fails as an expansion.
+/// - The emitted inheritance clause must name every protocol in the refinement chain.
+///   `extension Todo: PostgrestWritableRelation` alone reports "does not conform to inherited
+///   protocol PostgrestRelation", with no note saying which requirement is missing.
+public struct TableMacro: ExtensionMacro {
+  // MARK: Arguments
+
+  struct Arguments {
+    var name: String
+    var schema: String
+    var readOnly: Bool
+  }
+
+  static func arguments(from node: AttributeSyntax) -> Arguments {
+    var name = ""
+    var schema = "public"
+    var readOnly = false
+    for argument in node.arguments?.as(LabeledExprListSyntax.self) ?? [] {
+      switch argument.label?.text {
+      case nil:
+        name = argument.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue ?? ""
+      case "schema":
+        schema =
+          argument.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue ?? "public"
+      case "readOnly":
+        readOnly = argument.expression.as(BooleanLiteralExprSyntax.self)?.literal.text == "true"
+      default:
+        break
+      }
+    }
+    return Arguments(name: name, schema: schema, readOnly: readOnly)
+  }
+
+  // MARK: Expansion
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    guard declaration.is(StructDeclSyntax.self) else {
+      throw MacroExpansionErrorMessage("@Table can only be applied to a struct")
+    }
+    let arguments = arguments(from: node)
+    let access = declaration.postgrestAccessLevel
+    let properties = declaration.postgrestStoredProperties()
+
+    var body: [String] = [
+      "  \(access)static let relationName = \"\(arguments.name)\"",
+      "  \(access)static let schema = \"\(arguments.schema)\"",
+      "  \(access)static let selectString = \"*\"",
+      columnNameFunction(access: access, type: type.trimmedDescription, properties: properties),
+    ]
+    if let codingKeys = codingKeys(for: properties) {
+      body.append(codingKeys)
+    }
+    if !arguments.readOnly {
+      // `Insert` drops the primary key and makes defaulted columns optional, so a row can be
+      // inserted without naming a column the database fills in. `Update` makes every column
+      // optional, so a partial update names only what it changes.
+      let writable = properties.filter { !$0.isPrimaryKey }
+      body.append(
+        writeShape(
+          named: "Insert",
+          access: access,
+          fields: writable.map { ($0, $0.isOptional || $0.hasDefault ? $0.optionalType : $0.type) }
+        )
+      )
+      body.append(
+        writeShape(named: "Update", access: access, fields: writable.map { ($0, $0.optionalType) })
+      )
+    }
+
+    return [
+      try ExtensionDeclSyntax(
+        """
+        extension \(type.trimmed)\(raw: inheritanceClause(arguments, protocols)) {
+        \(raw: body.joined(separator: "\n\n"))
+        }
+        """
+      )
+    ]
+  }
+
+  // MARK: Generation
+
+  /// The inheritance clause to emit, or `""` when the type already declares everything.
+  ///
+  /// `protocols` is the subset of the attribute's declared `conformances:` the type does not
+  /// already satisfy, so a user who writes `struct Todo: Decodable` gets no duplicate — and no
+  /// "redundant conformance" error.
+  ///
+  /// `Decodable` is in the list and `Encodable` is not: rows are decoded from responses, and writes
+  /// go out through the `Encodable` `Insert` and `Update` shapes.
+  static func inheritanceClause(_ arguments: Arguments, _ protocols: [TypeSyntax]) -> String {
+    let wanted = [
+      "Decodable",
+      "Sendable",
+      "PostgrestRelation",
+      arguments.readOnly ? nil : "PostgrestWritableRelation",
+    ].compactMap { $0 }
+    let missing = Set(protocols.map(\.trimmedDescription))
+    let needed = wanted.filter(missing.contains)
+    return needed.isEmpty ? "" : ": \(needed.joined(separator: ", "))"
+  }
+
+  /// The key-path-to-column mapping.
+  ///
+  /// Every stored property gets a case, so `default` is reachable only through a key path to a
+  /// computed property — a mistake at the call site, not a query worth sending. `fatalError` says
+  /// so immediately; returning `""` would build a query with an empty column name and leave
+  /// PostgREST to reject it with a 400 that never names the key path.
+  static func columnNameFunction(
+    access: String,
+    type: String,
+    properties: [StoredProperty]
+  ) -> String {
+    var lines = [
+      "  \(access)static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {",
+      "    switch keyPath {",
+    ]
+    for property in properties {
+      lines.append("    case \\Self.\(property.name):")
+      lines.append("      return \"\(property.columnName)\"")
+    }
+    lines.append("    default:")
+    lines.append("      fatalError(\"\(type): no column is mapped for that key path\")")
+    lines.append("    }")
+    lines.append("  }")
+    return lines.joined(separator: "\n")
+  }
+
+  /// The `CodingKeys` enum, or `nil` when there is nothing to map.
+  ///
+  /// The same property list drives this and the column mapping, so the write path and the filter
+  /// path cannot disagree about a column name.
+  static func codingKeys(for properties: [StoredProperty], indent: String = "  ") -> String? {
+    guard !properties.isEmpty else { return nil }
+    var lines = ["\(indent)enum CodingKeys: String, CodingKey {"]
+    for property in properties {
+      lines.append("\(indent)  case \(property.name) = \"\(property.columnName)\"")
+    }
+    lines.append("\(indent)}")
+    return lines.joined(separator: "\n")
+  }
+
+  /// One of the nested write shapes, with its own `CodingKeys` and an init that defaults every
+  /// optional to `nil`.
+  ///
+  /// `CodingKeys` is not optional here: PostgREST's encoder sets no key strategy, so without it an
+  /// insert would send `isDone` while a filter on the same column sends `is_done`. Nor is the init
+  /// — the memberwise init of a `public` struct is internal, and a partial update would otherwise
+  /// have to spell out `nil` for every column it leaves alone.
+  static func writeShape(
+    named name: String,
+    access: String,
+    fields: [(property: StoredProperty, type: String)]
+  ) -> String {
+    var lines: [String] = ["  \(access)struct \(name): Encodable, Sendable {"]
+
+    for field in fields {
+      lines.append("    \(access)var \(field.property.name): \(field.type)")
+    }
+
+    if let codingKeys = codingKeys(for: fields.map(\.property), indent: "    ") {
+      lines.append("")
+      lines.append(codingKeys)
+    }
+
+    let parameters =
+      fields
+      .map { "\($0.property.name): \($0.type)\($0.type.hasSuffix("?") ? " = nil" : "")" }
+      .joined(separator: ", ")
+    lines.append("")
+    lines.append("    \(access)init(\(parameters)) {")
+    for field in fields {
+      lines.append("      self.\(field.property.name) = \(field.property.name)")
+    }
+    lines.append("    }")
+    lines.append("  }")
+    return lines.joined(separator: "\n")
+  }
+}

--- a/Tests/PostgrestMacrosTests/RequestCapture.swift
+++ b/Tests/PostgrestMacrosTests/RequestCapture.swift
@@ -1,0 +1,55 @@
+//
+//  RequestCapture.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import ConcurrencyExtras
+import Foundation
+import PostgrestMacros
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// Captures the `URLRequest` a typed query produces, so a test can assert on it in its own context.
+///
+/// A trimmed sibling of `QueryCapture` in `PostgRESTTests`. The two test targets cannot share a
+/// helper without a third target, and a macro test needs far less of it than the builder tests do.
+struct RequestCapture {
+  let client: PostgrestClient
+  private let captured = LockIsolated(URLRequest?.none)
+
+  init(body: String = "[]") {
+    let captured = self.captured
+    client = PostgrestClient(
+      url: URL(string: "https://example.supabase.co")!,
+      headers: ["X-Client-Info": "postgrest-swift/test"],
+      fetch: { request in
+        captured.setValue(request)
+        let response = HTTPURLResponse(
+          url: request.url!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: ["Content-Type": "application/json"]
+        )!
+        return (Data(body.utf8), response)
+      }
+    )
+  }
+
+  /// The query string, percent-decoded so assertions read in the spelling PostgREST documents.
+  var query: String? {
+    guard let query = captured.value?.url?.query else { return nil }
+    return query.removingPercentEncoding ?? query
+  }
+
+  /// The path of the captured request's URL, which ends in the relation name.
+  var path: String? { captured.value?.url?.path }
+
+  /// The captured request body decoded as UTF-8.
+  var bodyString: String? {
+    captured.value?.httpBody.map { String(decoding: $0, as: UTF8.self) }
+  }
+}

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -1,0 +1,117 @@
+//
+//  TableIntegrationTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import PostgrestMacros
+import Testing
+
+// Declared at file scope on purpose. `@Table` attaches an extension, and Swift does not allow an
+// extension of a type nested inside another type, so annotating a nested struct fails to compile.
+@Table("todos")
+struct IntegrationTodo: Hashable {
+  @PrimaryKey var id: Int
+  var task: String
+  @Default var isDone: Bool
+  @Column("due_at") var dueDate: Date?
+}
+
+@Table("active_todos", readOnly: true)
+struct IntegrationActiveTodo {
+  var id: Int
+  var task: String
+}
+
+@Suite
+struct TableIntegrationTests {
+  typealias Todo = IntegrationTodo
+
+  @Test
+  func macroSuppliesTheRelationName() {
+    #expect(Todo.relationName == "todos")
+    #expect(Todo.schema == "public")
+    #expect(Todo.selectString == "*")
+  }
+
+  @Test
+  func macroMapsKeyPathsToColumns() {
+    #expect(Todo.columnName(for: \.id) == "id")
+    #expect(Todo.columnName(for: \.isDone) == "is_done")
+    #expect(Todo.columnName(for: \.dueDate) == "due_at")
+  }
+
+  @Test
+  func insertExcludesThePrimaryKeyAndUsesColumnNames() throws {
+    let data = try JSONEncoder().encode(Todo.Insert(task: "buy milk", isDone: false))
+    let json = String(decoding: data, as: UTF8.self)
+    #expect(json.contains("\"id\"") == false)
+    #expect(json.contains("\"is_done\"") == true)
+    #expect(json.contains("\"isDone\"") == false)
+  }
+
+  @Test
+  func aNilOptionalIsOmittedSoTheDatabaseDefaultApplies() throws {
+    // `@Default var isDone` is optional in `Insert` precisely so it can be left out. Encoding it
+    // as `null` would insert NULL instead of letting the column default apply.
+    let data = try JSONEncoder().encode(Todo.Insert(task: "buy milk"))
+    let json = String(decoding: data, as: UTF8.self)
+    #expect(json == #"{"task":"buy milk"}"#)
+  }
+
+  @Test
+  func aPartialUpdateNamesOnlyWhatItChanges() throws {
+    let data = try JSONEncoder().encode(Todo.Update(isDone: true))
+    let json = String(decoding: data, as: UTF8.self)
+    #expect(json == #"{"is_done":true}"#)
+  }
+
+  @Test
+  func aMacroTypeFlowsThroughTheTypedQuery() async throws {
+    let capture = RequestCapture(
+      body: #"[{"id":1,"task":"buy milk","is_done":false,"due_at":null}]"#
+    )
+    let todos = try await capture.client
+      .from(Todo.self)
+      .select()
+      .eq(\.isDone, false)
+      .order(\.id, ascending: false)
+      .execute()
+      .value
+
+    #expect(todos == [Todo(id: 1, task: "buy milk", isDone: false, dueDate: nil)])
+    #expect(capture.path?.hasSuffix("/todos") == true)
+    #expect(capture.query?.contains("select=*") == true)
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+    #expect(capture.query?.contains("id.desc") == true)
+  }
+
+  @Test
+  func aMacroTypeFlowsThroughATypedWrite() async throws {
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .insert(Todo.Insert(task: "buy milk"))
+      .execute()
+
+    #expect(capture.path?.hasSuffix("/todos") == true)
+    #expect(capture.bodyString == #"{"task":"buy milk"}"#)
+  }
+
+  @Test
+  func aReadOnlyRelationIsStillQueryable() async throws {
+    let capture = RequestCapture(body: #"[{"id":1,"task":"buy milk"}]"#)
+    let rows = try await capture.client
+      .from(IntegrationActiveTodo.self)
+      .select()
+      .eq(\.task, "buy milk")
+      .execute()
+      .value
+
+    #expect(rows.count == 1)
+    #expect(capture.path?.hasSuffix("/active_todos") == true)
+    #expect(capture.query?.contains("task=eq.buy milk") == true)
+  }
+}

--- a/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
@@ -1,0 +1,67 @@
+//
+//  TableMacroSupportTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import Testing
+
+@testable import PostgrestMacrosPlugin
+
+/// Covers the two pieces `assertMacro` cannot reach.
+///
+/// `MacroTesting` expands a macro without its declaration, so it always passes an empty
+/// `conformingTo:` and the recorded expansions show `extension Todo {` with no inheritance clause.
+/// The clause is what makes the conformance land, so it is asserted here directly.
+@Suite
+struct TableMacroSupportTests {
+  private func clause(readOnly: Bool, missing: [String]) -> String {
+    TableMacro.inheritanceClause(
+      TableMacro.Arguments(name: "todos", schema: "public", readOnly: readOnly),
+      missing.map { TypeSyntax(stringLiteral: $0) }
+    )
+  }
+
+  @Test
+  func namesEveryLinkInTheRefinementChain() {
+    // `PostgrestWritableRelation` alone is not enough: a macro-generated extension does not derive
+    // the inherited conformance, and reports a missing `PostgrestRelation` with no useful note.
+    #expect(
+      clause(
+        readOnly: false,
+        missing: ["Decodable", "Sendable", "PostgrestRelation", "PostgrestWritableRelation"]
+      ) == ": Decodable, Sendable, PostgrestRelation, PostgrestWritableRelation"
+    )
+  }
+
+  @Test
+  func readOnlyStopsAtTheReadableRelation() {
+    #expect(
+      clause(readOnly: true, missing: ["Decodable", "Sendable", "PostgrestRelation"])
+        == ": Decodable, Sendable, PostgrestRelation"
+    )
+  }
+
+  @Test
+  func skipsWhatTheTypeAlreadyDeclares() {
+    // `struct Todo: Decodable, Sendable` must not get a second Decodable conformance.
+    #expect(
+      clause(readOnly: false, missing: ["PostgrestRelation", "PostgrestWritableRelation"])
+        == ": PostgrestRelation, PostgrestWritableRelation"
+    )
+    #expect(clause(readOnly: false, missing: []) == "")
+  }
+
+  @Test
+  func convertsPropertyNamesToColumnNames() {
+    #expect(camelToSnakeCase("isDone") == "is_done")
+    #expect(camelToSnakeCase("dueDate") == "due_date")
+    #expect(camelToSnakeCase("task") == "task")
+    #expect(camelToSnakeCase("htmlURL") == "html_url")
+    #expect(camelToSnakeCase("urlSession") == "url_session")
+    #expect(camelToSnakeCase("id") == "id")
+  }
+}

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -278,4 +278,254 @@ struct TableMacroTests {
       """#
     }
   }
+  @Test
+  func coversEveryBindingInAMultiBindingDeclaration() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String, note: String
+        var draft, review: String
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String, note: String
+        var draft, review: String
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          case \Self.note:
+            return "note"
+          case \Self.draft:
+            return "draft"
+          case \Self.review:
+            return "review"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+          case note = "note"
+          case draft = "draft"
+          case review = "review"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var task: String
+          var note: String
+          var draft: String
+          var review: String
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+            case note = "note"
+            case draft = "draft"
+            case review = "review"
+          }
+
+          init(task: String, note: String, draft: String, review: String) {
+            self.task = task
+            self.note = note
+            self.draft = draft
+            self.review = review
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var task: String?
+          var note: String?
+          var draft: String?
+          var review: String?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+            case note = "note"
+            case draft = "draft"
+            case review = "review"
+          }
+
+          init(task: String? = nil, note: String? = nil, draft: String? = nil, review: String? = nil) {
+            self.task = task
+            self.note = note
+            self.draft = draft
+            self.review = review
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func includesAStoredPropertyWithObservers() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String = "" {
+          didSet { print(task) }
+        }
+        var count: Int {
+          task.count
+        }
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String = "" {
+          didSet { print(task) }
+        }
+        var count: Int {
+          task.count
+        }
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var task: String
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          init(task: String) {
+            self.task = task
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var task: String?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          init(task: String? = nil) {
+            self.task = task
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func doesNotBorrowATypeAnnotationForAnInitializedBinding() {
+    // `count` is an `Int` inferred from its initializer, not the `String` that `label` declares.
+    // Reading forward for a shared annotation is only correct for a binding that has no
+    // initializer of its own, so `count` is skipped rather than typed `String`.
+    //
+    // Skipping is the pre-existing behavior for any property whose type comes from an initializer
+    // (`var isDone = false`). It means the property silently gets no column, which wants a
+    // diagnostic — see the note in `postgrestStoredProperties()`.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var count = 1, label: String
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey var id: Int
+        var count = 1, label: String
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.label:
+            return "label"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case label = "label"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var label: String
+
+          enum CodingKeys: String, CodingKey {
+            case label = "label"
+          }
+
+          init(label: String) {
+            self.label = label
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var label: String?
+
+          enum CodingKeys: String, CodingKey {
+            case label = "label"
+          }
+
+          init(label: String? = nil) {
+            self.label = label
+          }
+        }
+      }
+      """#
+    }
+  }
+
 }

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -1,0 +1,281 @@
+//
+//  TableMacroTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import MacroTesting
+import Testing
+
+@testable import PostgrestMacrosPlugin
+
+/// `MacroTesting` expands the macro without its declaration, so `conformingTo:` is always empty
+/// here and the recorded extensions carry no inheritance clause. `TableMacroSupportTests` asserts
+/// the clause directly.
+@Suite(.macros(["Table": TableMacro.self]))
+struct TableMacroTests {
+  @Test
+  func expandsAWritableTable() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+        @Default var isDone: Bool
+        @Column("due_at") var dueDate: Date?
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+        @Default var isDone: Bool
+        @Column("due_at") var dueDate: Date?
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          case \Self.isDone:
+            return "is_done"
+          case \Self.dueDate:
+            return "due_at"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+          case isDone = "is_done"
+          case dueDate = "due_at"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var task: String
+          var isDone: Bool?
+          var dueDate: Date?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+            case isDone = "is_done"
+            case dueDate = "due_at"
+          }
+
+          init(task: String, isDone: Bool? = nil, dueDate: Date? = nil) {
+            self.task = task
+            self.isDone = isDone
+            self.dueDate = dueDate
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var task: String?
+          var isDone: Bool?
+          var dueDate: Date?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+            case isDone = "is_done"
+            case dueDate = "due_at"
+          }
+
+          init(task: String? = nil, isDone: Bool? = nil, dueDate: Date? = nil) {
+            self.task = task
+            self.isDone = isDone
+            self.dueDate = dueDate
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func readOnlyTableOmitsInsertAndUpdate() {
+    assertMacro {
+      """
+      @Table("active_todos", readOnly: true)
+      struct ActiveTodo {
+        var id: Int
+      }
+      """
+    } expansion: {
+      #"""
+      struct ActiveTodo {
+        var id: Int
+      }
+
+      extension ActiveTodo {
+        static let relationName = "active_todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          default:
+            fatalError("ActiveTodo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func propagatesTheAccessLevel() {
+    assertMacro {
+      """
+      @Table("todos", schema: "app")
+      public struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+      }
+      """
+    } expansion: {
+      #"""
+      public struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+      }
+
+      extension Todo {
+        public static let relationName = "todos"
+
+        public static let schema = "app"
+
+        public static let selectString = "*"
+
+        public static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+        }
+
+        public struct Insert: Encodable, Sendable {
+          public var task: String
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          public init(task: String) {
+            self.task = task
+          }
+        }
+
+        public struct Update: Encodable, Sendable {
+          public var task: String?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          public init(task: String? = nil) {
+            self.task = task
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func skipsComputedAndStaticMembers() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        static let table = "todos"
+        var htmlURL: String
+        var summary: String { htmlURL }
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        static let table = "todos"
+        var htmlURL: String
+        var summary: String { htmlURL }
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.htmlURL:
+            return "html_url"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case htmlURL = "html_url"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var htmlURL: String
+
+          enum CodingKeys: String, CodingKey {
+            case htmlURL = "html_url"
+          }
+
+          init(htmlURL: String) {
+            self.htmlURL = htmlURL
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var htmlURL: String?
+
+          enum CodingKeys: String, CodingKey {
+            case htmlURL = "html_url"
+          }
+
+          init(htmlURL: String? = nil) {
+            self.htmlURL = htmlURL
+          }
+        }
+      }
+      """#
+    }
+  }
+}

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -249,3 +249,4 @@ deinits
 
 # Term from AGENTS.md's Enum-like Values section (describing non-failable init(rawValue:)).
 failable
+memberwise

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -90,6 +90,16 @@ supporting_symbols:
   - PostgrestWritableRelation.Insert
   - PostgrestWritableRelation.Update
 
+  # The `PostgrestMacros` attributes. `@Table` synthesizes the relation
+  # conformance used by every database.* typed entry point, and the three
+  # markers are inputs to that one expansion rather than capabilities of their
+  # own. Attribute names are unprefixed on purpose — nothing re-exports
+  # `PostgrestMacros`, so a user opts in with an explicit import.
+  - Table
+  - Column
+  - PrimaryKey
+  - Default
+
 features:
 
   # ── Auth ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes SDK-1516. Stacked on #1258.

## What

```swift
@Table("todos")
struct Todo {
  @PrimaryKey var id: Int
  var task: String
  @Default var isDone: Bool
  @Column("due_at") var dueDate: Date?
}
```

`CodingKeys` and the column mapping are generated from one input, so the write path and the filter path cannot disagree about a column. `@PrimaryKey` is excluded from `Insert` and `@Default` is optional there; `@Table("active_todos", readOnly: true)` conforms to `PostgrestRelation` only, so the writes from #1255 are not offered on a view.

## Three things the plan did not call for, each a defect without it

- **`Insert` and `Update` carry their own `CodingKeys`.** `JSONEncoder.supabase()` sets a date strategy and *no* `keyEncodingStrategy`, so without them an insert sends `"isDone"` while a filter on the same column sends `is_done`.
- **`Insert` and `Update` get explicit inits defaulting every optional to `nil`.** A partial update would otherwise spell out `nil` for every column it leaves alone, and the memberwise init of a `public` struct is internal.
- **`public` and `package` are propagated.** A protocol witness must be at least as accessible as the conformance, so `@Table` on a `public struct` does not compile otherwise.

## Two macro rules that cost the most time

Both are recorded in `TableMacro`'s doc comment, because both fail with a diagnostic that does not say what is wrong:

1. A macro-generated extension **cannot** witness a requirement with a member added by a *member* role of the same attribute. The identical text compiles when hand-written and fails as an expansion. So `@Table` is extension-role only.
2. The emitted inheritance clause must name **every** protocol in the refinement chain. `extension Todo: PostgrestWritableRelation` alone reports "does not conform to inherited protocol `PostgrestRelation`", with no note naming the unmet requirement.

The clause is built from the compiler's `conformingTo:` list, so `struct Todo: Decodable, Sendable` gets no redundant conformance. `MacroTesting` expands without the declaration and always passes an empty list, so the clause is asserted directly in `TableMacroSupportTests` rather than left uncovered.

## `columnName(for:)` traps instead of returning `""`

The `default:` arm is reachable only through a key path to a computed property. `fatalError` names the type immediately; `""` would build a query with an empty column name and leave PostgREST to answer with a 400 that never mentions the key path. This matches the hand-written fixture already in `PostgrestRelationTests`.

## Tests

11 new tests. Expansion snapshots via `swift-macro-testing`; `TableIntegrationTests` drives a `@Table` type through `from(_:).select().eq(_:_:).order(_:)`, through `insert`, and through a read-only relation, asserting the request each produces. Full suite: 1245 passing.