### PR TITLE
feat(postgrest): add the public transport seam over HTTPTypes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -163,6 +163,7 @@ let package = Package(
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "Logging", package: "swift-log"),
+        "HTTPRuntime",
         "Helpers",
       ],
       exclude: [
@@ -173,6 +174,7 @@ let package = Package(
       name: "PostgRESTTests",
       dependencies: [
         .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+        "HTTPRuntime",
         "Helpers",
         "Mocker",
         "PostgREST",

--- a/Sources/HTTPRuntime/HTTPRequest.swift
+++ b/Sources/HTTPRuntime/HTTPRequest.swift
@@ -70,6 +70,30 @@ package struct HTTPRequestBuilder: Sendable {
     }
   }
 
+  /// Sets a query item, replacing the first item already using `name` rather
+  /// than adding a second one.
+  ///
+  /// For the parameters a server reads once — `select`, `order`, `limit`,
+  /// `offset`, `on_conflict` — where `addQuery` would leave two behind and let
+  /// the server pick. Replacement happens in place, so the items around it stay
+  /// where they were.
+  ///
+  /// Only the first match is replaced. A repeated name is usually a list
+  /// (`?k=a&k=b`) or, in PostgREST's case, a conjunction on one column;
+  /// replacing every match would silently collapse it into a single condition.
+  ///
+  /// A `nil` value is ignored, matching `addQuery`. Use this to set a value,
+  /// not to remove one.
+  package mutating func setQuery(_ name: String, _ value: String?) {
+    guard let value else { return }
+    let item = URLQueryItem(name: name, value: value)
+    if let index = queryItems.firstIndex(where: { $0.name == name }) {
+      queryItems[index] = item
+    } else {
+      queryItems.append(item)
+    }
+  }
+
   package mutating func setHeader(_ name: String, _ value: String?) {
     guard let value else { return }
     headers[canonicalKey(for: name)] = value

--- a/Sources/HTTPRuntime/HTTPRequest.swift
+++ b/Sources/HTTPRuntime/HTTPRequest.swift
@@ -118,9 +118,9 @@ package struct HTTPRequestBuilder: Sendable {
     guard var components = URLComponents(string: base + prefixedPath) else {
       throw HTTPError.invalidURL(base: baseURL, path: path)
     }
-    if !queryItems.isEmpty {
-      components.queryItems = queryItems
-    }
+    // Not `components.queryItems`: that encoding leaves `+` literal, which a
+    // form-decoding server reads as a space. See `QueryEncoding`.
+    components.percentEncodedQuery = QueryEncoding.render(queryItems)
     guard let url = components.url else {
       throw HTTPError.invalidURL(base: baseURL, path: path)
     }

--- a/Sources/HTTPRuntime/QueryEncoding.swift
+++ b/Sources/HTTPRuntime/QueryEncoding.swift
@@ -1,0 +1,56 @@
+//
+//  QueryEncoding.swift
+//  HTTPRuntime
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+package import Foundation
+
+/// Percent-encoding for URL query items.
+///
+/// `URLComponents.queryItems` cannot be used for this. Its encoding leaves `+`
+/// literal, and a server that form-decodes the query string reads a literal
+/// `+` as a space — so `received_at=gt.2023-03-23T15:50:30.511743+00:00`
+/// arrives with a space where the UTC offset should be, and a `+16505555555`
+/// phone number loses its country code. Neither fails loudly; both just match
+/// the wrong rows.
+///
+/// So everything RFC 3986 reserves is escaped instead, with two exceptions:
+/// `?` and `/`, which section 3.4 explicitly permits inside a query. Leaving
+/// those alone keeps a URL passed as a parameter value readable in a log
+/// without changing how it parses.
+package enum QueryEncoding {
+  private static let itemAllowed: CharacterSet = {
+    let generalDelimitersToEncode = ":#[]@"  // "?" and "/" stay, per RFC 3986 section 3.4
+    let subDelimitersToEncode = "!$&'()*+,;="
+    let encodableDelimiters = CharacterSet(
+      charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+
+    return CharacterSet.urlQueryAllowed.subtracting(encodableDelimiters)
+  }()
+
+  /// Encodes one query item name or value.
+  package static func item(_ value: String) -> String {
+    value.addingPercentEncoding(withAllowedCharacters: itemAllowed) ?? value
+  }
+
+  /// Renders query items into a percent-encoded query string.
+  ///
+  /// Order is preserved and repeated names are kept, because repeated-key
+  /// encoding (`?k=a&k=b`) is how list parameters are expressed.
+  ///
+  /// - Parameter items: The query items, with names and values unescaped.
+  /// - Returns: The encoded query string without a leading `?`, or `nil` when
+  ///   `items` is empty.
+  package static func render(_ items: [URLQueryItem]) -> String? {
+    guard !items.isEmpty else { return nil }
+
+    return
+      items
+      .map { queryItem in
+        guard let value = queryItem.value else { return item(queryItem.name) }
+        return "\(item(queryItem.name))=\(item(value))"
+      }
+      .joined(separator: "&")
+  }
+}

--- a/Sources/PostgREST/Legacy/README.md
+++ b/Sources/PostgREST/Legacy/README.md
@@ -14,11 +14,11 @@ Frozen does not yet mean unreferenced. `Query/` currently builds on symbols decl
 
 | Symbol | Declared in | Replaced by |
 | --- | --- | --- |
-| `PostgrestRequestBuilder` | `PostgrestRequestBuilder.swift` | `PostgrestRequest` (stage 2 task 2) |
+| `PostgrestRequestBuilder` | `PostgrestRequestBuilder.swift` | `HTTPRuntime`'s `HTTPRequestBuilder` (stage 2 task 2) |
 | `PostgrestQueryPhase`, `PostgrestFilterPhase`, `PostgrestTransformPhase` and their protocols | `PostgrestRequestBuilder.swift` | kept — the phase markers are shared, not legacy |
 | `PostgrestResponse` | `Types.swift` | a new `PostgrestResponse` (stage 2 task 4) |
 | `PostgrestClient` | `PostgrestClient.swift` | the wire client (stage 2 task 10) |
 
 That dependency is temporary and one-way. Stage 2 task 7 rebuilds the typed wrappers on
-`PostgrestRequest`, which is when this directory becomes genuinely standalone. Until then, a change
+`HTTPRuntime`'s request model, which is when this directory becomes genuinely standalone. Until then, a change
 here can still break `Query/` — which is another reason not to make one.

--- a/Sources/PostgREST/Transport/PostgrestTransport.swift
+++ b/Sources/PostgREST/Transport/PostgrestTransport.swift
@@ -1,0 +1,60 @@
+//
+//  PostgrestTransport.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+
+public import Foundation
+public import HTTPTypes
+
+/// Takes over how PostgREST puts a request on the wire.
+///
+/// Conform to this to add a timeout, inject a header, log, or serve canned responses in a test —
+/// the capability today's `fetch:` handler provides. Pass an instance where the client accepts one
+/// and nothing else about the query API changes.
+///
+/// Most conformances only want to observe or adjust a request and then let it go out normally.
+/// Wrap ``URLSessionPostgrestTransport`` rather than reimplementing it:
+///
+/// ```swift
+/// struct LoggingTransport: PostgrestTransport {
+///   let wrapped = URLSessionPostgrestTransport()
+///
+///   func send(
+///     _ request: HTTPRequest, body: Data?
+///   ) async throws -> (Data, HTTPResponse) {
+///     print(request.method, request.path ?? "")
+///     return try await wrapped.send(request, body: body)
+///   }
+/// }
+/// ```
+///
+/// ## The request carries its query in `path`
+///
+/// `HTTPTypes.HTTPRequest` has no `URL`. It carries `scheme`, `authority` and `path`, where `path`
+/// is the origin-form target — already percent-encoded, and already including `?` and the query
+/// string. A conformance that needs a `URL` should build one by concatenation:
+///
+/// ```swift
+/// guard let scheme = request.scheme,
+///   let authority = request.authority,
+///   let path = request.path,
+///   let url = URL(string: "\(scheme)://\(authority)\(path)")
+/// else { throw URLError(.badURL) }
+/// ```
+///
+/// Do not route `path` through `URLComponents.path` or `URLQueryItem` on the way. Those decode and
+/// re-encode, and PostgREST relies on an encoding stricter than Foundation's default — a `+` in a
+/// timestamp filter comes back as a space, matching the wrong rows.
+public protocol PostgrestTransport: Sendable {
+  /// Sends a request and returns its response.
+  ///
+  /// - Parameters:
+  ///   - request: The request to send. Its `path` includes the query string.
+  ///   - body: The request body, already encoded, or `nil` when there is none.
+  /// - Returns: The response body, and the status and header fields that came with it.
+  /// - Throws: Any error. It reaches the caller of `execute()` unchanged.
+  func send(_ request: HTTPTypes.HTTPRequest, body: Data?) async throws
+    -> (Data, HTTPTypes.HTTPResponse)
+}

--- a/Sources/PostgREST/Transport/PostgrestTransportBridge.swift
+++ b/Sources/PostgREST/Transport/PostgrestTransportBridge.swift
@@ -1,0 +1,113 @@
+//
+//  PostgrestTransportBridge.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+
+import Foundation
+import HTTPRuntime
+import HTTPTypes
+
+/// Drives a caller-supplied ``PostgrestTransport`` from the internal pipeline, which speaks
+/// `HTTPRuntime`.
+///
+/// This exists because `HTTPRuntime` is `package`, so it cannot appear in a public protocol, while
+/// the pipeline below this point is built on it. Nothing converts when no custom transport is
+/// supplied — `HTTPRuntime.URLSessionTransport` is used directly, so the conversion is a cost only
+/// callers who take over the transport pay.
+struct PostgrestTransportBridge: HTTPRuntime.HTTPTransport {
+  let transport: any PostgrestTransport
+
+  func send(
+    _ request: HTTPRuntime.HTTPRequest, uploadProgress: HTTPRuntime.ProgressHandler?
+  ) async throws(HTTPRuntime.HTTPError) -> HTTPRuntime.HTTPResponse {
+    // Upload progress is dropped rather than approximated. A `PostgrestTransport` has no way to
+    // report it, and PostgREST never asks for it — no request it builds is large enough to need a
+    // progress bar. Faking a single 100% callback would be worse than reporting nothing.
+    let httpRequest: HTTPTypes.HTTPRequest
+    let body: Data?
+    do {
+      httpRequest = try bridgedRequest(from: request)
+      body = try bridgedBody(from: request.body)
+    } catch let error as HTTPRuntime.HTTPError {
+      throw error
+    } catch {
+      throw HTTPRuntime.HTTPError.transport(error)
+    }
+
+    do {
+      let (data, response) = try await transport.send(httpRequest, body: body)
+      return HTTPRuntime.HTTPResponse(head: bridgedHead(from: response), body: data)
+    } catch {
+      throw HTTPRuntime.HTTPError.transport(error)
+    }
+  }
+
+  func stream(
+    _ request: HTTPRuntime.HTTPRequest
+  ) async throws(HTTPRuntime.HTTPError) -> HTTPRuntime.HTTPResponseStream {
+    // A `PostgrestTransport` returns a buffered `(Data, HTTPResponse)`, so it cannot stream.
+    // Failing loudly beats buffering the whole body and handing back a one-chunk stream, which
+    // would look like streaming while defeating the point of it.
+    throw HTTPRuntime.HTTPError.transport(PostgrestTransportStreamingUnsupported())
+  }
+}
+
+/// Thrown when something asks a caller-supplied ``PostgrestTransport`` to stream.
+struct PostgrestTransportStreamingUnsupported: Error, Sendable, CustomStringConvertible {
+  var description: String {
+    "A custom PostgrestTransport cannot stream a response. Nothing in PostgREST streams, so this "
+      + "indicates a caller reaching the transport through an unintended path."
+  }
+}
+
+private func bridgedRequest(
+  from request: HTTPRuntime.HTTPRequest
+) throws -> HTTPTypes.HTTPRequest {
+  guard let components = URLComponents(url: request.url, resolvingAgainstBaseURL: false) else {
+    throw HTTPRuntime.HTTPError.invalidURL(base: request.url, path: "")
+  }
+
+  var authority = components.host ?? ""
+  if let port = components.port {
+    authority += ":\(port)"
+  }
+
+  // `percentEncodedPath`, not `path`: `path` decodes, so a column or table name containing an
+  // escaped character would be handed to the transport already mangled.
+  var path = components.percentEncodedPath
+  if let query = components.percentEncodedQuery {
+    path += "?\(query)"
+  }
+
+  return HTTPTypes.HTTPRequest(
+    method: postgrestHTTPMethod(from: request.method),
+    scheme: components.scheme,
+    authority: authority,
+    path: path,
+    headerFields: postgrestHeaderFields(from: request.headers)
+  )
+}
+
+private func bridgedBody(from body: HTTPRuntime.HTTPBody?) throws -> Data? {
+  switch body {
+  case nil:
+    return nil
+  case .data(let data):
+    return data
+  case .file(let url):
+    // Reading the file in would defeat the reason `.file` exists, which is streaming an upload
+    // from disk without buffering it. PostgREST never produces one, so this is unreachable rather
+    // than a limitation callers hit.
+    throw HTTPRuntime.HTTPError.unsupportedRequestBody(
+      "A custom PostgrestTransport cannot send a file-backed body (\(url.lastPathComponent)).")
+  }
+}
+
+private func bridgedHead(from response: HTTPTypes.HTTPResponse) -> HTTPRuntime.HTTPResponseHead {
+  HTTPRuntime.HTTPResponseHead(
+    status: response.status.code,
+    headers: postgrestHeaderDictionary(from: response.headerFields)
+  )
+}

--- a/Sources/PostgREST/Transport/PostgrestTransportConversions.swift
+++ b/Sources/PostgREST/Transport/PostgrestTransportConversions.swift
@@ -1,0 +1,112 @@
+//
+//  PostgrestTransportConversions.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+
+import Foundation
+import HTTPRuntime
+import HTTPTypes
+
+/// Maps a method across the two spellings.
+///
+/// Written as an exhaustive switch rather than `HTTPTypes.HTTPRequest.Method(rawValue:)`, which is
+/// failable: every case here is known good, so there is no error path to invent, and adding a verb
+/// to `HTTPRuntime.HTTPMethod` becomes a compile error instead of a runtime `nil`.
+func postgrestHTTPMethod(
+  from method: HTTPRuntime.HTTPMethod
+) -> HTTPTypes.HTTPRequest.Method {
+  switch method {
+  case .get: .get
+  case .post: .post
+  case .put: .put
+  case .patch: .patch
+  case .delete: .delete
+  case .head: .head
+  }
+}
+
+/// Maps a method back, for a transport handing a request to `HTTPRuntime`.
+///
+/// - Throws: `HTTPRuntime.HTTPError.transport` for a method `HTTPRuntime` has no case for. Only
+///   reachable for verbs PostgREST never sends, such as `OPTIONS`.
+func postgrestHTTPMethod(
+  from method: HTTPTypes.HTTPRequest.Method
+) throws -> HTTPRuntime.HTTPMethod {
+  guard let mapped = HTTPRuntime.HTTPMethod(rawValue: method.rawValue) else {
+    throw HTTPRuntime.HTTPError.transport(PostgrestUnsupportedMethod(method: method.rawValue))
+  }
+  return mapped
+}
+
+/// Thrown for an HTTP method `HTTPRuntime` cannot express.
+struct PostgrestUnsupportedMethod: Error, Sendable, CustomStringConvertible {
+  let method: String
+
+  var description: String { "HTTPRuntime has no case for the HTTP method \(method)." }
+}
+
+/// Rebuilds a URL from the pseudo-header fields, without decoding the path or query.
+///
+/// - Throws: `URLError(.badURL)` when a pseudo-header field is missing or the pieces do not form a
+///   URL. Concatenation is deliberate: `URLComponents` would re-encode the query, and PostgREST
+///   needs an encoding stricter than Foundation's default.
+func postgrestRequestURL(from request: HTTPTypes.HTTPRequest) throws -> URL {
+  guard let scheme = request.scheme,
+    let authority = request.authority,
+    let path = request.path,
+    let url = URL(string: "\(scheme)://\(authority)\(path)")
+  else {
+    throw URLError(.badURL)
+  }
+  return url
+}
+
+/// Converts header fields to the dictionary `HTTPRuntime` uses.
+///
+/// Repeated field names are joined with `", "` per RFC 9110 section 5.3, which is what makes a
+/// dictionary a lossless representation for every field PostgREST sends or receives.
+///
+/// Names keep the casing they were written with — `rawName`, not `canonicalName`, which lowercases
+/// for HTTP/2. Every consumer downstream matches case-insensitively, so the choice only affects
+/// what a log or a recorded request looks like, and `Prefer` reads better there than `prefer`.
+func postgrestHeaderDictionary(from fields: HTTPTypes.HTTPFields) -> [String: String] {
+  var headers: [String: String] = [:]
+  for field in fields {
+    let name = field.name.rawName
+    // Match case-insensitively, or `Prefer` and `prefer` become two entries and one of them is
+    // dropped by whichever consumer looks the header up.
+    let key = headers.keys.first { $0.caseInsensitiveCompare(name) == .orderedSame } ?? name
+    if let existing = headers[key] {
+      headers[key] = "\(existing), \(field.value)"
+    } else {
+      headers[key] = field.value
+    }
+  }
+  return headers
+}
+
+/// Converts a header dictionary to header fields.
+///
+/// A name `HTTPTypes` rejects is dropped. That is unreachable for anything PostgREST builds, and
+/// the alternative — failing the whole request over one malformed name — is worse for a caller who
+/// set an odd header deliberately.
+func postgrestHeaderFields(from headers: [String: String]) -> HTTPTypes.HTTPFields {
+  var fields = HTTPTypes.HTTPFields()
+  for (name, value) in headers.sorted(by: { $0.key < $1.key }) {
+    guard let fieldName = HTTPTypes.HTTPField.Name(name) else { continue }
+    fields[fieldName] = value
+  }
+  return fields
+}
+
+/// Converts a response head to the `HTTPTypes` spelling.
+func postgrestHTTPResponse(
+  from head: HTTPRuntime.HTTPResponseHead
+) -> HTTPTypes.HTTPResponse {
+  HTTPTypes.HTTPResponse(
+    status: .init(code: head.status),
+    headerFields: postgrestHeaderFields(from: head.headers)
+  )
+}

--- a/Sources/PostgREST/Transport/URLSessionPostgrestTransport.swift
+++ b/Sources/PostgREST/Transport/URLSessionPostgrestTransport.swift
@@ -1,0 +1,54 @@
+//
+//  URLSessionPostgrestTransport.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+
+public import Foundation
+import HTTPRuntime
+public import HTTPTypes
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// The ``PostgrestTransport`` PostgREST uses when a caller supplies none, backed by `URLSession`.
+///
+/// Worth conforming through rather than around: a transport that only wants to observe or adjust a
+/// request can hold one of these and delegate, which keeps the URL assembly and its encoding rules
+/// in one place.
+public struct URLSessionPostgrestTransport: PostgrestTransport {
+  private let transport: HTTPRuntime.URLSessionTransport
+
+  /// Creates a transport over an existing session.
+  ///
+  /// - Parameter session: The session to send on. Defaults to `URLSession.shared`.
+  public init(session: URLSession = .shared) {
+    self.transport = HTTPRuntime.URLSessionTransport(session: session)
+  }
+
+  /// Creates a transport over a session built from a configuration.
+  ///
+  /// This is the seam for a request timeout: set `timeoutIntervalForRequest` on the configuration.
+  ///
+  /// - Parameter configuration: The configuration to build the session from.
+  public init(configuration: URLSessionConfiguration) {
+    self.transport = HTTPRuntime.URLSessionTransport(configuration: configuration)
+  }
+
+  public func send(
+    _ request: HTTPTypes.HTTPRequest, body: Data?
+  ) async throws -> (Data, HTTPTypes.HTTPResponse) {
+    let response = try await transport.send(
+      HTTPRuntime.HTTPRequest(
+        method: try postgrestHTTPMethod(from: request.method),
+        url: try postgrestRequestURL(from: request),
+        headers: postgrestHeaderDictionary(from: request.headerFields),
+        body: body.map { .data($0) }
+      )
+    )
+
+    return (response.body, postgrestHTTPResponse(from: response.head))
+  }
+}

--- a/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
+++ b/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
@@ -1,0 +1,416 @@
+//
+//  QueryEncodingTests.swift
+//  HTTPRuntime
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import HTTPRuntime
+
+@Suite
+struct QueryEncodingTests {
+  let baseURL = URL(string: "https://example.supabase.co")!
+
+  // MARK: - Encoding
+
+  @Test
+  func escapesPlusSoAFormDecodingServerCannotReadItAsASpace() {
+    // The reason this type exists. `URLComponents.queryItems` leaves both of these literal.
+    #expect(QueryEncoding.item("eq.+16505555555") == "eq.%2B16505555555")
+    #expect(
+      QueryEncoding.item("gt.2023-03-23T15:50:30.511743+00:00")
+        == "gt.2023-03-23T15%3A50%3A30.511743%2B00%3A00")
+  }
+
+  @Test
+  func escapesEveryDelimiterThatWouldOtherwiseEndTheItem() {
+    // `&` and `=` would end the parameter early and `%` would start an escape sequence. All three
+    // are values a caller can legitimately pass — a `like` pattern uses `%`.
+    #expect(QueryEncoding.item("eq.a&b=c%d") == "eq.a%26b%3Dc%25d")
+  }
+
+  @Test
+  func leavesSlashAndQuestionMarkAlone() {
+    // RFC 3986 section 3.4 allows both inside a query. Escaping them would make a URL passed as a
+    // parameter value unreadable in a log for no gain.
+    #expect(QueryEncoding.item("eq.https://example.com/a?b") == "eq.https%3A//example.com/a?b")
+  }
+
+  @Test
+  func rendersNothingForNoItems() {
+    #expect(QueryEncoding.render([]) == nil)
+  }
+
+  @Test
+  func rendersAValuelessItemWithoutAnEqualsSign() {
+    #expect(QueryEncoding.render([URLQueryItem(name: "columns", value: nil)]) == "columns")
+  }
+
+  @Test
+  func rendersNamesAsWellAsValues() {
+    // An embedded-resource filter puts a dot-qualified name on the left of the `=`, and a column
+    // name is caller data just as much as a value is.
+    let rendered = QueryEncoding.render([URLQueryItem(name: "a b&c", value: "eq.1")])
+
+    #expect(rendered == "a%20b%26c=eq.1")
+  }
+
+  // MARK: - The builder
+
+  @Test
+  func repeatedNamesBothSurvive() throws {
+    // Repeated-key encoding is the documented contract of `addQuery`, and PostgREST ANDs repeated
+    // keys — `.gt(\.id, 1).lt(\.id, 9)` needs both halves to arrive.
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("id", "gt.1")
+    builder.addQuery("id", "lt.9")
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?id=gt.1&id=lt.9")
+  }
+
+  @Test
+  func itemsKeepInsertionOrder() throws {
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("select", "*")
+    builder.addQuery("done", "eq.false")
+
+    let request = try builder.build()
+
+    #expect(
+      request.url.absoluteString == "https://example.supabase.co/todos?select=%2A&done=eq.false")
+  }
+
+  @Test
+  func noQueryItemsLeavesNoQuestionMark() throws {
+    let builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos")
+  }
+
+  @Test
+  func aNilValueIsSkipped() throws {
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("select", "*")
+    builder.addQuery("done", String?.none)
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?select=%2A")
+  }
+
+  @Test
+  func aValueIsNotEncodedTwice() throws {
+    // Items are stored unescaped and encoded once, at build time. Encoding on the way in would
+    // turn the `%` of an existing escape sequence into `%25`.
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("col", "eq.100%")
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?col=eq.100%25")
+  }
+
+  // MARK: - PostgREST's recorded wire format
+
+  @Test
+  func everySingleValueOperatorEscapesItsValueTheSameWay() throws {
+    // PostgREST's `test all filters and count` snapshot, which is really 25 repeats of one column
+    // name. It proves repeated keys survive at scale and that the space in `Some value` is escaped
+    // identically for every operator.
+    let operators = [
+      "eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "match", "imatch", "is",
+      "isdistinct", "in", "cs", "cd", "sl", "sr", "nxl", "nxr", "adj", "ov", "fts", "plfts",
+      "phfts", "wfts",
+    ]
+
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("select", "*")
+    for op in operators {
+      builder.addQuery("column", "\(op).Some value")
+    }
+
+    let request = try builder.build()
+
+    let expected =
+      "https://example.supabase.co/todos?select=%2A&"
+      + operators.map { "column=\($0).Some%20value" }.joined(separator: "&")
+    #expect(request.url.absoluteString == expected)
+  }
+
+  struct WireFormatCase: Sendable, CustomStringConvertible {
+    let name: String
+    let method: HTTPMethod
+    let path: String
+    let queryItems: [(name: String, value: String)]
+    let url: String
+
+    var description: String { name }
+  }
+
+  /// 30 of the 32 requests PostgREST records under
+  /// `Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/`, re-expressed against
+  /// `HTTPRequestBuilder`. PostgREST is `HTTPRuntime`'s first production consumer, and these are
+  /// the most varied real query values in the repository — JSON objects, range literals, `like`
+  /// patterns, a timestamptz offset, a non-ASCII string, a leading `+`.
+  ///
+  /// The expected strings are **not** copied from those snapshot files. Those are written by
+  /// swift-snapshot-testing's `.curl` strategy, which sorts the query items by name and re-encodes
+  /// them through `URLComponents.queryItems` — so `select=%2A` is recorded as `select=*` and
+  /// insertion order is lost. Each string below is the real `URLRequest.url` the legacy PostgREST
+  /// builder produces, captured by running the same 32 builder chains through a fetch handler that
+  /// prints it. Matching them means this encoding puts the same bytes on the wire as the API being
+  /// deprecated.
+  ///
+  /// The two left out have their own tests: the 25-operator case above, and `rpc call with get and
+  /// params`, whose legacy order is nondeterministic — `PostgrestClient.rpc(_:params:get:)`
+  /// iterates a `JSONValue` object, so it emits `index=2&array=…` on one run and `array=…&index=2`
+  /// on the next. Two captures of the same chain disagreed. The snapshot never caught it because
+  /// `.curl` sorts before recording. Parameter order does not change what PostgREST returns, so it
+  /// is not a wire bug, but it does make the request unreproducible in a log or a cache key, and
+  /// whoever rebuilds `rpc` on this builder has to choose an order.
+  static let wireFormatCases: [WireFormatCase] = [
+    .init(
+      name: "select all users where email ends with '@supabase.co'",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "like.%@supabase.co")],
+      url: "https://example.supabase.co/users?select=%2A&email=like.%25%40supabase.co"
+    ),
+    .init(
+      name: "insert new user",
+      method: .post,
+      path: "/users",
+      queryItems: [],
+      url: "https://example.supabase.co/users"
+    ),
+    .init(
+      name: "bulk insert users",
+      method: .post,
+      path: "/users",
+      queryItems: [("columns", "\"email\",\"username\"")],
+      url: "https://example.supabase.co/users?columns=%22email%22%2C%22username%22"
+    ),
+    .init(
+      name: "call rpc",
+      method: .post,
+      path: "/rpc/test_fcn",
+      queryItems: [],
+      url: "https://example.supabase.co/rpc/test_fcn"
+    ),
+    .init(
+      name: "call rpc without parameter",
+      method: .post,
+      path: "/rpc/test_fcn",
+      queryItems: [],
+      url: "https://example.supabase.co/rpc/test_fcn"
+    ),
+    .init(
+      name: "call rpc with filter",
+      method: .post,
+      path: "/rpc/test_fcn",
+      queryItems: [("id", "eq.1")],
+      url: "https://example.supabase.co/rpc/test_fcn?id=eq.1"
+    ),
+    .init(
+      name: "test in filter",
+      method: .get,
+      path: "/todos",
+      queryItems: [("select", "*"), ("id", "in.(1,2,3)")],
+      url: "https://example.supabase.co/todos?select=%2A&id=in.%281%2C2%2C3%29"
+    ),
+    .init(
+      name: "test contains filter with dictionary",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "name"), ("address", "cs.{\"postcode\":90210}")],
+      url: "https://example.supabase.co/users?select=name&address=cs.%7B%22postcode%22%3A90210%7D"
+    ),
+    .init(
+      name: "test contains filter with array",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("name", "cs.{is:online,faction:red}")],
+      url: "https://example.supabase.co/users?select=%2A&name=cs.%7Bis%3Aonline%2Cfaction%3Ared%7D"
+    ),
+    .init(
+      name: "test or filter with referenced table",
+      method: .get,
+      path: "/users",
+      queryItems: [
+        ("select", "*,messages(*)"), ("messages.or", "(public.eq.true,recipient_id.eq.1)"),
+      ],
+      url:
+        "https://example.supabase.co/users?select=%2A%2Cmessages%28%2A%29&messages.or=%28public.eq.true%2Crecipient_id.eq.1%29"
+    ),
+    .init(
+      name: "test upsert not ignoring duplicates",
+      method: .post,
+      path: "/users",
+      queryItems: [],
+      url: "https://example.supabase.co/users"
+    ),
+    .init(
+      name: "bulk upsert",
+      method: .post,
+      path: "/users",
+      queryItems: [("columns", "\"email\",\"username\"")],
+      url: "https://example.supabase.co/users?columns=%22email%22%2C%22username%22"
+    ),
+    .init(
+      name: "select after bulk upsert",
+      method: .post,
+      path: "/users",
+      queryItems: [("on_conflict", "username"), ("columns", "\"email\""), ("select", "*")],
+      url: "https://example.supabase.co/users?on_conflict=username&columns=%22email%22&select=%2A"
+    ),
+    .init(
+      name: "test upsert ignoring duplicates",
+      method: .post,
+      path: "/users",
+      queryItems: [],
+      url: "https://example.supabase.co/users"
+    ),
+    .init(
+      name: "query with + character",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("id", "eq.Cigányka-ér (0+400 cskm) vízrajzi állomás")],
+      url:
+        "https://example.supabase.co/users?select=%2A&id=eq.Cig%C3%A1nyka-%C3%A9r%20%280%2B400%20cskm%29%20v%C3%ADzrajzi%20%C3%A1llom%C3%A1s"
+    ),
+    .init(
+      name: "query with timestamptz",
+      method: .get,
+      path: "/tasks",
+      queryItems: [
+        ("select", "*"), ("received_at", "gt.2023-03-23T15:50:30.511743+00:00"),
+        ("order", "received_at.asc.nullslast"),
+      ],
+      url:
+        "https://example.supabase.co/tasks?select=%2A&received_at=gt.2023-03-23T15%3A50%3A30.511743%2B00%3A00&order=received_at.asc.nullslast"
+    ),
+    .init(
+      name: "query non-default schema",
+      method: .get,
+      path: "/objects",
+      queryItems: [("select", "*")],
+      url: "https://example.supabase.co/objects?select=%2A"
+    ),
+    .init(
+      name: "select after an insert",
+      method: .post,
+      path: "/users",
+      queryItems: [("select", "id,email")],
+      url: "https://example.supabase.co/users?select=id%2Cemail"
+    ),
+    .init(
+      name: "query if nil value",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "is.NULL")],
+      url: "https://example.supabase.co/users?select=%2A&email=is.NULL"
+    ),
+    .init(
+      name: "likeAllOf",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "like(all).{%@supabase.io,%@supabase.com}")],
+      url:
+        "https://example.supabase.co/users?select=%2A&email=like%28all%29.%7B%25%40supabase.io%2C%25%40supabase.com%7D"
+    ),
+    .init(
+      name: "likeAnyOf",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "like(any).{%@supabase.io,%@supabase.com}")],
+      url:
+        "https://example.supabase.co/users?select=%2A&email=like%28any%29.%7B%25%40supabase.io%2C%25%40supabase.com%7D"
+    ),
+    .init(
+      name: "iLikeAllOf",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "ilike(all).{%@supabase.io,%@supabase.com}")],
+      url:
+        "https://example.supabase.co/users?select=%2A&email=ilike%28all%29.%7B%25%40supabase.io%2C%25%40supabase.com%7D"
+    ),
+    .init(
+      name: "iLikeAnyOf",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("email", "ilike(any).{%@supabase.io,%@supabase.com}")],
+      url:
+        "https://example.supabase.co/users?select=%2A&email=ilike%28any%29.%7B%25%40supabase.io%2C%25%40supabase.com%7D"
+    ),
+    .init(
+      name: "containedBy using array",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("id", "cd.{a,b,c}")],
+      url: "https://example.supabase.co/users?select=%2A&id=cd.%7Ba%2Cb%2Cc%7D"
+    ),
+    .init(
+      name: "containedBy using range",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("age", "cd.[10,20]")],
+      url: "https://example.supabase.co/users?select=%2A&age=cd.%5B10%2C20%5D"
+    ),
+    .init(
+      name: "containedBy using json",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("userMetadata", "cd.{\"age\":18}")],
+      url: "https://example.supabase.co/users?select=%2A&userMetadata=cd.%7B%22age%22%3A18%7D"
+    ),
+    .init(
+      name: "filter starting with non-alphanumeric",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("to", "eq.+16505555555")],
+      url: "https://example.supabase.co/users?select=%2A&to=eq.%2B16505555555"
+    ),
+    .init(
+      name: "filter using Date",
+      method: .get,
+      path: "/users",
+      queryItems: [("select", "*"), ("created_at", "gt.1970-01-01T00:00:00.000Z")],
+      url: "https://example.supabase.co/users?select=%2A&created_at=gt.1970-01-01T00%3A00%3A00.000Z"
+    ),
+    .init(
+      name: "rpc call with head",
+      method: .head,
+      path: "/rpc/sum",
+      queryItems: [],
+      url: "https://example.supabase.co/rpc/sum"
+    ),
+    .init(
+      name: "rpc call with get",
+      method: .get,
+      path: "/rpc/sum",
+      queryItems: [],
+      url: "https://example.supabase.co/rpc/sum"
+    ),
+  ]
+
+  @Test(arguments: wireFormatCases)
+  func matchesTheRecordedPostgrestWireFormat(_ testCase: WireFormatCase) throws {
+    var builder = HTTPRequestBuilder(
+      method: testCase.method, baseURL: baseURL, path: testCase.path)
+    for item in testCase.queryItems {
+      builder.addQuery(item.name, item.value)
+    }
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == testCase.url)
+    #expect(request.method == testCase.method)
+  }
+}

