### PR TITLE
fix(postgrest): keep observed stored properties as columns

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e02e24d410edd1a54b0cc6c1b179cf93c6fab7b27de683761e1eb6b27f8e8b8c",
+  "originHash" : "66fc84e1d93fc7d8e6e79e85cb1c6583c07ea159d66325d0329cfeba57a7a06a",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -83,6 +83,15 @@
       }
     },
     {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
+      }
+    },
+    {
       "identity" : "swift-secp256k1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/21-DOT-DEV/swift-secp256k1.git",
@@ -105,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -197,6 +197,7 @@ let package = Package(
       name: "PostgrestMacrosTests",
       dependencies: [
         .product(name: "MacroTesting", package: "swift-macro-testing"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
         "PostgrestMacros",
         "PostgrestMacrosPlugin",
       ]

--- a/Package.swift
+++ b/Package.swift
@@ -183,6 +183,7 @@ let package = Package(
       name: "PostgrestMacrosPlugin",
       dependencies: [
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version:6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import CompilerPluginSupport
 import Foundation
 import PackageDescription
 
@@ -17,6 +18,9 @@ let package = Package(
     .library(name: "Auth", targets: ["Auth"]),
     .library(name: "Functions", targets: ["Functions"]),
     .library(name: "PostgREST", targets: ["PostgREST"]),
+    // Opt-in. `Supabase` deliberately does not re-export this, so swift-syntax is compiled
+    // only for users who write `import PostgrestMacros`.
+    .library(name: "PostgrestMacros", targets: ["PostgrestMacros"]),
     .library(name: "Realtime", targets: ["Realtime"]),
     .library(name: "Storage", targets: ["Storage"]),
     .library(name: "Supabase", targets: ["Supabase"]),
@@ -28,6 +32,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
     .package(url: "https://github.com/apple/swift-http-types.git", from: "1.3.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "601.0.0"..<"605.0.0"),
     // Pinned below 1.11.0: that version requires swift-tools-version 6.2, above this
     // package's current floor (Xcode 16.4+ / Swift 6.1). Widening this range raises
     // the effective minimum toolchain for every consumer — see SDK-1412.
@@ -36,6 +41,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
     .package(url: "https://github.com/WeTransfer/Mocker", from: "3.0.0"),
@@ -173,6 +179,28 @@ let package = Package(
         "__Snapshots__"
       ]
     ),
+    .macro(
+      name: "PostgrestMacrosPlugin",
+      dependencies: [
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      ]
+    ),
+    .target(
+      name: "PostgrestMacros",
+      dependencies: [
+        "PostgREST",
+        "PostgrestMacrosPlugin",
+      ]
+    ),
+    .testTarget(
+      name: "PostgrestMacrosTests",
+      dependencies: [
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+        "PostgrestMacros",
+        "PostgrestMacrosPlugin",
+      ]
+    ),
     .target(
       name: "RealtimeV2",
       dependencies: [
@@ -281,9 +309,16 @@ for target in package.targets {
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ImmutableWeakCaptures"),
     .enableUpcomingFeature("InferIsolatedConformances"),
-    .enableUpcomingFeature("InternalImportsByDefault"),
-    .enableUpcomingFeature("MemberImportVisibility"),
   ]
+
+  // The compiler-plugin target must declare its macro types `public` to satisfy SwiftSyntax's
+  // `CompilerPlugin` protocol, and `InternalImportsByDefault` rejects a public conformance to a
+  // protocol from an internally-imported module. Plugins run at build time and ship no
+  // distributable API, so the two import-visibility features gain nothing there.
+  if target.name != "PostgrestMacrosPlugin" {
+    swiftSettings.append(.enableUpcomingFeature("InternalImportsByDefault"))
+    swiftSettings.append(.enableUpcomingFeature("MemberImportVisibility"))
+  }
 
   target.swiftSettings = swiftSettings
 }

--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -1,0 +1,103 @@
+//
+//  PostgrestTypedMutation.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+/// A write request against a writable relation.
+///
+/// Obtain one from `insert`, `upsert`, `update` or `delete` on a ``PostgrestTypedSource``. Those
+/// methods exist only where the relation conforms to ``PostgrestWritableRelation``, so a read-only
+/// view cannot be written.
+///
+/// Like the builder it wraps, this is a value type: chaining off the same mutation twice gives
+/// two independent requests.
+public struct PostgrestTypedMutation<R: PostgrestWritableRelation>: PostgrestKeyPathFilterable,
+  Sendable
+{
+  public typealias Relation = R
+  public typealias Phase = PostgrestFilterPhase
+
+  /// The underlying string-based builder.
+  public let builder: PostgrestFilterBuilder
+
+  /// Wraps a builder in the typed mutation surface.
+  ///
+  /// - Parameter builder: The builder to wrap.
+  public init(builder: PostgrestFilterBuilder) {
+    self.builder = builder
+  }
+
+  /// Requests the affected rows back, decoded as `[R]`.
+  ///
+  /// This replaces the `Prefer` header rather than appending to it. The write methods set
+  /// `return=minimal` so a plain ``execute()`` does not transfer rows, and appending would leave
+  /// `Prefer: return=minimal,return=representation`, which is contradictory.
+  /// `return=representation` alone returns every column, so no `select` parameter is needed.
+  ///
+  /// > Note: Because this replaces the whole header, do not combine it with any other `Prefer`
+  /// > preference on a mutation. Slice 0 sets none.
+  ///
+  /// - Returns: A ``PostgrestTypedQuery`` decoding into `[R]`.
+  public func returning() -> PostgrestTypedQuery<R, [R], PostgrestFilterPhase> {
+    PostgrestTypedQuery(
+      builder: builder.setHeader(name: "Prefer", value: "return=representation")
+    )
+  }
+
+  /// Sends the request, discarding the response body.
+  @discardableResult
+  public func execute() async throws -> PostgrestResponse<Void> {
+    try await builder.execute()
+  }
+}
+
+extension PostgrestTypedSource where R: PostgrestWritableRelation {
+  /// Inserts a row.
+  ///
+  /// - Parameter values: The row to insert, in the relation's `Insert` shape. Primary keys and
+  ///   defaulted columns are absent or optional there.
+  /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func insert(_ values: R.Insert) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(builder: try builder.insert(values, returning: .minimal))
+  }
+
+  /// Inserts rows, updating any that conflict.
+  ///
+  /// - Parameters:
+  ///   - values: The rows to upsert.
+  ///   - onConflict: Comma-separated unique columns that determine a duplicate. Defaults to the
+  ///     relation's primary key.
+  /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func upsert(
+    _ values: R.Insert,
+    onConflict: String? = nil
+  ) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(
+      builder: try builder.upsert(values, onConflict: onConflict, returning: .minimal)
+    )
+  }
+
+  /// Updates the rows matched by the filters applied to the returned value.
+  ///
+  /// > Important: With no filter this updates every row in the relation.
+  ///
+  /// - Parameter values: The columns to change, in the relation's `Update` shape.
+  /// - Returns: A ``PostgrestTypedMutation`` to scope, then execute.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func update(_ values: R.Update) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(builder: try builder.update(values, returning: .minimal))
+  }
+
+  /// Deletes the rows matched by the filters applied to the returned value.
+  ///
+  /// > Important: With no filter this deletes every row in the relation.
+  ///
+  /// - Returns: A ``PostgrestTypedMutation`` to scope, then execute.
+  public func delete() -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(builder: builder.delete(returning: .minimal))
+  }
+}

--- a/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
@@ -1,0 +1,108 @@
+//
+//  PostgrestTypedQuery+Filters.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+/// A wrapper that scopes a request by key path.
+///
+/// ``PostgrestTypedQuery`` conforms, so the key-path filter set is declared once here rather than
+/// repeated on every wrapper that needs it. You do not conform your own types to this.
+///
+/// Only filters live here. `order` and `limit` move the request into
+/// ``PostgrestTransformPhase``, so they cannot return `Self` and are declared on
+/// ``PostgrestTypedQuery`` instead.
+public protocol PostgrestKeyPathFilterable {
+  /// The relation whose key paths this wrapper accepts.
+  associatedtype Relation: PostgrestRelation
+
+  /// The phase of the underlying request. Filters require a filterable phase.
+  associatedtype Phase: PostgrestFilterablePhase
+
+  /// The underlying string-based builder.
+  var builder: PostgrestRequestBuilder<Phase> { get }
+
+  /// Wraps a builder, preserving the wrapper's type.
+  init(builder: PostgrestRequestBuilder<Phase>)
+}
+
+extension PostgrestTypedQuery: PostgrestKeyPathFilterable
+where Phase: PostgrestFilterablePhase {
+  public typealias Relation = R
+}
+
+extension PostgrestKeyPathFilterable {
+  /// Matches rows where the column at `column` equals `value`.
+  public func eq<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.eq(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is not equal to `value`.
+  public func neq<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.neq(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is greater than `value`.
+  public func gt<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.gt(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is greater than or equal to `value`.
+  public func gte<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.gte(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is less than `value`.
+  public func lt<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.lt(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is less than or equal to `value`.
+  public func lte<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
+    Self(builder: builder.lte(Relation.columnName(for: column), value: value))
+  }
+
+  /// Matches rows where the column at `column` is one of `values`.
+  public func `in`<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ values: [V]) -> Self {
+    Self(builder: builder.in(Relation.columnName(for: column), values: values))
+  }
+
+  /// Matches rows where the optional column at `column` is SQL `NULL`.
+  public func isNull<V>(_ column: KeyPath<Relation, V?>) -> Self {
+    Self(builder: builder.filter(Relation.columnName(for: column), operator: "is", value: "null"))
+  }
+
+  /// Matches rows where the optional column at `column` is not SQL `NULL`.
+  public func isNotNull<V>(_ column: KeyPath<Relation, V?>) -> Self {
+    Self(
+      builder: builder.filter(Relation.columnName(for: column), operator: "not.is", value: "null")
+    )
+  }
+}
+
+extension PostgrestTypedQuery where Phase: PostgrestTransformablePhase {
+  /// Sorts the result by the column at `column`.
+  ///
+  /// Ordering moves the request into ``PostgrestTransformPhase``, so no further filter can be
+  /// applied after it — the same rule the string-based builders follow.
+  public func order<V>(
+    _ column: KeyPath<R, V>,
+    ascending: Bool = true,
+    nullsFirst: Bool = false
+  ) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> {
+    PostgrestTypedQuery<R, Output, PostgrestTransformPhase>(
+      builder: builder.order(
+        R.columnName(for: column), ascending: ascending, nullsFirst: nullsFirst
+      )
+    )
+  }
+
+  /// Limits the number of rows returned.
+  ///
+  /// Like ``order(_:ascending:nullsFirst:)`` this moves the request into
+  /// ``PostgrestTransformPhase``.
+  public func limit(_ count: Int) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> {
+    PostgrestTypedQuery<R, Output, PostgrestTransformPhase>(builder: builder.limit(count))
+  }
+}

--- a/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
@@ -7,8 +7,9 @@
 
 /// A wrapper that scopes a request by key path.
 ///
-/// ``PostgrestTypedQuery`` conforms, so the key-path filter set is declared once here rather than
-/// repeated on every wrapper that needs it. You do not conform your own types to this.
+/// Both ``PostgrestTypedQuery`` and ``PostgrestTypedMutation`` conform, so the key-path filter set
+/// is declared once here rather than repeated on every wrapper. You do not conform your own types
+/// to this.
 ///
 /// Only filters live here. `order` and `limit` move the request into
 /// ``PostgrestTransformPhase``, so they cannot return `Self` and are declared on

--- a/Sources/PostgREST/Query/PostgrestTypedSource.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedSource.swift
@@ -37,4 +37,23 @@ public struct PostgrestTypedSource<R: PostgrestRelation>: Sendable {
   public func select() -> PostgrestTypedQuery<R, [R], PostgrestFilterPhase> {
     PostgrestTypedQuery(builder: builder.select(R.selectString))
   }
+
+  /// Selects the columns declared by a selection type.
+  ///
+  /// ```swift
+  /// let rows = try await client.from(Todo.self).select(TodoSummary.self).execute().value
+  /// ```
+  ///
+  /// The `where` clause is what makes a declared selection safe to pass around: a selection names
+  /// the relation it was declared against, so handing it to a different relation is *no such
+  /// overload* rather than a request PostgREST rejects.
+  ///
+  /// - Parameter selection: A type declaring the columns to fetch, normally annotated with
+  ///   `@SelectionOf` from the `PostgrestMacros` module.
+  /// - Returns: A ``PostgrestTypedQuery`` decoding into `[S]`.
+  public func select<S: PostgrestSelection>(
+    _ selection: S.Type
+  ) -> PostgrestTypedQuery<R, [S], PostgrestFilterPhase> where S.Source == R {
+    PostgrestTypedQuery(builder: builder.select(S.selectString))
+  }
 }

--- a/Sources/PostgREST/Relations/PostgrestRelation.swift
+++ b/Sources/PostgREST/Relations/PostgrestRelation.swift
@@ -11,6 +11,13 @@
 /// `PostgrestMacros` module, or emitted by the schema generator. Hand-written conformances are
 /// supported and are the escape hatch when neither fits.
 public protocol PostgrestSelection: Decodable, Sendable {
+  /// The relation this shape selects from.
+  ///
+  /// Naming the source is what stops a selection being handed to the wrong relation. A relation is
+  /// its own source, fixed by the same-type constraint on ``PostgrestRelation``, so a hand-written
+  /// relation conformance declares nothing here.
+  associatedtype Source: PostgrestRelation
+
   /// The PostgREST `select` expression for this shape, for example `"id,task"`.
   static var selectString: String { get }
 }
@@ -19,7 +26,7 @@ public protocol PostgrestSelection: Decodable, Sendable {
 ///
 /// "Relation" is Postgres's own term for that family. Selecting a whole row is the degenerate
 /// selection, which is why this refines ``PostgrestSelection``.
-public protocol PostgrestRelation: PostgrestSelection {
+public protocol PostgrestRelation: PostgrestSelection where Source == Self {
   /// The relation's name as PostgREST addresses it.
   static var relationName: String { get }
 

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -8,3 +8,66 @@
 // Re-exported so a single `import PostgrestMacros` is enough: the macros synthesize conformances to
 // protocols that live in `PostgREST`, and a user should not have to import both.
 @_exported public import PostgREST
+
+/// Synthesizes ``PostgrestRelation`` conformance for a struct that maps to a relation.
+///
+/// ```swift
+/// @Table("todos")
+/// struct Todo {
+///   @PrimaryKey var id: Int
+///   var task: String
+///   @Default var isDone: Bool
+///   @Column("due_at") var dueDate: Date?
+/// }
+/// ```
+///
+/// Property names convert camelCase to snake_case; ``Column(_:)`` overrides a single name. The
+/// generated `CodingKeys` and the generated column mapping come from the same input, so an insert
+/// body and a filter can never disagree about a column.
+///
+/// The annotated type must be declared at file scope. The macro attaches an extension, and Swift
+/// does not allow an extension of a type nested inside another type.
+///
+/// - Parameters:
+///   - name: The relation's name as PostgREST addresses it.
+///   - schema: The Postgres schema. Defaults to `"public"`.
+///   - readOnly: Pass `true` for a view. The type then conforms to ``PostgREST/PostgrestRelation``
+///     only, and the write methods are not available on it.
+@attached(
+  extension,
+  conformances: Decodable, Sendable, PostgrestRelation, PostgrestWritableRelation,
+  names: named(relationName), named(schema), named(selectString), named(columnName(for:)),
+  named(CodingKeys), named(Insert), named(Update)
+)
+public macro Table(
+  _ name: String,
+  schema: String = "public",
+  readOnly: Bool = false
+) = #externalMacro(module: "PostgrestMacrosPlugin", type: "TableMacro")
+
+/// Overrides the database column name for a property.
+///
+/// Use it for any name the camelCase-to-snake_case convention cannot produce.
+///
+/// - Parameter name: The column name PostgREST expects.
+@attached(peer)
+public macro Column(_ name: String) =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "MarkerMacro"
+  )
+
+/// Marks a property as the relation's primary key, excluding it from the generated `Insert`.
+@attached(peer)
+public macro PrimaryKey() =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "MarkerMacro"
+  )
+
+/// Marks a property as having a database default, making it optional in the generated `Insert`.
+///
+/// Leaving it `nil` omits the column from the request body, so the database fills it in.
+@attached(peer)
+public macro Default() =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "MarkerMacro"
+  )

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -71,3 +71,33 @@ public macro Default() =
   #externalMacro(
     module: "PostgrestMacrosPlugin", type: "MarkerMacro"
   )
+
+/// Declares a named subset of a relation's columns.
+///
+/// ```swift
+/// @SelectionOf(Todo.self)
+/// struct TodoSummary {
+///   var id: Int
+///   var isDone: Bool
+/// }
+///
+/// let rows = try await client.from(Todo.self).select(TodoSummary.self).execute().value
+/// ```
+///
+/// Property names follow the same snake_case conversion as ``Table(_:schema:readOnly:)``, and
+/// ``Column(_:)`` overrides one. The expansion emits references to the relation's own columns, so a
+/// property that names no column on it fails to compile.
+///
+/// The annotated type must be declared at file scope. The macro attaches an extension, and Swift
+/// does not allow an extension of a type nested inside another type.
+///
+/// - Parameter relation: The relation this selects from, for example `Todo.self`.
+@attached(
+  extension,
+  conformances: Decodable, Sendable, PostgrestSelection,
+  names: named(Source), named(selectString), named(CodingKeys), named(_columnCheck)
+)
+public macro SelectionOf(_ relation: Any.Type) =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "SelectionOfMacro"
+  )

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -1,0 +1,10 @@
+//
+//  Macros.swift
+//  PostgrestMacros
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+// Re-exported so a single `import PostgrestMacros` is enough: the macros synthesize conformances to
+// protocols that live in `PostgREST`, and a user should not have to import both.
+@_exported public import PostgREST

--- a/Sources/PostgrestMacrosPlugin/MarkerMacros.swift
+++ b/Sources/PostgrestMacrosPlugin/MarkerMacros.swift
@@ -1,0 +1,20 @@
+//
+//  MarkerMacros.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// The marker attributes carry no expansion of their own — `@Table` reads them off the properties.
+public struct MarkerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    []
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/Plugin.swift
+++ b/Sources/PostgrestMacrosPlugin/Plugin.swift
@@ -10,5 +10,8 @@ import SwiftSyntaxMacros
 
 @main
 struct PostgrestMacrosPlugin: CompilerPlugin {
-  let providingMacros: [any Macro.Type] = []
+  let providingMacros: [any Macro.Type] = [
+    MarkerMacro.self,
+    TableMacro.self,
+  ]
 }

--- a/Sources/PostgrestMacrosPlugin/Plugin.swift
+++ b/Sources/PostgrestMacrosPlugin/Plugin.swift
@@ -12,6 +12,7 @@ import SwiftSyntaxMacros
 struct PostgrestMacrosPlugin: CompilerPlugin {
   let providingMacros: [any Macro.Type] = [
     MarkerMacro.self,
+    SelectionOfMacro.self,
     TableMacro.self,
   ]
 }

--- a/Sources/PostgrestMacrosPlugin/Plugin.swift
+++ b/Sources/PostgrestMacrosPlugin/Plugin.swift
@@ -1,0 +1,14 @@
+//
+//  Plugin.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct PostgrestMacrosPlugin: CompilerPlugin {
+  let providingMacros: [any Macro.Type] = []
+}

--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -40,6 +40,9 @@ public struct SelectionOfMacro: ExtensionMacro {
       )
       return []
     }
+    if declaration.postgrestDiagnoseUnannotatedProperties(macro: "@SelectionOf", in: context) {
+      return []
+    }
     let access = declaration.postgrestAccessLevel
     let properties = declaration.postgrestStoredProperties()
 

--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -30,12 +30,15 @@ public struct SelectionOfMacro: ExtensionMacro {
     in context: some MacroExpansionContext
   ) throws -> [ExtensionDeclSyntax] {
     guard declaration.is(StructDeclSyntax.self) else {
-      throw MacroExpansionErrorMessage("@SelectionOf can only be applied to a struct")
+      context.error("@SelectionOf can only be applied to a struct", at: node)
+      return []
     }
     guard let relation = relation(from: node) else {
-      throw MacroExpansionErrorMessage(
-        "@SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)"
+      context.error(
+        "@SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)",
+        at: node
       )
+      return []
     }
     let access = declaration.postgrestAccessLevel
     let properties = declaration.postgrestStoredProperties()

--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -1,0 +1,83 @@
+//
+//  SelectionOfMacro.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Expands `@SelectionOf` into a selection conformance.
+///
+/// Like ``TableMacro``, everything is emitted from the extension role and the inheritance clause
+/// names the whole refinement chain — a macro-generated extension derives neither.
+public struct SelectionOfMacro: ExtensionMacro {
+  /// The relation named by `@SelectionOf(Todo.self)`, or `nil` if the argument is not a `T.self`.
+  static func relation(from node: AttributeSyntax) -> String? {
+    guard
+      let expression = node.arguments?.as(LabeledExprListSyntax.self)?.first?.expression,
+      let base = expression.as(MemberAccessExprSyntax.self)?.base
+    else { return nil }
+    return base.trimmedDescription
+  }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    guard declaration.is(StructDeclSyntax.self) else {
+      throw MacroExpansionErrorMessage("@SelectionOf can only be applied to a struct")
+    }
+    guard let relation = relation(from: node) else {
+      throw MacroExpansionErrorMessage(
+        "@SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)"
+      )
+    }
+    let access = declaration.postgrestAccessLevel
+    let properties = declaration.postgrestStoredProperties()
+
+    var body: [String] = [
+      "  \(access)typealias Source = \(relation)",
+      "  \(access)static let selectString = \"\(properties.map(\.columnName).joined(separator: ","))\"",
+    ]
+    if let codingKeys = codingKeys(for: properties) {
+      body.append(codingKeys)
+    }
+    body.append(columnCheck(relation: relation, properties: properties))
+
+    let clause = inheritanceClause(
+      wanted: ["Decodable", "Sendable", "PostgrestSelection"], missing: protocols
+    )
+    return [
+      try ExtensionDeclSyntax(
+        """
+        extension \(type.trimmed)\(raw: clause) {
+        \(raw: body.joined(separator: "\n\n"))
+        }
+        """
+      )
+    ]
+  }
+
+  /// The cross-type check.
+  ///
+  /// A macro sees syntax only and cannot inspect the relation's members. It can *emit* references
+  /// to them, though, and the compiler checks the expansion — so a property that names no column
+  /// on the relation fails on the emitted line. That is what makes a declared selection fully
+  /// checked rather than checked by convention.
+  static func columnCheck(relation: String, properties: [StoredProperty]) -> String {
+    var lines = [
+      "  /// Fails to compile if a property does not name a column on \(relation).",
+      "  private static let _columnCheck: [String] = [",
+    ]
+    for property in properties {
+      lines.append("    \(relation).columnName(for: \\\(relation).\(property.name)),")
+    }
+    lines.append("  ]")
+    return lines.joined(separator: "\n")
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/Support/CamelToSnake.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/CamelToSnake.swift
@@ -1,0 +1,30 @@
+//
+//  CamelToSnake.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+/// Converts a Swift property name to its snake_case database column name.
+///
+/// `isDone` becomes `is_done`; `dueDate` becomes `due_date`; an already-lowercase name is unchanged.
+/// A run of capitals is one word, so `htmlURL` becomes `html_url` and `urlSession` stays
+/// `url_session`.
+func camelToSnakeCase(_ name: String) -> String {
+  var out = ""
+  var previousWasUpper = false
+  for (index, character) in name.enumerated() {
+    if character.isUppercase {
+      let nextIsLower = name.dropFirst(index + 1).first?.isLowercase ?? false
+      if index > 0, !previousWasUpper || nextIsLower {
+        out.append("_")
+      }
+      out.append(Character(character.lowercased()))
+      previousWasUpper = true
+    } else {
+      out.append(character)
+      previousWasUpper = false
+    }
+  }
+  return out
+}

--- a/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
@@ -72,7 +72,7 @@ extension DeclGroupSyntax {
         let binding = variable.bindings.first,
         let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
         binding.typeAnnotation == nil,
-        binding.accessorBlock == nil
+        binding.postgrestIsStored
       else { continue }
 
       let name = identifier.identifier.text

--- a/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
@@ -45,3 +45,47 @@ extension DeclGroupSyntax {
     return nil
   }
 }
+
+extension DeclGroupSyntax {
+  /// Reports every stored property whose type comes only from its initializer.
+  ///
+  /// `postgrestStoredProperties()` reads syntax, so `var isDone = false` gives it no annotation to
+  /// read and the property is dropped from `CodingKeys`, `columnName(for:)`, `Insert` and `Update`.
+  /// Nothing about that is loud: the initializer doubles as a decoding default, so the type still
+  /// compiles, the column simply never round-trips, and the mistake surfaces only when a query
+  /// names the key path and hits the generated `fatalError`. A macro cannot recover the type from
+  /// the initializer expression, so the author is asked for an annotation instead.
+  ///
+  /// Returns `true` if anything was reported, so the caller can stop before emitting an expansion
+  /// that leaves the column out.
+  func postgrestDiagnoseUnannotatedProperties(
+    macro: String,
+    in context: some MacroExpansionContext
+  ) -> Bool {
+    var reported = false
+    // The same members `postgrestStoredProperties()` would have taken, minus the annotation: a
+    // static member or a computed property maps to no column by design, not by mistake.
+    for member in memberBlock.members {
+      guard
+        let variable = member.decl.as(VariableDeclSyntax.self),
+        !variable.modifiers.contains(where: { $0.name.text == "static" }),
+        let binding = variable.bindings.first,
+        let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+        binding.typeAnnotation == nil,
+        binding.accessorBlock == nil
+      else { continue }
+
+      let name = identifier.identifier.text
+      context.error(
+        """
+        \(macro) requires an explicit type annotation on '\(name)', as in \
+        'var \(name): <Type> = ...' — without one the macro cannot infer the type, and the column \
+        is dropped
+        """,
+        at: binding.pattern
+      )
+      reported = true
+    }
+    return reported
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
@@ -1,0 +1,47 @@
+//
+//  Diagnostics.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// An error attached to a specific syntax node.
+///
+/// Throwing `MacroExpansionErrorMessage` puts the caret on the attribute, which is wrong for a
+/// per-property misuse: the reader needs to see the property that caused it.
+struct PostgrestDiagnostic: DiagnosticMessage {
+  let message: String
+  var severity: DiagnosticSeverity { .error }
+  var diagnosticID: MessageID { MessageID(domain: "PostgrestMacros", id: message) }
+}
+
+extension MacroExpansionContext {
+  /// Emits an error pointing at `node`.
+  func error(_ message: String, at node: some SyntaxProtocol) {
+    diagnose(Diagnostic(node: node, message: PostgrestDiagnostic(message: message)))
+  }
+}
+
+extension DeclGroupSyntax {
+  /// The first `@Relationship` attribute on a stored property, if any.
+  ///
+  /// Embeds belong to a selection, never to a relation (spec §4.5), so `@Table` rejects one.
+  ///
+  /// Forward-looking: `@Relationship` itself lands in stage 3, so today a user who writes it gets
+  /// "unknown attribute" from the compiler first. Matching on the attribute *name* puts the guard
+  /// in place for the day the macro exists.
+  func postgrestRelationshipAttribute() -> AttributeSyntax? {
+    for member in memberBlock.members {
+      guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+      for attribute in variable.attributes.compactMap({ $0.as(AttributeSyntax.self) })
+      where attribute.attributeName.trimmedDescription == "Relationship" {
+        return attribute
+      }
+    }
+    return nil
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/Support/Generation.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Generation.swift
@@ -1,0 +1,39 @@
+//
+//  Generation.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+
+/// The `CodingKeys` enum for a property list, or `nil` when there is nothing to map.
+///
+/// `@Table` and `@SelectionOf` share it so a relation and a selection of it spell the same column
+/// the same way.
+func codingKeys(for properties: [StoredProperty], indent: String = "  ") -> String? {
+  guard !properties.isEmpty else { return nil }
+  var lines = ["\(indent)enum CodingKeys: String, CodingKey {"]
+  for property in properties {
+    lines.append("\(indent)  case \(property.name) = \"\(property.columnName)\"")
+  }
+  lines.append("\(indent)}")
+  return lines.joined(separator: "\n")
+}
+
+/// The inheritance clause to emit on a macro-generated extension, or `""` when there is nothing
+/// left to add.
+///
+/// Two rules are baked in, and both fail confusingly if you skip them:
+///
+/// - `wanted` must name every protocol in the refinement chain. A macro-generated extension does
+///   not derive an inherited conformance, so `extension Todo: PostgrestWritableRelation` alone
+///   reports a missing `PostgrestRelation` with no note saying which requirement is unmet.
+/// - `missing` is the compiler's `conformingTo:` list, which excludes whatever the type already
+///   declares. Filtering by it is what keeps `struct Todo: Decodable` from getting a second
+///   `Decodable` conformance.
+func inheritanceClause(wanted: [String], missing: [TypeSyntax]) -> String {
+  let missing = Set(missing.map(\.trimmedDescription))
+  let needed = wanted.filter(missing.contains)
+  return needed.isEmpty ? "" : ": \(needed.joined(separator: ", "))"
+}

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -1,0 +1,80 @@
+//
+//  StoredProperty.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+
+/// One stored property of an annotated type, with the marker attributes that affect it.
+struct StoredProperty {
+  var name: String
+  var type: String
+  var isOptional: Bool
+  var isPrimaryKey: Bool
+  var hasDefault: Bool
+  var explicitColumn: String?
+
+  /// The database column name: an explicit `@Column`, otherwise the snake_case form.
+  var columnName: String { explicitColumn ?? camelToSnakeCase(name) }
+
+  /// The property's type made optional, or left alone if it already is.
+  var optionalType: String { isOptional ? type : "\(type)?" }
+}
+
+extension DeclGroupSyntax {
+  /// Reads the stored properties, skipping computed properties and static members.
+  ///
+  /// A key path to a skipped property therefore maps to no column, which is what the generated
+  /// `columnName(for:)` traps on.
+  func postgrestStoredProperties() -> [StoredProperty] {
+    memberBlock.members.compactMap { member -> StoredProperty? in
+      guard
+        let variable = member.decl.as(VariableDeclSyntax.self),
+        !variable.modifiers.contains(where: { $0.name.text == "static" }),
+        let binding = variable.bindings.first,
+        let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+        let annotation = binding.typeAnnotation?.type,
+        binding.accessorBlock == nil
+      else { return nil }
+
+      let attributes = variable.attributes.compactMap { $0.as(AttributeSyntax.self) }
+      func attribute(_ name: String) -> AttributeSyntax? {
+        attributes.first { $0.attributeName.trimmedDescription == name }
+      }
+
+      let column =
+        attribute("Column")?
+        .arguments?.as(LabeledExprListSyntax.self)?.first?
+        .expression.as(StringLiteralExprSyntax.self)?
+        .representedLiteralValue
+
+      let typeText = annotation.trimmedDescription
+      return StoredProperty(
+        name: identifier.identifier.text,
+        type: typeText,
+        isOptional: typeText.hasSuffix("?") || typeText.hasPrefix("Optional<"),
+        isPrimaryKey: attribute("PrimaryKey") != nil,
+        hasDefault: attribute("Default") != nil,
+        explicitColumn: column
+      )
+    }
+  }
+
+  /// The access level to repeat on generated members, with a trailing space, or `""`.
+  ///
+  /// Only `public` and `package` are propagated. A protocol witness must be at least as accessible
+  /// as the conformance, and an internal witness already satisfies a `fileprivate` or `private`
+  /// one.
+  var postgrestAccessLevel: String {
+    for modifier in modifiers {
+      switch modifier.name.tokenKind {
+      case .keyword(.public): return "public "
+      case .keyword(.package): return "package "
+      default: continue
+      }
+    }
+    return ""
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -23,6 +23,31 @@ struct StoredProperty {
   var optionalType: String { isOptional ? type : "\(type)?" }
 }
 
+extension PatternBindingSyntax {
+  /// Whether the binding stores a value, rather than computing one.
+  ///
+  /// A non-nil `accessorBlock` is not enough to call a property computed: `willSet` and `didSet`
+  /// land in that same block, and an observed property still holds a value and still needs its
+  /// column. Anything else in the block computes the value instead — an explicit `get`, a `_read`
+  /// or `unsafeAddress` accessor, or a bare code block standing in for an implicit getter — and
+  /// maps to no column.
+  var postgrestIsStored: Bool {
+    guard let accessorBlock else { return true }
+    switch accessorBlock.accessors {
+    case .getter:
+      // `var summary: String { htmlURL }` — an implicit getter, with no accessor to inspect.
+      return false
+    case .accessors(let accessors):
+      return accessors.allSatisfy {
+        switch $0.accessorSpecifier.tokenKind {
+        case .keyword(.willSet), .keyword(.didSet): return true
+        default: return false
+        }
+      }
+    }
+  }
+}
+
 extension DeclGroupSyntax {
   /// Reads the stored properties, skipping computed properties and static members.
   ///
@@ -41,7 +66,7 @@ extension DeclGroupSyntax {
         let binding = variable.bindings.first,
         let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
         let annotation = binding.typeAnnotation?.type,
-        binding.accessorBlock == nil
+        binding.postgrestIsStored
       else { return nil }
 
       let attributes = variable.attributes.compactMap { $0.as(AttributeSyntax.self) }

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -28,6 +28,11 @@ extension DeclGroupSyntax {
   ///
   /// A key path to a skipped property therefore maps to no column, which is what the generated
   /// `columnName(for:)` traps on.
+  ///
+  /// A property whose type comes only from its initializer is skipped as well — there is no
+  /// annotation to read. That one is a mistake rather than a design, so
+  /// `postgrestDiagnoseUnannotatedProperties(macro:in:)` reports it and the macro stops before
+  /// anything reaches here.
   func postgrestStoredProperties() -> [StoredProperty] {
     memberBlock.members.compactMap { member -> StoredProperty? in
       guard

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -58,7 +58,15 @@ public struct TableMacro: ExtensionMacro {
     in context: some MacroExpansionContext
   ) throws -> [ExtensionDeclSyntax] {
     guard declaration.is(StructDeclSyntax.self) else {
-      throw MacroExpansionErrorMessage("@Table can only be applied to a struct")
+      context.error("@Table can only be applied to a struct", at: node)
+      return []
+    }
+    if let relationship = declaration.postgrestRelationshipAttribute() {
+      context.error(
+        "@Relationship belongs on a @SelectionOf type, not on @Table",
+        at: relationship
+      )
+      return []
     }
     let arguments = arguments(from: node)
     let access = declaration.postgrestAccessLevel

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -68,6 +68,9 @@ public struct TableMacro: ExtensionMacro {
       )
       return []
     }
+    if declaration.postgrestDiagnoseUnannotatedProperties(macro: "@Table", in: context) {
+      return []
+    }
     let arguments = arguments(from: node)
     let access = declaration.postgrestAccessLevel
     let properties = declaration.postgrestStoredProperties()

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -1,0 +1,202 @@
+//
+//  TableMacro.swift
+//  PostgrestMacrosPlugin
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Expands `@Table` into a relation conformance.
+///
+/// Everything is emitted from the extension role, and none of it from a member role. Two rules
+/// force that shape, and both fail confusingly if you get them wrong:
+///
+/// - A macro-generated extension cannot witness a requirement with a member added by a *member*
+///   role of the same attribute. Splitting the witnesses across the two roles compiles as
+///   hand-written source and fails as an expansion.
+/// - The emitted inheritance clause must name every protocol in the refinement chain.
+///   `extension Todo: PostgrestWritableRelation` alone reports "does not conform to inherited
+///   protocol PostgrestRelation", with no note saying which requirement is missing.
+public struct TableMacro: ExtensionMacro {
+  // MARK: Arguments
+
+  struct Arguments {
+    var name: String
+    var schema: String
+    var readOnly: Bool
+  }
+
+  static func arguments(from node: AttributeSyntax) -> Arguments {
+    var name = ""
+    var schema = "public"
+    var readOnly = false
+    for argument in node.arguments?.as(LabeledExprListSyntax.self) ?? [] {
+      switch argument.label?.text {
+      case nil:
+        name = argument.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue ?? ""
+      case "schema":
+        schema =
+          argument.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue ?? "public"
+      case "readOnly":
+        readOnly = argument.expression.as(BooleanLiteralExprSyntax.self)?.literal.text == "true"
+      default:
+        break
+      }
+    }
+    return Arguments(name: name, schema: schema, readOnly: readOnly)
+  }
+
+  // MARK: Expansion
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    guard declaration.is(StructDeclSyntax.self) else {
+      throw MacroExpansionErrorMessage("@Table can only be applied to a struct")
+    }
+    let arguments = arguments(from: node)
+    let access = declaration.postgrestAccessLevel
+    let properties = declaration.postgrestStoredProperties()
+
+    var body: [String] = [
+      "  \(access)static let relationName = \"\(arguments.name)\"",
+      "  \(access)static let schema = \"\(arguments.schema)\"",
+      "  \(access)static let selectString = \"*\"",
+      columnNameFunction(access: access, type: type.trimmedDescription, properties: properties),
+    ]
+    if let codingKeys = codingKeys(for: properties) {
+      body.append(codingKeys)
+    }
+    if !arguments.readOnly {
+      // `Insert` drops the primary key and makes defaulted columns optional, so a row can be
+      // inserted without naming a column the database fills in. `Update` makes every column
+      // optional, so a partial update names only what it changes.
+      let writable = properties.filter { !$0.isPrimaryKey }
+      body.append(
+        writeShape(
+          named: "Insert",
+          access: access,
+          fields: writable.map { ($0, $0.isOptional || $0.hasDefault ? $0.optionalType : $0.type) }
+        )
+      )
+      body.append(
+        writeShape(named: "Update", access: access, fields: writable.map { ($0, $0.optionalType) })
+      )
+    }
+
+    return [
+      try ExtensionDeclSyntax(
+        """
+        extension \(type.trimmed)\(raw: inheritanceClause(arguments, protocols)) {
+        \(raw: body.joined(separator: "\n\n"))
+        }
+        """
+      )
+    ]
+  }
+
+  // MARK: Generation
+
+  /// The inheritance clause to emit, or `""` when the type already declares everything.
+  ///
+  /// `protocols` is the subset of the attribute's declared `conformances:` the type does not
+  /// already satisfy, so a user who writes `struct Todo: Decodable` gets no duplicate — and no
+  /// "redundant conformance" error.
+  ///
+  /// `Decodable` is in the list and `Encodable` is not: rows are decoded from responses, and writes
+  /// go out through the `Encodable` `Insert` and `Update` shapes.
+  static func inheritanceClause(_ arguments: Arguments, _ protocols: [TypeSyntax]) -> String {
+    let wanted = [
+      "Decodable",
+      "Sendable",
+      "PostgrestRelation",
+      arguments.readOnly ? nil : "PostgrestWritableRelation",
+    ].compactMap { $0 }
+    let missing = Set(protocols.map(\.trimmedDescription))
+    let needed = wanted.filter(missing.contains)
+    return needed.isEmpty ? "" : ": \(needed.joined(separator: ", "))"
+  }
+
+  /// The key-path-to-column mapping.
+  ///
+  /// Every stored property gets a case, so `default` is reachable only through a key path to a
+  /// computed property — a mistake at the call site, not a query worth sending. `fatalError` says
+  /// so immediately; returning `""` would build a query with an empty column name and leave
+  /// PostgREST to reject it with a 400 that never names the key path.
+  static func columnNameFunction(
+    access: String,
+    type: String,
+    properties: [StoredProperty]
+  ) -> String {
+    var lines = [
+      "  \(access)static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {",
+      "    switch keyPath {",
+    ]
+    for property in properties {
+      lines.append("    case \\Self.\(property.name):")
+      lines.append("      return \"\(property.columnName)\"")
+    }
+    lines.append("    default:")
+    lines.append("      fatalError(\"\(type): no column is mapped for that key path\")")
+    lines.append("    }")
+    lines.append("  }")
+    return lines.joined(separator: "\n")
+  }
+
+  /// The `CodingKeys` enum, or `nil` when there is nothing to map.
+  ///
+  /// The same property list drives this and the column mapping, so the write path and the filter
+  /// path cannot disagree about a column name.
+  static func codingKeys(for properties: [StoredProperty], indent: String = "  ") -> String? {
+    guard !properties.isEmpty else { return nil }
+    var lines = ["\(indent)enum CodingKeys: String, CodingKey {"]
+    for property in properties {
+      lines.append("\(indent)  case \(property.name) = \"\(property.columnName)\"")
+    }
+    lines.append("\(indent)}")
+    return lines.joined(separator: "\n")
+  }
+
+  /// One of the nested write shapes, with its own `CodingKeys` and an init that defaults every
+  /// optional to `nil`.
+  ///
+  /// `CodingKeys` is not optional here: PostgREST's encoder sets no key strategy, so without it an
+  /// insert would send `isDone` while a filter on the same column sends `is_done`. Nor is the init
+  /// — the memberwise init of a `public` struct is internal, and a partial update would otherwise
+  /// have to spell out `nil` for every column it leaves alone.
+  static func writeShape(
+    named name: String,
+    access: String,
+    fields: [(property: StoredProperty, type: String)]
+  ) -> String {
+    var lines: [String] = ["  \(access)struct \(name): Encodable, Sendable {"]
+
+    for field in fields {
+      lines.append("    \(access)var \(field.property.name): \(field.type)")
+    }
+
+    if let codingKeys = codingKeys(for: fields.map(\.property), indent: "    ") {
+      lines.append("")
+      lines.append(codingKeys)
+    }
+
+    let parameters =
+      fields
+      .map { "\($0.property.name): \($0.type)\($0.type.hasSuffix("?") ? " = nil" : "")" }
+      .joined(separator: ", ")
+    lines.append("")
+    lines.append("    \(access)init(\(parameters)) {")
+    for field in fields {
+      lines.append("      self.\(field.property.name) = \(field.property.name)")
+    }
+    lines.append("    }")
+    lines.append("  }")
+    return lines.joined(separator: "\n")
+  }
+}

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -90,10 +90,11 @@ public struct TableMacro: ExtensionMacro {
       )
     }
 
+    let clause = inheritanceClause(wanted: wantedConformances(arguments), missing: protocols)
     return [
       try ExtensionDeclSyntax(
         """
-        extension \(type.trimmed)\(raw: inheritanceClause(arguments, protocols)) {
+        extension \(type.trimmed)\(raw: clause) {
         \(raw: body.joined(separator: "\n\n"))
         }
         """
@@ -103,24 +104,17 @@ public struct TableMacro: ExtensionMacro {
 
   // MARK: Generation
 
-  /// The inheritance clause to emit, or `""` when the type already declares everything.
-  ///
-  /// `protocols` is the subset of the attribute's declared `conformances:` the type does not
-  /// already satisfy, so a user who writes `struct Todo: Decodable` gets no duplicate — and no
-  /// "redundant conformance" error.
+  /// The protocols `@Table` conforms the annotated type to.
   ///
   /// `Decodable` is in the list and `Encodable` is not: rows are decoded from responses, and writes
   /// go out through the `Encodable` `Insert` and `Update` shapes.
-  static func inheritanceClause(_ arguments: Arguments, _ protocols: [TypeSyntax]) -> String {
-    let wanted = [
+  static func wantedConformances(_ arguments: Arguments) -> [String] {
+    [
       "Decodable",
       "Sendable",
       "PostgrestRelation",
       arguments.readOnly ? nil : "PostgrestWritableRelation",
     ].compactMap { $0 }
-    let missing = Set(protocols.map(\.trimmedDescription))
-    let needed = wanted.filter(missing.contains)
-    return needed.isEmpty ? "" : ": \(needed.joined(separator: ", "))"
   }
 
   /// The key-path-to-column mapping.
@@ -146,20 +140,6 @@ public struct TableMacro: ExtensionMacro {
     lines.append("      fatalError(\"\(type): no column is mapped for that key path\")")
     lines.append("    }")
     lines.append("  }")
-    return lines.joined(separator: "\n")
-  }
-
-  /// The `CodingKeys` enum, or `nil` when there is nothing to map.
-  ///
-  /// The same property list drives this and the column mapping, so the write path and the filter
-  /// path cannot disagree about a column name.
-  static func codingKeys(for properties: [StoredProperty], indent: String = "  ") -> String? {
-    guard !properties.isEmpty else { return nil }
-    var lines = ["\(indent)enum CodingKeys: String, CodingKey {"]
-    for property in properties {
-      lines.append("\(indent)  case \(property.name) = \"\(property.columnName)\"")
-    }
-    lines.append("\(indent)}")
     return lines.joined(separator: "\n")
   }
 

--- a/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Supabase.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5e68a3cf2de6edf2abec2dfb983a8393d24cb9fc0b0786db3b5f16fa4672d712",
+  "originHash" : "9d9f6b0fc1bc72b8bfc309542e450e769d50124b550f98600e5d16cb59f23a43",
   "pins" : [
     {
       "identity" : "appauth-ios",
@@ -215,6 +215,24 @@
       "state" : {
         "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
       }
     },
     {

--- a/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
@@ -1,0 +1,110 @@
+//
+//  PostgrestTypedMutationTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestTypedMutationTests {
+  struct Todo: PostgrestWritableRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+    var isDone: Bool
+
+    /// A hand-written conformance has to keep these in step with `columnName(for:)` itself. The
+    /// `@Column` macro generates both from one input so they cannot drift.
+    enum CodingKeys: String, CodingKey {
+      case id
+      case task
+      case isDone = "is_done"
+    }
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.task: "task"
+      case \Self.isDone: "is_done"
+      default: fatalError("unmapped key path")
+      }
+    }
+
+    struct Insert: Encodable, Sendable {
+      var task: String
+      var isDone: Bool?
+    }
+    struct Update: Encodable, Sendable {
+      var task: String?
+      var isDone: Bool?
+    }
+  }
+
+  /// A view: conforms to `PostgrestRelation` only, so the writes must not be offered.
+  struct ActiveTodo: PostgrestRelation {
+    static let relationName = "active_todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  @Test
+  func insertSendsTheInsertShape() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .insert(Todo.Insert(task: "buy milk", isDone: nil)).execute()
+    #expect(capture.httpMethod == "POST")
+    // The Insert shape excludes the primary key, so `id` must not appear in the body.
+    #expect(capture.bodyString?.contains("\"task\":\"buy milk\"") == true)
+    #expect(capture.bodyString?.contains("\"id\"") == false)
+  }
+
+  @Test
+  func preferHeaderIsUnambiguousWhenReturningRows() async throws {
+    let capture = QueryCapture(body: #"[{"id":1,"task":"buy milk","is_done":false}]"#)
+    _ = try await capture.client.from(Todo.self)
+      .insert(Todo.Insert(task: "buy milk", isDone: nil)).returning().execute()
+    let prefer = capture.header("Prefer") ?? ""
+    #expect(prefer.contains("return=representation"))
+    #expect(prefer.contains("return=minimal") == false)
+  }
+
+  @Test
+  func updateScopesByKeyPath() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .update(Todo.Update(task: "done", isDone: true)).eq(\.id, 1).execute()
+    #expect(capture.query?.contains("id=eq.1") == true)
+  }
+
+  @Test
+  func deleteScopesByKeyPath() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).delete().eq(\.id, 1).execute()
+    #expect(capture.query?.contains("id=eq.1") == true)
+  }
+
+  @Test
+  func returningDecodesRows() async throws {
+    let capture = QueryCapture(body: #"[{"id":1,"task":"buy milk","is_done":false}]"#)
+    let rows = try await capture.client.from(Todo.self)
+      .insert(Todo.Insert(task: "buy milk", isDone: nil)).returning().execute().value
+    #expect(rows.first?.task == "buy milk")
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestTypedQueryFilterTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedQueryFilterTests.swift
@@ -1,0 +1,93 @@
+//
+//  PostgrestTypedQueryFilterTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestTypedQueryFilterTests {
+  struct Todo: PostgrestRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+    var isDone: Bool
+    var dueDate: Date?
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.task: "task"
+      case \Self.isDone: "is_done"
+      case \Self.dueDate: "due_date"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  @Test
+  func eqUsesTheMappedColumnName() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().eq(\.isDone, false).execute()
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+  }
+
+  @Test
+  func comparisonOperatorsRenderTheirPrefix() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().gt(\.id, 10).lte(\.id, 20).execute()
+    #expect(capture.query?.contains("id=gt.10") == true)
+    #expect(capture.query?.contains("id=lte.20") == true)
+  }
+
+  @Test
+  func inRendersAParenthesisedList() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().in(\.task, ["a", "b"]).execute()
+    #expect(capture.query?.contains("task=in.(a,b)") == true)
+  }
+
+  @Test
+  func isNullAndIsNotNullRenderCorrectly() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().isNull(\.dueDate).execute()
+    #expect(capture.query?.contains("due_date=is.null") == true)
+
+    let other = QueryCapture()
+    _ = try await other.client.from(Todo.self).select().isNotNull(\.dueDate).execute()
+    #expect(other.query?.contains("due_date=not.is.null") == true)
+  }
+
+  /// The typed wrappers hold value-typed builders, so two chains branched off one query are
+  /// independent. Under the old class-based builders the second request also carried the first
+  /// chain's filter.
+  @Test
+  func branchingTwoChainsOffOneQueryDoesNotAlias() async throws {
+    let capture = QueryCapture()
+    let base = capture.client.from(Todo.self).select()
+
+    _ = try await base.eq(\.isDone, true).execute()
+    #expect(capture.query?.contains("is_done=eq.true") == true)
+
+    _ = try await base.gt(\.id, 5).execute()
+    #expect(capture.query?.contains("id=gt.5") == true)
+    #expect(capture.query?.contains("is_done") == false)
+  }
+
+  @Test
+  func orderAndLimitUseTheMappedColumnName() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select().order(\.dueDate, ascending: false).limit(5).execute()
+    #expect(capture.query?.contains("order=due_date.desc") == true)
+    #expect(capture.query?.contains("limit=5") == true)
+  }
+}

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -102,4 +102,154 @@ struct DiagnosticsTests {
       """
     }
   }
+
+  @Test
+  func tableRejectsAPropertyWithNoTypeAnnotation() {
+    // Left alone, the property has a default, so `Decodable` synthesis still succeeds. The column
+    // never round-trips and the mistake surfaces only when `columnName(for:)` traps at runtime.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var isDone = false
+      }
+      """
+    } diagnostics: {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var isDone = false
+            ┬─────
+            ╰─ 🛑 @Table requires an explicit type annotation on 'isDone', as in 'var isDone: <Type> = ...' — without one the macro cannot infer the type, and the column is dropped
+      }
+      """
+    }
+  }
+
+  @Test
+  func tableReportsEveryPropertyWithNoTypeAnnotation() {
+    // One diagnostic per property, so the author fixes them all in one pass.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var isDone = false
+        var task = ""
+      }
+      """
+    } diagnostics: {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var isDone = false
+            ┬─────
+            ╰─ 🛑 @Table requires an explicit type annotation on 'isDone', as in 'var isDone: <Type> = ...' — without one the macro cannot infer the type, and the column is dropped
+        var task = ""
+            ┬───
+            ╰─ 🛑 @Table requires an explicit type annotation on 'task', as in 'var task: <Type> = ...' — without one the macro cannot infer the type, and the column is dropped
+      }
+      """
+    }
+  }
+
+  @Test
+  func tableAcceptsMembersThatMapToNoColumn() {
+    // A static member and a computed property are not stored, so neither maps to a column and
+    // neither is a missing annotation.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+        static let placeholder = "none"
+        var summary: String { "todo" }
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+        static let placeholder = "none"
+        var summary: String { "todo" }
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var task: String
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          init(task: String) {
+            self.task = task
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var task: String?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          init(task: String? = nil) {
+            self.task = task
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func selectionOfRejectsAPropertyWithNoTypeAnnotation() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+        var isDone = false
+      }
+      """
+    } diagnostics: {
+      """
+      @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+        var isDone = false
+            ┬─────
+            ╰─ 🛑 @SelectionOf requires an explicit type annotation on 'isDone', as in 'var isDone: <Type> = ...' — without one the macro cannot infer the type, and the column is dropped
+      }
+      """
+    }
+  }
 }

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -1,0 +1,105 @@
+//
+//  DiagnosticsTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import MacroTesting
+import Testing
+
+@testable import PostgrestMacrosPlugin
+
+@Suite(.macros(["Table": TableMacro.self, "SelectionOf": SelectionOfMacro.self]))
+struct DiagnosticsTests {
+  @Test
+  func tableRejectsAClass() {
+    assertMacro {
+      """
+      @Table("todos")
+      class Todo {
+        var id: Int = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @Table("todos")
+      ┬──────────────
+      ╰─ 🛑 @Table can only be applied to a struct
+      class Todo {
+        var id: Int = 0
+      }
+      """
+    }
+  }
+
+  @Test
+  func tableRejectsARelationshipProperty() {
+    // Forward-looking. `@Relationship` lands in stage 3, so today the compiler rejects the unknown
+    // attribute first; `assertMacro` has no such check, which is what lets this be tested now.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        var id: Int
+        @Relationship(\\Comment.todoID) var comments: [Comment]
+      }
+      """
+    } diagnostics: {
+      #"""
+      @Table("todos")
+      struct Todo {
+        var id: Int
+        @Relationship(\Comment.todoID) var comments: [Comment]
+        ┬─────────────────────────────
+        ╰─ 🛑 @Relationship belongs on a @SelectionOf type, not on @Table
+      }
+      """#
+    }
+  }
+
+  @Test
+  func selectionOfRejectsAClass() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      class TodoSummary {
+        var id: Int = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @SelectionOf(Todo.self)
+      ┬──────────────────────
+      ╰─ 🛑 @SelectionOf can only be applied to a struct
+      class TodoSummary {
+        var id: Int = 0
+      }
+      """
+    }
+  }
+
+  @Test
+  func selectionOfRequiresARelationType() {
+    // Bare `@SelectionOf` is what `assertMacro` can express. In real code the compiler catches the
+    // missing argument first, and this fires on an argument that is not a `T.self` member access —
+    // `@SelectionOf(someTypeVariable)`.
+    assertMacro {
+      """
+      @SelectionOf
+      struct TodoSummary {
+        var id: Int
+      }
+      """
+    } diagnostics: {
+      """
+      @SelectionOf
+      ┬───────────
+      ╰─ 🛑 @SelectionOf requires a relation type, e.g. @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+      }
+      """
+    }
+  }
+}

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -252,4 +252,28 @@ struct DiagnosticsTests {
       """
     }
   }
+
+  @Test
+  func tableRejectsAnObservedPropertyWithNoTypeAnnotation() {
+    // Observed *and* unannotated. The accessor block must not excuse the missing annotation.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var isDone = false { didSet { print(isDone) } }
+      }
+      """
+    } diagnostics: {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var isDone = false { didSet { print(isDone) } }
+            ┬─────
+            ╰─ 🛑 @Table requires an explicit type annotation on 'isDone', as in 'var isDone: <Type> = ...' — without one the macro cannot infer the type, and the column is dropped
+      }
+      """
+    }
+  }
 }

--- a/Tests/PostgrestMacrosTests/PluginTests.swift
+++ b/Tests/PostgrestMacrosTests/PluginTests.swift
@@ -1,0 +1,20 @@
+//
+//  PluginTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Testing
+
+@testable import PostgrestMacros
+
+@Suite
+struct PluginTests {
+  @Test
+  func macroModuleReExportsPostgREST() {
+    // Compiles only if PostgrestMacros re-exports PostgREST, which is what lets a user write a
+    // single `import PostgrestMacros`.
+    #expect(PostgrestClient.Configuration.defaultHeaders["X-Client-Info"] != nil)
+  }
+}

--- a/Tests/PostgrestMacrosTests/RequestCapture.swift
+++ b/Tests/PostgrestMacrosTests/RequestCapture.swift
@@ -1,0 +1,55 @@
+//
+//  RequestCapture.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import ConcurrencyExtras
+import Foundation
+import PostgrestMacros
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+/// Captures the `URLRequest` a typed query produces, so a test can assert on it in its own context.
+///
+/// A trimmed sibling of `QueryCapture` in `PostgRESTTests`. The two test targets cannot share a
+/// helper without a third target, and a macro test needs far less of it than the builder tests do.
+struct RequestCapture {
+  let client: PostgrestClient
+  private let captured = LockIsolated(URLRequest?.none)
+
+  init(body: String = "[]") {
+    let captured = self.captured
+    client = PostgrestClient(
+      url: URL(string: "https://example.supabase.co")!,
+      headers: ["X-Client-Info": "postgrest-swift/test"],
+      fetch: { request in
+        captured.setValue(request)
+        let response = HTTPURLResponse(
+          url: request.url!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: ["Content-Type": "application/json"]
+        )!
+        return (Data(body.utf8), response)
+      }
+    )
+  }
+
+  /// The query string, percent-decoded so assertions read in the spelling PostgREST documents.
+  var query: String? {
+    guard let query = captured.value?.url?.query else { return nil }
+    return query.removingPercentEncoding ?? query
+  }
+
+  /// The path of the captured request's URL, which ends in the relation name.
+  var path: String? { captured.value?.url?.path }
+
+  /// The captured request body decoded as UTF-8.
+  var bodyString: String? {
+    captured.value?.httpBody.map { String(decoding: $0, as: UTF8.self) }
+  }
+}

--- a/Tests/PostgrestMacrosTests/SelectionIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionIntegrationTests.swift
@@ -1,0 +1,73 @@
+//
+//  SelectionIntegrationTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import PostgrestMacros
+import Testing
+
+// File scope, for the same reason as `TableIntegrationTests`: `@Table` and `@SelectionOf` both
+// attach extensions, which cannot be nested inside another type.
+@Table("todos")
+struct SelectionTodo {
+  @PrimaryKey var id: Int
+  var task: String
+  @Default var isDone: Bool
+  @Column("due_at") var dueDate: Date?
+}
+
+@SelectionOf(SelectionTodo.self)
+struct SelectionTodoSummary: Hashable {
+  var id: Int
+  var isDone: Bool
+}
+
+@SelectionOf(SelectionTodo.self)
+struct SelectionTodoDueDate {
+  @Column("due_at") var dueDate: Date?
+}
+
+@Suite
+struct SelectionIntegrationTests {
+  typealias TodoSummary = SelectionTodoSummary
+
+  @Test
+  func selectStringListsTheDeclaredColumns() {
+    #expect(TodoSummary.selectString == "id,is_done")
+  }
+
+  @Test
+  func columnOverridesApply() {
+    #expect(SelectionTodoDueDate.selectString == "due_at")
+  }
+
+  @Test
+  func aSelectionNamesItsSource() {
+    // `select(_:)` is gated on this, so a selection cannot be handed to another relation.
+    #expect(TodoSummary.Source.relationName == "todos")
+  }
+
+  @Test
+  func aRelationIsItsOwnSource() {
+    #expect(SelectionTodo.Source.relationName == "todos")
+  }
+
+  @Test
+  func selectSendsTheSelectStringAndDecodesTheSelection() async throws {
+    let capture = RequestCapture(body: #"[{"id":1,"is_done":false}]"#)
+    let rows = try await capture.client
+      .from(SelectionTodo.self)
+      .select(TodoSummary.self)
+      .eq(\.isDone, false)
+      .execute()
+      .value
+
+    #expect(rows == [TodoSummary(id: 1, isDone: false)])
+    #expect(capture.path?.hasSuffix("/todos") == true)
+    #expect(capture.query?.contains("select=id,is_done") == true)
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+  }
+}

--- a/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
@@ -83,4 +83,41 @@ struct SelectionOfMacroTests {
       """#
     }
   }
+
+  @Test
+  func keepsObservedStoredProperties() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+        var isDone: Bool = false { didSet { print(isDone) } }
+      }
+      """
+    } expansion: {
+      #"""
+      struct TodoSummary {
+        var id: Int
+        var isDone: Bool = false { didSet { print(isDone) } }
+      }
+
+      extension TodoSummary {
+        typealias Source = Todo
+
+        static let selectString = "id,is_done"
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case isDone = "is_done"
+        }
+
+        /// Fails to compile if a property does not name a column on Todo.
+        private static let _columnCheck: [String] = [
+          Todo.columnName(for: \Todo.id),
+          Todo.columnName(for: \Todo.isDone),
+        ]
+      }
+      """#
+    }
+  }
 }

--- a/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
@@ -1,0 +1,86 @@
+//
+//  SelectionOfMacroTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import MacroTesting
+import Testing
+
+@testable import PostgrestMacrosPlugin
+
+/// As in `TableMacroTests`, `MacroTesting` expands without the declaration, so `conformingTo:` is
+/// always empty here and the recorded extensions carry no inheritance clause.
+@Suite(.macros(["SelectionOf": SelectionOfMacro.self]))
+struct SelectionOfMacroTests {
+  @Test
+  func expandsAColumnSubset() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+        @Column("due_at") var dueDate: Date?
+      }
+      """
+    } expansion: {
+      #"""
+      struct TodoSummary {
+        var id: Int
+        @Column("due_at") var dueDate: Date?
+      }
+
+      extension TodoSummary {
+        typealias Source = Todo
+
+        static let selectString = "id,due_at"
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case dueDate = "due_at"
+        }
+
+        /// Fails to compile if a property does not name a column on Todo.
+        private static let _columnCheck: [String] = [
+          Todo.columnName(for: \Todo.id),
+          Todo.columnName(for: \Todo.dueDate),
+        ]
+      }
+      """#
+    }
+  }
+
+  @Test
+  func propagatesTheAccessLevel() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      public struct TodoSummary {
+        var isDone: Bool
+      }
+      """
+    } expansion: {
+      #"""
+      public struct TodoSummary {
+        var isDone: Bool
+      }
+
+      extension TodoSummary {
+        public typealias Source = Todo
+
+        public static let selectString = "is_done"
+
+        enum CodingKeys: String, CodingKey {
+          case isDone = "is_done"
+        }
+
+        /// Fails to compile if a property does not name a column on Todo.
+        private static let _columnCheck: [String] = [
+          Todo.columnName(for: \Todo.isDone),
+        ]
+      }
+      """#
+    }
+  }
+}

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -1,0 +1,117 @@
+//
+//  TableIntegrationTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import Foundation
+import PostgrestMacros
+import Testing
+
+// Declared at file scope on purpose. `@Table` attaches an extension, and Swift does not allow an
+// extension of a type nested inside another type, so annotating a nested struct fails to compile.
+@Table("todos")
+struct IntegrationTodo: Hashable {
+  @PrimaryKey var id: Int
+  var task: String
+  @Default var isDone: Bool
+  @Column("due_at") var dueDate: Date?
+}
+
+@Table("active_todos", readOnly: true)
+struct IntegrationActiveTodo {
+  var id: Int
+  var task: String
+}
+
+@Suite
+struct TableIntegrationTests {
+  typealias Todo = IntegrationTodo
+
+  @Test
+  func macroSuppliesTheRelationName() {
+    #expect(Todo.relationName == "todos")
+    #expect(Todo.schema == "public")
+    #expect(Todo.selectString == "*")
+  }
+
+  @Test
+  func macroMapsKeyPathsToColumns() {
+    #expect(Todo.columnName(for: \.id) == "id")
+    #expect(Todo.columnName(for: \.isDone) == "is_done")
+    #expect(Todo.columnName(for: \.dueDate) == "due_at")
+  }
+
+  @Test
+  func insertExcludesThePrimaryKeyAndUsesColumnNames() throws {
+    let data = try JSONEncoder().encode(Todo.Insert(task: "buy milk", isDone: false))
+    let json = String(decoding: data, as: UTF8.self)
+    #expect(json.contains("\"id\"") == false)
+    #expect(json.contains("\"is_done\"") == true)
+    #expect(json.contains("\"isDone\"") == false)
+  }
+
+  @Test
+  func aNilOptionalIsOmittedSoTheDatabaseDefaultApplies() throws {
+    // `@Default var isDone` is optional in `Insert` precisely so it can be left out. Encoding it
+    // as `null` would insert NULL instead of letting the column default apply.
+    let data = try JSONEncoder().encode(Todo.Insert(task: "buy milk"))
+    let json = String(decoding: data, as: UTF8.self)
+    #expect(json == #"{"task":"buy milk"}"#)
+  }
+
+  @Test
+  func aPartialUpdateNamesOnlyWhatItChanges() throws {
+    let data = try JSONEncoder().encode(Todo.Update(isDone: true))
+    let json = String(decoding: data, as: UTF8.self)
+    #expect(json == #"{"is_done":true}"#)
+  }
+
+  @Test
+  func aMacroTypeFlowsThroughTheTypedQuery() async throws {
+    let capture = RequestCapture(
+      body: #"[{"id":1,"task":"buy milk","is_done":false,"due_at":null}]"#
+    )
+    let todos = try await capture.client
+      .from(Todo.self)
+      .select()
+      .eq(\.isDone, false)
+      .order(\.id, ascending: false)
+      .execute()
+      .value
+
+    #expect(todos == [Todo(id: 1, task: "buy milk", isDone: false, dueDate: nil)])
+    #expect(capture.path?.hasSuffix("/todos") == true)
+    #expect(capture.query?.contains("select=*") == true)
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+    #expect(capture.query?.contains("id.desc") == true)
+  }
+
+  @Test
+  func aMacroTypeFlowsThroughATypedWrite() async throws {
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .insert(Todo.Insert(task: "buy milk"))
+      .execute()
+
+    #expect(capture.path?.hasSuffix("/todos") == true)
+    #expect(capture.bodyString == #"{"task":"buy milk"}"#)
+  }
+
+  @Test
+  func aReadOnlyRelationIsStillQueryable() async throws {
+    let capture = RequestCapture(body: #"[{"id":1,"task":"buy milk"}]"#)
+    let rows = try await capture.client
+      .from(IntegrationActiveTodo.self)
+      .select()
+      .eq(\.task, "buy milk")
+      .execute()
+      .value
+
+    #expect(rows.count == 1)
+    #expect(capture.path?.hasSuffix("/active_todos") == true)
+    #expect(capture.query?.contains("task=eq.buy milk") == true)
+  }
+}

--- a/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
@@ -1,0 +1,67 @@
+//
+//  TableMacroSupportTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import Testing
+
+@testable import PostgrestMacrosPlugin
+
+/// Covers the two pieces `assertMacro` cannot reach.
+///
+/// `MacroTesting` expands a macro without its declaration, so it always passes an empty
+/// `conformingTo:` and the recorded expansions show `extension Todo {` with no inheritance clause.
+/// The clause is what makes the conformance land, so it is asserted here directly.
+@Suite
+struct TableMacroSupportTests {
+  private func clause(readOnly: Bool, missing: [String]) -> String {
+    TableMacro.inheritanceClause(
+      TableMacro.Arguments(name: "todos", schema: "public", readOnly: readOnly),
+      missing.map { TypeSyntax(stringLiteral: $0) }
+    )
+  }
+
+  @Test
+  func namesEveryLinkInTheRefinementChain() {
+    // `PostgrestWritableRelation` alone is not enough: a macro-generated extension does not derive
+    // the inherited conformance, and reports a missing `PostgrestRelation` with no useful note.
+    #expect(
+      clause(
+        readOnly: false,
+        missing: ["Decodable", "Sendable", "PostgrestRelation", "PostgrestWritableRelation"]
+      ) == ": Decodable, Sendable, PostgrestRelation, PostgrestWritableRelation"
+    )
+  }
+
+  @Test
+  func readOnlyStopsAtTheReadableRelation() {
+    #expect(
+      clause(readOnly: true, missing: ["Decodable", "Sendable", "PostgrestRelation"])
+        == ": Decodable, Sendable, PostgrestRelation"
+    )
+  }
+
+  @Test
+  func skipsWhatTheTypeAlreadyDeclares() {
+    // `struct Todo: Decodable, Sendable` must not get a second Decodable conformance.
+    #expect(
+      clause(readOnly: false, missing: ["PostgrestRelation", "PostgrestWritableRelation"])
+        == ": PostgrestRelation, PostgrestWritableRelation"
+    )
+    #expect(clause(readOnly: false, missing: []) == "")
+  }
+
+  @Test
+  func convertsPropertyNamesToColumnNames() {
+    #expect(camelToSnakeCase("isDone") == "is_done")
+    #expect(camelToSnakeCase("dueDate") == "due_date")
+    #expect(camelToSnakeCase("task") == "task")
+    #expect(camelToSnakeCase("htmlURL") == "html_url")
+    #expect(camelToSnakeCase("urlSession") == "url_session")
+    #expect(camelToSnakeCase("id") == "id")
+  }
+}

--- a/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
@@ -19,9 +19,11 @@ import Testing
 @Suite
 struct TableMacroSupportTests {
   private func clause(readOnly: Bool, missing: [String]) -> String {
-    TableMacro.inheritanceClause(
-      TableMacro.Arguments(name: "todos", schema: "public", readOnly: readOnly),
-      missing.map { TypeSyntax(stringLiteral: $0) }
+    inheritanceClause(
+      wanted: TableMacro.wantedConformances(
+        TableMacro.Arguments(name: "todos", schema: "public", readOnly: readOnly)
+      ),
+      missing: missing.map { TypeSyntax(stringLiteral: $0) }
     )
   }
 

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -278,4 +278,156 @@ struct TableMacroTests {
       """#
     }
   }
