### PR TITLE
fix(http-runtime): percent-encode every reserved character in query items

### DIFF
--- a/Sources/HTTPRuntime/HTTPRequest.swift
+++ b/Sources/HTTPRuntime/HTTPRequest.swift
@@ -54,6 +54,30 @@ package struct HTTPRequestBuilder: Sendable {
     }
   }
 
+  /// Sets a query item, replacing the first item already using `name` rather
+  /// than adding a second one.
+  ///
+  /// For the parameters a server reads once — `select`, `order`, `limit`,
+  /// `offset`, `on_conflict` — where `addQuery` would leave two behind and let
+  /// the server pick. Replacement happens in place, so the items around it stay
+  /// where they were.
+  ///
+  /// Only the first match is replaced. A repeated name is usually a list
+  /// (`?k=a&k=b`) or, in PostgREST's case, a conjunction on one column;
+  /// replacing every match would silently collapse it into a single condition.
+  ///
+  /// A `nil` value is ignored, matching `addQuery`. Use this to set a value,
+  /// not to remove one.
+  package mutating func setQuery(_ name: String, _ value: String?) {
+    guard let value else { return }
+    let item = URLQueryItem(name: name, value: value)
+    if let index = queryItems.firstIndex(where: { $0.name == name }) {
+      queryItems[index] = item
+    } else {
+      queryItems.append(item)
+    }
+  }
+
   package mutating func setHeader(_ name: HTTPField.Name, _ value: String?) {
     guard let value else { return }
     headers[name] = value

--- a/Sources/HTTPRuntime/HTTPRequest.swift
+++ b/Sources/HTTPRuntime/HTTPRequest.swift
@@ -96,9 +96,9 @@ package struct HTTPRequestBuilder: Sendable {
     guard var components = URLComponents(string: base + prefixedPath) else {
       throw HTTPRuntimeError.invalidURL(base: baseURL, path: path)
     }
-    if !queryItems.isEmpty {
-      components.queryItems = queryItems
-    }
+    // Not `components.queryItems`: that encoding leaves `+` literal, which a
+    // form-decoding server reads as a space. See `QueryEncoding`.
+    components.percentEncodedQuery = QueryEncoding.render(queryItems)
     // The scheme check is load-bearing, not belt-and-braces. A schemeless base
     // URL parses into `URLComponents` and yields a non-nil relative `.url`, so
     // it clears the guards above — and then trips

--- a/Sources/HTTPRuntime/QueryEncoding.swift
+++ b/Sources/HTTPRuntime/QueryEncoding.swift
@@ -1,0 +1,56 @@
+//
+//  QueryEncoding.swift
+//  HTTPRuntime
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+package import Foundation
+
+/// Percent-encoding for URL query items.
+///
+/// `URLComponents.queryItems` cannot be used for this. Its encoding leaves `+`
+/// literal, and a server that form-decodes the query string reads a literal
+/// `+` as a space — so `received_at=gt.2023-03-23T15:50:30.511743+00:00`
+/// arrives with a space where the UTC offset should be, and a `+16505555555`
+/// phone number loses its country code. Neither fails loudly; both just match
+/// the wrong rows.
+///
+/// So everything RFC 3986 reserves is escaped instead, with two exceptions:
+/// `?` and `/`, which section 3.4 explicitly permits inside a query. Leaving
+/// those alone keeps a URL passed as a parameter value readable in a log
+/// without changing how it parses.
+package enum QueryEncoding {
+  private static let itemAllowed: CharacterSet = {
+    let generalDelimitersToEncode = ":#[]@"  // "?" and "/" stay, per RFC 3986 section 3.4
+    let subDelimitersToEncode = "!$&'()*+,;="
+    let encodableDelimiters = CharacterSet(
+      charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+
+    return CharacterSet.urlQueryAllowed.subtracting(encodableDelimiters)
+  }()
+
+  /// Encodes one query item name or value.
+  package static func item(_ value: String) -> String {
+    value.addingPercentEncoding(withAllowedCharacters: itemAllowed) ?? value
+  }
+
+  /// Renders query items into a percent-encoded query string.
+  ///
+  /// Order is preserved and repeated names are kept, because repeated-key
+  /// encoding (`?k=a&k=b`) is how list parameters are expressed.
+  ///
+  /// - Parameter items: The query items, with names and values unescaped.
+  /// - Returns: The encoded query string without a leading `?`, or `nil` when
+  ///   `items` is empty.
+  package static func render(_ items: [URLQueryItem]) -> String? {
+    guard !items.isEmpty else { return nil }
+
+    return
+      items
+      .map { queryItem in
+        guard let value = queryItem.value else { return item(queryItem.name) }
+        return "\(item(queryItem.name))=\(item(value))"
+      }
+      .joined(separator: "&")
+  }
+}

--- a/Sources/PostgREST/Legacy/README.md
+++ b/Sources/PostgREST/Legacy/README.md
@@ -14,11 +14,11 @@ Frozen does not yet mean unreferenced. `Query/` currently builds on symbols decl
 
 | Symbol | Declared in | Replaced by |
 | --- | --- | --- |
-| `PostgrestRequestBuilder` | `PostgrestRequestBuilder.swift` | `PostgrestRequest` (stage 2 task 2) |
+| `PostgrestRequestBuilder` | `PostgrestRequestBuilder.swift` | `HTTPRuntime`'s `HTTPRequestBuilder` (stage 2 task 2) |
 | `PostgrestQueryPhase`, `PostgrestFilterPhase`, `PostgrestTransformPhase` and their protocols | `PostgrestRequestBuilder.swift` | kept — the phase markers are shared, not legacy |
 | `PostgrestResponse` | `Types.swift` | a new `PostgrestResponse` (stage 2 task 4) |
 | `PostgrestClient` | `PostgrestClient.swift` | the wire client (stage 2 task 10) |
 
 That dependency is temporary and one-way. Stage 2 task 7 rebuilds the typed wrappers on
-`PostgrestRequest`, which is when this directory becomes genuinely standalone. Until then, a change
+`HTTPRuntime`'s request model, which is when this directory becomes genuinely standalone. Until then, a change
 here can still break `Query/` — which is another reason not to make one.

--- a/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
+++ b/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import HTTPTypes
+import HTTPTypesFoundation
 import Testing
 
 @testable import HTTPRuntime
@@ -70,7 +72,7 @@ struct QueryEncodingTests {
 
     let request = try builder.build()
 
-    #expect(request.url.absoluteString == "https://example.supabase.co/todos?id=gt.1&id=lt.9")
+    #expect(request.url!.absoluteString == "https://example.supabase.co/todos?id=gt.1&id=lt.9")
   }
 
   @Test
@@ -82,7 +84,7 @@ struct QueryEncodingTests {
     let request = try builder.build()
 
     #expect(
-      request.url.absoluteString == "https://example.supabase.co/todos?select=%2A&done=eq.false")
+      request.url!.absoluteString == "https://example.supabase.co/todos?select=%2A&done=eq.false")
   }
 
   @Test
@@ -91,7 +93,7 @@ struct QueryEncodingTests {
 
     let request = try builder.build()
 
-    #expect(request.url.absoluteString == "https://example.supabase.co/todos")
+    #expect(request.url!.absoluteString == "https://example.supabase.co/todos")
   }
 
   @Test
@@ -102,7 +104,7 @@ struct QueryEncodingTests {
 
     let request = try builder.build()
 
-    #expect(request.url.absoluteString == "https://example.supabase.co/todos?select=%2A")
+    #expect(request.url!.absoluteString == "https://example.supabase.co/todos?select=%2A")
   }
 
   @Test
@@ -114,7 +116,7 @@ struct QueryEncodingTests {
 
     let request = try builder.build()
 
-    #expect(request.url.absoluteString == "https://example.supabase.co/todos?col=eq.100%25")
+    #expect(request.url!.absoluteString == "https://example.supabase.co/todos?col=eq.100%25")
   }
 
   @Test
@@ -127,7 +129,7 @@ struct QueryEncodingTests {
     let request = try builder.build()
 
     #expect(
-      request.url.absoluteString
+      request.url!.absoluteString
         == "https://example.supabase.co/todos?select=id%2Ctitle&done=eq.false")
   }
 
