### PR TITLE
test(postgrest): pin filter-operand escaping, and why it is asymmetric

### DIFF
--- a/Sources/Helpers/PostgRESTFilterValue.swift
+++ b/Sources/Helpers/PostgRESTFilterValue.swift
@@ -14,6 +14,15 @@ package func postgrestFilterValueNeedsQuoting(_ value: String) -> Bool {
 /// Escapes a raw filter value for safe inclusion in a PostgREST filter such as
 /// `in.(...)`. Values containing reserved characters (`,`, `(`, `)`, `"`, `\`)
 /// or surrounding whitespace are double-quoted, with `\` and `"` backslash-escaped.
+///
+/// > Important: This applies **only** to an operand inside a delimited list — `in.(...)`,
+/// > `not.in.(...)`, or a group such as `or=(...)`. It must not be applied to a top-level scalar
+/// > operand like `eq.`, `like.` or `match.`, where the operand runs to the end of the
+/// > query-parameter value and nothing inside it is structural. PostgREST treats a double quote in
+/// > that position as *data, not syntax*, so quoting there changes what is compared rather than
+/// > delimiting it: measured against PostgREST 14.15, `txt=eq."a,b"` returns no rows where
+/// > `txt=eq.a,b` returns the right one. See `PostgrestFilterOperandEscapingTests` for the full
+/// > measurement, and SDK-1510 for the report that this asymmetry is a bug (it is not).
 package func escapePostgRESTFilterValue(_ raw: String) -> String {
   guard postgrestFilterValueNeedsQuoting(raw) else { return raw }
   let escaped = raw.replacingOccurrences(of: "\\", with: "\\\\")

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -129,6 +129,12 @@ extension PostgrestRequestBuilder where Phase: PostgrestFilterablePhase {
   /// .or("done.eq.true,priority.gt.3")
   /// ```
   ///
+  /// > Important: The comma is structural here, so a *value* containing one must be double-quoted
+  /// > or the server rejects the whole request. Unlike ``eq(_:value:)`` — where the operand runs to
+  /// > the end of the query parameter and needs no quoting — `or=(name.eq.a,b)` is an HTTP 400
+  /// > `PGRST100`. Write `.or(#"name.eq."a,b""#)` instead, backslash-escaping any `"` or `\` inside
+  /// > the quotes. This method does no escaping for you by design; see ``filter(_:operator:value:)``.
+  ///
   /// - Parameters:
   ///   - filters: A comma-separated list of PostgREST filter expressions combined with OR logic.
   ///   - referencedTable: The name of an embedded table to apply the OR filter on. Defaults to `nil`.
@@ -812,6 +818,11 @@ extension PostgrestRequestBuilder where Phase: PostgrestFilterablePhase {
   /// // Equivalent to .eq("status", value: "active")
   /// .filter("status", operator: "eq", value: "active")
   /// ```
+  ///
+  /// > Note: A scalar operand needs no quoting — it runs to the end of the query parameter, so
+  /// > `value: "a,b"` is sent and matched correctly. Quoting it would be wrong, because PostgREST
+  /// > compares against the quote marks too. An operand inside a delimited list is the opposite
+  /// > case and must be quoted: `operator: "in", value: #"("a,b")"#`.
   ///
   /// - Parameters:
   ///   - column: The column to filter on.

--- a/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5e68a3cf2de6edf2abec2dfb983a8393d24cb9fc0b0786db3b5f16fa4672d712",
+  "originHash" : "ce98c8c2118be1dadf3377b12de9ee2ad8507404cc71f530ccf16c1b12de7a31",
   "pins" : [
     {
       "identity" : "appauth-ios",
@@ -215,6 +215,15 @@
       "state" : {
         "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     },
     {

--- a/Tests/PostgRESTTests/PostgrestFilterOperandEscapingTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterOperandEscapingTests.swift
@@ -1,0 +1,184 @@
+//
+//  PostgrestFilterOperandEscapingTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+
+import Testing
+
+@testable import PostgREST
+
+/// Pins where filter-operand escaping is applied, and — more importantly — where it must **not** be.
+///
+/// `escapePostgRESTFilterValue` is called at exactly two call sites, `in` and `notIn`. That looks
+/// like an oversight, and it has been filed as one (SDK-1510). It is not. The asymmetry tracks the
+/// PostgREST grammar exactly: a top-level operand runs to the **end of the query-parameter value**,
+/// so nothing inside it is structural and nothing needs escaping. Escaping is only needed where the
+/// operand sits inside a delimited list.
+///
+/// Measured against PostgREST 14.15 (`public.ecr.aws/supabase/postgrest:v14.15`) on Postgres 17,
+/// against a `text` column, one row per value:
+///
+/// | Context | Unquoted | Quoted |
+/// |---|---|---|
+/// | `txt=eq.a,b` | 200, **correct row** | `eq."a,b"` → 200, `[]` |
+/// | `txt=in.(a,b)` | 200, `[]` — matches nothing | `in.("a,b")` → 200, **correct row** |
+/// | `or=(txt.eq.a,b)` | **400 `PGRST100`** | `or=(txt.eq."a,b")` → 200, **correct row** |
+///
+/// Every awkward scalar value round-trips correctly with no escaping at all — `a,b`, `a"b`, `a\b`,
+/// `a(b)c`, `a.b`, `a:b`, `a&b`, `a=b`, `a+b`, `a b`, `" lead"`, `(1,2)`, `{a,b}`, `eq.x`, `a%b`,
+/// `a#b`, `a'b`, `null`, `true`, `*`, `a->b`, `a->>b`. Quoting any of them returns `[]`.
+///
+/// The decisive observation is that PostgREST treats a double quote in a scalar operand as **data,
+/// not syntax**: a row whose stored value is literally `"quoted"`, quote characters included, is the
+/// row that `txt=eq.%22quoted%22` returns. So quoting a scalar operand does not delimit it — it
+/// changes what is being compared.
+///
+/// Do not "fix" the asymmetry these tests describe. Quoting the scalar operators would silently
+/// return zero rows for any value containing a comma, quote, backslash, paren or edge whitespace,
+/// and would break `match`/`imatch` for essentially every non-trivial regex.
+@Suite
+struct PostgrestFilterOperandEscapingTests {
+  // MARK: - Scalar operands are sent through unescaped, and that is correct
+
+  @Test
+  func eqSendsCommaUnescaped() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().eq("name", value: "a,b").execute()
+    #expect(capture.query?.contains("name=eq.a,b") == true)
+  }
+
+  @Test
+  func eqSendsEmbeddedQuoteUnescaped() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().eq("name", value: #"a"b"#).execute()
+    #expect(capture.query?.contains(#"name=eq.a"b"#) == true)
+  }
+
+  @Test
+  func eqSendsBackslashUnescaped() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().eq("name", value: #"a\b"#).execute()
+    #expect(capture.query?.contains(#"name=eq.a\b"#) == true)
+  }
+
+  @Test
+  func eqLeavesPlainValueAlone() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().eq("name", value: "plain").execute()
+    #expect(capture.query?.contains("name=eq.plain") == true)
+  }
+
+  /// Edge whitespace is data. `escapePostgRESTFilterValue` would quote this one; the scalar
+  /// operators must not, because the server compares against the quote marks too.
+  @Test
+  func eqPreservesLeadingWhitespaceUnquoted() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().eq("name", value: " lead").execute()
+    #expect(capture.query?.contains("name=eq. lead") == true)
+  }
+
+  /// A regex operand is the case quoting would damage most: the escaper doubles the backslash.
+  @Test
+  func matchSendsRegexUnescaped() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select()
+      .match("email", pattern: #"@supabase\.io$"#).execute()
+    #expect(capture.query?.contains(#"email=match.@supabase\.io$"#) == true)
+  }
+
+  /// `not` wraps the same scalar shape, so it follows the same rule.
+  @Test
+  func notWrappedOperandStaysUnescaped() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select()
+      .not("name", operator: .eq, value: "a,b").execute()
+    #expect(capture.query?.contains("name=not.eq.a,b") == true)
+  }
+
+  @Test
+  func comparisonOperatorsAllSendCommaUnescaped() async throws {
+    let cases: [(String, (PostgrestFilterBuilder) -> PostgrestFilterBuilder)] = [
+      ("neq", { $0.neq("c", value: "a,b") }),
+      ("gt", { $0.gt("c", value: "a,b") }),
+      ("gte", { $0.gte("c", value: "a,b") }),
+      ("lt", { $0.lt("c", value: "a,b") }),
+      ("lte", { $0.lte("c", value: "a,b") }),
+      ("like", { $0.like("c", pattern: "a,b") }),
+      ("ilike", { $0.ilike("c", pattern: "a,b") }),
+      ("imatch", { $0.imatch("c", pattern: "a,b") }),
+      ("isdistinct", { $0.isDistinct("c", value: "a,b") }),
+    ]
+
+    for (op, apply) in cases {
+      let capture = QueryCapture()
+      _ = try await apply(capture.client.from("t").select()).execute()
+      #expect(capture.query?.contains("c=\(op).a,b") == true, "\(op) escaped its operand")
+    }
+  }
+
+  // MARK: - Delimited-list operands are escaped, and that is also correct
+
+  /// `in.(a,b)` matches nothing on the server — the comma splits the list. Quoting is required.
+  @Test
+  func inQuotesAnOperandContainingAComma() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().in("name", values: ["a,b"]).execute()
+    #expect(capture.query?.contains(#"name=in.("a,b")"#) == true)
+  }
+
+  @Test
+  func inBackslashEscapesAnEmbeddedQuote() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().in("name", values: [#"a"b"#]).execute()
+    #expect(capture.query?.contains(#"name=in.("a\"b")"#) == true)
+  }
+
+  @Test
+  func inLeavesAPlainOperandUnquoted() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().in("name", values: ["plain"]).execute()
+    #expect(capture.query?.contains("name=in.(plain)") == true)
+  }
+
+  @Test
+  func notInQuotesAnOperandContainingAComma() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().notIn("name", values: ["a,b"]).execute()
+    #expect(capture.query?.contains(#"name=not.in.("a,b")"#) == true)
+  }
+
+  // MARK: - Array-literal operands escape one layer down, per element
+
+  /// The commas *between* elements are structural; the comma *inside* an element is data. That
+  /// split is what `postgrestArrayElement` implements, and it is the correct layer — quoting the
+  /// whole literal instead yields `cs."{a,b}"`, which the server rejects with `22P02 malformed
+  /// array literal`.
+  @Test
+  func containsEscapesPerElementNotWholeLiteral() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select()
+      .contains("tags", value: ["a,b", "c"]).execute()
+    #expect(capture.query?.contains(#"tags=cs.{"a,b",c}"#) == true)
+  }
+
+  /// A `String` operand here is the caller hand-writing the literal, so it is passed through. The
+  /// braces and commas are theirs and are structural.
+  @Test
+  func containsPassesAHandWrittenLiteralThrough() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("users").select().contains("tags", value: "{a,b}").execute()
+    #expect(capture.query?.contains("tags=cs.{a,b}") == true)
+  }
+
+  /// A range literal is made of reserved characters. Quoting it yields `sl."[a,b)"`, which the
+  /// server rejects with `22P02 malformed range literal`.
+  @Test
+  func rangeOperandIsPassedThrough() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from("events").select()
+      .rangeLt("scheduled", range: "[2024-01-01,2024-06-01)").execute()
+    #expect(capture.query?.contains("scheduled=sl.[2024-01-01,2024-06-01)") == true)
+  }
+}


