### PR TITLE
docs(postgrest-v3): withdraw the escaping "defect" — measured, it is correct

### DIFF
--- a/docs/design/postgrest-v3-stage-1-plan.md
+++ b/docs/design/postgrest-v3-stage-1-plan.md
@@ -230,7 +230,26 @@ follow-up decision; do not change them here.
 
 ---
 
-## Task 2: Establish and fix filter-value escaping
+## Task 2: Establish filter-value escaping — RESOLVED, no behavior change
+
+> **Outcome (2026-08-22, SDK-1510).** The characterization step did its job and the task inverted:
+> the asymmetry is correct, and Step 3 below would have been a regression. Spec §9.5 has the server
+> measurement. Delivered instead: `Tests/PostgRESTTests/PostgrestFilterOperandEscapingTests.swift`
+> pinning both halves of the rule, plus doc notes on `escapePostgRESTFilterValue`, `or` and `filter`.
+>
+> **What the server actually does.** A double quote in a top-level scalar operand is *data, not
+> syntax* — a row storing literally `"quoted"` is what `txt=eq.%22quoted%22` returns. So `eq."a,b"`
+> matches nothing where `eq.a,b` matches correctly, and 22 awkward scalar values (`a,b`, `a"b`,
+> `a\b`, `a(b)c`, `a.b`, `a&b`, `a b`, `(1,2)`, `{a,b}`, `a->>b`, …) all round-trip fine unescaped.
+> The rule is **positional**: escape only where the operand sits inside a delimited list. `in` and
+> `notIn` are the only two builders in that position, so two out of thirty is the right number.
+> Array and range literals escape one layer down, per element, via `postgrestArrayElement`; quoting
+> the whole literal gives `22P02 malformed array literal` / `malformed range literal`.
+>
+> **The one real find.** In `or`, the comma *is* structural — `or=(txt.eq.a,b)` is a 400 `PGRST100`.
+> That is the only place a caller must quote by hand, and it was undocumented.
+>
+> The steps below are kept as written, for the record. Do not execute Step 3.
 
 `escapePostgRESTFilterValue` is called only by `in` and `notIn`. What breaks for the other operators
 is unverified, so this task writes characterization tests first and only then changes behavior.
@@ -242,7 +261,7 @@ is unverified, so this task writes characterization tests first and only then ch
 **Interfaces:**
 - Consumes: `QueryCapture` from Task 1.
 
-- [ ] **Step 1: Write characterization tests that record current behavior**
+- [x] **Step 1: Write characterization tests that record current behavior**
 
 ```swift
 @Test
@@ -270,15 +289,24 @@ func eqLeavesPlainValueUnquoted() async throws {
 }
 ```
 
-- [ ] **Step 2: Run them and record what actually happens**
+- [x] **Step 2: Run them and record what actually happens**
 
 Run: `swift test --filter PostgrestFilterBuilderTests`
 Expected: the first two FAIL (no escaping today), the third PASSES.
 
+Observed: exactly that. `eq.a,b`, `eq.a"b`, `eq.plain`, `match.@supabase\.io$` all raw;
+`in.("a,b")` and `cs.{"a,b",c}` correctly escaped.
+
 Write the observed failure output into the commit message in Step 5. If the first two *pass*,
 escaping is already applied somewhere and this task is unnecessary — stop and report.
 
-- [ ] **Step 3: Apply escaping in the shared render path**
+> The stop-condition as written was too narrow. It only caught "escaping already applied", not
+> "escaping must not be applied". The test assertions above *assume the conclusion* — they assert
+> `eq."a,b"` is desirable rather than measuring whether the server accepts it. A characterization
+> test should record what the code emits; deciding whether that is right needs the server. Adding a
+> Step 2b (ask the server) is what turned this task around.
+
+- [ ] ~~**Step 3: Apply escaping in the shared render path**~~ — **do not do this. It is a regression.**
 
 The operators build their value with string interpolation. Add one private helper and route the
 single-value operators through it. In `Sources/PostgREST/PostgrestFilterBuilder.swift`:
@@ -307,26 +335,33 @@ Apply the identical change to `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, 
 literals `true`, `false`, `null`), `in`/`notIn` (already escaped), `or`, `filter`, or the full-text
 search operators, whose values are `tsquery` expressions where quoting changes meaning.
 
-- [ ] **Step 4: Run the full PostgREST suite**
+- [x] **Step 4: Run the full PostgREST suite**
 
 Run: `swift test --filter PostgRESTTests`
 Expected: the three new tests PASS. Snapshot tests in `BuildURLRequestTests` may now differ — inspect
 each diff and confirm it is an intended escaping change before re-recording. Do not blanket
 re-record.
 
-- [ ] **Step 5: Format, spell-check, commit**
+Observed: 1232 tests in 124 suites pass. No snapshot differed, because no behavior changed — which is
+itself the confirmation that Step 3 was not applied.
+
+- [x] **Step 5: Format, spell-check, commit**
 
 ```bash
 ./scripts/format.sh
 ./scripts/spell-check.sh
-git add Sources/PostgREST/PostgrestFilterBuilder.swift \
-        Tests/PostgRESTTests/PostgrestFilterBuilderTests.swift
-git commit -m "fix(postgrest): escape filter operands for every single-value operator
+git add Sources/Helpers/PostgRESTFilterValue.swift \
+        Sources/PostgREST/PostgrestFilterBuilder.swift \
+        Tests/PostgRESTTests/PostgrestFilterOperandEscapingTests.swift
+git commit -m "test(postgrest): pin filter-operand escaping, and why it is asymmetric
 
-escapePostgRESTFilterValue was called only by in/notIn, so a value
-containing a comma, parenthesis, quote or backslash was interpolated raw
-into eq, neq, gt, like and the range operators. Full-text search, is, and
-the list operators keep their existing handling."
+escapePostgRESTFilterValue is called only by in/notIn, which reads like an
+oversight and was filed as one. Measured against PostgREST 14.15: it is
+correct. A top-level scalar operand runs to the end of the query-parameter
+value, so nothing in it is structural, and quoting it changes what is
+compared rather than delimiting it. Escaping belongs only where the operand
+sits inside a delimited list. No behavior change; the rule is now pinned by
+tests and documented at all three call sites."
 ```
 
 ---

--- a/docs/design/postgrest-v3.md
+++ b/docs/design/postgrest-v3.md
@@ -1108,16 +1108,62 @@ Two consequences for the design:
 `messages.or=(…)`, `messages.order=id.desc` and `messages.limit=1` all apply correctly within an
 embedded scope, including combined with `!inner`. The §4.4 scope construct is expressible as designed.
 
+### 9.5 Filter operand escaping — the asymmetry is correct
+
+Run 2026-08-22 against PostgREST **14.15** on Postgres 17, same container method. Prompted by
+SDK-1510, which read the escaping asymmetry noted in §10.1 as a defect and proposed routing every
+single-value operator through `escapePostgRESTFilterValue`. The measurement says that would be a
+regression.
+
+**A double quote in a top-level scalar operand is data, not syntax.** A row whose stored value is
+literally `"quoted"`, quote characters included, is the row `txt=eq.%22quoted%22` returns. Had quotes
+been a delimiter, that query would have matched the row containing `quoted`.
+
+| Context | Unquoted | Quoted |
+|---|---|---|
+| `txt=eq.a,b` | 200 — correct row | `eq."a,b"` → 200, `[]` |
+| `txt=eq.plain` | 200 — correct row | `eq."plain"` → 200, `[]` |
+| `txt=in.(a,b)` | 200, `[]` — matches nothing | `in.("a,b")` → 200, correct row |
+| `or=(txt.eq.a,b)` | **400 `PGRST100`** | `or=(txt.eq."a,b")` → 200, correct row |
+
+Every awkward scalar value round-trips correctly with no escaping at all — `a,b`, `a"b`, `a\b`,
+`a(b)c`, `a.b`, `a:b`, `a&b`, `a=b`, `a+b`, `a b`, `" lead"`, `(1,2)`, `{a,b}`, `eq.x`, `a%b`, `a#b`,
+`a'b`, `null`, `true`, `*`, `a->b`, `a->>b`. Quoting each returns zero rows. No scalar operand could
+be constructed that needs quoting.
+
+Three consequences:
+
+- **The rule is positional, not per-operator.** A top-level operand runs to the end of the
+  query-parameter value, so nothing inside it is structural. Escaping is needed only where the
+  operand sits inside a delimited list, and `in` / `notIn` are the only two builders in that
+  position. Two out of thirty is the right number.
+- **Array and range literals escape one layer down.** `contains` / `containedBy` / `overlaps` with an
+  `Array` operand already quote **per element** through `postgrestArrayElement` — the commas between
+  elements are structural, the comma inside an element is data. Quoting the whole literal yields
+  `cs."{a,b}"`, rejected with `22P02 malformed array literal`; ranges fail the same way with
+  `22P02 malformed range literal`.
+- **`or` is the one place a caller must escape by hand.** There the comma *is* structural, so an
+  unquoted comma in a value is a 400 rather than a wrong row. `or` and `filter` are raw escape
+  hatches by design, and now say so.
+
+The wider lesson for this document: §10.1 called the asymmetry "a defect" from code shape alone, in
+the same sentence that admitted the behavior was unverified. The shape was evidence of a *question*,
+not of a bug. Both §10.1 entries needed the same server check; only one survived it.
+
 ## 10. Minimum testable surface
 
 Staging in §5 says what order to build in. This section says what the *first shippable slice* is —
 the smallest thing that can go out and generate real feedback. It is broken into tasks in
 [`postgrest-v3-stage-1-plan.md`](./postgrest-v3-stage-1-plan.md).
 