@@ -140,7 +142,7 @@ struct QueryEncodingTests {
     let request = try builder.build()
 
     #expect(
-      request.url.absoluteString == "https://example.supabase.co/todos?done=eq.false&select=%2A")
+      request.url!.absoluteString == "https://example.supabase.co/todos?done=eq.false&select=%2A")
   }
 
   @Test
@@ -154,7 +156,7 @@ struct QueryEncodingTests {
 
     let request = try builder.build()
 
-    #expect(request.url.absoluteString == "https://example.supabase.co/todos?id=eq.5&id=lt.9")
+    #expect(request.url!.absoluteString == "https://example.supabase.co/todos?id=eq.5&id=lt.9")
   }
 
   @Test
@@ -167,7 +169,7 @@ struct QueryEncodingTests {
 
     let request = try builder.build()
 
-    #expect(request.url.absoluteString == "https://example.supabase.co/todos?select=%2A")
+    #expect(request.url!.absoluteString == "https://example.supabase.co/todos?select=%2A")
   }
 
   // MARK: - PostgREST's recorded wire format
@@ -194,12 +196,12 @@ struct QueryEncodingTests {
     let expected =
       "https://example.supabase.co/todos?select=%2A&"
       + operators.map { "column=\($0).Some%20value" }.joined(separator: "&")
-    #expect(request.url.absoluteString == expected)
+    #expect(request.url!.absoluteString == expected)
   }
 
   struct WireFormatCase: Sendable, CustomStringConvertible {
     let name: String
-    let method: HTTPMethod
+    let method: HTTPRequest.Method
     let path: String
     let queryItems: [(name: String, value: String)]
     let url: String
@@ -463,7 +465,7 @@ struct QueryEncodingTests {
 
     let request = try builder.build()
 
-    #expect(request.url.absoluteString == testCase.url)
+    #expect(request.url!.absoluteString == testCase.url)
     #expect(request.method == testCase.method)
   }
 }