--- a/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
+++ b/Tests/HTTPRuntimeTests/QueryEncodingTests.swift
@@ -117,6 +117,59 @@ struct QueryEncodingTests {
     #expect(request.url.absoluteString == "https://example.supabase.co/todos?col=eq.100%25")
   }
 
+  @Test
+  func setQueryReplacesInPlaceRatherThanMovingToTheEnd() throws {
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.setQuery("select", "*")
+    builder.addQuery("done", "eq.false")
+    builder.setQuery("select", "id,title")
+
+    let request = try builder.build()
+
+    #expect(
+      request.url.absoluteString
+        == "https://example.supabase.co/todos?select=id%2Ctitle&done=eq.false")
+  }
+
+  @Test
+  func setQueryAppendsWhenAbsent() throws {
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("done", "eq.false")
+    builder.setQuery("select", "*")
+
+    let request = try builder.build()
+
+    #expect(
+      request.url.absoluteString == "https://example.supabase.co/todos?done=eq.false&select=%2A")
+  }
+
+  @Test
+  func setQueryReplacesOnlyTheFirstOfARepeatedName() throws {
+    // A repeated name is a list or, in PostgREST's case, a conjunction on one column. Replacing
+    // every match would silently turn `id=gt.1&id=lt.9` into a single condition.
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.addQuery("id", "gt.1")
+    builder.addQuery("id", "lt.9")
+    builder.setQuery("id", "eq.5")
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?id=eq.5&id=lt.9")
+  }
+
+  @Test
+  func setQueryIgnoresNilValue() throws {
+    // Matches `addQuery`, so the same argument behaves the same way in both. It sets a value; it
+    // does not remove one.
+    var builder = HTTPRequestBuilder(method: .get, baseURL: baseURL, path: "/todos")
+    builder.setQuery("select", "*")
+    builder.setQuery("select", String?.none)
+
+    let request = try builder.build()
+
+    #expect(request.url.absoluteString == "https://example.supabase.co/todos?select=%2A")
+  }
+
   // MARK: - PostgREST's recorded wire format
 
   @Test