-### 10.1 Two fixes that need none of this
+### 10.1 One fix that needs none of this
 
-Both are bugs in the shipped API today, fixable against the current builders, and they should not
-wait on the rewrite.
+This section originally listed two. The second turned out not to be a bug at all — §9.5 records the
+measurement. It is kept below, struck through, because the reasoning that made it look like a bug is
+the kind that will recur.
+
+The remaining one is a real bug in the shipped API today, fixable against the current builders, and
+it should not wait on the rewrite.
 
 **`nil` in a comparison filter produces wrong rows.** `Optional.none.rawValue` is `"NULL"` — asserted
 in `Tests/PostgRESTTests/PostgrestFilterValueTests.swift` — and `eq` interpolates it directly, so
@@ -1126,10 +1172,16 @@ PostgREST matches the row whose value is the literal string, so this silently ma
 `"NULL"` and misses actual nulls. On an `integer` column it is a 400 instead. Fix: reject `nil` in the
 comparison operators and route callers to `is`.
 
-**Escaping is applied to two operators out of thirty.** `escapePostgRESTFilterValue` in
+~~**Escaping is applied to two operators out of thirty.** `escapePostgRESTFilterValue` in
 `Sources/Helpers/PostgRESTFilterValue.swift` is called only by `in` and `notIn`. What breaks for the
 others is unverified, so this needs a test that establishes the behavior before the fix — but the
-asymmetry alone is a defect.
+asymmetry alone is a defect.~~
+
+**Withdrawn.** The asymmetry is correct and the "fix" was a regression. §9.5 has the measurement;
+`Tests/PostgRESTTests/PostgrestFilterOperandEscapingTests.swift` pins it. The clause that misled was
+"the asymmetry alone is a defect" — an inference from code shape, asserted in the same breath as the
+admission that the behavior was unverified. Two out of thirty is exactly the right number, because
+only two of the thirty put their operand inside a delimited list.
 
 ### 10.2 Slice 0
 