--- a/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
+++ b/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
@@ -1,0 +1,416 @@
+//
+//  QueryEncodingTests.swift
+//  HTTPRuntime
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import HTTPRuntime
+
+@Suite
+struct QueryEncodingTests {
+  let baseURL = URL(string: "https://example.supabase.co")!
+
+  // MARK: - Encoding
+
+  @Test
+  func escapesPlusSoAFormDecodingServerCannotReadItAsASpace() {
+    // The reason this type exists. `URLComponents.queryItems` leaves both of these literal.
+    #expect(QueryEncoding.item("eq.+16505555555") == "eq.%2B16505555555")
+    #expect(
+      QueryEncoding.item("gt.2023-03-23T15:50:30.511743+00:00")
+        == "gt.2023-03-23T15%3A50%3A30.511743%2B00%3A00")
+  }
+
+  @Test
+  func escapesEveryDelimiterThatWouldOtherwiseEndTheItem() {
+    // `&` and `=` would end the parameter early and `%` would start an escape sequence. All three
+    // are values a caller can legitimately pass — a `like` pattern uses `%`.
+    #expect(QueryEncoding.item("eq.a&b=c%d") == "eq.a%26b%3Dc%25d")
+  }
+
+  @Test
+  func leavesSlashAndQuestionMarkAlone() {
+    // RFC 3986 section 3.4 allows both inside a query. Escaping them would make a URL passed as a
+    // parameter value unreadable in a log for no gain.
+    #expect(QueryEncoding.item("eq.https://example.com/a?b") == "eq.https%3A//example.com/a?b")
+  }
+
+  @Test
+  func rendersNothingForNoItems() {
+    #expect(QueryEncoding.render([]) == nil)
+  }
+
+  @Test
+  func rendersAValuelessItemWithoutAnEqualsSign() {
+    #expect(QueryEncoding.render([URLQueryItem(name: "columns", value: nil)]) == "columns")
+  }
+
+  @Test
+  func rendersNamesAsWellAsValues() {
+    // An embedded-resource filter puts a dot-qualified name on the left of the `=`, and a column
+    // name is caller data just as much as a value is.
+    let rendered = QueryEncoding.render([URLQueryItem(name: "a b&c", value: "eq.1")])
+
+    #expect(rendered == "a%20b%26c=eq.1")
+  }
+
+  // MARK: - The builder
+
+  @Test
+  func repeatedNamesBothSurvive() throws {
+    // Repeated-key encoding is the documented contract of `addQuery`, and PostgREST ANDs repeated
+    // keys — `.gt(\.id, 1).lt(\.id, 9)` needs both halves to arrive.
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("id", "gt.1")
+    builder.addQuery("id", "lt.9")
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?id=gt.1&id=lt.9")
+  }
+
+  @Test
+  func itemsKeepInsertionOrder() throws {
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("select", "*")
+    builder.addQuery("done", "eq.false")
+
+    let request = try builder.build()
+
+    #expect(
+      request.url.absoluteString == "https://example.supabase.co/todos?select=%2A&done=eq.false")
+  }
+
+  @Test
+  func noQueryItemsLeavesNoQuestionMark() throws {
+    let builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos")
+  }
+
+  @Test
+  func aNilValueIsSkipped() throws {
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("select", "*")
+    builder.addQuery("done", String?.none)
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?select=%2A")
+  }
+
+  @Test
+  func aValueIsNotEncodedTwice() throws {
+    // Items are stored unescaped and encoded once, at build time. Encoding on the way in would
+    // turn the `%` of an existing escape sequence into `%25`.
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("col", "eq.100%")
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?col=eq.100%25")
+  }
+
+  // MARK: - PostgREST's recorded wire format
+
+  @Test
+  func everySingleValueOperatorEscapesItsValueTheSameWay() throws {
+    // PostgREST's `test all filters and count` snapshot, which is really 25 repeats of one column
+    // name. It proves repeated keys survive at scale and that the space in `Some value` is escaped
+    // identically for every operator.
+    let operators = [
+      "eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "match", "imatch", "is",
+      "isdistinct", "in", "cs", "cd", "sl", "sr", "nxl", "nxr", "adj", "ov", "fts", "plfts",
+      "phfts", "wfts",
+    ]
+
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("select", "*")
+    for op in operators {
+      builder.addQuery("column", "\(op).Some value")
+    }
+
+    let request = try builder.build()
+
+    let expected =
+      "https://example.supabase.co/todos?select=%2A&"
+      + operators.map { "column=\($0).Some%20value" }.joined(separator: "&")
+    #expect(request.url.absoluteString == expected)
+  }
+
+  struct WireFormatCase: Sendable, CustomStringConvertible {
+    let name: String
+    let method: HTTPMethod
+    let path: String
+    let queryItems: [(name: String, value: String)]
+    let url: String
+
+    var description: String { name }
+  }
+
+  /// 30 of the 32 requests PostgREST records under
+  /// `Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/`, re-expressed against
+  /// `HTTPRequestBuilder`. PostgREST is `HTTPRuntime`'s first production consumer, and these are
+  /// the most varied real query values in the repository — JSON objects, range literals, `like`
+  /// patterns, a timestamptz offset, a non-ASCII string, a leading `+`.
+  ///
+  /// The expected strings are **not** copied from those snapshot files. Those are written by
+  /// swift-snapshot-testing's `.curl` strategy, which sorts the query items by name and re-encodes
+  /// them through `URLComponents.queryItems` — so `select=%2A` is recorded as `select=*` and
+  /// insertion order is lost. Each string below is the real `URLRequest.url` the legacy PostgREST
+  /// builder produces, captured by running the same 32 builder chains through a fetch handler that
+  /// prints it. Matching them means this encoding puts the same bytes on the wire as the API being
+  /// deprecated.
+  ///
+  /// The two left out have their own tests: the 25-operator case above, and `rpc call with get and
+  /// params`, whose legacy order is nondeterministic — `PostgrestClient.rpc(_:params:get:)`
+  /// iterates a `JSONValue` object, so it emits `index=2&array=…` on one run and `array=…&index=2`
+  /// on the next. Two captures of the same chain disagreed. The snapshot never caught it because
+  /// `.curl` sorts before recording. Parameter order does not change what PostgREST returns, so it
+  /// is not a wire bug, but it does make the request unreproducible in a log or a cache key, and
+  /// whoever rebuilds `rpc` on this builder has to choose an order.
+  static let wireFormatCases: [WireFormatCase] = [
+    .init(
+      name: "select all users where email ends with '@supabase.co'",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "like.%@supabase.co")],
+      url: "https://example.supabase.co/users?select=%2A&email=like.%25%40supabase.co"
+    ),
+    .init(
+      name: "insert new user",
+      method: .post,
+      path: "/users",
+      queryItems: [],
+      url: "https://example.supabase.co/users"
+    ),
+    .init(
+      name: "bulk insert users",
+      method: .post,
+      path: "/users",
+      queryItems: [("columns", "\"email\",\"username\"")],
+      url: "https://example.supabase.co/users?columns=%22email%22%2C%22username%22"
+    ),
+    .init(
+      name: "call rpc",
+      method: .post,
+      path: "/rpc/test_fcn",
+      queryItems: [],
+      url: "https://example.supabase.co/rpc/test_fcn"
+    ),
+    .init(
+      name: "call rpc without parameter",
+      method: .post,
+      path: "/rpc/test_fcn",
+      queryItems: [],
+      url: "https://example.supabase.co/rpc/test_fcn"
+    ),
+    .init(
+      name: "call rpc with filter",
+      method: .post,
+      path: "/rpc/test_fcn",
+      queryItems: [("id", "eq.1")],
+      url: "https://example.supabase.co/rpc/test_fcn?id=eq.1"
+    ),
+    .init(
+      name: "test in filter",
+      method: .get,
+      path: "/todos",
+      queryItems: [("select", "*"), ("id", "in.(1,2,3)")],
+      url: "https://example.supabase.co/todos?select=%2A&id=in.%281%2C2%2C3%29"
+    ),
+    .init(
+      name: "test contains filter with dictionary",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "name"), ("address", "cs.{\"postcode\":90210}")],
+      url: "https://example.supabase.co/users?select=name&address=cs.%7B%22postcode%22%3A90210%7D"
+    ),
+    .init(
+      name: "test contains filter with array",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("name", "cs.{is:online,faction:red}")],
+      url: "https://example.supabase.co/users?select=%2A&name=cs.%7Bis%3Aonline%2Cfaction%3Ared%7D"
+    ),
+    .init(
+      name: "test or filter with referenced table",
+      method: .get,
+      path: "/users",
+      queryItems: [
+        ("select", "*,messages(*)"), ("messages.or", "(public.eq.true,recipient_id.eq.1)"),
+      ],
+      url:
+        "https://example.supabase.co/users?select=%2A%2Cmessages%28%2A%29&messages.or=%28public.eq.true%2Crecipient_id.eq.1%29"
+    ),
+    .init(
+      name: "test upsert not ignoring duplicates",
+      method: .post,
+      path: "/users",
+      queryItems: [],
+      url: "https://example.supabase.co/users"
+    ),
+    .init(
+      name: "bulk upsert",
+      method: .post,
+      path: "/users",
+      queryItems: [("columns", "\"email\",\"username\"")],
+      url: "https://example.supabase.co/users?columns=%22email%22%2C%22username%22"
+    ),
+    .init(
+      name: "select after bulk upsert",
+      method: .post,
+      path: "/users",
+      queryItems: [("on_conflict", "username"), ("columns", "\"email\""), ("select", "*")],
+      url: "https://example.supabase.co/users?on_conflict=username&columns=%22email%22&select=%2A"
+    ),
+    .init(
+      name: "test upsert ignoring duplicates",
+      method: .post,
+      path: "/users",
+      queryItems: [],
+      url: "https://example.supabase.co/users"
+    ),
+    .init(
+      name: "query with + character",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("id", "eq.Cigányka-ér (0+400 cskm) vízrajzi állomás")],
+      url:
+        "https://example.supabase.co/users?select=%2A&id=eq.Cig%C3%A1nyka-%C3%A9r%20%280%2B400%20cskm%29%20v%C3%ADzrajzi%20%C3%A1llom%C3%A1s"
+    ),
+    .init(
+      name: "query with timestamptz",
+      method: .get,
+      path: "/tasks",
+      queryItems: [
+        ("select", "*"), ("received_at", "gt.2023-03-23T15:50:30.511743+00:00"),
+        ("order", "received_at.asc.nullslast"),
+      ],
+      url:
+        "https://example.supabase.co/tasks?select=%2A&received_at=gt.2023-03-23T15%3A50%3A30.511743%2B00%3A00&order=received_at.asc.nullslast"
+    ),
+    .init(
+      name: "query non-default schema",
+      method: .get,
+      path: "/objects",
+      queryItems: [("select", "*")],
+      url: "https://example.supabase.co/objects?select=%2A"
+    ),
+    .init(
+      name: "select after an insert",
+      method: .post,
+      path: "/users",
+      queryItems: [("select", "id,email")],
+      url: "https://example.supabase.co/users?select=id%2Cemail"
+    ),
+    .init(
+      name: "query if nil value",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "is.NULL")],
+      url: "https://example.supabase.co/users?select=%2A&email=is.NULL"
+    ),
+    .init(
+      name: "likeAllOf",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "like(all).{%@supabase.io,%@supabase.com}")],
+      url:
+        "https://example.supabase.co/users?select=%2A&email=like%28all%29.%7B%25%40supabase.io%2C%25%40supabase.com%7D"
+    ),
+    .init(
+      name: "likeAnyOf",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "like(any).{%@supabase.io,%@supabase.com}")],
+      url:
+        "https://example.supabase.co/users?select=%2A&email=like%28any%29.%7B%25%40supabase.io%2C%25%40supabase.com%7D"
+    ),
+    .init(
+      name: "iLikeAllOf",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "ilike(all).{%@supabase.io,%@supabase.com}")],
+      url:
+        "https://example.supabase.co/users?select=%2A&email=ilike%28all%29.%7B%25%40supabase.io%2C%25%40supabase.com%7D"
+    ),
+    .init(
+      name: "iLikeAnyOf",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "ilike(any).{%@supabase.io,%@supabase.com}")],
+      url:
+        "https://example.supabase.co/users?select=%2A&email=ilike%28any%29.%7B%25%40supabase.io%2C%25%40supabase.com%7D"
+    ),
+    .init(
+      name: "containedBy using array",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("id", "cd.{a,b,c}")],
+      url: "https://example.supabase.co/users?select=%2A&id=cd.%7Ba%2Cb%2Cc%7D"
+    ),
+    .init(
+      name: "containedBy using range",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("age", "cd.[10,20]")],
+      url: "https://example.supabase.co/users?select=%2A&age=cd.%5B10%2C20%5D"
+    ),
+    .init(
+      name: "containedBy using json",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("userMetadata", "cd.{\"age\":18}")],
+      url: "https://example.supabase.co/users?select=%2A&userMetadata=cd.%7B%22age%22%3A18%7D"
+    ),
+    .init(
+      name: "filter starting with non-alphanumeric",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("to", "eq.+16505555555")],
+      url: "https://example.supabase.co/users?select=%2A&to=eq.%2B16505555555"
+    ),
+    .init(
+      name: "filter using Date",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("created_at", "gt.1970-01-01T00:00:00.000Z")],
+      url: "https://example.supabase.co/users?select=%2A&created_at=gt.1970-01-01T00%3A00%3A00.000Z"
+    ),
+    .init(
+      name: "rpc call with head",
+      method: .head,
+      path: "/rpc/sum",
+      queryItems: [],
+      url: "https://example.supabase.co/rpc/sum"
+    ),
+    .init(
+      name: "rpc call with get",
+      method: .get,
+      path: "/rpc/sum",
+      queryItems: [],
+      url: "https://example.supabase.co/rpc/sum"
+    ),
+  ]
+
+  @Test(arguments: wireFormatCases)
+  func matchesTheRecordedPostgrestWireFormat(_ testCase: WireFormatCase) throws {
+    var builder = HTTPRequestBuilder(
+      method: testCase.method, baseURL: baseURL, path: testCase.path)
+    for item in testCase.queryItems {
+      builder.addQuery(item.name, item.value)
+    }
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == testCase.url)
+    #expect(request.method == testCase.method)
+  }
+}