### PR DESCRIPTION
## What this is

SDK-1510 reported that `escapePostgRESTFilterValue` is called only by `in` and `notIn` while every other operator interpolates the raw value, and asked for the remaining ~18 operators to be routed through the escaper too.

I investigated by characterization test first, as the issue asked, then verified each form against live PostgREST **14.15** (`public.ecr.aws/supabase/postgrest:v14.15`) on Postgres 17.

**The requested change is a regression, not a fix.** So this PR changes no behavior. It pins the existing (correct) behavior and documents why it is asymmetric.

## The measurement

PostgREST treats a double quote in a top-level scalar operand as **data, not syntax**. The clincher — a row whose stored value is literally `"quoted"`, quote characters included, is the row that `txt=eq.%22quoted%22` returns. If quotes were syntax it would have matched the row containing `quoted`.

| Context | Unquoted | Quoted |
|---|---|---|
| `txt=eq.a,b` | 200, **correct row** | `eq."a,b"` → 200, `[]` |
| `txt=eq.plain` | 200, **correct row** | `eq."plain"` → 200, `[]` |
| `txt=in.(a,b)` | 200, `[]` — matches nothing | `in.("a,b")` → 200, **correct row** |
| `or=(txt.eq.a,b)` | **400 `PGRST100`** | `or=(txt.eq."a,b")` → 200, **correct row** |

