### PR TITLE
fix(postgrest): let a typed update clear a nullable column

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -86,10 +86,40 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   ///
   /// > Important: With no filter this updates every row in the relation.
   ///
-  /// - Parameter values: The columns to change, in the relation's `Update` shape.
+  /// The closure assigns to the columns this update changes. A column it never names stays out of
+  /// the request body and the database leaves it alone; a column assigned `nil` is sent as an
+  /// explicit `null` and is cleared.
+  ///
+  /// ```swift
+  /// try await client.from(Todo.self)
+  ///   .update {
+  ///     $0.task = "buy oat milk"
+  ///     $0.dueDate = nil
+  ///   }
+  ///   .eq(\.id, 1)
+  ///   .execute()
+  /// ```
+  ///
+  /// - Parameter build: A closure that assigns to the columns to change.
   /// - Returns: A ``PostgrestTypedMutation`` to scope, then execute.
-  /// - Throws: An encoding error if `values` cannot be serialized.
-  public func update(_ values: R.Update) throws -> PostgrestTypedMutation<R> {
+  /// - Throws: An encoding error if the assigned values cannot be serialized.
+  public func update(
+    _ build: (inout PostgrestUpdate<R>) -> Void
+  ) throws -> PostgrestTypedMutation<R> {
+    try update(PostgrestUpdate(build))
+  }
+
+  /// Updates the rows matched by the filters applied to the returned value.
+  ///
+  /// Takes an update built elsewhere, so the layer that decides what changes does not have to be
+  /// the layer that sends it.
+  ///
+  /// > Important: With no filter this updates every row in the relation.
+  ///
+  /// - Parameter values: The columns to change.
+  /// - Returns: A ``PostgrestTypedMutation`` to scope, then execute.
+  /// - Throws: An encoding error if the assigned values cannot be serialized.
+  public func update(_ values: PostgrestUpdate<R>) throws -> PostgrestTypedMutation<R> {
     PostgrestTypedMutation(builder: try builder.update(values, returning: .minimal))
   }
 

--- a/Sources/PostgREST/Query/PostgrestUpdate.swift
+++ b/Sources/PostgREST/Query/PostgrestUpdate.swift
@@ -1,0 +1,106 @@
+//
+//  PostgrestUpdate.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 25/08/26.
+//
+
+import Foundation
+
+/// The columns an update writes, and what it writes to each.
+///
+/// An update is a set of column assignments, not a partial row. That distinction is what lets a
+/// nullable column be cleared: a column is in the request body because it was assigned, and the
+/// value it carries is whatever was assigned to it. Assigning `nil` sends an explicit `null`;
+/// never naming a column leaves it out of the body, and the database leaves it alone.
+///
+/// ```swift
+/// try await client.from(Todo.self)
+///   .update {
+///     $0.task = "buy oat milk"   // {"task": "buy oat milk"}
+///     $0.dueDate = nil           // {"due_at": null}
+///   }
+///   .eq(\.id, 1)
+///   .execute()
+/// ```
+///
+/// A column whose property is not optional cannot be assigned `nil`, so a `NOT NULL` column
+/// cannot be cleared by accident — that is a compile error, not a 400 from the server.
+///
+/// Assigning the same column twice keeps the last value.
+@dynamicMemberLookup
+public struct PostgrestUpdate<R: PostgrestWritableRelation>: Encodable, Sendable {
+  private var values: [String: PostgrestUpdateValue] = [:]
+
+  /// Builds an update from a closure that assigns to the columns it changes.
+  ///
+  /// Building the payload as a value, rather than only inline at the call site, is what lets one
+  /// layer decide what an update changes and another layer send it.
+  ///
+  /// - Parameter build: A closure that assigns to the columns this update writes.
+  public init(_ build: (inout PostgrestUpdate<R>) -> Void) {
+    build(&self)
+  }
+
+  /// Whether this update names no columns at all.
+  ///
+  /// An empty update encodes to `{}`, which asks PostgREST to change nothing.
+  public var isEmpty: Bool { values.isEmpty }
+
+  /// Assigns a value to the column backing a property.
+  ///
+  /// Only the setter is meaningful. An update describes what to write, so there is nothing to
+  /// read back, and the getter is marked unavailable rather than left to trap at runtime.
+  ///
+  /// - Parameter keyPath: A key path to one of the relation's stored properties.
+  public subscript<V: Encodable & Sendable>(dynamicMember keyPath: KeyPath<R, V>) -> V {
+    @available(
+      *, unavailable,
+      message: "An update names the columns it writes; it does not read them back."
+    )
+    get { fatalError("PostgrestUpdate is write-only") }
+    set { values[R.columnName(for: keyPath)] = PostgrestUpdateValue(newValue) }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: PostgrestUpdateColumnKey.self)
+    for (column, value) in values {
+      // Not `encodeIfPresent`. An assigned `nil` reaches here as a boxed `Optional.none`, and
+      // this call routes it to `encodeNil`, which is the explicit `null` on the wire. The
+      // synthesized `Encodable` of a struct with optional fields calls `encodeIfPresent`
+      // instead, which is exactly why the previous `Update` row shape could not clear a column.
+      try container.encode(value, forKey: PostgrestUpdateColumnKey(column))
+    }
+  }
+}
+
+/// One assigned value, kept behind an existential so a single payload can hold columns of
+/// different types.
+struct PostgrestUpdateValue: Encodable, Sendable {
+  private let value: any Encodable & Sendable
+
+  init(_ value: any Encodable & Sendable) {
+    self.value = value
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    try value.encode(to: encoder)
+  }
+}
+
+/// A coding key for a column name that is only known at runtime.
+struct PostgrestUpdateColumnKey: CodingKey {
+  let stringValue: String
+
+  init(_ stringValue: String) {
+    self.stringValue = stringValue
+  }
+
+  init?(stringValue: String) {
+    self.stringValue = stringValue
+  }
+
+  var intValue: Int? { nil }
+
+  init?(intValue: Int) { nil }
+}