@@ -1163,7 +1215,7 @@ entire point of slice 0 is that people actually try it.
 |---|---|---|
 | Typed columns on filters | Removes the most common real bug: a typo'd column string becoming a runtime 400 | Medium — needs the macro |
 | Correct `Insert` / `Update` | Removes "I sent `id` on insert" and "every field optional to update one" | Low, once the macro exists |
-| The two fixes in §10.1 | Silently wrong rows | Very low |
+| The fix in §10.1 | Silently wrong rows | Very low |
 | Read-only relations | Writing to a view becomes a compile error | Very low |
 | `embedded` / `requiring` | Highest severity — PostgREST's default silently returns every parent row | High — needs selections and relationships |
 | Filter tree and `or` | Removes hand-written PostgREST filter strings | Medium-high, narrower reach |


### PR DESCRIPTION
Companion to https://github.com/supabase/supabase-swift/pull/1268. That PR lands the tests and the SDK doc notes; this one corrects the design doc that pointed at the wrong thing.

## What was wrong

§10.1, "Two fixes that need none of this", listed:

> **Escaping is applied to two operators out of thirty.** [...] What breaks for the others is unverified, so this needs a test that establishes the behavior before the fix — **but the asymmetry alone is a defect.**

The first of the two fixes (SDK-1509, `nil` in a comparison filter) was real and shipped in #1238. This second one is not a bug, and the proposed fix was a regression across eleven operators.

## The measurement

New **§9.5**, against PostgREST 14.15 on Postgres 17, same throwaway-container method as the rest of §9.

PostgREST treats a double quote in a top-level scalar operand as **data, not syntax**. A row whose stored value is literally `"quoted"` — quote characters included — is the row that `txt=eq.%22quoted%22` returns. Had quotes been a delimiter, it would have matched the row containing `quoted`.

| Context | Unquoted | Quoted |
|---|---|---|
| `txt=eq.a,b` | 200 — correct row | `eq."a,b"` → 200, `[]` |
| `txt=eq.plain` | 200 — correct row | `eq."plain"` → 200, `[]` |
| `txt=in.(a,b)` | 200, `[]` — matches nothing | `in.("a,b")` → 200, correct row |
| `or=(txt.eq.a,b)` | **400 `PGRST100`** | `or=(txt.eq."a,b")` → 200, correct row |

22 awkward scalar values round-trip correctly with no escaping at all. Quoting each returns zero rows. None could be constructed that needs quoting.

## Why the asymmetry is correct

The rule is **positional, not per-operator**. A top-level operand runs to the end of the query-parameter value, so nothing inside it is structural. Escaping is needed only where the operand sits inside a delimited list — and `in`/`notIn` are the only two builders in that position. Two out of thirty is the right number.

Array and range literals escape one layer down, per element, via `postgrestArrayElement`. Quoting the whole literal yields `22P02 malformed array literal` / `malformed range literal`.

## The one real find

In `or`, the comma **is** structural, so an unquoted comma in a value is a 400 rather than a wrong row. That is the only place a caller must quote by hand, and it was undocumented. #1268 documents it.

## Changes

- **`postgrest-v3.md`** — new §9.5 with the measurement; §10.1 retitled "One fix that needs none of this" with the withdrawn entry struck through and kept for the record; §10.3 row updated.
- **`postgrest-v3-stage-1-plan.md`** — Task 2 marked resolved, Step 3 struck out with "do not execute", observed results recorded in Steps 2 and 4, and the commit block updated to what actually shipped.

## The process note worth keeping

Task 2's stop-condition was "if the characterization tests pass before the fix, escaping is already applied and this task is unnecessary — stop and report." That only catches *escaping already applied*, never *escaping must not be applied*. And its example assertions asserted `eq."a,b"` was desirable rather than measuring whether the server accepts it — a characterization test that assumes its conclusion.

§10.1 called the asymmetry "a defect" from code shape alone, in the same sentence that admitted the behavior was unverified. The shape was evidence of a question, not of a bug. Both §10.1 entries needed the same server check; only one survived it.

Refs SDK-1510.