Every awkward scalar value already round-trips correctly with no escaping at all:

`a,b` · `a"b` · `a\b` · `a(b)c` · `a.b` · `a:b` · `a&b` · `a=b` · `a+b` · `a b` · `" lead"` · `(1,2)` · `{a,b}` · `eq.x` · `a%b` · `a#b` · `a'b` · `null` · `true` · `*` · `a->b` · `a->>b`

Quoting any of them returns zero rows. I could not construct a scalar operand that needs quoting.

## Why the asymmetry is correct

It tracks the grammar exactly. A top-level operand runs to the **end of the query-parameter value**, so nothing inside it is structural and nothing needs escaping. Escaping is only needed where the operand sits inside a delimited list — and `in`/`notIn` are the only two builders in that position.

Array-literal operands escape one layer down, **per element**, via `postgrestArrayElement`. That is the correct layer: the commas *between* elements are structural, the comma *inside* an element is data. Quoting the whole literal instead yields `cs."{a,b}"`, which the server rejects with `22P02 malformed array literal`. Range literals fail the same way with `22P02 malformed range literal`.

Applying the issue as written would have silently returned zero rows for any value containing a comma, quote, backslash, paren or edge whitespace across **eleven** operators — `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `match`, `imatch`, `isDistinct` — and broken `match`/`imatch` for essentially every non-trivial regex.

## What changed

No behavior, and therefore no snapshots to re-record.

- **`Tests/PostgRESTTests/PostgrestFilterOperandEscapingTests.swift`** (new) — 15 tests pinning both halves of the rule, with the server measurements in the suite doc comment so this does not get re-filed and "fixed".
- **`Sources/Helpers/PostgRESTFilterValue.swift`** — documents on `escapePostgRESTFilterValue` that it is for delimited-list operands only, and why applying it to a scalar operand changes what is compared rather than delimiting it.
- **`Sources/PostgREST/PostgrestFilterBuilder.swift`** — documents the one real caller-facing trap the investigation uncovered: in `or`, the comma **is** structural, so an unquoted comma in a value is a 400. Neither `or` nor `filter` said anything about it. Also notes the inverse on `filter`, so the escape hatch's two cases are spelled out.

## Verification

- `swift test` — 1232 tests in 124 suites pass
- `./scripts/spell-check.sh` — 361 files, 0 issues
- `./scripts/test-docs.sh` — clean
- `./scripts/format.sh` — applied

Refs SDK-1510, which I am closing as not-a-bug. The design doc §10.1 claim that this asymmetry is a defect is corrected separately on `docs/postgrest-v3-design`.