--- a/Sources/PostgREST/Relations/PostgrestRelation.swift
+++ b/Sources/PostgREST/Relations/PostgrestRelation.swift
@@ -57,15 +57,16 @@ extension PostgrestRelation {
 
 /// A relation the database accepts writes for: a table, or a view Postgres reports as updatable.
 ///
-/// `Insert` and `Update` have no defaults on purpose. Defaulting them to `Self` would mean
-/// requiring every column on both — including the ones the database fills in on insert, and the
-/// ones an update is not touching.
+/// `Insert` has no default on purpose. Defaulting it to `Self` would mean requiring every column,
+/// including the ones the database fills in.
+///
+/// There is no matching `Update` shape. An insert sends a row, so a row type fits it; an update
+/// sends a set of column assignments, which ``PostgrestUpdate`` builds from this relation's key
+/// paths. Modelling both as row types is what once made clearing a nullable column impossible —
+/// a single optional field cannot mean both "not assigned" and "assigned null".
 public protocol PostgrestWritableRelation: PostgrestRelation {
   /// The shape accepted by an insert: every column, optional exactly where the database can fill
   /// it in — a nullable column, or one with a default. A primary key is included, and required
   /// unless it is also defaulted.
   associatedtype Insert: Encodable & Sendable
-
-  /// The shape accepted by an update: every column optional.
-  associatedtype Update: Encodable & Sendable
 }

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -103,10 +103,12 @@ public struct TableMacro: ExtensionMacro {
       // — including each half of a compound key — is required, which is what makes a join table
       // insertable and an incomplete key a compile error rather than a 400.
       //
-      // `Update` makes every column optional, the key included, so a partial update names only
-      // what it changes. Targeting is a separate concern — the caller filters the mutation — so
-      // holding the key back would not have protected a row's identity, only made a natural key
-      // impossible to rename.
+      // There is no matching `Update` shape. An update names the columns it writes, and a row
+      // type cannot say that: one optional field would have to mean both "not assigned" and
+      // "assigned null", so a nullable column could never be cleared. `PostgrestUpdate` builds
+      // the assignments from this type's key paths instead, and `columnName(for:)` above is all
+      // it needs from the macro. Targeting stays a separate concern — the caller filters the
+      // mutation — so the key is assignable like any other column.
       body.append(
         writeShape(
           named: "Insert",
@@ -115,10 +117,6 @@ public struct TableMacro: ExtensionMacro {
             ($0, $0.isOptional || $0.hasDefault ? $0.optionalType : $0.type)
           }
         )
-      )
-      body.append(
-        writeShape(
-          named: "Update", access: access, fields: properties.map { ($0, $0.optionalType) })
       )
     }
 

--- a/Tests/PostgRESTTests/PostgrestRelationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestRelationTests.swift
@@ -33,10 +33,6 @@ struct PostgrestRelationTests {
       var task: String
       var isDone: Bool?
     }
-    struct Update: Encodable, Sendable {
-      var task: String?
-      var isDone: Bool?
-    }
   }
 
   @Test

