### PR TITLE
fix(postgrest): require one stored property per declaration

### DIFF
--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -40,6 +40,9 @@ public struct SelectionOfMacro: ExtensionMacro {
       )
       return []
     }
+    if declaration.postgrestDiagnoseMultipleBindings(macro: "@SelectionOf", in: context) {
+      return []
+    }
     if declaration.postgrestDiagnoseUnannotatedProperties(macro: "@SelectionOf", in: context) {
       return []
     }

--- a/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
@@ -56,6 +56,9 @@ extension DeclGroupSyntax {
   /// names the key path and hits the generated `fatalError`. A macro cannot recover the type from
   /// the initializer expression, so the author is asked for an annotation instead.
   ///
+  /// Reads `bindings.first` because ``postgrestDiagnoseMultipleBindings(macro:in:)`` has already
+  /// rejected anything that binds more than one property.
+  ///
   /// Returns `true` if anything was reported, so the caller can stop before emitting an expansion
   /// that leaves the column out.
   func postgrestDiagnoseUnannotatedProperties(
@@ -88,4 +91,56 @@ extension DeclGroupSyntax {
     }
     return reported
   }
+}
+
+extension DeclGroupSyntax {
+  /// Reports every declaration that binds more than one property.
+  ///
+  /// `var task: String, note: String` declares two stored properties, and
+  /// `postgrestStoredProperties()` reads only `bindings.first`, so `note` was dropped from every
+  /// generated member.
+  ///
+  /// Iterating the bindings instead is not the fix. A marker attribute sits on the *declaration*,
+  /// not on a binding, so `@Column("a") var x: Int, y: Int` would name one column twice and
+  /// `@PrimaryKey var x: Int, y: Int` would claim two primary keys. And `var task, note: String`
+  /// parses as one binding with no annotation and one with it, so the type would have to be
+  /// propagated backwards the way the compiler does it. One property per declaration removes both
+  /// problems, and the shape it asks for is the one this SDK writes anyway.
+  ///
+  /// Runs before ``postgrestDiagnoseUnannotatedProperties(macro:in:)``, so the shared-annotation
+  /// form is told to split rather than to annotate a type it already has.
+  func postgrestDiagnoseMultipleBindings(
+    macro: String,
+    in context: some MacroExpansionContext
+  ) -> Bool {
+    var reported = false
+    for member in memberBlock.members {
+      guard
+        let variable = member.decl.as(VariableDeclSyntax.self),
+        !variable.modifiers.contains(where: { $0.name.text == "static" }),
+        variable.bindings.count > 1
+      else { continue }
+
+      let names = variable.bindings.compactMap {
+        $0.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+      }
+      context.error(
+        """
+        \(macro) requires one stored property per declaration; split \
+        \(postgrestNameList(names)) into separate declarations
+        """,
+        at: variable.bindings
+      )
+      reported = true
+    }
+    return reported
+  }
+}
+
+/// `'a'`, then `'a' and 'b'`, then `'a', 'b' and 'c'`.
+private func postgrestNameList(_ names: [String]) -> String {
+  let quoted = names.map { "'\($0)'" }
+  guard let last = quoted.last else { return "" }
+  guard quoted.count > 1 else { return last }
+  return quoted.dropLast().joined(separator: ", ") + " and " + last
 }

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -58,6 +58,10 @@ extension DeclGroupSyntax {
   /// annotation to read. That one is a mistake rather than a design, so
   /// `postgrestDiagnoseUnannotatedProperties(macro:in:)` reports it and the macro stops before
   /// anything reaches here.
+  ///
+  /// Reading `bindings.first` is safe for the same reason: a declaration that binds more than one
+  /// property is rejected by `postgrestDiagnoseMultipleBindings(macro:in:)` first, so whatever
+  /// gets here binds exactly one.
   func postgrestStoredProperties() -> [StoredProperty] {
     memberBlock.members.compactMap { member -> StoredProperty? in
       guard

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -68,6 +68,9 @@ public struct TableMacro: ExtensionMacro {
       )
       return []
     }
+    if declaration.postgrestDiagnoseMultipleBindings(macro: "@Table", in: context) {
+      return []
+    }
     if declaration.postgrestDiagnoseUnannotatedProperties(macro: "@Table", in: context) {
       return []
     }

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -276,4 +276,146 @@ struct DiagnosticsTests {
       """
     }
   }
+
+  @Test
+  func tableRejectsMoreThanOnePropertyPerDeclaration() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String, note: String
+      }
+      """
+    } diagnostics: {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String, note: String
+            ┬─────────────────────────
+            ╰─ 🛑 @Table requires one stored property per declaration; split 'task' and 'note' into separate declarations
+      }
+      """
+    }
+  }
+
+  @Test
+  func tableRejectsASharedTypeAnnotation() {
+    // `var task, note: String` gives the parser one binding with no annotation and one with it.
+    // The split message has to win here, or the author is told to annotate a type they did write.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task, note: String
+      }
+      """
+    } diagnostics: {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task, note: String
+            ┬─────────────────
+            ╰─ 🛑 @Table requires one stored property per declaration; split 'task' and 'note' into separate declarations
+      }
+      """
+    }
+  }
+
+  @Test
+  func tableAcceptsAStaticDeclarationThatBindsSeveralNames() {
+    // A static member maps to no column either way, so splitting it would buy nothing.
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+        static let first = "a", second = "b"
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey var id: Int
+        var task: String
+        static let first = "a", second = "b"
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var task: String
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          init(task: String) {
+            self.task = task
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var task: String?
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+          }
+
+          init(task: String? = nil) {
+            self.task = task
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func selectionOfRejectsMoreThanOnePropertyPerDeclaration() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+        var task: String, note: String, tag: String
+      }
+      """
+    } diagnostics: {
+      """
+      @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+        var task: String, note: String, tag: String
+            ┬──────────────────────────────────────
+            ╰─ 🛑 @SelectionOf requires one stored property per declaration; split 'task', 'note' and 'tag' into separate declarations
+      }
+      """
+    }
+  }
 }