+
+  @Test
+  func keepsObservedStoredProperties() {
+    // `willSet`/`didSet` put an accessor block on a property that still holds a value, so it still
+    // needs its column.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var isDone: Bool = false { didSet { print(isDone) } }
+        var task: String { willSet { print(newValue) } }
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey var id: Int
+        var isDone: Bool = false { didSet { print(isDone) } }
+        var task: String { willSet { print(newValue) } }
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.isDone:
+            return "is_done"
+          case \Self.task:
+            return "task"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case isDone = "is_done"
+          case task = "task"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var isDone: Bool
+          var task: String
+
+          enum CodingKeys: String, CodingKey {
+            case isDone = "is_done"
+            case task = "task"
+          }
+
+          init(isDone: Bool, task: String) {
+            self.isDone = isDone
+            self.task = task
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var isDone: Bool?
+          var task: String?
+
+          enum CodingKeys: String, CodingKey {
+            case isDone = "is_done"
+            case task = "task"
+          }
+
+          init(isDone: Bool? = nil, task: String? = nil) {
+            self.isDone = isDone
+            self.task = task
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func skipsPropertiesThatComputeTheirValue() {
+    // Every accessor block that is not observers-only: an explicit getter, a getter with a setter,
+    // and a `_read` coroutine. None holds a value, so none maps to a column.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        var task: String
+        var upper: String { get { task } }
+        var settable: String { get { task } set { task = newValue } }
+        var yielded: String { _read { yield task } }
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        var task: String
+        var upper: String { get { task } }
+        var settable: String { get { task } set { task = newValue } }
+        var yielded: String { _read { yield task } }
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.task:
+            return "task"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case task = "task"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var task: String
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          init(task: String) {
+            self.task = task
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var task: String?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          init(task: String? = nil) {
+            self.task = task
+          }
+        }
+      }
+      """#
+    }
+  }
 }

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -1,0 +1,281 @@
+//
+//  TableMacroTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 21/08/26.
+//
+
+import MacroTesting
+import Testing
+
+@testable import PostgrestMacrosPlugin
+
+/// `MacroTesting` expands the macro without its declaration, so `conformingTo:` is always empty
+/// here and the recorded extensions carry no inheritance clause. `TableMacroSupportTests` asserts
+/// the clause directly.
+@Suite(.macros(["Table": TableMacro.self]))
+struct TableMacroTests {
+  @Test
+  func expandsAWritableTable() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+        @Default var isDone: Bool
+        @Column("due_at") var dueDate: Date?
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+        @Default var isDone: Bool
+        @Column("due_at") var dueDate: Date?
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          case \Self.isDone:
+            return "is_done"
+          case \Self.dueDate:
+            return "due_at"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+          case isDone = "is_done"
+          case dueDate = "due_at"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var task: String
+          var isDone: Bool?
+          var dueDate: Date?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+            case isDone = "is_done"
+            case dueDate = "due_at"
+          }
+
+          init(task: String, isDone: Bool? = nil, dueDate: Date? = nil) {
+            self.task = task
+            self.isDone = isDone
+            self.dueDate = dueDate
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var task: String?
+          var isDone: Bool?
+          var dueDate: Date?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+            case isDone = "is_done"
+            case dueDate = "due_at"
+          }
+
+          init(task: String? = nil, isDone: Bool? = nil, dueDate: Date? = nil) {
+            self.task = task
+            self.isDone = isDone
+            self.dueDate = dueDate
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func readOnlyTableOmitsInsertAndUpdate() {
+    assertMacro {
+      """
+      @Table("active_todos", readOnly: true)
+      struct ActiveTodo {
+        var id: Int
+      }
+      """
+    } expansion: {
+      #"""
+      struct ActiveTodo {
+        var id: Int
+      }
+
+      extension ActiveTodo {
+        static let relationName = "active_todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          default:
+            fatalError("ActiveTodo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func propagatesTheAccessLevel() {
+    assertMacro {
+      """
+      @Table("todos", schema: "app")
+      public struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+      }
+      """
+    } expansion: {
+      #"""
+      public struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+      }
+
+      extension Todo {
+        public static let relationName = "todos"
+
+        public static let schema = "app"
+
+        public static let selectString = "*"
+
+        public static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+        }
+
+        public struct Insert: Encodable, Sendable {
+          public var task: String
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          public init(task: String) {
+            self.task = task
+          }
+        }
+
+        public struct Update: Encodable, Sendable {
+          public var task: String?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          public init(task: String? = nil) {
+            self.task = task
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func skipsComputedAndStaticMembers() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        static let table = "todos"
+        var htmlURL: String
+        var summary: String { htmlURL }
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        static let table = "todos"
+        var htmlURL: String
+        var summary: String { htmlURL }
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.htmlURL:
+            return "html_url"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case htmlURL = "html_url"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var htmlURL: String
+
+          enum CodingKeys: String, CodingKey {
+            case htmlURL = "html_url"
+          }
+
+          init(htmlURL: String) {
+            self.htmlURL = htmlURL
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var htmlURL: String?
+
+          enum CodingKeys: String, CodingKey {
+            case htmlURL = "html_url"
+          }
+
+          init(htmlURL: String? = nil) {
+            self.htmlURL = htmlURL
+          }
+        }
+      }
+      """#
+    }
+  }
+}

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -249,3 +249,4 @@ deinits
 
 # Term from AGENTS.md's Enum-like Values section (describing non-failable init(rawValue:)).
 failable
+memberwise

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -55,6 +55,11 @@ supporting_symbols:
   - PostgrestArrayElement
   - PostgrestArrayElement.postgrestArrayElement
   - PostgrestFilterValue.postgrestArrayElement
+  - PostgrestKeyPathFilterable
+  - PostgrestKeyPathFilterable.Phase
+  - PostgrestKeyPathFilterable.Relation
+  - PostgrestKeyPathFilterable.builder
+  - PostgrestKeyPathFilterable.init
   - PostgrestQueryPhase
   - PostgrestRelation
   - PostgrestRelation.columnName
@@ -74,6 +79,7 @@ supporting_symbols:
   - PostgrestSelection.selectString
   - PostgrestTransformPhase
   - PostgrestTransformablePhase
+  - PostgrestTypedQuery.Relation
   - PostgrestWritableRelation
   - PostgrestWritableRelation.Insert
   - PostgrestWritableRelation.Update
@@ -601,31 +607,37 @@ features:
     symbols:
       - PostgrestRequestBuilder.eq
       - PostgrestRequestBuilder.equals
+      - PostgrestKeyPathFilterable.eq
   database.using_filters.neq:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.neq
       - PostgrestRequestBuilder.notEquals
+      - PostgrestKeyPathFilterable.neq
   database.using_filters.gt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.gt
       - PostgrestRequestBuilder.greaterThan
+      - PostgrestKeyPathFilterable.gt
   database.using_filters.gte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.gte
       - PostgrestRequestBuilder.greaterThanOrEquals
+      - PostgrestKeyPathFilterable.gte
   database.using_filters.lt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.lt
       - PostgrestRequestBuilder.lowerThan
+      - PostgrestKeyPathFilterable.lt
   database.using_filters.lte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.lte
       - PostgrestRequestBuilder.lowerThanOrEquals
+      - PostgrestKeyPathFilterable.lte
   database.using_filters.like:
     status: implemented
     symbols:
@@ -638,10 +650,13 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.is
+      - PostgrestKeyPathFilterable.isNull
+      - PostgrestKeyPathFilterable.isNotNull
   database.using_filters.in:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.in
+      - PostgrestKeyPathFilterable.in
   database.using_filters.contains:
     status: implemented
     symbols:
@@ -773,10 +788,12 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.order
+      - PostgrestTypedQuery.order
   database.using_modifiers.limit:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.limit
+      - PostgrestTypedQuery.limit
   database.using_modifiers.range:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -82,6 +82,7 @@ supporting_symbols:
   - PostgrestRequestBuilder.setHeader
   - PostgrestRequestBuilder.webFullTextSearch
   - PostgrestSelection
+  - PostgrestSelection.Source
   - PostgrestSelection.selectString
   - PostgrestTransformPhase
   - PostgrestTransformablePhase
@@ -96,6 +97,7 @@ supporting_symbols:
   # own. Attribute names are unprefixed on purpose — nothing re-exports
   # `PostgrestMacros`, so a user opts in with an explicit import.
   - Table
+  - SelectionOf
   - Column
   - PrimaryKey
   - Default

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -90,6 +90,16 @@ supporting_symbols:
   - PostgrestWritableRelation.Insert
   - PostgrestWritableRelation.Update
 
+  # The `PostgrestMacros` attributes. `@Table` synthesizes the relation
+  # conformance used by every database.* typed entry point, and the three
+  # markers are inputs to that one expansion rather than capabilities of their
+  # own. Attribute names are unprefixed on purpose — nothing re-exports
+  # `PostgrestMacros`, so a user opts in with an explicit import.
+  - Table
+  - Column
+  - PrimaryKey
+  - Default
+
 features:
 
   # ── Auth ───────────────────────────────────────────────────────────────────

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -60,6 +60,12 @@ supporting_symbols:
   - PostgrestKeyPathFilterable.Relation
   - PostgrestKeyPathFilterable.builder
   - PostgrestKeyPathFilterable.init
+  - PostgrestTypedMutation
+  - PostgrestTypedMutation.Phase
+  - PostgrestTypedMutation.Relation
+  - PostgrestTypedMutation.builder
+  - PostgrestTypedMutation.init
+  - PostgrestTypedMutation.execute
   - PostgrestQueryPhase
   - PostgrestRelation
   - PostgrestRelation.columnName
@@ -576,18 +582,22 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.insert
+      - PostgrestTypedSource.insert
   database.mutate.update:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.update
+      - PostgrestTypedSource.update
   database.mutate.upsert:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.upsert
+      - PostgrestTypedSource.upsert
   database.mutate.delete:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.delete
+      - PostgrestTypedSource.delete
   database.mutate.select_after_mutation:
     status: implemented
     symbols:
@@ -595,6 +605,7 @@ features:
       - PostgrestRequestBuilder.update
       - PostgrestRequestBuilder.upsert
       - PostgrestRequestBuilder.delete
+      - PostgrestTypedMutation.returning
     supporting_symbols:
       - PostgrestReturningOptions
       - PostgrestReturningOptions.init


### PR DESCRIPTION
Stacked on #1274.

## What

`postgrestStoredProperties()` skipped every binding with a non-nil `accessorBlock`. That filter means to skip computed properties, but observers land in the same block, so a genuinely stored property:

```swift
@Table("todos")
struct Todo {
  @PrimaryKey var id: Int
  var isDone: Bool = false { didSet { print(isDone) } }
}
```

was treated as computed and silently got no column — no `CodingKeys` case, no `columnName(for:)` case, and no field in `Insert` or `Update`.

The filter now inspects the block's contents via a shared `PatternBindingSyntax.postgrestIsStored`:

- accessors that are only `willSet`/`didSet` → stored, keep the column
- an explicit `get`, a `get`+`set` pair, a `_read`/`unsafeAddress` accessor, or a bare code block standing in for an implicit getter → computed, still no column

## Why the diagnostic changed too

`postgrestDiagnoseUnannotatedProperties(macro:in:)` (added in #1274) deliberately mirrors the member filter in `postgrestStoredProperties()`, so it carried the same `accessorBlock == nil` narrowing. Without the same fix, `var isDone = false { didSet { ... } }` — both observed *and* unannotated — stayed silently dropped with no diagnostic. Both call sites now share one helper, which is what keeps them in step.

## How it was tested

Swift Testing, `assertMacro` from MacroTesting:

- `TableMacroTests.keepsObservedStoredProperties` — a `didSet` property and a `willSet` property both get their column, `CodingKeys` case, and `Insert`/`Update` field
- `TableMacroTests.skipsPropertiesThatComputeTheirValue` — regression guard over an explicit getter, a getter with a setter, and a `_read` coroutine
- `SelectionOfMacroTests.keepsObservedStoredProperties` — the observed property lands in `selectString` and in `_columnCheck`
- `DiagnosticsTests.tableRejectsAnObservedPropertyWithNoTypeAnnotation` — an accessor block does not excuse a missing annotation

The three new positive tests were watched failing first; the recorded diff showed the observed properties missing from every generated member and `Insert`/`Update` collapsing to `init()`. `skipsPropertiesThatComputeTheirValue` passed from the start, which is the point — it pins behaviour the fix must not change.

Full suite: 1264 tests pass. `./scripts/format.sh` and `./scripts/spell-check.sh` clean.

## Review notes

The `case .getter` arm covers `var summary: String { htmlURL }`, where SwiftSyntax gives a bare `CodeBlockItemListSyntax` and there is no accessor specifier to inspect. That is the shape the original `accessorBlock == nil` check was really aiming at.

## Risk

Unreleased macros, so no released API changes and no migration-guide entry. The behaviour change is strictly additive for observed properties: a type that previously compiled with a silently missing column now gets that column, which is what the author wrote.

## Known gap, not addressed here

`variable.bindings.first` still means a comma-separated declaration (`var task: String, note: String`) contributes only one column. Tracked separately.