--- a/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
@@ -20,6 +20,7 @@ struct PostgrestTypedMutationTests {
     var id: Int
     var task: String
     var isDone: Bool
+    var note: String?
 
     /// A hand-written conformance has to keep these in step with `columnName(for:)` itself. The
     /// `@Column` macro generates both from one input so they cannot drift.
@@ -27,6 +28,7 @@ struct PostgrestTypedMutationTests {
       case id
       case task
       case isDone = "is_done"
+      case note
     }
 
     static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
@@ -34,16 +36,13 @@ struct PostgrestTypedMutationTests {
       case \Self.id: "id"
       case \Self.task: "task"
       case \Self.isDone: "is_done"
+      case \Self.note: "note"
       default: fatalError("unmapped key path")
       }
     }
 
     struct Insert: Encodable, Sendable {
       var task: String
-      var isDone: Bool?
-    }
-    struct Update: Encodable, Sendable {
-      var task: String?
       var isDone: Bool?
     }
   }
@@ -89,8 +88,34 @@ struct PostgrestTypedMutationTests {
   func updateScopesByKeyPath() async throws {
     let capture = QueryCapture()
     _ = try await capture.client.from(Todo.self)
-      .update(Todo.Update(task: "done", isDone: true)).eq(\.id, 1).execute()
+      .update { $0.task = "done" }.eq(\.id, 1).execute()
     #expect(capture.query?.contains("id=eq.1") == true)
+  }
+
+  @Test
+  func updateSendsAnExplicitNullForAnAssignedNil() async throws {
+    // The whole point of SDK-1610: the body has to carry `null`, not drop the key.
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .update { $0.note = nil }.eq(\.id, 1).execute()
+    #expect(capture.bodyString == #"{"note":null}"#)
+  }
+
+  @Test
+  func updateOmitsAColumnItNeverNames() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .update { $0.task = "done" }.eq(\.id, 1).execute()
+    #expect(capture.bodyString == #"{"task":"done"}"#)
+  }
+
+  @Test
+  func anUpdateBuiltAheadOfTimeCanBeHandedToTheSource() async throws {
+    // The payload is a value, so one layer can decide the change and another can send it.
+    let update = PostgrestUpdate<Todo> { $0.note = nil }
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).update(update).eq(\.id, 1).execute()
+    #expect(capture.bodyString == #"{"note":null}"#)
   }
 
   @Test

