### PR TITLE
fix(postgrest): make the primary key optional in Insert, not absent

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -57,7 +57,8 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   /// Inserts a row.
   ///
   /// - Parameter values: The row to insert, in the relation's `Insert` shape. Primary keys and
-  ///   defaulted columns are absent or optional there.
+  ///   defaulted columns are optional there, so either can be left out and filled in by the
+  ///   database.
   /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
   /// - Throws: An encoding error if `values` cannot be serialized.
   public func insert(_ values: R.Insert) throws -> PostgrestTypedMutation<R> {

--- a/Sources/PostgREST/Relations/PostgrestRelation.swift
+++ b/Sources/PostgREST/Relations/PostgrestRelation.swift
@@ -42,11 +42,13 @@ public protocol PostgrestRelation: PostgrestSelection where Source == Self {
 
 /// A relation the database accepts writes for: a table, or a view Postgres reports as updatable.
 ///
-/// `Insert` and `Update` have no defaults on purpose. Defaulting them to `Self` would mean sending
-/// the primary key on insert and requiring every column on update.
+/// `Insert` and `Update` have no defaults on purpose. Defaulting them to `Self` would mean
+/// requiring every column on both — including the ones the database fills in on insert, and the
+/// ones an update is not touching.
 public protocol PostgrestWritableRelation: PostgrestRelation {
-  /// The shape accepted by an insert: primary keys excluded, defaulted and nullable columns
-  /// optional.
+  /// The shape accepted by an insert: every column, optional exactly where the database can fill
+  /// it in — a nullable column, or one with a default. A primary key is included, and required
+  /// unless it is also defaulted.
   associatedtype Insert: Encodable & Sendable
 
   /// The shape accepted by an update: every column optional.

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -56,7 +56,14 @@ public macro Column(_ name: String) =
     module: "PostgrestMacrosPlugin", type: "MarkerMacro"
   )
 
-/// Marks a property as the relation's primary key, excluding it from the generated `Insert`.
+/// Marks a property as part of the relation's primary key, making it optional in the generated
+/// `Insert`.
+///
+/// Leaving it `nil` omits the column, so a database-generated key fills itself in. Supplying it
+/// sends it, which is what a compound natural key needs — nothing in the database generates those.
+///
+/// Apply it to more than one property for a compound key. The key is left out of `Update`, which
+/// targets rows by key rather than changing it.
 @attached(peer)
 public macro PrimaryKey() =
   #externalMacro(

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -14,7 +14,7 @@
 /// ```swift
 /// @Table("todos")
 /// struct Todo {
-///   @PrimaryKey var id: Int
+///   @PrimaryKey @Default var id: Int
 ///   var task: String
 ///   @Default var isDone: Bool
 ///   @Column("due_at") var dueDate: Date?
@@ -56,14 +56,23 @@ public macro Column(_ name: String) =
     module: "PostgrestMacrosPlugin", type: "MarkerMacro"
   )
 
-/// Marks a property as part of the relation's primary key, making it optional in the generated
-/// `Insert`.
+/// Marks a property as part of the relation's primary key.
 ///
-/// Leaving it `nil` omits the column, so a database-generated key fills itself in. Supplying it
-/// sends it, which is what a compound natural key needs — nothing in the database generates those.
+/// This does **not** make the column optional in `Insert`. Being the key says nothing about
+/// whether the database can supply the value — a `SERIAL` or identity column can, and a natural
+/// key like a country code cannot. Add ``Default()`` for the ones it can:
 ///
-/// Apply it to more than one property for a compound key. The key is left out of `Update`, which
-/// targets rows by key rather than changing it.
+/// ```swift
+/// @PrimaryKey @Default var id: Int      // generated — omit it on insert
+/// @PrimaryKey var code: String          // natural — required on insert
+/// ```
+///
+/// Apply it to more than one property for a compound key. Each half is then required unless it is
+/// also ``Default()``, so an incomplete key is a compile error rather than a request PostgREST
+/// rejects. This matches how `postgres-meta` types supabase-js: it makes a column optional from
+/// `is_nullable || is_identity || default_value !== null`, and never consults the primary key.
+///
+/// The key is left out of `Update`, which targets rows by key rather than changing it.
 @attached(peer)
 public macro PrimaryKey() =
   #externalMacro(
@@ -72,7 +81,9 @@ public macro PrimaryKey() =
 
 /// Marks a property as having a database default, making it optional in the generated `Insert`.
 ///
-/// Leaving it `nil` omits the column from the request body, so the database fills it in.
+/// Leaving it `nil` omits the column from the request body, so the database fills it in. This is
+/// the only marker that makes a column optional — including for a primary key, which needs
+/// `@PrimaryKey @Default` when the database generates it.
 @attached(peer)
 public macro Default() =
   #externalMacro(

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -23,6 +23,19 @@ struct StoredProperty {
   var optionalType: String { isOptional ? type : "\(type)?" }
 }
 
+/// Whether a written type is spelled as an `Optional`.
+///
+/// Both spellings have to be recognized everywhere optionality is decided: `Int?` and
+/// `Optional<Int>` are the same type, and a generated schema can emit either. Recognizing one and
+/// not the other is what let an `Optional<T>` field lose the `= nil` default in a generated
+/// initializer while a `?`-spelled one kept it.
+///
+/// A `Swift.Optional<Int>` spelling is not matched. It is legal but vanishingly rare, and a macro
+/// cannot resolve module qualification from syntax alone.
+func postgrestIsOptionalType(_ type: String) -> Bool {
+  type.hasSuffix("?") || type.hasPrefix("Optional<")
+}
+
 extension DeclGroupSyntax {
   /// Reads the stored properties, skipping computed properties and static members.
   ///
@@ -78,7 +91,7 @@ extension DeclGroupSyntax {
         return StoredProperty(
           name: identifier.identifier.text,
           type: typeText,
-          isOptional: typeText.hasSuffix("?") || typeText.hasPrefix("Optional<"),
+          isOptional: postgrestIsOptionalType(typeText),
           isPrimaryKey: attribute("PrimaryKey") != nil,
           hasDefault: attribute("Default") != nil,
           explicitColumn: column

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -85,10 +85,14 @@ public struct TableMacro: ExtensionMacro {
       body.append(codingKeys)
     }
     if !arguments.readOnly {
-      // `Insert` carries every column and makes the primary key optional alongside the defaulted
-      // ones, so a row can be inserted without naming a column the database fills in. Dropping the
-      // key instead only works when the database generates it: a compound natural key is supplied
-      // by the client, and leaving it out made such a table impossible to insert into at all.
+      // `Insert` carries every column, and a column is optional exactly when the database can
+      // fill it in: it is nullable, or it has a default. Being the primary key is not one of the
+      // reasons — `postgres-meta`, which generates supabase-js's types from the same column
+      // metadata, computes `is_nullable || is_identity || default_value !== null` and never
+      // consults the key. `@Default` already carries what `is_identity || default_value !== null`
+      // means, so a generated key is spelled `@PrimaryKey @Default var id: Int` and a natural one
+      // — including each half of a compound key — is required, which is what makes a join table
+      // insertable and an incomplete key a compile error rather than a 400.
       //
       // `Update` targets rows by key and changes the rest, so the key stays out and every
       // remaining column is optional — a partial update names only what it changes.
@@ -97,7 +101,7 @@ public struct TableMacro: ExtensionMacro {
           named: "Insert",
           access: access,
           fields: properties.map {
-            ($0, $0.isOptional || $0.hasDefault || $0.isPrimaryKey ? $0.optionalType : $0.type)
+            ($0, $0.isOptional || $0.hasDefault ? $0.optionalType : $0.type)
           }
         )
       )

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -189,7 +189,10 @@ public struct TableMacro: ExtensionMacro {
 
     let parameters =
       fields
-      .map { "\($0.property.name): \($0.type)\($0.type.hasSuffix("?") ? " = nil" : "")" }
+      // The default follows the *generated* parameter type, not the property's own. In `Update`
+      // every column is optional even when the property is not, so testing the property here would
+      // drop the default that makes a partial update possible.
+      .map { "\($0.property.name): \($0.type)\(postgrestIsOptionalType($0.type) ? " = nil" : "")" }
       .joined(separator: ", ")
     lines.append("")
     lines.append("    \(access)init(\(parameters)) {")

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -85,17 +85,23 @@ public struct TableMacro: ExtensionMacro {
       body.append(codingKeys)
     }
     if !arguments.readOnly {
-      // `Insert` drops the primary key and makes defaulted columns optional, so a row can be
-      // inserted without naming a column the database fills in. `Update` makes every column
-      // optional, so a partial update names only what it changes.
-      let writable = properties.filter { !$0.isPrimaryKey }
+      // `Insert` carries every column and makes the primary key optional alongside the defaulted
+      // ones, so a row can be inserted without naming a column the database fills in. Dropping the
+      // key instead only works when the database generates it: a compound natural key is supplied
+      // by the client, and leaving it out made such a table impossible to insert into at all.
+      //
+      // `Update` targets rows by key and changes the rest, so the key stays out and every
+      // remaining column is optional — a partial update names only what it changes.
       body.append(
         writeShape(
           named: "Insert",
           access: access,
-          fields: writable.map { ($0, $0.isOptional || $0.hasDefault ? $0.optionalType : $0.type) }
+          fields: properties.map {
+            ($0, $0.isOptional || $0.hasDefault || $0.isPrimaryKey ? $0.optionalType : $0.type)
+          }
         )
       )
+      let writable = properties.filter { !$0.isPrimaryKey }
       body.append(
         writeShape(named: "Update", access: access, fields: writable.map { ($0, $0.optionalType) })
       )

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -203,13 +203,16 @@ struct DiagnosticsTests {
         }
 
         struct Insert: Encodable, Sendable {
+          var id: Int?
           var task: String
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
           }
 
-          init(task: String) {
+          init(id: Int? = nil, task: String) {
+            self.id = id
             self.task = task
           }
         }

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -203,7 +203,7 @@ struct DiagnosticsTests {
         }
 
         struct Insert: Encodable, Sendable {
-          var id: Int?
+          var id: Int
           var task: String
 
           enum CodingKeys: String, CodingKey {
@@ -211,7 +211,7 @@ struct DiagnosticsTests {
             case task = "task"
           }
 
-          init(id: Int? = nil, task: String) {
+          init(id: Int, task: String) {
             self.id = id
             self.task = task
           }

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -13,14 +13,18 @@ import Testing
 // extension of a type nested inside another type, so annotating a nested struct fails to compile.
 @Table("todos")
 struct IntegrationTodo: Hashable {
-  @PrimaryKey var id: Int
+  // `@Default` is what makes the key optional in `Insert`, not `@PrimaryKey`. It says the database
+  // generates this one — an identity column or a column with a default — matching what
+  // `postgres-meta` reads to make a column optional for supabase-js.
+  @PrimaryKey @Default var id: Int
   var task: String
   @Default var isDone: Bool
   @Column("due_at") var dueDate: Date?
 }
 
-// A compound natural key. Nothing in the database generates these, so an `Insert` that dropped
-// them would make the table impossible to write to.
+// A compound natural key. Nothing in the database generates these, so neither half is `@Default`
+// and both are required by `Insert` — an incomplete key is a compile error, and an `Insert` that
+// dropped them made the table impossible to write to at all.
 @Table("user_roles")
 struct IntegrationUserRole {
   @PrimaryKey var userID: Int
@@ -55,6 +59,7 @@ struct TableIntegrationTests {
   @Test
   func insertOmitsANilPrimaryKeyAndUsesColumnNames() throws {
     // The key is optional rather than absent, so leaving it out still lets the database fill it in.
+    // Optional because it is `@Default`, not because it is the key.
     let data = try JSONEncoder().encode(Todo.Insert(task: "buy milk", isDone: false))
     let json = String(decoding: data, as: UTF8.self)
     #expect(json.contains("\"id\"") == false)
@@ -73,6 +78,11 @@ struct TableIntegrationTests {
   func insertCarriesAWholeCompoundPrimaryKey() throws {
     // The acceptance criterion for a join table: both halves of the key reach the wire, so the row
     // can actually be created.
+    //
+    // Both are also *required*, because neither is `@Default`. `IntegrationUserRole.Insert()` and
+    // `.Insert(userID: 1)` no longer compile, which is the point — before, they compiled and sent
+    // an incomplete body for PostgREST to reject at runtime. Swift cannot assert that something
+    // fails to compile, so this notes it rather than covering it.
     let data = try JSONEncoder().encode(IntegrationUserRole.Insert(userID: 1, roleID: 2))
     let json = String(decoding: data, as: UTF8.self)
     #expect(json.contains("\"user_id\":1") == true)

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -32,6 +32,14 @@ struct IntegrationUserRole {
   var grantedAt: Date?
 }
 
+// `Optional<T>` rather than `T?`, to keep the generated defaults honest for both spellings.
+@Table("notes")
+struct IntegrationNote {
+  @PrimaryKey @Default var id: Int
+  var body: String
+  var tag: Optional<String>
+}
+
 @Table("active_todos", readOnly: true)
 struct IntegrationActiveTodo {
   var id: Int
@@ -87,6 +95,20 @@ struct TableIntegrationTests {
     let json = String(decoding: data, as: UTF8.self)
     #expect(json.contains("\"user_id\":1") == true)
     #expect(json.contains("\"role_id\":2") == true)
+  }
+
+  @Test
+  func anOptionalSpelledColumnCanBeOmitted() throws {
+    // This is the assertion the expansion test cannot make: `MacroTesting` compares generated
+    // text, it does not compile it. Both calls omit `tag`, which only compiles if the generated
+    // initializers defaulted an `Optional<String>` to nil.
+    let insert = try JSONEncoder().encode(IntegrationNote.Insert(body: "hello"))
+    #expect(String(decoding: insert, as: UTF8.self) == #"{"body":"hello"}"#)
+
+    // `Update()` naming nothing at all is the stronger half — a partial update was impossible on
+    // such a table before, because every `Optional<T>` column had to be passed.
+    let update = try JSONEncoder().encode(IntegrationNote.Update())
+    #expect(String(decoding: update, as: UTF8.self) == "{}")
   }
 
   @Test

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -19,6 +19,15 @@ struct IntegrationTodo: Hashable {
   @Column("due_at") var dueDate: Date?
 }
 
+// A compound natural key. Nothing in the database generates these, so an `Insert` that dropped
+// them would make the table impossible to write to.
+@Table("user_roles")
+struct IntegrationUserRole {
+  @PrimaryKey var userID: Int
+  @PrimaryKey var roleID: Int
+  var grantedAt: Date?
+}
+
 @Table("active_todos", readOnly: true)
 struct IntegrationActiveTodo {
   var id: Int
@@ -44,12 +53,30 @@ struct TableIntegrationTests {
   }
 
   @Test
-  func insertExcludesThePrimaryKeyAndUsesColumnNames() throws {
+  func insertOmitsANilPrimaryKeyAndUsesColumnNames() throws {
+    // The key is optional rather than absent, so leaving it out still lets the database fill it in.
     let data = try JSONEncoder().encode(Todo.Insert(task: "buy milk", isDone: false))
     let json = String(decoding: data, as: UTF8.self)
     #expect(json.contains("\"id\"") == false)
     #expect(json.contains("\"is_done\"") == true)
     #expect(json.contains("\"isDone\"") == false)
+  }
+
+  @Test
+  func insertCarriesAPrimaryKeyTheClientSupplies() throws {
+    let data = try JSONEncoder().encode(Todo.Insert(id: 7, task: "buy milk"))
+    let json = String(decoding: data, as: UTF8.self)
+    #expect(json.contains("\"id\":7") == true)
+  }
+
+  @Test
+  func insertCarriesAWholeCompoundPrimaryKey() throws {
+    // The acceptance criterion for a join table: both halves of the key reach the wire, so the row
+    // can actually be created.
+    let data = try JSONEncoder().encode(IntegrationUserRole.Insert(userID: 1, roleID: 2))
+    let json = String(decoding: data, as: UTF8.self)
+    #expect(json.contains("\"user_id\":1") == true)
+    #expect(json.contains("\"role_id\":2") == true)
   }
 
   @Test
@@ -113,5 +140,20 @@ struct TableIntegrationTests {
     #expect(rows.count == 1)
     #expect(capture.path?.hasSuffix("/active_todos") == true)
     #expect(capture.query?.contains("task=eq.buy milk") == true)
+  }
+
+  @Test
+  func aTypedUpsertCarriesTheConflictKey() async throws {
+    // `upsert` sends no `on_conflict`, so PostgREST resolves against the primary key — which has
+    // to be in the body for that to mean anything. While `Insert` dropped the key, the merge half
+    // of every upsert was unreachable and each call just inserted another row.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .upsert(Todo.Insert(id: 1, task: "buy milk"))
+      .execute()
+
+    #expect(capture.path?.hasSuffix("/todos") == true)
+    #expect(capture.bodyString?.contains(#""id":1"#) == true)
   }
 }

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -66,17 +66,20 @@ struct TableMacroTests {
         }
 
         struct Insert: Encodable, Sendable {
+          var id: Int?
           var task: String
           var isDone: Bool?
           var dueDate: Date?
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
             case isDone = "is_done"
             case dueDate = "due_at"
           }
 
-          init(task: String, isDone: Bool? = nil, dueDate: Date? = nil) {
+          init(id: Int? = nil, task: String, isDone: Bool? = nil, dueDate: Date? = nil) {
+            self.id = id
             self.task = task
             self.isDone = isDone
             self.dueDate = dueDate
@@ -185,13 +188,16 @@ struct TableMacroTests {
         }
 
         public struct Insert: Encodable, Sendable {
+          public var id: Int?
           public var task: String
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
           }
 
-          public init(task: String) {
+          public init(id: Int? = nil, task: String) {
+            self.id = id
             self.task = task
           }
         }
@@ -330,19 +336,22 @@ struct TableMacroTests {
         }
 
         struct Insert: Encodable, Sendable {
+          var id: Int?
           var task: String
           var note: String
           var draft: String
           var review: String
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
             case note = "note"
             case draft = "draft"
             case review = "review"
           }
 
-          init(task: String, note: String, draft: String, review: String) {
+          init(id: Int? = nil, task: String, note: String, draft: String, review: String) {
+            self.id = id
             self.task = task
             self.note = note
             self.draft = draft
@@ -426,13 +435,16 @@ struct TableMacroTests {
         }
 
         struct Insert: Encodable, Sendable {
+          var id: Int?
           var task: String
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
           }
 
-          init(task: String) {
+          init(id: Int? = nil, task: String) {
+            self.id = id
             self.task = task
           }
         }
@@ -446,6 +458,153 @@ struct TableMacroTests {
 
           init(task: String? = nil) {
             self.task = task
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func insertCarriesACompoundPrimaryKey() {
+    // A compound natural key is never database-generated, so the client is the only thing that can
+    // supply it. Dropping it from `Insert` made the row impossible to create.
+    assertMacro {
+      """
+      @Table("user_roles")
+      struct UserRole {
+        @PrimaryKey var userID: UUID
+        @PrimaryKey var roleID: UUID
+        var grantedAt: Date
+      }
+      """
+    } expansion: {
+      #"""
+      struct UserRole {
+        @PrimaryKey var userID: UUID
+        @PrimaryKey var roleID: UUID
+        var grantedAt: Date
+      }
+
+      extension UserRole {
+        static let relationName = "user_roles"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.userID:
+            return "user_id"
+          case \Self.roleID:
+            return "role_id"
+          case \Self.grantedAt:
+            return "granted_at"
+          default:
+            fatalError("UserRole: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case userID = "user_id"
+          case roleID = "role_id"
+          case grantedAt = "granted_at"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var userID: UUID?
+          var roleID: UUID?
+          var grantedAt: Date
+
+          enum CodingKeys: String, CodingKey {
+            case userID = "user_id"
+            case roleID = "role_id"
+            case grantedAt = "granted_at"
+          }
+
+          init(userID: UUID? = nil, roleID: UUID? = nil, grantedAt: Date) {
+            self.userID = userID
+            self.roleID = roleID
+            self.grantedAt = grantedAt
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var grantedAt: Date?
+
+          enum CodingKeys: String, CodingKey {
+            case grantedAt = "granted_at"
+          }
+
+          init(grantedAt: Date? = nil) {
+            self.grantedAt = grantedAt
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func insertOnATableThatIsNothingButACompoundKey() {
+    // A pure join table previously expanded to `Insert` with no fields and an empty `init()`.
+    assertMacro {
+      """
+      @Table("user_roles")
+      struct UserRole {
+        @PrimaryKey var userID: UUID
+        @PrimaryKey var roleID: UUID
+      }
+      """
+    } expansion: {
+      #"""
+      struct UserRole {
+        @PrimaryKey var userID: UUID
+        @PrimaryKey var roleID: UUID
+      }
+
+      extension UserRole {
+        static let relationName = "user_roles"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.userID:
+            return "user_id"
+          case \Self.roleID:
+            return "role_id"
+          default:
+            fatalError("UserRole: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case userID = "user_id"
+          case roleID = "role_id"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var userID: UUID?
+          var roleID: UUID?
+
+          enum CodingKeys: String, CodingKey {
+            case userID = "user_id"
+            case roleID = "role_id"
+          }
+
+          init(userID: UUID? = nil, roleID: UUID? = nil) {
+            self.userID = userID
+            self.roleID = roleID
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+
+          init() {
           }
         }
       }

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -15,13 +15,15 @@ import Testing
 /// the clause directly.
 @Suite(.macros(["Table": TableMacro.self]))
 struct TableMacroTests {
+  /// A generated surrogate key: `@Default` is what makes it optional in `Insert`, not
+  /// `@PrimaryKey`. See `insertOnATableThatIsNothingButACompoundKey` for a key without it.
   @Test
   func expandsAWritableTable() {
     assertMacro {
       """
       @Table("todos")
       struct Todo {
-        @PrimaryKey var id: Int
+        @PrimaryKey @Default var id: Int
         var task: String
         @Default var isDone: Bool
         @Column("due_at") var dueDate: Date?
@@ -30,7 +32,7 @@ struct TableMacroTests {
     } expansion: {
       #"""
       struct Todo {
-        @PrimaryKey var id: Int
+        @PrimaryKey @Default var id: Int
         var task: String
         @Default var isDone: Bool
         @Column("due_at") var dueDate: Date?
@@ -188,7 +190,7 @@ struct TableMacroTests {
         }
 
         public struct Insert: Encodable, Sendable {
-          public var id: Int?
+          public var id: Int
           public var task: String
 
           enum CodingKeys: String, CodingKey {
@@ -196,7 +198,7 @@ struct TableMacroTests {
             case task = "task"
           }
 
-          public init(id: Int? = nil, task: String) {
+          public init(id: Int, task: String) {
             self.id = id
             self.task = task
           }
@@ -336,7 +338,7 @@ struct TableMacroTests {
         }
 
         struct Insert: Encodable, Sendable {
-          var id: Int?
+          var id: Int
           var task: String
           var note: String
           var draft: String
@@ -350,7 +352,7 @@ struct TableMacroTests {
             case review = "review"
           }
 
-          init(id: Int? = nil, task: String, note: String, draft: String, review: String) {
+          init(id: Int, task: String, note: String, draft: String, review: String) {
             self.id = id
             self.task = task
             self.note = note
@@ -435,7 +437,7 @@ struct TableMacroTests {
         }
 
         struct Insert: Encodable, Sendable {
-          var id: Int?
+          var id: Int
           var task: String
 
           enum CodingKeys: String, CodingKey {
@@ -443,7 +445,7 @@ struct TableMacroTests {
             case task = "task"
           }
 
-          init(id: Int? = nil, task: String) {
+          init(id: Int, task: String) {
             self.id = id
             self.task = task
           }
@@ -513,8 +515,8 @@ struct TableMacroTests {
         }
 
         struct Insert: Encodable, Sendable {
-          var userID: UUID?
-          var roleID: UUID?
+          var userID: UUID
+          var roleID: UUID
           var grantedAt: Date
 
           enum CodingKeys: String, CodingKey {
@@ -523,7 +525,7 @@ struct TableMacroTests {
             case grantedAt = "granted_at"
           }
 
-          init(userID: UUID? = nil, roleID: UUID? = nil, grantedAt: Date) {
+          init(userID: UUID, roleID: UUID, grantedAt: Date) {
             self.userID = userID
             self.roleID = roleID
             self.grantedAt = grantedAt
@@ -549,6 +551,8 @@ struct TableMacroTests {
   @Test
   func insertOnATableThatIsNothingButACompoundKey() {
     // A pure join table previously expanded to `Insert` with no fields and an empty `init()`.
+    // Neither half is `@Default`, so both are required: `Insert()` and `Insert(userID:)` do not
+    // compile, and an incomplete key can no longer reach PostgREST as a 400.
     assertMacro {
       """
       @Table("user_roles")
@@ -588,15 +592,15 @@ struct TableMacroTests {
         }
 
         struct Insert: Encodable, Sendable {
-          var userID: UUID?
-          var roleID: UUID?
+          var userID: UUID
+          var roleID: UUID
 
           enum CodingKeys: String, CodingKey {
             case userID = "user_id"
             case roleID = "role_id"
           }
 
-          init(userID: UUID? = nil, roleID: UUID? = nil) {
+          init(userID: UUID, roleID: UUID) {
             self.userID = userID
             self.roleID = roleID
           }

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -615,4 +615,101 @@ struct TableMacroTests {
       """#
     }
   }
+  /// `Int?` and `Optional<Int>` are the same type, and optionality has to be recognized in both
+  /// spellings everywhere it is decided. The generated initializers used to give `= nil` only to
+  /// the `?` form, so an `Optional<T>` column had to be passed explicitly — including in `Update`,
+  /// whose whole contract is naming only what changes.
+  @Test
+  func acceptsTheOptionalSpellingOfAnOptional() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        @PrimaryKey @Default var id: Int
+        var task: String
+        var note: Optional<String>
+        @Default var tag: Optional<String>
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        @PrimaryKey @Default var id: Int
+        var task: String
+        var note: Optional<String>
+        @Default var tag: Optional<String>
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.task:
+            return "task"
+          case \Self.note:
+            return "note"
+          case \Self.tag:
+            return "tag"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+          case note = "note"
+          case tag = "tag"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var id: Int?
+          var task: String
+          var note: Optional<String>
+          var tag: Optional<String>
+
+          enum CodingKeys: String, CodingKey {
+            case id = "id"
+            case task = "task"
+            case note = "note"
+            case tag = "tag"
+          }
+
+          init(id: Int? = nil, task: String, note: Optional<String> = nil, tag: Optional<String> = nil) {
+            self.id = id
+            self.task = task
+            self.note = note
+            self.tag = tag
+          }
+        }
+
+        struct Update: Encodable, Sendable {
+          var task: String?
+          var note: Optional<String>
+          var tag: Optional<String>
+
+          enum CodingKeys: String, CodingKey {
+            case task = "task"
+            case note = "note"
+            case tag = "tag"
+          }
+
+          init(task: String? = nil, note: Optional<String> = nil, tag: Optional<String> = nil) {
+            self.task = task
+            self.note = note
+            self.tag = tag
+          }
+        }
+      }
+      """#
+    }
+  }
+
 }

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -76,6 +76,7 @@ imatch
 Imatch
 Inbucket
 initializers
+insertable
 inkey
 isdistinct
 johndoe


### PR DESCRIPTION
Fixes SDK-1606. Stacked on #1274.

## What

`@PrimaryKey` had exactly one effect in `TableMacro.swift`:

```swift
let writable = properties.filter { !$0.isPrimaryKey }
```

Key columns were dropped from `Insert` and `Update`. Right for a single database-generated `id`; wrong everywhere else.

### 1. A compound natural key made the table unwritable

```swift
@Table("user_roles")
struct UserRole {
  @PrimaryKey var userID: UUID
  @PrimaryKey var roleID: UUID
  var grantedAt: Date
}
```

generated `Insert { var grantedAt: Date }` — no way to send either key, so **no row could be created**. A pure join table got an `Insert` with no fields and an empty `init()`.

### 2. It broke `upsert`, for every table

`upsert(_ values: R.Insert, onConflict: String? = nil)` sends no `on_conflict` by default. Per [PostgREST's docs](https://docs.postgrest.org/en/stable/references/api/tables_views.html#upsert), upsert then operates on the primary key columns and "you must specify all of them" in the body. `Insert` never carried them — so the merge half of an upsert was unreachable and every call just inserted another row.

Nothing about either failure was loud: no compile error, no diagnostic.

## Why option 3

The marker conflated two facts that only coincide for a serial `id`:

1. this column identifies the row — what the marker is named for
2. the database generates it, so don't send it — what the filter implemented

(2) is already what `@Default` means — so `@Default` is what expresses it, and `@PrimaryKey` no longer does.

`Insert` now carries every column, and a column is optional exactly when the database can fill it in: it is nullable, or it has a default. That is `postgres-meta`'s rule verbatim — `is_nullable || is_identity || default_value !== null` — which is what types supabase-js from the same column metadata, and it never consults the primary key either.

A generated key is spelled with both markers. The plugin already read them independently, so this needed no plugin change:

```swift
@PrimaryKey @Default var id: Int      // generated — omit it on insert
@PrimaryKey var code: String          // natural — required on insert
```

```swift
Todo.Insert(task: "buy milk")            // id omitted, the database fills it (@Default)
Todo.Insert(id: 7, task: "buy milk")     // now possible
UserRole.Insert(userID: 1, roleID: 2)    // now possible
UserRole.Insert(userID: 1)               // compile error — half a key
UserRole.Insert()                        // compile error
```

> **Revised after review.** The first revision used `isOptional || hasDefault || isPrimaryKey`, making *every* key optional. [Review feedback](https://github.com/supabase/supabase-swift/pull/1278#pullrequestreview-5018711244) established that this diverges from supabase-js in the one place type safety matters, and that the "costs existing users nothing" argument for it does not apply to an API v2.55.1 never shipped. Changed in `cc2a3bb`.

`Update` is deliberately unchanged — it targets rows by key rather than changing it, so the key stays out. **Worth a reviewer opinion:** the same argument that motivates this PR also applies to *changing* a natural key, which `Update` still can't express. Kept out of scope here; happy to follow up.

## What this does not fix

This makes a correct `upsert` possible; it does not make an incorrect one impossible:

```swift
try client.from(Todo.self).upsert(Todo.Insert(task: "buy milk"))  // still silently just inserts
```

With no `onConflict:` and no key in the body, PostgREST has nothing to merge on. supabase-js has the same hole, so this is parity-neutral — but the typed layer exists to close exactly this kind of hole. A typed `onConflict: [PartialKeyPath<R>]`, or deriving `on_conflict` from the `@PrimaryKey` columns, would close it. Filed as [SDK-1616](https://linear.app/supabase/issue/SDK-1616/postgrest-typed-upsert-compiles-with-no-conflict-target-and-silently) — which turned up a prerequisite worth knowing: nothing exposes the primary key at runtime, since `@PrimaryKey` is consumed entirely at expansion time, so `@Table` would need to emit the key columns first.

## How it was tested

New, each watched failing first:

- `TableMacroTests.insertCarriesACompoundPrimaryKey` — before the fix the expansion was `init(grantedAt: Date)`
- `TableMacroTests.insertOnATableThatIsNothingButACompoundKey` — the pure join table
- `TableIntegrationTests.insertCarriesAPrimaryKeyTheClientSupplies` — `"id":7` reaches the wire
- `TableIntegrationTests.insertCarriesAWholeCompoundPrimaryKey` — `"user_id":1` and `"role_id":2` both reach the wire
- `TableIntegrationTests.aTypedUpsertCarriesTheConflictKey` — the upsert body now contains its own conflict target; there was no typed-upsert test at all before

The integration tests are the strongest evidence: against the pre-fix macro they don't *compile* — `extra argument 'id' in call` and `extra arguments at positions #1, #2 in call`.

> One note for anyone re-checking this locally: SwiftPM does **not** recompile a module when only the macro plugin changed, so reverting `TableMacro.swift` and re-running appears to pass against a stale expansion. Touch the test file to force it.

`insertExcludesThePrimaryKeyAndUsesColumnNames` is renamed to `insertOmitsANilPrimaryKeyAndUsesColumnNames` — its assertions still hold, but the key is now omitted-when-nil rather than excluded, and the old name claimed otherwise.

Existing expansion snapshots gained the key as an `Insert` field — required or optional depending on `@Default`. All re-recorded, not hand-edited, including the one inside `DiagnosticsTests` that also captures an expansion.

Full suite: 1269 tests pass. `./scripts/format.sh`, `./scripts/spell-check.sh`, and `./scripts/test-docs.sh` all clean.

## Docs corrected

Four comments asserted a behaviour this PR removes:

- `@PrimaryKey`: "Marks a property as the relation's primary key, excluding it from the generated `Insert`." Then, after the first revision, "making it optional in the generated `Insert`" — which would have shipped as a lie once the rule changed. It now says what the marker does and does not do, with both spellings side by side.
- `insert(_:)`: "Primary keys and defaulted columns are absent or optional there."
- `PostgrestWritableRelation.Insert`: "primary keys excluded, defaulted and nullable columns optional." Wrong twice over — keys are included, and their optionality follows `@Default`.
- The rationale above it: "Defaulting them to `Self` would mean sending the primary key on insert." Sending it is now intended, so the reasoning read backwards.

`@Default` also gains a line noting it is the only marker that makes a column optional, and the `@Table` example carries `@PrimaryKey @Default var id: Int` so the common case is what a reader copies.

## Not a breaking change

No `!` and no `V3_MIGRATION.md` entry: `PostgrestMacros` does not exist in v2.55.1, so this changes nothing a released version ever exposed. That matches how the rest of the macro stack was marked, against `refactor(postgrest)!` for the builders that did ship.