--- a/Tests/PostgRESTTests/PostgrestTransportTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTransportTests.swift
@@ -1,0 +1,361 @@
+//
+//  PostgrestTransportTests.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 22/08/26.
+//
+
+import ConcurrencyExtras
+import Foundation
+import HTTPRuntime
+import HTTPTypes
+import Mocker
+import TestHelpers
+import Testing
+
+@testable import PostgREST
+
+/// A transport that records what it was handed and replies with whatever it was told to.
+private struct RecordingTransport: PostgrestTransport {
+  let recorded = LockIsolated<[(request: HTTPTypes.HTTPRequest, body: Data?)]>([])
+  var status = 200
+  var responseHeaderFields = HTTPTypes.HTTPFields()
+  var responseBody = Data()
+  var failure: (any Error)?
+
+  func send(
+    _ request: HTTPTypes.HTTPRequest, body: Data?
+  ) async throws -> (Data, HTTPTypes.HTTPResponse) {
+    recorded.withValue { $0.append((request, body)) }
+    if let failure { throw failure }
+    return (
+      responseBody,
+      HTTPTypes.HTTPResponse(status: .init(code: status), headerFields: responseHeaderFields)
+    )
+  }
+}
+
+private struct StubFailure: Error, Equatable {}
+
+@Suite
+struct PostgrestTransportTests {
+
+  // MARK: - Request conversion
+
+  @Test
+  func passesMethodSchemeAuthorityAndPathThrough() async throws {
+    let transport = RecordingTransport()
+
+    _ = try await PostgrestTransportBridge(transport: transport).send(
+      HTTPRuntime.HTTPRequest(
+        method: .post,
+        url: URL(string: "https://example.supabase.co/rest/v1/todos")!
+      ))
+
+    let sent = try #require(transport.recorded.value.first).request
+    #expect(sent.method == .post)
+    #expect(sent.scheme == "https")
+    #expect(sent.authority == "example.supabase.co")
+    #expect(sent.path == "/rest/v1/todos")
+  }
+
+  @Test
+  func keepsThePathAndQueryPercentEncoded() async throws {
+    // The trap in this conversion. `URL.path` and `URLComponents.path` both decode, so reading
+    // either would hand the transport `select=*` where the wire carries `select=%2A` — and
+    // PostgREST's encoding is deliberately stricter than Foundation's default.
+    let transport = RecordingTransport()
+    let url = URL(
+      string: "https://example.supabase.co/todos?select=%2A&to=eq.%2B16505555555&c=eq.a%20b")!
+
+    _ = try await PostgrestTransportBridge(transport: transport).send(
+      HTTPRuntime.HTTPRequest(method: .get, url: url))
+
+    let sent = try #require(transport.recorded.value.first).request
+    #expect(sent.path == "/todos?select=%2A&to=eq.%2B16505555555&c=eq.a%20b")
+  }
+
+  @Test
+  func keepsAnExplicitPort() async throws {
+    let transport = RecordingTransport()
+
+    _ = try await PostgrestTransportBridge(transport: transport).send(
+      HTTPRuntime.HTTPRequest(
+        method: .get, url: URL(string: "http://localhost:54321/rest/v1/todos")!))
+
+    let sent = try #require(transport.recorded.value.first).request
+    #expect(sent.authority == "localhost:54321")
+    #expect(sent.path == "/rest/v1/todos")
+  }
+
+  @Test
+  func passesHeadersThrough() async throws {
+    let transport = RecordingTransport()
+
+    _ = try await PostgrestTransportBridge(transport: transport).send(
+      HTTPRuntime.HTTPRequest(
+        method: .get,
+        url: URL(string: "https://example.supabase.co/todos")!,
+        headers: ["Prefer": "count=exact", "Accept-Profile": "storage"]
+      ))
+
+    let sent = try #require(transport.recorded.value.first).request
+    #expect(sent.headerFields[.init("Prefer")!] == "count=exact")
+    #expect(sent.headerFields[.init("Accept-Profile")!] == "storage")
+  }
+
+  @Test
+  func passesADataBodyThroughUntouched() async throws {
+    let transport = RecordingTransport()
+    let body = Data(#"{"email":"johndoe@supabase.io"}"#.utf8)
+
+    _ = try await PostgrestTransportBridge(transport: transport).send(
+      HTTPRuntime.HTTPRequest(
+        method: .post, url: URL(string: "https://example.supabase.co/users")!, body: .data(body)))
+
+    #expect(try #require(transport.recorded.value.first).body == body)
+  }
+
+  @Test
+  func passesNoBodyAsNil() async throws {
+    let transport = RecordingTransport()
+
+    _ = try await PostgrestTransportBridge(transport: transport).send(
+      HTTPRuntime.HTTPRequest(method: .get, url: URL(string: "https://example.supabase.co/todos")!))
+
+    #expect(try #require(transport.recorded.value.first).body == nil)
+  }
+
+  @Test
+  func refusesAFileBackedBodyRatherThanBufferingIt() async throws {
+    // Reading the file in would defeat the reason `.file` exists. PostgREST never produces one, so
+    // this asserts the boundary is explicit rather than accidentally lenient.
+    let transport = RecordingTransport()
+    let request = HTTPRuntime.HTTPRequest(
+      method: .post,
+      url: URL(string: "https://example.supabase.co/users")!,
+      body: .file(URL(fileURLWithPath: "/tmp/upload.bin"))
+    )
+
+    await #expect(throws: HTTPRuntime.HTTPError.self) {
+      _ = try await PostgrestTransportBridge(transport: transport).send(request)
+    }
+    #expect(transport.recorded.value.isEmpty)
+  }
+
+  // MARK: - Response conversion
+
+  @Test
+  func convertsTheResponseStatusHeadersAndBody() async throws {
+    var transport = RecordingTransport()
+    transport.status = 206
+    transport.responseHeaderFields = [.contentRange: "0-9/100"]
+    transport.responseBody = Data("[]".utf8)
+
+    let response = try await PostgrestTransportBridge(transport: transport).send(
+      HTTPRuntime.HTTPRequest(method: .get, url: URL(string: "https://example.supabase.co/todos")!))
+
+    #expect(response.head.status == 206)
+    #expect(response.head.header("Content-Range") == "0-9/100")
+    #expect(response.body == Data("[]".utf8))
+  }
+
+  // MARK: - Failure paths
+
+  @Test
+  func wrapsATransportErrorRatherThanLosingIt() async throws {
+    var transport = RecordingTransport()
+    transport.failure = StubFailure()
+
+    let error = await #expect(throws: HTTPRuntime.HTTPError.self) {
+      _ = try await PostgrestTransportBridge(transport: transport).send(
+        HTTPRuntime.HTTPRequest(
+          method: .get, url: URL(string: "https://example.supabase.co/todos")!))
+    }
+
+    guard case .transport(let underlying) = try #require(error) else {
+      Issue.record("expected .transport, got \(String(describing: error))")
+      return
+    }
+    #expect(underlying as? StubFailure == StubFailure())
+  }
+
+  @Test
+  func refusesToStream() async throws {
+    // A `PostgrestTransport` returns a buffered response, so it cannot stream. Buffering the whole
+    // body and handing back a one-chunk stream would look like streaming while defeating it.
+    let transport = RecordingTransport()
+
+    await #expect(throws: HTTPRuntime.HTTPError.self) {
+      _ = try await PostgrestTransportBridge(transport: transport).stream(
+        HTTPRuntime.HTTPRequest(
+          method: .get, url: URL(string: "https://example.supabase.co/todos")!))
+    }
+  }
+
+  // MARK: - Conversion helpers
+
+  @Test
+  func repeatedHeaderFieldsJoinWithACommaPerRFC9110() {
+    var fields = HTTPTypes.HTTPFields()
+    fields.append(HTTPTypes.HTTPField(name: .init("Prefer")!, value: "count=exact"))
+    fields.append(HTTPTypes.HTTPField(name: .init("Prefer")!, value: "return=representation"))
+
+    #expect(
+      postgrestHeaderDictionary(from: fields)["Prefer"] == "count=exact, return=representation")
+  }
+
+  @Test
+  func mergesRepeatedHeaderNamesRegardlessOfCasing() {
+    // Otherwise `Prefer` and `prefer` become two dictionary entries and whichever consumer looks
+    // the header up sees only one of them.
+    var fields = HTTPTypes.HTTPFields()
+    fields.append(HTTPTypes.HTTPField(name: .init("Prefer")!, value: "count=exact"))
+    fields.append(HTTPTypes.HTTPField(name: .init("prefer")!, value: "return=representation"))
+
+    let headers = postgrestHeaderDictionary(from: fields)
+
+    #expect(headers.count == 1)
+    #expect(headers["Prefer"] == "count=exact, return=representation")
+  }
+
+  @Test
+  func rebuildsTheURLWithoutDecodingTheQuery() throws {
+    let request = HTTPTypes.HTTPRequest(
+      method: .get,
+      scheme: "https",
+      authority: "example.supabase.co",
+      path: "/todos?select=%2A&to=eq.%2B16505555555"
+    )
+
+    let url = try postgrestRequestURL(from: request)
+
+    #expect(
+      url.absoluteString
+        == "https://example.supabase.co/todos?select=%2A&to=eq.%2B16505555555")
+  }
+
+  @Test
+  func reportsAMethodHTTPRuntimeCannotExpress() {
+    // `OPTIONS` is a valid `HTTPTypes` method with no `HTTPRuntime.HTTPMethod` case. PostgREST
+    // never sends one, so this asserts the gap fails loudly instead of defaulting to GET.
+    #expect(throws: HTTPRuntime.HTTPError.self) {
+      _ = try postgrestHTTPMethod(from: HTTPTypes.HTTPRequest.Method.options)
+    }
+  }
+
+  @Test
+  func mapsEveryHTTPRuntimeMethod() {
+    let expected: [(HTTPRuntime.HTTPMethod, HTTPTypes.HTTPRequest.Method)] = [
+      (.get, .get), (.post, .post), (.put, .put), (.patch, .patch), (.delete, .delete),
+      (.head, .head),
+    ]
+
+    for (runtime, types) in expected {
+      #expect(postgrestHTTPMethod(from: runtime) == types)
+    }
+  }
+}
+
+extension PostgrestMockerTests {
+  @Suite(.mockerSerialized)
+  struct URLSessionPostgrestTransportTests {
+    /// Exercises the shipped implementation against a real `URLSession`, so the URL reassembly is
+    /// checked by URLSession's own parser rather than only by an assertion on a string.
+    private func transport() -> URLSessionPostgrestTransport {
+      let configuration = URLSessionConfiguration.default
+      configuration.protocolClasses = [MockingURLProtocol.self]
+      return URLSessionPostgrestTransport(configuration: configuration)
+    }
+
+    @Test
+    func sendsAndReturnsTheResponse() async throws {
+      Mock(
+        url: URL(string: "http://localhost:54321/rest/v1/todos")!,
+        ignoreQuery: true,
+        statusCode: 206,
+        data: [.get: Data("[]".utf8)],
+        additionalHeaders: ["Content-Range": "0-9/100"]
+      )
+      .register()
+
+      let (data, response) = try await transport().send(
+        HTTPTypes.HTTPRequest(
+          method: .get,
+          scheme: "http",
+          authority: "localhost:54321",
+          path: "/rest/v1/todos?select=%2A"
+        ),
+        body: nil
+      )
+
+      #expect(response.status.code == 206)
+      #expect(response.headerFields[.contentRange] == "0-9/100")
+      #expect(data == Data("[]".utf8))
+    }
+
+    @Test
+    func sendsTheQueryStringExactlyAsGiven() async throws {
+      // The round trip that matters: a strictly-escaped query has to survive URL reassembly and
+      // URLSession without being normalized back to its permissive spelling.
+      //
+      // Asserted on the recorded `URLRequest.url` rather than with `Mock.snapshotRequest`, because
+      // a curl snapshot cannot see this. That renderer sorts the query items and re-encodes them
+      // through `URLComponents`, which turns `%2A` back into `*` and `%2B` back into `+` — the
+      // exact regression this test exists to catch. Verified: the snapshot form of this assertion
+      // recorded `?select=*&to=eq.+16505555555` while the wire carried the escaped spelling.
+      let sent = LockIsolated<URLRequest?>(nil)
+      var mock = Mock(
+        url: URL(string: "http://localhost:54321/rest/v1/todos")!,
+        ignoreQuery: true,
+        statusCode: 200,
+        data: [.get: Data("[]".utf8)]
+      )
+      // Mocker calls this on the URL-loading queue, where Swift Testing has no current test, so a
+      // recorded issue there would be dropped. Capture now, assert after `send` returns.
+      mock.onRequestHandler = OnRequestHandler { request in
+        sent.setValue(request)
+      }
+      mock.register()
+
+      _ = try await transport().send(
+        HTTPTypes.HTTPRequest(
+          method: .get,
+          scheme: "http",
+          authority: "localhost:54321",
+          path: "/rest/v1/todos?select=%2A&to=eq.%2B16505555555"
+        ),
+        body: nil
+      )
+
+      let url = try #require(sent.value?.url)
+      #expect(
+        url.absoluteString
+          == "http://localhost:54321/rest/v1/todos?select=%2A&to=eq.%2B16505555555")
+    }
+
+    @Test
+    func sendsABody() async throws {
+      let body = Data(#"{"email":"johndoe@supabase.io"}"#.utf8)
+      Mock(
+        url: URL(string: "http://localhost:54321/rest/v1/users")!,
+        ignoreQuery: true,
+        statusCode: 201,
+        data: [.post: Data()]
+      )
+      .register()
+
+      let (_, response) = try await transport().send(
+        HTTPTypes.HTTPRequest(
+          method: .post,
+          scheme: "http",
+          authority: "localhost:54321",
+          path: "/rest/v1/users"
+        ),
+        body: body
+      )
+
+      #expect(response.status.code == 201)
+    }
+  }
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -71,6 +71,15 @@ supporting_symbols:
   - PostgrestRelation.columnName
   - PostgrestRelation.relationName
   - PostgrestRelation.schema
+  # The transport seam. `PostgrestTransport` is how a caller takes over
+  # sending — a timeout, an injected header, a test stub — so it underpins
+  # every database.* capability rather than belonging to one. `HTTPRuntime` is
+  # `package`, so it cannot appear here; this protocol is the public face of it.
+  - PostgrestTransport
+  - PostgrestTransport.send
+  - URLSessionPostgrestTransport
+  - URLSessionPostgrestTransport.init
+  - URLSessionPostgrestTransport.send
   - PostgrestRequestBuilder
   - PostgrestRequestBuilder.Operator
   - PostgrestRequestBuilder.execute


### PR DESCRIPTION
Closes SDK-1565. Stage 2 task 3, stacked on #1270.

Settles the open question spec §7 says must be settled before stage 2: **"How does a caller inject a transport?"**

```swift
public protocol PostgrestTransport: Sendable {
  func send(_ request: HTTPTypes.HTTPRequest, body: Data?) async throws
    -> (Data, HTTPTypes.HTTPResponse)
}
```

Nothing `package`-scoped appears in that signature, which is the whole reason it can be public. The two alternatives §4.7 lists lose for concrete reasons: promoting `HTTPRuntime` contradicts an explicit in-source comment (`HTTPMethod.swift`: "NEVER exposed as public SDK surface") and would put `HTTPError` under [ADR 0001](docs/adr/0001-public-error-types-are-structs.md) along with typed throws, `HTTPResponseStream`, `ProgressHandler` and `HTTPBody`; a URLSession-only seam drops the arbitrary interception standalone `PostgrestClient` users have today.

## The pipeline still speaks HTTPRuntime

Per §4.7, `HTTPRuntime` is reused rather than replaced. This is a façade over it, not a parallel implementation:

| | What happens |
| --- | --- |
| no custom transport | `HTTPRuntime.URLSessionTransport` used directly — nothing converts |
| custom transport | `PostgrestTransportBridge` adapts it to `HTTPRuntime.HTTPTransport` |

So the conversion cost is paid only by callers who take over the transport.

`URLSessionPostgrestTransport` is the shipped conformance, implemented over `HTTPRuntime.URLSessionTransport` rather than duplicating the URLSession handling. It exists mainly to be delegated to — a transport that only wants to observe or adjust should hold one and forward, which keeps URL assembly and its encoding rules in one place.

## Three conversion traps, each with a test

**The path must not be decoded.** `URL.path` and `URLComponents.path` both percent-decode, so reading either hands the transport `select=*` where the wire carries `select=%2A`. The bridge reads `percentEncodedPath`/`percentEncodedQuery` and rebuilds a URL by concatenation rather than through `URLComponents`, which would re-encode. This is the same hazard #1270 fixed one layer down; it would have been reintroduced here.

**A file-backed body is refused, not buffered.** Reading the file in would defeat the reason `HTTPBody.file` exists. PostgREST never produces one, so this throws `unsupportedRequestBody` rather than quietly working.

**Streaming fails loudly.** A `PostgrestTransport` returns a buffered `(Data, HTTPResponse)`. Buffering the whole body and handing back a one-chunk stream would look like streaming while defeating the point of it.

Header names keep the casing they were written with — `rawName`, not `canonicalName`, which lowercases for HTTP/2 — and repeated names merge case-insensitively, joined with `", "` per RFC 9110 §5.3.

## A curl snapshot cannot check the thing that matters

`sendsTheQueryStringExactlyAsGiven` asserts the recorded `URLRequest.url` directly, and the comment says why. Written first with `Mock.snapshotRequest`, it recorded

```
?select=*&to=eq.+16505555555
```

while the wire carried `?select=%2A&to=eq.%2B16505555555`. That renderer sorts the query items and re-encodes them through `URLComponents`, normalizing `%2A` back to `*` and `%2B` back to `+` — precisely the regression the test exists to catch. This is the hazard I flagged on #1270 for `HTTPRuntimeTestHelpers.curlCommand`, now confirmed for `TestHelpers`' `._curl` too. Worth knowing before SDK-1566 and SDK-1568 lean on those helpers.

The test also proves the strict escaping survives a real `URLSession`, not just a string assertion — it goes out through Mocker and comes back byte-identical.

## Not in this PR

The plan's Task 3 also deletes the hand-rolled retry loop and re-checks `db.retry`. Both need an execution path on the new core, and the typed API still executes through `Legacy/`. They belong with SDK-1568, which rebuilds the wrappers, and SDK-1572, which builds the client that holds a transport. Nothing wires a transport into a client yet, so this PR is the seam plus its bridge.

`Sources/PostgREST/Legacy/` is untouched.

## Verification

- `swift test` — 1291 tests in 135 suites pass (18 new)
- `./scripts/format.sh`, `./scripts/spell-check.sh` — clean
- `./scripts/test-docs.sh` — clean, no broken DocC links
- `sdk-compliance.yaml` — 5 new symbols under `supporting_symbols`, in its own commit