--- a/Tests/PostgRESTTests/PostgrestUpdateTests.swift
+++ b/Tests/PostgRESTTests/PostgrestUpdateTests.swift
@@ -1,0 +1,96 @@
+//
+//  PostgrestUpdateTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 25/08/26.
+//
+
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestUpdateTests {
+  struct Todo: PostgrestWritableRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+    var dueAt: String?
+
+    enum CodingKeys: String, CodingKey {
+      case id
+      case task
+      case dueAt = "due_at"
+    }
+
+    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.task: "task"
+      case \Self.dueAt: "due_at"
+      default: fatalError("unmapped key path")
+      }
+    }
+
+    struct Insert: Encodable, Sendable {
+      var task: String
+    }
+  }
+
+  /// Decodes an encoded payload back into a key/value map, because `JSONEncoder` does not
+  /// preserve the key order of a dictionary-backed keyed container. Comparing the JSON text
+  /// would make a passing test depend on hash ordering.
+  private func encoded(_ update: PostgrestUpdate<Todo>) throws -> [String: JSONValue] {
+    try JSONDecoder().decode([String: JSONValue].self, from: JSONEncoder().encode(update))
+  }
+
+  @Test
+  func assigningNilSendsAnExplicitNull() throws {
+    let update = PostgrestUpdate<Todo> { $0.dueAt = nil }
+    expectNoDifference(try encoded(update), ["due_at": .null])
+  }
+
+  @Test
+  func aColumnNeverAssignedIsAbsentFromTheBody() throws {
+    let update = PostgrestUpdate<Todo> { $0.task = "buy oat milk" }
+    expectNoDifference(try encoded(update), ["task": "buy oat milk"])
+  }
+
+  @Test
+  func clearingAndSettingCoexistInOnePayload() throws {
+    let update = PostgrestUpdate<Todo> {
+      $0.task = "buy oat milk"
+      $0.dueAt = nil
+    }
+    expectNoDifference(try encoded(update), ["task": "buy oat milk", "due_at": .null])
+  }
+
+  @Test
+  func theLastAssignmentToAColumnWins() throws {
+    let update = PostgrestUpdate<Todo> {
+      $0.task = "first"
+      $0.task = "second"
+    }
+    expectNoDifference(try encoded(update), ["task": "second"])
+  }
+
+  @Test
+  func anUpdateThatNamesNothingIsEmpty() throws {
+    let update = PostgrestUpdate<Todo> { _ in }
+    #expect(update.isEmpty)
+    expectNoDifference(try encoded(update), [:])
+  }
+
+  @Test
+  func aKeyColumnCanBeAssigned() throws {
+    // SDK-1607: renaming a natural key is a real operation, so the key is assignable like any
+    // other column. Targeting is the filter's job, not the payload's.
+    let update = PostgrestUpdate<Todo> { $0.id = 2 }
+    expectNoDifference(try encoded(update), ["id": 2])
+  }
+}

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -218,21 +218,6 @@ struct DiagnosticsTests {
             self.task = task
           }
         }