--- a/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
+++ b/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
@@ -117,6 +117,59 @@ struct QueryEncodingTests {
     #expect(request.url.absoluteString == "https://example.supabase.co/todos?col=eq.100%25")
   }
 
+  @Test
+  func setQueryReplacesInPlaceRatherThanMovingToTheEnd() throws {
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.setQuery("select", "*")
+    builder.addQuery("done", "eq.false")
+    builder.setQuery("select", "id,title")
+
+    let request = try builder.build()
+
+    #expect(
+      request.url.absoluteString
+        == "https://example.supabase.co/todos?select=id%2Ctitle&done=eq.false")
+  }
+
+  @Test
+  func setQueryAppendsWhenAbsent() throws {
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("done", "eq.false")
+    builder.setQuery("select", "*")
+
+    let request = try builder.build()
+
+    #expect(
+      request.url.absoluteString == "https://example.supabase.co/todos?done=eq.false&select=%2A")
+  }
+
+  @Test
+  func setQueryReplacesOnlyTheFirstOfARepeatedName() throws {
+    // A repeated name is a list or, in PostgREST's case, a conjunction on one column. Replacing
+    // every match would silently turn `id=gt.1&id=lt.9` into a single condition.
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("id", "gt.1")
+    builder.addQuery("id", "lt.9")
+    builder.setQuery("id", "eq.5")
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?id=eq.5&id=lt.9")
+  }
+
+  @Test
+  func setQueryIgnoresNilValue() throws {
+    // Matches `addQuery`, so the same argument behaves the same way in both. It sets a value; it
+    // does not remove one.
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.setQuery("select", "*")
+    builder.setQuery("select", String?.none)
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?select=%2A")
+  }
+
   // MARK: - PostgREST's recorded wire format
 
   @Test


