### PR TITLE
feat(postgrest): add @SelectionOf for column subsets

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedSource.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedSource.swift
@@ -37,4 +37,23 @@ public struct PostgrestTypedSource<R: PostgrestRelation>: Sendable {
   public func select() -> PostgrestTypedQuery<R, [R], PostgrestFilterPhase> {
     PostgrestTypedQuery(builder: builder.select(R.selectString))
   }
+
+  /// Selects the columns declared by a selection type.
+  ///
+  /// ```swift
+  /// let rows = try await client.from(Todo.self).select(TodoSummary.self).execute().value
+  /// ```
+  ///
+  /// The `where` clause is what makes a declared selection safe to pass around: a selection names
+  /// the relation it was declared against, so handing it to a different relation is *no such
+  /// overload* rather than a request PostgREST rejects.
+  ///
+  /// - Parameter selection: A type declaring the columns to fetch, normally annotated with
+  ///   `@SelectionOf` from the `PostgrestMacros` module.
+  /// - Returns: A ``PostgrestTypedQuery`` decoding into `[S]`.
+  public func select<S: PostgrestSelection>(
+    _ selection: S.Type
+  ) -> PostgrestTypedQuery<R, [S], PostgrestFilterPhase> where S.Source == R {
+    PostgrestTypedQuery(builder: builder.select(S.selectString))
+  }
 }

--- a/Sources/PostgREST/Relations/PostgrestRelation.swift
+++ b/Sources/PostgREST/Relations/PostgrestRelation.swift
@@ -11,6 +11,13 @@
 /// `PostgrestMacros` module, or emitted by the schema generator. Hand-written conformances are
 /// supported and are the escape hatch when neither fits.
 public protocol PostgrestSelection: Decodable, Sendable {
+  /// The relation this shape selects from.
+  ///
+  /// Naming the source is what stops a selection being handed to the wrong relation. A relation is
+  /// its own source, fixed by the same-type constraint on ``PostgrestRelation``, so a hand-written
+  /// relation conformance declares nothing here.
+  associatedtype Source: PostgrestRelation
+
   /// The PostgREST `select` expression for this shape, for example `"id,task"`.
   static var selectString: String { get }
 }