-
-        struct Update: Encodable, Sendable {
-          var id: Int?
-          var task: String?
-
-          enum CodingKeys: String, CodingKey {
-            case id = "id"
-            case task = "task"
-          }
-
-          init(id: Int? = nil, task: String? = nil) {
-            self.id = id
-            self.task = task
-          }
-        }
       }
       """#
     }

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -114,15 +114,10 @@ struct TableIntegrationTests {
   @Test
   func anOptionalSpelledColumnCanBeOmitted() throws {
     // This is the assertion the expansion test cannot make: `MacroTesting` compares generated
-    // text, it does not compile it. Both calls omit `tag`, which only compiles if the generated
-    // initializers defaulted an `Optional<String>` to nil.
+    // text, it does not compile it. The call omits `tag`, which only compiles if the generated
+    // initializer defaulted an `Optional<String>` to nil.
     let insert = try JSONEncoder().encode(IntegrationNote.Insert(body: "hello"))
     #expect(String(decoding: insert, as: UTF8.self) == #"{"body":"hello"}"#)
-
-    // `Update()` naming nothing at all is the stronger half — a partial update was impossible on
-    // such a table before, because every `Optional<T>` column had to be passed.
-    let update = try JSONEncoder().encode(IntegrationNote.Update())
-    #expect(String(decoding: update, as: UTF8.self) == "{}")
   }
 
   @Test
@@ -136,9 +131,23 @@ struct TableIntegrationTests {
 
   @Test
   func aPartialUpdateNamesOnlyWhatItChanges() throws {
-    let data = try JSONEncoder().encode(Todo.Update(isDone: true))
+    let data = try JSONEncoder().encode(PostgrestUpdate<Todo> { $0.isDone = true })
     let json = String(decoding: data, as: UTF8.self)
     #expect(json == #"{"is_done":true}"#)
+  }
+
+  @Test
+  func aMacroTypeCanClearANullableColumn() async throws {
+    // SDK-1610. `due_at` is nullable, so `nil` has to reach the wire as an explicit null rather
+    // than dropping the key, which is what "leave this column alone" means.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .update { $0.dueDate = nil }
+      .eq(\.id, 1)
+      .execute()
+
+    #expect(capture.bodyString == #"{"due_at":null}"#)
   }
 
   @Test
@@ -211,7 +220,7 @@ struct TableIntegrationTests {
     let capture = RequestCapture()
     _ = try await capture.client
       .from(IntegrationUserRole.self)
-      .update(IntegrationUserRole.Update(roleID: 3))
+      .update { $0.roleID = 3 }
       .eq(\.userID, 1)
       .execute()
 
@@ -224,7 +233,7 @@ struct TableIntegrationTests {
     let capture = RequestCapture()
     _ = try await capture.client
       .from(Todo.self)
-      .update(Todo.Update(task: "buy oat milk"))
+      .update { $0.task = "buy oat milk" }
       .eq(\.id, 1)
       .execute()
 

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -89,34 +89,13 @@ struct TableMacroTests {
             self.dueDate = dueDate
           }
         }
-
-        struct Update: Encodable, Sendable {
-          var id: Int?
-          var task: String?
-          var isDone: Bool?
-          var dueDate: Date?
-
-          enum CodingKeys: String, CodingKey {
-            case id = "id"
-            case task = "task"
-            case isDone = "is_done"
-            case dueDate = "due_at"
-          }
-
-          init(id: Int? = nil, task: String? = nil, isDone: Bool? = nil, dueDate: Date? = nil) {
-            self.id = id
-            self.task = task
-            self.isDone = isDone
-            self.dueDate = dueDate
-          }
-        }
       }
       """#
     }
   }
 
   @Test
-  func readOnlyTableOmitsInsertAndUpdate() {
+  func readOnlyTableOmitsInsert() {
     assertMacro {
       """
       @Table("active_todos", readOnly: true)
@@ -210,21 +189,6 @@ struct TableMacroTests {
             self.task = task
           }
         }
-
-        public struct Update: Encodable, Sendable {
-          public var id: Int?
-          public var task: String?
-
-          enum CodingKeys: String, CodingKey {
-            case id = "id"
-            case task = "task"
-          }
-
-          public init(id: Int? = nil, task: String? = nil) {
-            self.id = id
-            self.task = task
-          }
-        }
       }
       """#
     }
@@ -277,18 +241,6 @@ struct TableMacroTests {
           }
 
           init(htmlURL: String) {
-            self.htmlURL = htmlURL
-          }
-        }
-
-        struct Update: Encodable, Sendable {
-          var htmlURL: String?
-
-          enum CodingKeys: String, CodingKey {
-            case htmlURL = "html_url"
-          }
-
-          init(htmlURL: String? = nil) {
             self.htmlURL = htmlURL
           }
         }
@@ -372,30 +324,6 @@ struct TableMacroTests {
             self.review = review
           }
         }
