### PR TITLE
feat(postgrest): add actionable macro diagnostics

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -183,6 +183,7 @@ let package = Package(
       name: "PostgrestMacrosPlugin",
       dependencies: [
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
       ]
     ),

--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -30,12 +30,15 @@ public struct SelectionOfMacro: ExtensionMacro {
     in context: some MacroExpansionContext
   ) throws -> [ExtensionDeclSyntax] {
     guard declaration.is(StructDeclSyntax.self) else {
-      throw MacroExpansionErrorMessage("@SelectionOf can only be applied to a struct")
+      context.error("@SelectionOf can only be applied to a struct", at: node)
+      return []
     }
     guard let relation = relation(from: node) else {
-      throw MacroExpansionErrorMessage(
-        "@SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)"
+      context.error(
+        "@SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)",
+        at: node
       )
+      return []
     }
     let access = declaration.postgrestAccessLevel
     let properties = declaration.postgrestStoredProperties()

--- a/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
@@ -1,0 +1,47 @@
+//
+//  Diagnostics.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// An error attached to a specific syntax node.
+///
+/// Throwing `MacroExpansionErrorMessage` puts the caret on the attribute, which is wrong for a
+/// per-property misuse: the reader needs to see the property that caused it.
+struct PostgrestDiagnostic: DiagnosticMessage {
+  let message: String
+  var severity: DiagnosticSeverity { .error }
+  var diagnosticID: MessageID { MessageID(domain: "PostgrestMacros", id: message) }
+}
+
+extension MacroExpansionContext {
+  /// Emits an error pointing at `node`.
+  func error(_ message: String, at node: some SyntaxProtocol) {
+    diagnose(Diagnostic(node: node, message: PostgrestDiagnostic(message: message)))
+  }
+}
+
+extension DeclGroupSyntax {
+  /// The first `@Relationship` attribute on a stored property, if any.
+  ///
+  /// Embeds belong to a selection, never to a relation (spec §4.5), so `@Table` rejects one.
+  ///
+  /// Forward-looking: `@Relationship` itself lands in stage 3, so today a user who writes it gets
+  /// "unknown attribute" from the compiler first. Matching on the attribute *name* puts the guard
+  /// in place for the day the macro exists.
+  func postgrestRelationshipAttribute() -> AttributeSyntax? {
+    for member in memberBlock.members {
+      guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+      for attribute in variable.attributes.compactMap({ $0.as(AttributeSyntax.self) })
+      where attribute.attributeName.trimmedDescription == "Relationship" {
+        return attribute
+      }
+    }
+    return nil
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -58,7 +58,15 @@ public struct TableMacro: ExtensionMacro {
     in context: some MacroExpansionContext
   ) throws -> [ExtensionDeclSyntax] {
     guard declaration.is(StructDeclSyntax.self) else {
-      throw MacroExpansionErrorMessage("@Table can only be applied to a struct")
+      context.error("@Table can only be applied to a struct", at: node)
+      return []
+    }
+    if let relationship = declaration.postgrestRelationshipAttribute() {
+      context.error(
+        "@Relationship belongs on a @SelectionOf type, not on @Table",
+        at: relationship
+      )
+      return []
     }
     let arguments = arguments(from: node)
     let access = declaration.postgrestAccessLevel

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -1,0 +1,105 @@
+//
+//  DiagnosticsTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import MacroTesting
+import Testing
+
+@testable import PostgrestMacrosPlugin
+
+@Suite(.macros(["Table": TableMacro.self, "SelectionOf": SelectionOfMacro.self]))
+struct DiagnosticsTests {
+  @Test
+  func tableRejectsAClass() {
+    assertMacro {
+      """
+      @Table("todos")
+      class Todo {
+        var id: Int = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @Table("todos")
+      ┬──────────────
+      ╰─ 🛑 @Table can only be applied to a struct
+      class Todo {
+        var id: Int = 0
+      }
+      """
+    }
+  }
+
+  @Test
+  func tableRejectsARelationshipProperty() {
+    // Forward-looking. `@Relationship` lands in stage 3, so today the compiler rejects the unknown
+    // attribute first; `assertMacro` has no such check, which is what lets this be tested now.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        var id: Int
+        @Relationship(\\Comment.todoID) var comments: [Comment]
+      }
+      """
+    } diagnostics: {
+      #"""
+      @Table("todos")
+      struct Todo {
+        var id: Int
+        @Relationship(\Comment.todoID) var comments: [Comment]
+        ┬─────────────────────────────
+        ╰─ 🛑 @Relationship belongs on a @SelectionOf type, not on @Table
+      }
+      """#
+    }
+  }
+
+  @Test
+  func selectionOfRejectsAClass() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      class TodoSummary {
+        var id: Int = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @SelectionOf(Todo.self)
+      ┬──────────────────────
+      ╰─ 🛑 @SelectionOf can only be applied to a struct
+      class TodoSummary {
+        var id: Int = 0
+      }
+      """
+    }
+  }
+
+  @Test
+  func selectionOfRequiresARelationType() {
+    // Bare `@SelectionOf` is what `assertMacro` can express. In real code the compiler catches the
+    // missing argument first, and this fires on an argument that is not a `T.self` member access —
+    // `@SelectionOf(someTypeVariable)`.
+    assertMacro {
+      """
+      @SelectionOf
+      struct TodoSummary {
+        var id: Int
+      }
+      """
+    } diagnostics: {
+      """
+      @SelectionOf
+      ┬───────────
+      ╰─ 🛑 @SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+      }
+      """
+    }
+  }
+}


### PR DESCRIPTION
Closes SDK-1518. Last PR of M3, stacked on #1260.

A macro whose failure mode is an unreadable expansion error is worse than no macro. Spec §4.5 names diagnostics as a requirement, not polish.

| Misuse | Message |
| --- | --- |
| `@Table` on a class | `@Table can only be applied to a struct` |
| `@Relationship` on a `@Table` property | `@Relationship belongs on a @SelectionOf type, not on @Table` |
| `@SelectionOf` on a class | `@SelectionOf can only be applied to a struct` |
| `@SelectionOf` with no relation type | `@SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)` |

The `@Relationship` one enforces the boundary from spec §4.5: embeds belong to selections, never to relations.

## Emitted, not thrown

Every one goes through `context.diagnose`. A thrown `MacroExpansionErrorMessage` lands on the attribute, which is wrong for the `@Relationship` case — the reader needs to see the property that caused it. The recorded caret art shows it pointing at `@Relationship(\Comment.todoID)`, not at `@Table("todos")`. No thrown errors remain in either macro.

## One diagnostic is forward-looking, and the code says so

`@Relationship` lands in stage 3, so today a user who writes it gets "unknown attribute" from the compiler first. `TableMacro` matches on the attribute *name*, which puts the guard in place for the day the macro exists. `MacroTesting` expands without the declaration, which is what lets it be tested now.

Similarly, bare `@SelectionOf` is caught by the compiler's own missing-argument check in real code; the diagnostic fires on an argument that is not a `T.self` member access, such as `@SelectionOf(someTypeVariable)`. Both are noted at the test sites so nobody reads them as live paths.

## Tests

4 new tests, all `diagnostics:` blocks recorded from `assertMacro`'s own output. Full suite: 1256 passing.