### PR TITLE
fix(postgrest): let Update change a primary key column

### DIFF
--- a/Sources/PostgREST/Relations/PostgrestRelation.swift
+++ b/Sources/PostgREST/Relations/PostgrestRelation.swift
@@ -38,6 +38,21 @@ public protocol PostgrestRelation: PostgrestSelection where Source == Self {
   /// - Parameter keyPath: A key path to one of this type's stored properties.
   /// - Returns: The column name PostgREST expects in a query string.
   static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String
+
+  /// The columns making up the relation's primary key, in declaration order.
+  ///
+  /// Empty when the relation declares no key. A caller deriving a conflict target for an upsert
+  /// has to treat that as "cannot derive" rather than "conflicts on nothing" — an empty
+  /// `on_conflict` is not the same request.
+  static var primaryKeyColumns: [String] { get }
+}
+
+extension PostgrestRelation {
+  /// No declared key.
+  ///
+  /// `@Table` overrides this whenever a property is marked `@PrimaryKey`; a hand-written
+  /// conformance opts in by declaring it.
+  public static var primaryKeyColumns: [String] { [] }
 }
 
 /// A relation the database accepts writes for: a table, or a view Postgres reports as updatable.

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -72,7 +72,8 @@ public macro Column(_ name: String) =
 /// rejects. This matches how `postgres-meta` types supabase-js: it makes a column optional from
 /// `is_nullable || is_identity || default_value !== null`, and never consults the primary key.
 ///
-/// The key is left out of `Update`, which targets rows by key rather than changing it.
+/// `Update` carries the key like any other column, all optional, so a natural key can be renamed.
+/// Which rows a write touches is decided by the filters on the mutation, not by this marker.
 @attached(peer)
 public macro PrimaryKey() =
   #externalMacro(

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -37,7 +37,7 @@
   extension,
   conformances: Decodable, Sendable, PostgrestRelation, PostgrestWritableRelation,
   names: named(relationName), named(schema), named(selectString), named(columnName(for:)),
-  named(CodingKeys), named(Insert), named(Update)
+  named(primaryKeyColumns), named(CodingKeys), named(Insert), named(Update)
 )
 public macro Table(
   _ name: String,
@@ -74,6 +74,10 @@ public macro Column(_ name: String) =
 ///
 /// `Update` carries the key like any other column, all optional, so a natural key can be renamed.
 /// Which rows a write touches is decided by the filters on the mutation, not by this marker.
+///
+/// What the marker does produce is ``PostgREST/PostgrestRelation/primaryKeyColumns``, the column
+/// names in declaration order. That is what lets a caller — or a future `upsert` — name a conflict
+/// target without repeating the key as a string.
 @attached(peer)
 public macro PrimaryKey() =
   #externalMacro(

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -81,6 +81,15 @@ public struct TableMacro: ExtensionMacro {
       "  \(access)static let selectString = \"*\"",
       columnNameFunction(access: access, type: type.trimmedDescription, properties: properties),
     ]
+    // The one thing `@PrimaryKey` uniquely does. Without this the marker is inert: after the key
+    // stopped gating `Insert` optionality and stopped being filtered out of `Update`, writing it or
+    // omitting it expanded byte-for-byte the same. Emitted only when a key is declared, so a
+    // keyless relation falls back to the protocol's empty default.
+    let keyColumns = properties.filter(\.isPrimaryKey).map(\.columnName)
+    if !keyColumns.isEmpty {
+      let list = keyColumns.map { "\"\($0)\"" }.joined(separator: ", ")
+      body.append("  \(access)static let primaryKeyColumns: [String] = [\(list)]")
+    }
     if let codingKeys = codingKeys(for: properties) {
       body.append(codingKeys)
     }

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -94,8 +94,10 @@ public struct TableMacro: ExtensionMacro {
       // — including each half of a compound key — is required, which is what makes a join table
       // insertable and an incomplete key a compile error rather than a 400.
       //
-      // `Update` targets rows by key and changes the rest, so the key stays out and every
-      // remaining column is optional — a partial update names only what it changes.
+      // `Update` makes every column optional, the key included, so a partial update names only
+      // what it changes. Targeting is a separate concern — the caller filters the mutation — so
+      // holding the key back would not have protected a row's identity, only made a natural key
+      // impossible to rename.
       body.append(
         writeShape(
           named: "Insert",
@@ -105,9 +107,9 @@ public struct TableMacro: ExtensionMacro {
           }
         )
       )
-      let writable = properties.filter { !$0.isPrimaryKey }
       body.append(
-        writeShape(named: "Update", access: access, fields: writable.map { ($0, $0.optionalType) })
+        writeShape(
+          named: "Update", access: access, fields: properties.map { ($0, $0.optionalType) })
       )
     }
 

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -197,6 +197,8 @@ struct DiagnosticsTests {
           }
         }
 