-
-        struct Update: Encodable, Sendable {
-          var id: Int?
-          var task: String?
-          var note: String?
-          var draft: String?
-          var review: String?
-
-          enum CodingKeys: String, CodingKey {
-            case id = "id"
-            case task = "task"
-            case note = "note"
-            case draft = "draft"
-            case review = "review"
-          }
-
-          init(id: Int? = nil, task: String? = nil, note: String? = nil, draft: String? = nil, review: String? = nil) {
-            self.id = id
-            self.task = task
-            self.note = note
-            self.draft = draft
-            self.review = review
-          }
-        }
       }
       """#
     }
@@ -463,21 +391,6 @@ struct TableMacroTests {
           }
 
           init(id: Int, task: String) {
-            self.id = id
-            self.task = task
-          }
-        }
-
-        struct Update: Encodable, Sendable {
-          var id: Int?
-          var task: String?
-
-          enum CodingKeys: String, CodingKey {
-            case id = "id"
-            case task = "task"
-          }
-
-          init(id: Int? = nil, task: String? = nil) {
             self.id = id
             self.task = task
           }
@@ -553,24 +466,6 @@ struct TableMacroTests {
             self.grantedAt = grantedAt
           }
         }
-
-        struct Update: Encodable, Sendable {
-          var userID: UUID?
-          var roleID: UUID?
-          var grantedAt: Date?
-
-          enum CodingKeys: String, CodingKey {
-            case userID = "user_id"
-            case roleID = "role_id"
-            case grantedAt = "granted_at"
-          }
-
-          init(userID: UUID? = nil, roleID: UUID? = nil, grantedAt: Date? = nil) {
-            self.userID = userID
-            self.roleID = roleID
-            self.grantedAt = grantedAt
-          }
-        }
       }
       """#
     }