### PR DESCRIPTION
Stacked on #1275.

## What

`postgrestStoredProperties()` reads `bindings.first`, so a comma-separated declaration only ever contributed one column:

```
@Table("todos")
struct Todo {
  @PrimaryKey var id: Int
  var task: String, note: String
      ┬─────────────────────────
      ╰─ 🛑 @Table requires one stored property per declaration; split 'task' and 'note' into separate declarations
}
```

Before this, `note` was silently dropped from `CodingKeys`, `columnName(for:)`, `Insert` and `Update`.

## Why a diagnostic, not iterating the bindings

Iterating `variable.bindings` and emitting a column per binding was the obvious alternative. It doesn't hold up:

- **Marker attributes attach to the declaration, not to a binding.** `@Column("a") var x: Int, y: Int` would name one column twice, and `@PrimaryKey var x: Int, y: Int` would claim two primary keys. Both would have to be rejected anyway, so the ambiguity doesn't go away — it just moves.
- **`var task, note: String` needs the compiler's annotation-propagation rule.** The parser gives one binding with *no* annotation and one with it. I confirmed this against the actual macro before choosing: on `main` + #1274 the shared-annotation form produces

  > 🛑 @Table requires an explicit type annotation on 'task' …

  for a property whose type the author plainly did write. Getting option 1 right means reimplementing that propagation by hand.

One property per declaration removes both problems, and it's the shape this SDK writes anyway.

## Ordering matters

The check runs *ahead* of `postgrestDiagnoseUnannotatedProperties(macro:in:)`, which is what makes `var task, note: String` get the split message instead of the misleading annotation one. `DiagnosticsTests.tableRejectsASharedTypeAnnotation` pins that ordering — it fails if the two checks are ever swapped.

That ordering also makes `bindings.first` correct by construction in both readers rather than a silent narrowing. Both doc comments now say so, so the next person doesn't "fix" it back.

## How it was tested

`Tests/PostgrestMacrosTests/DiagnosticsTests.swift`, Swift Testing with recorded caret art:

- `tableRejectsMoreThanOnePropertyPerDeclaration`
- `tableRejectsASharedTypeAnnotation` — the `var task, note: String` form
- `tableAcceptsAStaticDeclarationThatBindsSeveralNames` — `static let first = "a", second = "b"` maps to no column either way, so splitting it would buy nothing; full expansion snapshot asserts no diagnostic fires
- `selectionOfRejectsMoreThanOnePropertyPerDeclaration` — three names, which also covers the `'a', 'b' and 'c'` joiner

All watched failing first. Full suite: 1268 tests pass. `./scripts/format.sh` and `./scripts/spell-check.sh` clean.

## Risk

Unreleased macros, so no released API changes and no migration-guide entry. This one is a *narrowing* rather than an addition: a declaration that previously compiled with a silently missing column is now an error naming the fix.

With this landed, all three silent-column-drop paths in the macro's property reader are closed — missing annotation (#1274), observers (#1275), and multiple bindings (here).