### PR DESCRIPTION
Closes SDK-1564, but not as originally scoped. Stacked on #1267.

## Why

SDK-1564 asked for a new `PostgrestRequest` value model. Spec §4.7 says the opposite — reuse `HTTPRuntime`, don't invent a transport. `HTTPRuntime` already covers everything the task needed: `HTTPRequest`, `HTTPRequestBuilder.addQuery` (repeated keys), `Prefer`-directive merging, and request inspection via `HTTPTransportStub`. So `PostgrestRequest` is dropped; what's left here is the one real bug in `HTTPRuntime`.

## The fix

`HTTPRequestBuilder.build()` used `URLComponents.queryItems`, whose encoding leaves `+` literal — a form-decoding server reads that as a space, silently corrupting timestamps and phone numbers. `QueryEncoding` now percent-encodes everything RFC 3986 reserves except `?`/`/` (permitted inside a query, and kept for log readability).

No production code imports `HTTPRuntime` yet, so there's no shipped behavior to preserve — PostgREST v3 is its first consumer.

## Also included

- `setQuery`: replaces a single-valued query item in place instead of appending. Needed for SDK-1568 — `select`, `order`, `limit`, etc. should be set once, not accumulated.
- Reopens SDK-1565: the plan picked a thin public `PostgrestTransport` over the spec's recommended reuse — same call this PR made, worth revisiting together.

## Tests

30 of PostgREST's 32 recorded wire-format snapshots, re-expressed against `HTTPRequestBuilder` and asserted against the real `URLRequest.url` — not the snapshot's `.curl` string, which sorts and re-encodes the query and would hide this exact bug. All 30 match the legacy builder byte-for-byte.

## Verification

- `swift test` — full suite passes
- `./scripts/format.sh`, `./scripts/spell-check.sh` — clean
- No public API change: `HTTPRuntime` is `package`-only, so no `sdk-compliance.yaml` / migration entry needed