@@ -631,21 +526,6 @@ struct TableMacroTests {
           }
 
           init(userID: UUID, roleID: UUID) {
-            self.userID = userID
-            self.roleID = roleID
-          }
-        }
-
-        struct Update: Encodable, Sendable {
-          var userID: UUID?
-          var roleID: UUID?
-
-          enum CodingKeys: String, CodingKey {
-            case userID = "user_id"
-            case roleID = "role_id"
-          }
-
-          init(userID: UUID? = nil, roleID: UUID? = nil) {
             self.userID = userID
             self.roleID = roleID
           }
@@ -724,27 +604,6 @@ struct TableMacroTests {
           }
 
           init(id: Int? = nil, task: String, note: Optional<String> = nil, tag: Optional<String> = nil) {
-            self.id = id
-            self.task = task
-            self.note = note
-            self.tag = tag
-          }
-        }
-
-        struct Update: Encodable, Sendable {
-          var id: Int?
-          var task: String?
-          var note: Optional<String>
-          var tag: Optional<String>
-
-          enum CodingKeys: String, CodingKey {
-            case id = "id"
-            case task = "task"
-            case note = "note"
-            case tag = "tag"
-          }
-
-          init(id: Int? = nil, task: String? = nil, note: Optional<String> = nil, tag: Optional<String> = nil) {
             self.id = id
             self.task = task
             self.note = note

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -66,6 +66,15 @@ supporting_symbols:
   - PostgrestTypedMutation.builder
   - PostgrestTypedMutation.init
   - PostgrestTypedMutation.execute
+  # The update payload is a set of column assignments rather than a row shape, which is what lets
+  # a nullable column be cleared: a column is in the body because it was assigned, and `nil` is
+  # sent as an explicit null. Shared by the typed update entry point and any caller that builds an
+  # update ahead of time and hands it over.
+  - PostgrestUpdate
+  - PostgrestUpdate.init
+  - PostgrestUpdate.isEmpty
+  - PostgrestUpdate.subscript
+  - PostgrestUpdate.encode
   - PostgrestQueryPhase
   - PostgrestRelation
   - PostgrestRelation.columnName
@@ -90,7 +99,6 @@ supporting_symbols:
   - PostgrestTypedQuery.Relation
   - PostgrestWritableRelation
   - PostgrestWritableRelation.Insert
-  - PostgrestWritableRelation.Update
 
   # The `PostgrestMacros` attributes. `@Table` synthesizes the relation
   # conformance used by every database.* typed entry point, and the three


### PR DESCRIPTION
## The problem

A nullable column could not be set to SQL `NULL` through the typed API. There was no value a caller could pass that produced `{"due_at": null}`.

```swift
@Table("todos")
struct Todo {
  @PrimaryKey @Default var id: Int
  var task: String
  @Column("due_at") var dueDate: Date?
}

try await client.from(Todo.self)
  .update(Todo.Update(dueDate: nil))   // sends {} — the column is untouched
  .eq(\.id, 1)
  .execute()
```

Clearing a due date meant dropping to the legacy string builder and hand-rolling a payload that encodes an explicit null, which gives up the typed surface entirely. supabase-js has no such gap: `postgres-meta` emits every `Update` field as `"due_at"?: string | null`, so `{ due_at: null }` type-checks and `JSON.stringify` keeps the null.

## Why it happened

`@Table` generated `Update` as a **partial row** — every column made optional:

```swift
struct Update: Encodable, Sendable {
  var id: Int?
  var task: String?
  var dueDate: Date?   // already optional; `optionalType` does not double-wrap
}
```

That gives one optional field two jobs it cannot both do. `nil` has to mean *"leave this column alone"*, because that is how a partial update omits a column — and Swift's **synthesized** `Encodable` enforces exactly that, emitting `encodeIfPresent` for every optional property:

```swift
try container.encodeIfPresent(dueDate, forKey: .dueDate)  // nil -> key omitted
```

So `nil` was already spoken for. The same `nil` that means "don't touch this" would have to also mean "write NULL here", and one slot cannot carry both "is this column named" and "what value does it take".

The bug is therefore in the *shape*, not the encoder. `Insert` is genuinely a row, so a row type fits it. An update is not a row — it is a set of column assignments, and a partial row has no way to say that.

## How this fixes it

`Update` stops being a generated row type. `PostgrestUpdate<R>` records assignments instead, keyed by key path, so **presence in the body is the act of assigning** and the value assigned is what gets sent. The two facts are now carried separately:

```swift
try await client.from(Todo.self)
  .update {
    $0.task = "buy oat milk"   // {"task": "buy oat milk"}
    $0.dueDate = nil           // {"due_at": null}   <- now expressible
  }                            // id never named    -> absent from the body
  .eq(\.id, 1)
  .execute()
```

Three mechanics make that work:

1. **Assignment is the signal.** A `@dynamicMemberLookup` setter appends `columnName(for: keyPath) -> value`. A column you never write to is never in the dictionary, so it never reaches the body. "Leave it alone" stays the default and needs no spelling.
2. **A hand-written `encode(to:)` replaces the synthesized one.** This is the direct fix for the `encodeIfPresent` behaviour above — `container.encode(value, forKey:)` on a boxed `Optional.none` routes to `encodeNil`, which is the explicit `null` on the wire.
3. **Optionality still guards NOT NULL.** The setter binds `V` to the property's own type, so `$0.task = nil` on a non-optional `String` is a compile error (`'nil' cannot be assigned to type 'String'`). A `NOT NULL` column cannot be cleared by accident — caught by the compiler rather than by a 400 from the server.

The two cases are distinguishable at the call site without reading the macro source: you either wrote the line or you did not.

This also **removes** generated code rather than adding it. The `Update` struct and `associatedtype Update` both go, replaced by one hand-written generic type, so `@Table` expands smaller and a hand-written conformance now only has to supply `columnName(for:)`. And it settles #1280 / SDK-1607 by the same mechanism — the primary key is assignable in the closure like any other column, with no shape question left.

## Considered and rejected

- **Double optional (`Date??`).** Correct, but `Update(dueDate: nil)` still silently means "unchanged", so the trap survives for anyone who misses the second layer.
- **A `FieldUpdate<T>` sentinel.** Explicit, but it changes every field's type and adds generated code to fix a problem caused by generating the wrong type.
- **`.update(...).clearing(\.dueDate)`.** Costs existing callers nothing, but splits the payload across two carriers — an `Update` value built in one layer could no longer describe a clear on its own, which is most of what having a value was for.

Cross-checked against [`pointfreeco/swift-structured-queries`](https://github.com/pointfreeco/swift-structured-queries) (the engine behind `sqlite-data`). It reaches the same conclusion independently: `Updates<Base>` accumulates `(column, value)` pairs by assignment, and its `@Table` macro actively refuses to double-optionalize — `@Column(lazyInitializable:)` on an already-optional column emits a warning with a fix-it to remove it.

## Review notes

**Look at first:** `PostgrestUpdate.encode(to:)`, and the `@available(*, unavailable)` getter on the subscript — an update is write-only, and plain assignment never calls a subscript's getter, so this is a compile-time message rather than a runtime trap.

**Risk:** this reshapes `Update` a third time, after #1278 and #1280. That is only cheap right now — there are five call sites, all in tests, none in `Sources` or `Examples`. The window closes once `Update` is treated as stable. Unreleased surface (`PostgrestMacros` is not in v2.55.1), so no `!` marker and no `V3_MIGRATION.md` entry.

## Testing

- Full suite: `1285 tests in 133 suites passed ... with 10 known issues`. Baseline captured before any edit was 1275 tests / 132 suites with the same 10.
- `./scripts/format.sh` no diff · `./scripts/spell-check.sh` 0 issues · `./scripts/test-docs.sh` clean.
- Compliance symbols verified against the real extractor rather than guessed: ran `swift package dump-symbol-graph` plus `supabase/sdk`'s `normalize-symbolgraph` locally, confirmed the five emitted `PostgrestUpdate.*` names and the disappearance of `PostgrestWritableRelation.Update`, and `validate-compliance` reports the file valid.

New tests cover both halves at the wire level, asserting on the encoded HTTP body: explicit null present (`assigningNilSendsAnExplicitNull`, `updateSendsAnExplicitNullForAnAssignedNil`, `aMacroTypeCanClearANullableColumn`) and omitted-when-unchanged (`aColumnNeverAssignedIsAbsentFromTheBody`, `updateOmitsAColumnItNeverNames`, `updateStillOmitsAKeyItIsNotChanging`). SDK-1607's guarantee is carried forward by `aKeyColumnCanBeAssigned` and `updateCanChangeAKeyColumn`.

**Not verified:** PostgREST's docs do not actually state the present / absent / explicit-null semantics for `PATCH`, and I did not exercise the empty-payload case against a live server. An empty `PostgrestUpdate` sends `{}`, which is what an all-nil `Update` sent before, so nothing regresses either way. The `database.mutate.update` spec in `supabase/sdk` is being written separately and should pin those down.

<details>
<summary>Generated: file-by-file summary</summary>

- `Sources/PostgREST/Query/PostgrestUpdate.swift` (new) — `@dynamicMemberLookup` over `KeyPath<R, V>`, storing `column -> boxed value`; hand-written `encode(to:)` with a runtime `CodingKey`.
- `Sources/PostgREST/Query/PostgrestTypedMutation.swift` — `update` gains a closure overload and a prebuilt-`PostgrestUpdate<R>` overload, so the payload can be built in one layer and sent from another.
- `Sources/PostgREST/Relations/PostgrestRelation.swift` — `associatedtype Update` removed.
- `Sources/PostgrestMacrosPlugin/TableMacro.swift` — stops emitting the `Update` struct.
- `sdk-compliance.yaml` — drops `PostgrestWritableRelation.Update`, adds the five `PostgrestUpdate.*` symbols.
- Tests — new `PostgrestUpdateTests`; macro expansion snapshots regenerated; `readOnlyTableOmitsInsertAndUpdate` renamed to `readOnlyTableOmitsInsert`.

</details>

Fixes SDK-1610