@@ -19,7 +26,7 @@ public protocol PostgrestSelection: Decodable, Sendable {
 ///
 /// "Relation" is Postgres's own term for that family. Selecting a whole row is the degenerate
 /// selection, which is why this refines ``PostgrestSelection``.
-public protocol PostgrestRelation: PostgrestSelection {
+public protocol PostgrestRelation: PostgrestSelection where Source == Self {
   /// The relation's name as PostgREST addresses it.
   static var relationName: String { get }
 

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -71,3 +71,33 @@ public macro Default() =
   #externalMacro(
     module: "PostgrestMacrosPlugin", type: "MarkerMacro"
   )
+
+/// Declares a named subset of a relation's columns.
+///
+/// ```swift
+/// @SelectionOf(Todo.self)
+/// struct TodoSummary {
+///   var id: Int
+///   var isDone: Bool
+/// }
+///
+/// let rows = try await client.from(Todo.self).select(TodoSummary.self).execute().value
+/// ```
+///
+/// Property names follow the same snake_case conversion as ``Table(_:schema:readOnly:)``, and
+/// ``Column(_:)`` overrides one. The expansion emits references to the relation's own columns, so a
+/// property that names no column on it fails to compile.
+///
+/// The annotated type must be declared at file scope. The macro attaches an extension, and Swift
+/// does not allow an extension of a type nested inside another type.
+///
+/// - Parameter relation: The relation this selects from, for example `Todo.self`.
+@attached(
+  extension,
+  conformances: Decodable, Sendable, PostgrestSelection,
+  names: named(Source), named(selectString), named(CodingKeys), named(_columnCheck)
+)
+public macro SelectionOf(_ relation: Any.Type) =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "SelectionOfMacro"
+  )

--- a/Sources/PostgrestMacrosPlugin/Plugin.swift
+++ b/Sources/PostgrestMacrosPlugin/Plugin.swift
@@ -12,6 +12,7 @@ import SwiftSyntaxMacros
 struct PostgrestMacrosPlugin: CompilerPlugin {
   let providingMacros: [any Macro.Type] = [
     MarkerMacro.self,
+    SelectionOfMacro.self,
     TableMacro.self,
   ]
 }

--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -42,7 +42,7 @@ public struct SelectionOfMacro: ExtensionMacro {
 
     var body: [String] = [
       "  \(access)typealias Source = \(relation)",
-      "  \(access)static let selectString = \"\(properties.map(\.columnName).joined(separator: ","))\"",
+      selectString(access: access, relation: relation, properties: properties),
     ]
     if let codingKeys = codingKeys(for: properties) {
       body.append(codingKeys)
@@ -63,12 +63,51 @@ public struct SelectionOfMacro: ExtensionMacro {
     ]
   }
 
+  /// The `select` list, with each column read from the relation rather than re-derived here.
+  ///
+  /// A selection knows its own property names; it does not know what column the relation maps them
+  /// to. Snake-casing locally gets that wrong the moment the relation carries a `@Column`:
+  /// a selection declaring `var dueDate: Date?` over a relation with `@Column("due_at")` asked
+  /// PostgREST for `due_date`, a column that does not exist. Nothing caught it — `_columnCheck`
+  /// proves the *key path* resolves, not that the name matches.
+  ///
+  /// So the column comes from `Source.columnName(for:)`, which is the mapping the relation already
+  /// validated. That makes the value a runtime one rather than a literal, which is why it is
+  /// assembled with `joined(separator:)`.
+  ///
+  /// Each entry is emitted as a PostgREST alias, `key:column`. The alias is what keeps
+  /// `CodingKeys` correct: the response comes back keyed by the selection's own name, so the
+  /// generated coding keys need no knowledge of the relation's column names — which a macro could
+  /// not give them anyway, since a `CodingKey` raw value has to be a literal. When the two names
+  /// agree the alias is a no-op, so it is emitted unconditionally rather than guessed at.
+  static func selectString(
+    access: String, relation: String, properties: [StoredProperty]
+  ) -> String {
+    guard !properties.isEmpty else {
+      return "  \(access)static let selectString = \"\""
+    }
+
+    var lines = ["  \(access)static let selectString = ["]
+    for property in properties {
+      lines.append(
+        "    \"\(property.columnName):\\(\(relation).columnName(for: \\\(relation).\(property.name)))\","
+      )
+    }
+    lines.append("  ].joined(separator: \",\")")
+    return lines.joined(separator: "\n")
+  }
+
   /// The cross-type check.
   ///
   /// A macro sees syntax only and cannot inspect the relation's members. It can *emit* references
   /// to them, though, and the compiler checks the expansion — so a property that names no column
   /// on the relation fails on the emitted line. That is what makes a declared selection fully
   /// checked rather than checked by convention.
+  ///
+  /// Now that ``selectString(access:relation:properties:)`` calls `columnName(for:)` on every
+  /// property, it carries the same proof, and this array is redundant. It is kept because it says
+  /// out loud what the check is for; the diagnostic a reader gets from a bad key path is the same
+  /// either way.
   static func columnCheck(relation: String, properties: [StoredProperty]) -> String {
     var lines = [
       "  /// Fails to compile if a property does not name a column on \(relation).",

--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -1,0 +1,83 @@
+//
+//  SelectionOfMacro.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Expands `@SelectionOf` into a selection conformance.
+///
+/// Like ``TableMacro``, everything is emitted from the extension role and the inheritance clause
+/// names the whole refinement chain — a macro-generated extension derives neither.
+public struct SelectionOfMacro: ExtensionMacro {
+  /// The relation named by `@SelectionOf(Todo.self)`, or `nil` if the argument is not a `T.self`.
+  static func relation(from node: AttributeSyntax) -> String? {
+    guard
+      let expression = node.arguments?.as(LabeledExprListSyntax.self)?.first?.expression,
+      let base = expression.as(MemberAccessExprSyntax.self)?.base
+    else { return nil }
+    return base.trimmedDescription
+  }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    guard declaration.is(StructDeclSyntax.self) else {
+      throw MacroExpansionErrorMessage("@SelectionOf can only be applied to a struct")
+    }
+    guard let relation = relation(from: node) else {
+      throw MacroExpansionErrorMessage(
+        "@SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)"
+      )
+    }
+    let access = declaration.postgrestAccessLevel
+    let properties = declaration.postgrestStoredProperties()
+
+    var body: [String] = [
+      "  \(access)typealias Source = \(relation)",
+      "  \(access)static let selectString = \"\(properties.map(\.columnName).joined(separator: ","))\"",
+    ]
+    if let codingKeys = codingKeys(for: properties) {
+      body.append(codingKeys)
+    }
+    body.append(columnCheck(relation: relation, properties: properties))
+
+    let clause = inheritanceClause(
+      wanted: ["Decodable", "Sendable", "PostgrestSelection"], missing: protocols
+    )
+    return [
+      try ExtensionDeclSyntax(
+        """
+        extension \(type.trimmed)\(raw: clause) {
+        \(raw: body.joined(separator: "\n\n"))
+        }
+        """
+      )
+    ]
+  }
+
+  /// The cross-type check.
+  ///
+  /// A macro sees syntax only and cannot inspect the relation's members. It can *emit* references
+  /// to them, though, and the compiler checks the expansion — so a property that names no column
+  /// on the relation fails on the emitted line. That is what makes a declared selection fully
+  /// checked rather than checked by convention.
+  static func columnCheck(relation: String, properties: [StoredProperty]) -> String {
+    var lines = [
+      "  /// Fails to compile if a property does not name a column on \(relation).",
+      "  private static let _columnCheck: [String] = [",
+    ]
+    for property in properties {
+      lines.append("    \(relation).columnName(for: \\\(relation).\(property.name)),")
+    }
+    lines.append("  ]")
+    return lines.joined(separator: "\n")
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/Support/Generation.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Generation.swift
@@ -1,0 +1,39 @@
+//
+//  Generation.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+
+/// The `CodingKeys` enum for a property list, or `nil` when there is nothing to map.
+///
+/// `@Table` and `@SelectionOf` share it so a relation and a selection of it spell the same column
+/// the same way.
+func codingKeys(for properties: [StoredProperty], indent: String = "  ") -> String? {
+  guard !properties.isEmpty else { return nil }
+  var lines = ["\(indent)enum CodingKeys: String, CodingKey {"]
+  for property in properties {
+    lines.append("\(indent)  case \(property.name) = \"\(property.columnName)\"")
+  }
+  lines.append("\(indent)}")
+  return lines.joined(separator: "\n")
+}
+
+/// The inheritance clause to emit on a macro-generated extension, or `""` when there is nothing
+/// left to add.
+///
+/// Two rules are baked in, and both fail confusingly if you skip them:
+///
+/// - `wanted` must name every protocol in the refinement chain. A macro-generated extension does
+///   not derive an inherited conformance, so `extension Todo: PostgrestWritableRelation` alone
+///   reports a missing `PostgrestRelation` with no note saying which requirement is unmet.
+/// - `missing` is the compiler's `conformingTo:` list, which excludes whatever the type already
+///   declares. Filtering by it is what keeps `struct Todo: Decodable` from getting a second
+///   `Decodable` conformance.
+func inheritanceClause(wanted: [String], missing: [TypeSyntax]) -> String {
+  let missing = Set(missing.map(\.trimmedDescription))
+  let needed = wanted.filter(missing.contains)
+  return needed.isEmpty ? "" : ": \(needed.joined(separator: ", "))"
+}

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -90,10 +90,11 @@ public struct TableMacro: ExtensionMacro {
       )
     }
 
+    let clause = inheritanceClause(wanted: wantedConformances(arguments), missing: protocols)
     return [
       try ExtensionDeclSyntax(
         """
-        extension \(type.trimmed)\(raw: inheritanceClause(arguments, protocols)) {
+        extension \(type.trimmed)\(raw: clause) {
         \(raw: body.joined(separator: "\n\n"))
         }
         """
@@ -103,24 +104,17 @@ public struct TableMacro: ExtensionMacro {
 
   // MARK: Generation
 
-  /// The inheritance clause to emit, or `""` when the type already declares everything.
-  ///
-  /// `protocols` is the subset of the attribute's declared `conformances:` the type does not
-  /// already satisfy, so a user who writes `struct Todo: Decodable` gets no duplicate — and no
-  /// "redundant conformance" error.
+  /// The protocols `@Table` conforms the annotated type to.
   ///
   /// `Decodable` is in the list and `Encodable` is not: rows are decoded from responses, and writes
   /// go out through the `Encodable` `Insert` and `Update` shapes.
-  static func inheritanceClause(_ arguments: Arguments, _ protocols: [TypeSyntax]) -> String {
-    let wanted = [
+  static func wantedConformances(_ arguments: Arguments) -> [String] {
+    [
       "Decodable",
       "Sendable",
       "PostgrestRelation",
       arguments.readOnly ? nil : "PostgrestWritableRelation",
     ].compactMap { $0 }
-    let missing = Set(protocols.map(\.trimmedDescription))
-    let needed = wanted.filter(missing.contains)
-    return needed.isEmpty ? "" : ": \(needed.joined(separator: ", "))"
   }
 
   /// The key-path-to-column mapping.
@@ -146,20 +140,6 @@ public struct TableMacro: ExtensionMacro {
     lines.append("      fatalError(\"\(type): no column is mapped for that key path\")")
     lines.append("    }")
     lines.append("  }")
-    return lines.joined(separator: "\n")
-  }
-
-  /// The `CodingKeys` enum, or `nil` when there is nothing to map.
-  ///
-  /// The same property list drives this and the column mapping, so the write path and the filter
-  /// path cannot disagree about a column name.
-  static func codingKeys(for properties: [StoredProperty], indent: String = "  ") -> String? {
-    guard !properties.isEmpty else { return nil }
-    var lines = ["\(indent)enum CodingKeys: String, CodingKey {"]
-    for property in properties {
-      lines.append("\(indent)  case \(property.name) = \"\(property.columnName)\"")
-    }
-    lines.append("\(indent)}")
     return lines.joined(separator: "\n")
   }
 

--- a/Tests/PostgrestMacrosTests/SelectionIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionIntegrationTests.swift
@@ -1,0 +1,73 @@
+//
+//  SelectionIntegrationTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import PostgrestMacros
+import Testing
+
+// File scope, for the same reason as `TableIntegrationTests`: `@Table` and `@SelectionOf` both
+// attach extensions, which cannot be nested inside another type.
+@Table("todos")
+struct SelectionTodo {
+  @PrimaryKey var id: Int
+  var task: String
+  @Default var isDone: Bool
+  @Column("due_at") var dueDate: Date?
+}
+
+@SelectionOf(SelectionTodo.self)
+struct SelectionTodoSummary: Hashable {
+  var id: Int
+  var isDone: Bool
+}
+
+@SelectionOf(SelectionTodo.self)
+struct SelectionTodoDueDate {
+  @Column("due_at") var dueDate: Date?
+}
+
+@Suite
+struct SelectionIntegrationTests {
+  typealias TodoSummary = SelectionTodoSummary
+
+  @Test
+  func selectStringListsTheDeclaredColumns() {
+    #expect(TodoSummary.selectString == "id,is_done")
+  }
+
+  @Test
+  func columnOverridesApply() {
+    #expect(SelectionTodoDueDate.selectString == "due_at")
+  }
+
+  @Test
+  func aSelectionNamesItsSource() {
+    // `select(_:)` is gated on this, so a selection cannot be handed to another relation.
+    #expect(TodoSummary.Source.relationName == "todos")
+  }
+
+  @Test
+  func aRelationIsItsOwnSource() {
+    #expect(SelectionTodo.Source.relationName == "todos")
+  }
+
+  @Test
+  func selectSendsTheSelectStringAndDecodesTheSelection() async throws {
+    let capture = RequestCapture(body: #"[{"id":1,"is_done":false}]"#)
+    let rows = try await capture.client
+      .from(SelectionTodo.self)
+      .select(TodoSummary.self)
+      .eq(\.isDone, false)
+      .execute()
+      .value
+
+    #expect(rows == [TodoSummary(id: 1, isDone: false)])
+    #expect(capture.path?.hasSuffix("/todos") == true)
+    #expect(capture.query?.contains("select=id,is_done") == true)
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+  }
+}

--- a/Tests/PostgrestMacrosTests/SelectionIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionIntegrationTests.swift
@@ -30,18 +30,36 @@ struct SelectionTodoDueDate {
   @Column("due_at") var dueDate: Date?
 }
 
+/// The same property, without repeating the relation's `@Column`.
+@SelectionOf(SelectionTodo.self)
+struct SelectionTodoInheritedColumn {
+  var dueDate: Date?
+}
+
 @Suite
 struct SelectionIntegrationTests {
   typealias TodoSummary = SelectionTodoSummary
 
   @Test
   func selectStringListsTheDeclaredColumns() {
-    #expect(TodoSummary.selectString == "id,is_done")
+    // Each entry is a PostgREST alias, `key:column`. The column comes from the relation; the key
+    // is what the response is returned under, and it is what `CodingKeys` decodes. Here the two
+    // agree, so the alias is a no-op.
+    #expect(TodoSummary.selectString == "id:id,is_done:is_done")
   }
 
   @Test
   func columnOverridesApply() {
-    #expect(SelectionTodoDueDate.selectString == "due_at")
+    #expect(SelectionTodoDueDate.selectString == "due_at:due_at")
+  }
+
+  @Test
+  func aSelectionInheritsTheRelationsColumnMapping() {
+    // The regression this guards: `dueDate` snake-cases to `due_date`, but the relation maps it to
+    // `due_at`. Deriving the column locally asked PostgREST for a column that does not exist, and
+    // nothing caught it — `_columnCheck` proves the key path resolves, not that the name matches.
+    // Reading the column from the relation makes repeating `@Column` on a selection unnecessary.
+    #expect(SelectionTodoInheritedColumn.selectString == "due_date:due_at")
   }
 
   @Test
@@ -67,7 +85,9 @@ struct SelectionIntegrationTests {
 
     #expect(rows == [TodoSummary(id: 1, isDone: false)])
     #expect(capture.path?.hasSuffix("/todos") == true)
-    #expect(capture.query?.contains("select=id,is_done") == true)
+    // `RequestCapture.query` is the decoded query, so the aliases read as written here. On the
+    // wire the `:` and `,` are escaped.
+    #expect(capture.query?.contains("select=id:id,is_done:is_done") == true)
     #expect(capture.query?.contains("is_done=eq.false") == true)
   }
 }

--- a/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
@@ -34,7 +34,10 @@ struct SelectionOfMacroTests {
       extension TodoSummary {
         typealias Source = Todo
 
-        static let selectString = "id,due_at"
+        static let selectString = [
+          "id:\(Todo.columnName(for: \Todo.id))",
+          "due_at:\(Todo.columnName(for: \Todo.dueDate))",
+        ].joined(separator: ",")
 
         enum CodingKeys: String, CodingKey {
           case id = "id"
@@ -69,7 +72,9 @@ struct SelectionOfMacroTests {
       extension TodoSummary {
         public typealias Source = Todo
 
-        public static let selectString = "is_done"
+        public static let selectString = [
+          "is_done:\(Todo.columnName(for: \Todo.isDone))",
+        ].joined(separator: ",")
 
         enum CodingKeys: String, CodingKey {
           case isDone = "is_done"

--- a/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
@@ -1,0 +1,86 @@
+//
+//  SelectionOfMacroTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import MacroTesting
+import Testing
+
+@testable import PostgrestMacrosPlugin
+
+/// As in `TableMacroTests`, `MacroTesting` expands without the declaration, so `conformingTo:` is
+/// always empty here and the recorded extensions carry no inheritance clause.
+@Suite(.macros(["SelectionOf": SelectionOfMacro.self]))
+struct SelectionOfMacroTests {
+  @Test
+  func expandsAColumnSubset() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+        @Column("due_at") var dueDate: Date?
+      }
+      """
+    } expansion: {
+      #"""
+      struct TodoSummary {
+        var id: Int
+        @Column("due_at") var dueDate: Date?
+      }
+
+      extension TodoSummary {
+        typealias Source = Todo
+
+        static let selectString = "id,due_at"
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case dueDate = "due_at"
+        }
+
+        /// Fails to compile if a property does not name a column on Todo.
+        private static let _columnCheck: [String] = [
+          Todo.columnName(for: \Todo.id),
+          Todo.columnName(for: \Todo.dueDate),
+        ]
+      }
+      """#
+    }
+  }
+
+  @Test
+  func propagatesTheAccessLevel() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      public struct TodoSummary {
+        var isDone: Bool
+      }
+      """
+    } expansion: {
+      #"""
+      public struct TodoSummary {
+        var isDone: Bool
+      }
+
+      extension TodoSummary {
+        public typealias Source = Todo
+
+        public static let selectString = "is_done"
+
+        enum CodingKeys: String, CodingKey {
+          case isDone = "is_done"
+        }
+
+        /// Fails to compile if a property does not name a column on Todo.
+        private static let _columnCheck: [String] = [
+          Todo.columnName(for: \Todo.isDone),
+        ]
+      }
+      """#
+    }
+  }
+}

--- a/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
@@ -19,9 +19,11 @@ import Testing
 @Suite
 struct TableMacroSupportTests {
   private func clause(readOnly: Bool, missing: [String]) -> String {
-    TableMacro.inheritanceClause(
-      TableMacro.Arguments(name: "todos", schema: "public", readOnly: readOnly),
-      missing.map { TypeSyntax(stringLiteral: $0) }
+    inheritanceClause(
+      wanted: TableMacro.wantedConformances(
+        TableMacro.Arguments(name: "todos", schema: "public", readOnly: readOnly)
+      ),
+      missing: missing.map { TypeSyntax(stringLiteral: $0) }
     )
   }
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -82,6 +82,7 @@ supporting_symbols:
   - PostgrestRequestBuilder.setHeader
   - PostgrestRequestBuilder.webFullTextSearch
   - PostgrestSelection
+  - PostgrestSelection.Source
   - PostgrestSelection.selectString
   - PostgrestTransformPhase
   - PostgrestTransformablePhase
@@ -96,6 +97,7 @@ supporting_symbols:
   # own. Attribute names are unprefixed on purpose — nothing re-exports
   # `PostgrestMacros`, so a user opts in with an explicit import.
   - Table
+  - SelectionOf
   - Column
   - PrimaryKey
   - Default


### PR DESCRIPTION
Closes SDK-1517. Stacked on #1259.

## What

```swift
@SelectionOf(Todo.self)
struct TodoSummary {
  var id: Int
  var isDone: Bool
}
// TodoSummary.selectString == "id,is_done"

let rows = try await client.from(Todo.self).select(TodoSummary.self).execute().value
```

A macro sees syntax only and cannot inspect `Todo`'s members. It can *emit* references to them, and the compiler checks the expansion, so a property that names no column on the relation fails on the emitted `_columnCheck` line. That is what makes a declared selection fully checked rather than checked by convention.

## Also closes a hole the RFC asked for and the protocol did not enforce

`_columnCheck` proves every column exists on `Todo`, but nothing stopped `from(Other.self).select(TodoSummary.self)` from compiling. Headline decision 8 says a selection "must name its source", so:

```swift
public protocol PostgrestSelection: Decodable, Sendable {
  associatedtype Source: PostgrestRelation
  static var selectString: String { get }
}

public protocol PostgrestRelation: PostgrestSelection where Source == Self { … }
```

The same-type constraint on the refinement means a relation is its own source, so **hand-written relation conformances declare nothing new** — every existing `PostgRESTTests` suite compiles unchanged. `select(_:)` is then gated on `S.Source == R`, and a mismatched pair is *no such overload* rather than a PostgREST 400.

This edits the protocol file introduced in #1252. Flagging it explicitly since that PR is still in review: the alternative was landing the refinement in stage 3, and it costs nothing to hand-written conformances now.

## Note for reviewers of the plan

`docs/design/postgrest-v3-stage-1-plan.md` Task 9 step 5 writes the return type as `PostgrestTypedQuery<R, [S]>`. The type that shipped in #1253 has three parameters, so the third is `PostgrestFilterPhase`, matching the existing whole-row `select()`.

## Shape

`@SelectionOf` follows the same two rules `@Table` had to learn — extension role only, whole refinement chain in the inheritance clause. The shared `codingKeys` and `inheritanceClause` helpers move to `Support/Generation.swift`, so a relation and a selection of it cannot spell the same column differently.

## Out of scope

`@Relationship`, embeds, and the `embedded` / `requiring` scope. Those are stage 3.

## Tests

7 new tests. `SelectionIntegrationTests.selectSendsTheSelectStringAndDecodesTheSelection` asserts the request against a stub rather than only checking `selectString`. Full suite: 1252 passing.