+        static let primaryKeyColumns: [String] = ["id"]
+
         enum CodingKeys: String, CodingKey {
           case id = "id"
           case task = "task"

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -218,13 +218,16 @@ struct DiagnosticsTests {
         }
 
         struct Update: Encodable, Sendable {
+          var id: Int?
           var task: String?
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
           }
 
-          init(task: String? = nil) {
+          init(id: Int? = nil, task: String? = nil) {
+            self.id = id
             self.task = task
           }
         }

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -188,4 +188,32 @@ struct TableIntegrationTests {
     #expect(capture.path?.hasSuffix("/todos") == true)
     #expect(capture.bodyString?.contains(#""id":1"#) == true)
   }
+
+  @Test
+  func updateCanChangeAKeyColumn() async throws {
+    // Renaming a natural key is a real operation. Targeting is a separate concern — the filter
+    // below is what picks the row — so keeping the key out of the payload only removed the
+    // ability to change it.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(IntegrationUserRole.self)
+      .update(IntegrationUserRole.Update(roleID: 3))
+      .eq(\.userID, 1)
+      .execute()
+
+    #expect(capture.bodyString == #"{"role_id":3}"#)
+  }
+
+  @Test
+  func updateStillOmitsAKeyItIsNotChanging() async throws {
+    // The addition is purely additive: a caller that does not name the key is unaffected.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .update(Todo.Update(task: "buy oat milk"))
+      .eq(\.id, 1)
+      .execute()
+
+    #expect(capture.bodyString == #"{"task":"buy oat milk"}"#)
+  }
 }

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -98,6 +98,20 @@ struct TableIntegrationTests {
   }
 
   @Test
+  func macroReportsThePrimaryKeyColumns() {
+    // The only thing `@PrimaryKey` produces now that it no longer gates `Insert` optionality or
+    // filters `Update`. Declaration order, and column names rather than property names.
+    #expect(Todo.primaryKeyColumns == ["id"])
+    #expect(IntegrationUserRole.primaryKeyColumns == ["user_id", "role_id"])
+  }
+
+  @Test
+  func aRelationWithNoDeclaredKeyReportsNone() {
+    // Falls through to the protocol default rather than expanding to an empty literal.
+    #expect(IntegrationActiveTodo.primaryKeyColumns.isEmpty)
+  }
+
+  @Test
   func anOptionalSpelledColumnCanBeOmitted() throws {
     // This is the assertion the expansion test cannot make: `MacroTesting` compares generated
     // text, it does not compile it. Both calls omit `tag`, which only compiles if the generated

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -89,17 +89,20 @@ struct TableMacroTests {
         }
 
         struct Update: Encodable, Sendable {
+          var id: Int?
           var task: String?
           var isDone: Bool?
           var dueDate: Date?
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
             case isDone = "is_done"
             case dueDate = "due_at"
           }
 
-          init(task: String? = nil, isDone: Bool? = nil, dueDate: Date? = nil) {
+          init(id: Int? = nil, task: String? = nil, isDone: Bool? = nil, dueDate: Date? = nil) {
+            self.id = id
             self.task = task
             self.isDone = isDone
             self.dueDate = dueDate
@@ -205,13 +208,16 @@ struct TableMacroTests {
         }
 
         public struct Update: Encodable, Sendable {
+          public var id: Int?
           public var task: String?
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
           }
 
-          public init(task: String? = nil) {
+          public init(id: Int? = nil, task: String? = nil) {
+            self.id = id
             self.task = task
           }
         }
@@ -362,19 +368,22 @@ struct TableMacroTests {
         }
 
         struct Update: Encodable, Sendable {
+          var id: Int?
           var task: String?
           var note: String?
           var draft: String?
           var review: String?
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
             case note = "note"
             case draft = "draft"
             case review = "review"
           }
 
-          init(task: String? = nil, note: String? = nil, draft: String? = nil, review: String? = nil) {
+          init(id: Int? = nil, task: String? = nil, note: String? = nil, draft: String? = nil, review: String? = nil) {
+            self.id = id
             self.task = task
             self.note = note
             self.draft = draft
@@ -452,13 +461,16 @@ struct TableMacroTests {
         }
 
         struct Update: Encodable, Sendable {
+          var id: Int?
           var task: String?
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
           }
 
-          init(task: String? = nil) {
+          init(id: Int? = nil, task: String? = nil) {
+            self.id = id
             self.task = task
           }
         }
@@ -533,13 +545,19 @@ struct TableMacroTests {
         }
 
         struct Update: Encodable, Sendable {
+          var userID: UUID?
+          var roleID: UUID?
           var grantedAt: Date?
 
           enum CodingKeys: String, CodingKey {
+            case userID = "user_id"
+            case roleID = "role_id"
             case grantedAt = "granted_at"
           }
 
-          init(grantedAt: Date? = nil) {
+          init(userID: UUID? = nil, roleID: UUID? = nil, grantedAt: Date? = nil) {
+            self.userID = userID
+            self.roleID = roleID
             self.grantedAt = grantedAt
           }
         }
@@ -607,8 +625,17 @@ struct TableMacroTests {
         }
 
         struct Update: Encodable, Sendable {
+          var userID: UUID?
+          var roleID: UUID?
 
-          init() {
+          enum CodingKeys: String, CodingKey {
+            case userID = "user_id"
+            case roleID = "role_id"
+          }
+
+          init(userID: UUID? = nil, roleID: UUID? = nil) {
+            self.userID = userID
+            self.roleID = roleID
           }
         }
       }

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -60,6 +60,8 @@ struct TableMacroTests {
           }
         }
 
+        static let primaryKeyColumns: [String] = ["id"]
+
         enum CodingKeys: String, CodingKey {
           case id = "id"
           case task = "task"
@@ -186,6 +188,8 @@ struct TableMacroTests {
             fatalError("Todo: no column is mapped for that key path")
           }
         }
+
+        public static let primaryKeyColumns: [String] = ["id"]
 
         enum CodingKeys: String, CodingKey {
           case id = "id"
@@ -335,6 +339,8 @@ struct TableMacroTests {
           }
         }
 
+        static let primaryKeyColumns: [String] = ["id"]
+
         enum CodingKeys: String, CodingKey {
           case id = "id"
           case task = "task"
@@ -440,6 +446,8 @@ struct TableMacroTests {
           }
         }
 
+        static let primaryKeyColumns: [String] = ["id"]
+
         enum CodingKeys: String, CodingKey {
           case id = "id"
           case task = "task"
@@ -519,6 +527,8 @@ struct TableMacroTests {
             fatalError("UserRole: no column is mapped for that key path")
           }
         }
+
+        static let primaryKeyColumns: [String] = ["user_id", "role_id"]
 
         enum CodingKeys: String, CodingKey {
           case userID = "user_id"
@@ -603,6 +613,8 @@ struct TableMacroTests {
             fatalError("UserRole: no column is mapped for that key path")
           }
         }
+
+        static let primaryKeyColumns: [String] = ["user_id", "role_id"]
 
         enum CodingKeys: String, CodingKey {
           case userID = "user_id"
@@ -689,6 +701,8 @@ struct TableMacroTests {
           }
         }
 
+        static let primaryKeyColumns: [String] = ["id"]
+
         enum CodingKeys: String, CodingKey {
           case id = "id"
           case task = "task"
@@ -718,17 +732,20 @@ struct TableMacroTests {
         }
 
         struct Update: Encodable, Sendable {
+          var id: Int?
           var task: String?
           var note: Optional<String>
           var tag: Optional<String>
 
           enum CodingKeys: String, CodingKey {
+            case id = "id"
             case task = "task"
             case note = "note"
             case tag = "tag"
           }
 
-          init(task: String? = nil, note: Optional<String> = nil, tag: Optional<String> = nil) {
+          init(id: Int? = nil, task: String? = nil, note: Optional<String> = nil, tag: Optional<String> = nil) {
+            self.id = id
             self.task = task
             self.note = note
             self.tag = tag

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -69,6 +69,7 @@ supporting_symbols:
   - PostgrestQueryPhase
   - PostgrestRelation
   - PostgrestRelation.columnName
+  - PostgrestRelation.primaryKeyColumns
   - PostgrestRelation.relationName
   - PostgrestRelation.schema
   - PostgrestRequestBuilder


### PR DESCRIPTION
Fixes SDK-1607. Stacked on #1278.

## What

`Update` dropped primary-key columns along with `Insert`, so a key could never be changed through the typed API:

```swift
try client.from(UserRole.self)
  .update(UserRole.Update(roleID: 3))   // extra argument 'roleID' in call
  .eq(\.userID, 1)
```

Renaming a natural key — the `slug` in a table keyed on `(tenant_id, slug)` — meant dropping to the legacy builder.

## Why the exclusion bought nothing

`update(_:)` returns a `PostgrestTypedMutation` the caller filters separately, so targeting and payload are independent concerns. Its own doc already warns that with no filter it updates every row. Holding the key back never stopped a write from rewriting identity — it only removed the ability to do so deliberately.

Every `Update` field is already optional and defaults to `nil`, so this is purely additive: a caller who doesn't name the key is unaffected, and the column stays out of the request body.

## The counter-argument, for the record

Excluding the key gives the typed API a property: a `.update()` can never rewrite a row's identity. That is coherent, and changing a primary key is often a smell — delete and re-insert is usually better.

Rejected as the deciding factor because the protection is narrow (the same call with no filter can already overwrite every *other* column) and it costs a legitimate operation with no typed alternative. Flagging it explicitly since this is the one judgment call in the PR — if you'd rather keep the guard, this is the commit to drop.

Deliberately split from #1278 rather than folded in: that one fixed "this table cannot be written to at all" plus a silently degraded `upsert`. This is a missing capability with a workaround, and it deserved its own review rather than riding along on a case that wasn't in doubt.

## Result

The `writable` filter is gone.

> **Revised after review.** That left `isPrimaryKey` with *no* behavioural use at all. This PR removed the `Update` filter, and [#1278's revision](https://github.com/supabase/supabase-swift/pull/1278) removed `|| isPrimaryKey` from the `Insert` rule, so after rebasing, writing `@PrimaryKey` or omitting it expanded byte-for-byte the same — the marker was inert. [Review finding 1](https://github.com/supabase/supabase-swift/pull/1280#pullrequestreview-5018712411) called that out, and it was not filed as a follow-up because it is a decision for these two PRs.
>
> Resolved by giving the marker the one job only it can do: `PostgrestRelation.primaryKeyColumns`, the key's column names in declaration order.
>
> ```swift
> static let primaryKeyColumns: [String] = ["user_id", "role_id"]
> ```
>
> Emitted only when a key is declared, so a keyless relation falls through to a protocol default of `[]` and its expansion is unchanged. The requirement carries that default rather than being mandatory, so hand-written conformances keep compiling. This is also the prerequisite [SDK-1616](https://linear.app/supabase/issue/SDK-1616/postgrest-typed-upsert-compiles-with-no-conflict-target-and-silently) needs to derive an upsert's `on_conflict` — previously unbuildable, because the key never survived expansion.

## How it was tested

Both watched failing first:

- `TableIntegrationTests.updateCanChangeAKeyColumn` — `{"role_id":3}` reaches the wire, filtered by `.eq(\.userID, 1)`. Against the pre-fix macro this doesn't compile: `extra argument 'roleID' in call`.
- `TableIntegrationTests.updateStillOmitsAKeyItIsNotChanging` — `Todo.Update(task:)` still sends `{"task":"buy oat milk"}` and nothing else, so the addition costs existing callers nothing.

Seven existing expansion snapshots gained the key as an optional `Update` field. All re-recorded, not hand-edited.

Full suite: 1271 tests pass. `./scripts/format.sh`, `./scripts/spell-check.sh`, and `./scripts/test-docs.sh` all clean.

## Docs corrected

The `@PrimaryKey` doc added in #1278 said the key "is left out of `Update`, which targets rows by key rather than changing it." That is now false and is replaced.

## Not a breaking change

No `!` and no `V3_MIGRATION.md` entry: `PostgrestMacros` does not exist in v2.55.1, so this changes nothing a released version ever exposed.
