### PR TITLE
fix(postgrest): close the typed upsert's missing conflict target

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -65,20 +65,40 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
     PostgrestTypedMutation(builder: try builder.insert(values, returning: .minimal))
   }
 
-  /// Inserts rows, updating any that conflict.
+  /// Inserts a row, updating it instead if it conflicts on a unique constraint of your choosing.
+  ///
+  /// ```swift
+  /// // merge on the `email` unique index rather than on the key
+  /// try await client.from(User.self)
+  ///   .upsert(User.Insert(email: "a@example.com", name: "Ada"), onConflict: \.email)
+  ///   .execute()
+  /// ```
+  ///
+  /// The target is spelled as key paths, so a column that does not exist is a compile error rather
+  /// than a PostgREST 400 naming a column you cannot grep for. Splitting it into a first column
+  /// plus the rest also makes an empty target unrepresentable — `on_conflict=` with nothing after
+  /// it is a different request, not a missing one.
+  ///
+  /// To merge on the primary key, use ``upsert(_:)``, which derives the target instead.
   ///
   /// - Parameters:
-  ///   - values: The rows to upsert.
-  ///   - onConflict: Comma-separated unique columns that determine a duplicate. Defaults to the
-  ///     relation's primary key.
+  ///   - values: The row to upsert, in the relation's `Insert` shape.
+  ///   - column: The first column of the unique constraint to merge on.
+  ///   - additional: The remaining columns, for a constraint spanning more than one.
   /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
   /// - Throws: An encoding error if `values` cannot be serialized.
   public func upsert(
     _ values: R.Insert,
-    onConflict: String? = nil
+    onConflict column: PartialKeyPath<R>,
+    _ additional: PartialKeyPath<R>...
   ) throws -> PostgrestTypedMutation<R> {
-    PostgrestTypedMutation(
-      builder: try builder.upsert(values, onConflict: onConflict, returning: .minimal)
+    let columns = CollectionOfOne(column) + additional
+    return PostgrestTypedMutation(
+      builder: try builder.upsert(
+        values,
+        onConflict: columns.map { R.columnName(for: $0) }.joined(separator: ","),
+        returning: .minimal
+      )
     )
   }
 
@@ -130,5 +150,37 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   /// - Returns: A ``PostgrestTypedMutation`` to scope, then execute.
   public func delete() -> PostgrestTypedMutation<R> {
     PostgrestTypedMutation(builder: builder.delete(returning: .minimal))
+  }
+}
+
+extension PostgrestTypedSource where R: PostgrestWritableRelation & PostgrestKeyedRelation {
+  /// Inserts a row, updating it instead if it conflicts on the relation's primary key.
+  ///
+  /// ```swift
+  /// try await client.from(Todo.self)
+  ///   .upsert(Todo.Insert(id: 1, task: "buy milk"))
+  ///   .execute()
+  /// ```
+  ///
+  /// The conflict target comes from ``PostgrestKeyedRelation/primaryKeyColumns``, which is why this
+  /// overload exists only where the relation declares a key. On a keyless relation the database has
+  /// nothing to merge on, so an upsert with no target is not a merge at all — it inserts another row
+  /// every call. Requiring the conformance makes that a compile error instead; use
+  /// ``upsert(_:onConflict:_:)`` there and name a unique constraint the relation does have.
+  ///
+  /// > Note: The target only takes effect if the columns it names are in the body. A key the
+  /// > database generates is optional in `Insert`, so omitting it still inserts.
+  ///
+  /// - Parameter values: The row to upsert, in the relation's `Insert` shape.
+  /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func upsert(_ values: R.Insert) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(
+      builder: try builder.upsert(
+        values,
+        onConflict: R.primaryKeyColumns.joined(separator: ","),
+        returning: .minimal
+      )
+    )
   }
 }

--- a/Sources/PostgREST/Relations/PostgrestRelation.swift
+++ b/Sources/PostgREST/Relations/PostgrestRelation.swift
@@ -35,24 +35,33 @@ public protocol PostgrestRelation: PostgrestSelection where Source == Self {
 
   /// The database column name backing a property.
   ///
+  /// Takes a `PartialKeyPath` rather than a `KeyPath<Self, V>` because the property's type
+  /// is not part of the answer — a column name is a column name. Callers that do care about the
+  /// type, every filter among them, constrain it in their own signature and pass the key path
+  /// straight through; `KeyPath` is a `PartialKeyPath` subclass, so that costs nothing at the call
+  /// site.
+  ///
   /// - Parameter keyPath: A key path to one of this type's stored properties.
   /// - Returns: The column name PostgREST expects in a query string.
-  static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String
-
-  /// The columns making up the relation's primary key, in declaration order.
-  ///
-  /// Empty when the relation declares no key. A caller deriving a conflict target for an upsert
-  /// has to treat that as "cannot derive" rather than "conflicts on nothing" — an empty
-  /// `on_conflict` is not the same request.
-  static var primaryKeyColumns: [String] { get }
+  static func columnName(for keyPath: PartialKeyPath<Self>) -> String
 }
 
-extension PostgrestRelation {
-  /// No declared key.
+/// A relation that declares a primary key.
+///
+/// Conformance is what makes the key-derived operations available, so it is deliberately a separate
+/// protocol rather than an optional member on ``PostgrestRelation``: a relation with no key does
+/// not conform, and reaching for one of those operations on it is *no such overload* instead of a
+/// request the database cannot honor.
+///
+/// `@Table` conforms a type to this whenever a property is marked `@PrimaryKey`. A hand-written
+/// conformance opts in by declaring ``primaryKeyColumns``.
+public protocol PostgrestKeyedRelation: PostgrestRelation {
+  /// The columns making up the relation's primary key, in declaration order.
   ///
-  /// `@Table` overrides this whenever a property is marked `@PrimaryKey`; a hand-written
-  /// conformance opts in by declaring it.
-  public static var primaryKeyColumns: [String] { [] }
+  /// There is no default. An empty array would conform a keyless relation and let it derive an
+  /// empty `on_conflict`, which is a different request rather than a missing one — so "declares no
+  /// key" is spelled as not conforming at all.
+  static var primaryKeyColumns: [String] { get }
 }
 
 /// A relation the database accepts writes for: a table, or a view Postgres reports as updatable.

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -35,7 +35,8 @@
 ///     only, and the write methods are not available on it.
 @attached(
   extension,
-  conformances: Decodable, Sendable, PostgrestRelation, PostgrestWritableRelation,
+  conformances: Decodable, Sendable, PostgrestRelation, PostgrestKeyedRelation,
+  PostgrestWritableRelation,
   names: named(relationName), named(schema), named(selectString), named(columnName(for:)),
   named(primaryKeyColumns), named(CodingKeys), named(Insert), named(Update)
 )
@@ -75,9 +76,11 @@ public macro Column(_ name: String) =
 /// `Update` carries the key like any other column, all optional, so a natural key can be renamed.
 /// Which rows a write touches is decided by the filters on the mutation, not by this marker.
 ///
-/// What the marker does produce is ``PostgREST/PostgrestRelation/primaryKeyColumns``, the column
-/// names in declaration order. That is what lets a caller — or a future `upsert` — name a conflict
-/// target without repeating the key as a string.
+/// What the marker does produce is a ``PostgREST/PostgrestKeyedRelation`` conformance, carrying
+/// ``PostgREST/PostgrestKeyedRelation/primaryKeyColumns`` — the column names in declaration order.
+/// That conformance is what makes `upsert(_:)` available: it derives the conflict target from the
+/// key, so no caller repeats it as a string. Leave the marker off and the relation does not conform,
+/// which turns an upsert with no target into a compile error rather than a silent plain insert.
 @attached(peer)
 public macro PrimaryKey() =
   #externalMacro(

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -83,8 +83,10 @@ public struct TableMacro: ExtensionMacro {
     ]
     // The one thing `@PrimaryKey` uniquely does. Without this the marker is inert: after the key
     // stopped gating `Insert` optionality and stopped being filtered out of `Update`, writing it or
-    // omitting it expanded byte-for-byte the same. Emitted only when a key is declared, so a
-    // keyless relation falls back to the protocol's empty default.
+    // omitting it expanded byte-for-byte the same. Emitted only when a key is declared, and the
+    // `PostgrestKeyedRelation` conformance below rides on the same condition — the requirement has
+    // no default, so a keyless relation does not conform, which is what withholds the
+    // derived-conflict-target `upsert` from it at compile time.
     let keyColumns = properties.filter(\.isPrimaryKey).map(\.columnName)
     if !keyColumns.isEmpty {
       let list = keyColumns.map { "\"\($0)\"" }.joined(separator: ", ")
@@ -120,7 +122,10 @@ public struct TableMacro: ExtensionMacro {
       )
     }
 
-    let clause = inheritanceClause(wanted: wantedConformances(arguments), missing: protocols)
+    let clause = inheritanceClause(
+      wanted: wantedConformances(arguments, hasPrimaryKey: !keyColumns.isEmpty),
+      missing: protocols
+    )
     return [
       try ExtensionDeclSyntax(
         """
@@ -137,12 +142,16 @@ public struct TableMacro: ExtensionMacro {
   /// The protocols `@Table` conforms the annotated type to.
   ///
   /// `Decodable` is in the list and `Encodable` is not: rows are decoded from responses, and writes
-  /// go out through the `Encodable` `Insert` and `Update` shapes.
-  static func wantedConformances(_ arguments: Arguments) -> [String] {
+  /// go out through the `Encodable` `Insert` shape.
+  ///
+  /// Keyed and writable are independent axes: a view Postgres reports a key for is keyed and still
+  /// read-only, and an append-only table is writable with no key at all.
+  static func wantedConformances(_ arguments: Arguments, hasPrimaryKey: Bool) -> [String] {
     [
       "Decodable",
       "Sendable",
       "PostgrestRelation",
+      hasPrimaryKey ? "PostgrestKeyedRelation" : nil,
       arguments.readOnly ? nil : "PostgrestWritableRelation",
     ].compactMap { $0 }
   }
@@ -159,7 +168,7 @@ public struct TableMacro: ExtensionMacro {
     properties: [StoredProperty]
   ) -> String {
     var lines = [
-      "  \(access)static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {",
+      "  \(access)static func columnName(for keyPath: PartialKeyPath<Self>) -> String {",
       "    switch keyPath {",
     ]
     for property in properties {

--- a/Tests/PostgRESTTests/PostgrestRelationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestRelationTests.swift
@@ -20,7 +20,7 @@ struct PostgrestRelationTests {
     var task: String
     var isDone: Bool
 
-    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"
       case \Self.task: "task"

--- a/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
@@ -31,7 +31,7 @@ struct PostgrestTypedMutationTests {
       case note
     }
 
-    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"
       case \Self.task: "task"
@@ -55,7 +55,7 @@ struct PostgrestTypedMutationTests {
 
     var id: Int
 
-    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"
       default: fatalError("unmapped key path")

--- a/Tests/PostgRESTTests/PostgrestTypedQueryFilterTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedQueryFilterTests.swift
@@ -22,7 +22,7 @@ struct PostgrestTypedQueryFilterTests {
     var isDone: Bool
     var dueDate: Date?
 
-    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"
       case \Self.task: "task"

--- a/Tests/PostgRESTTests/PostgrestTypedSourceTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedSourceTests.swift
@@ -20,7 +20,7 @@ struct PostgrestTypedSourceTests {
     var id: Int
     var task: String
 
-    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"
       case \Self.task: "task"

--- a/Tests/PostgRESTTests/PostgrestUpdateTests.swift
+++ b/Tests/PostgRESTTests/PostgrestUpdateTests.swift
@@ -28,7 +28,7 @@ struct PostgrestUpdateTests {
       case dueAt = "due_at"
     }
 
-    static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"
       case \Self.task: "task"

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -186,7 +186,7 @@ struct DiagnosticsTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
             return "id"

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -40,6 +40,15 @@ struct IntegrationNote {
   var tag: Optional<String>
 }
 
+// A writable table with no declared key — an append-only log. It must not conform to
+// `PostgrestKeyedRelation`, so the derived-target `upsert` is simply not available on it: there is
+// no key for PostgREST to merge on, and the call would quietly insert another row every time.
+@Table("audit_events")
+struct IntegrationAuditEvent {
+  var action: String
+  var recordedBy: String
+}
+
 @Table("active_todos", readOnly: true)
 struct IntegrationActiveTodo {
   var id: Int
@@ -106,9 +115,30 @@ struct TableIntegrationTests {
   }
 
   @Test
-  func aRelationWithNoDeclaredKeyReportsNone() {
-    // Falls through to the protocol default rather than expanding to an empty literal.
-    #expect(IntegrationActiveTodo.primaryKeyColumns.isEmpty)
+  func onlyARelationWithADeclaredKeyIsKeyed() {
+    // The conformance *is* the mechanism. `primaryKeyColumns` is mandatory on
+    // `PostgrestKeyedRelation`, so "no key" is a missing conformance rather than an empty array —
+    // and an empty `on_conflict`, which is a different request, stops being representable.
+    #expect(Todo.self is any PostgrestKeyedRelation.Type)
+    #expect(IntegrationUserRole.self is any PostgrestKeyedRelation.Type)
+    #expect(!(IntegrationAuditEvent.self is any PostgrestKeyedRelation.Type))
+    #expect(!(IntegrationActiveTodo.self is any PostgrestKeyedRelation.Type))
+  }
+
+  @Test
+  func aKeylessRelationCanStillUpsertOnAnExplicitTarget() async throws {
+    // Losing the derived overload must not cost the keyless relation the operation itself. A
+    // unique constraint it does have is still a legal target.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(IntegrationAuditEvent.self)
+      .upsert(
+        IntegrationAuditEvent.Insert(action: "sign_in", recordedBy: "service_role"),
+        onConflict: \.action
+      )
+      .execute()
+
+    #expect(capture.query?.contains("on_conflict=action") == true)
   }
 
   @Test
@@ -199,9 +229,9 @@ struct TableIntegrationTests {
 
   @Test
   func aTypedUpsertCarriesTheConflictKey() async throws {
-    // `upsert` sends no `on_conflict`, so PostgREST resolves against the primary key — which has
-    // to be in the body for that to mean anything. While `Insert` dropped the key, the merge half
-    // of every upsert was unreachable and each call just inserted another row.
+    // The conflict target only means something if the columns it names are in the body. While
+    // `Insert` dropped the key, the merge half of every upsert was unreachable and each call just
+    // inserted another row.
     let capture = RequestCapture()
     _ = try await capture.client
       .from(Todo.self)
@@ -210,6 +240,59 @@ struct TableIntegrationTests {
 
     #expect(capture.path?.hasSuffix("/todos") == true)
     #expect(capture.bodyString?.contains(#""id":1"#) == true)
+  }
+
+  @Test
+  func aTypedUpsertDerivesTheConflictTargetFromTheKey() async throws {
+    // PostgREST resolves an absent `on_conflict` against the primary key already, so this is the
+    // same request either way. Naming it is what makes the request say what it merges on, and it
+    // is only reachable because the relation declares a key — a keyless one has no such overload.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .upsert(Todo.Insert(id: 1, task: "buy milk"))
+      .execute()
+
+    #expect(capture.query?.contains("on_conflict=id") == true)
+  }
+
+  @Test
+  func aTypedUpsertDerivesACompoundConflictTarget() async throws {
+    // A join table conflicts on both halves of its key, in declaration order.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(IntegrationUserRole.self)
+      .upsert(IntegrationUserRole.Insert(userID: 1, roleID: 2))
+      .execute()
+
+    #expect(capture.query?.contains("on_conflict=user_id,role_id") == true)
+  }
+
+  @Test
+  func aTypedUpsertTakesAnExplicitConflictTarget() async throws {
+    // Merging on a unique constraint that is not the primary key is the reason the override
+    // exists. Spelled as a key path, so a column that does not exist is a compile error rather
+    // than a PostgREST 400.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(IntegrationNote.self)
+      .upsert(IntegrationNote.Insert(body: "remember the milk", tag: "home"), onConflict: \.tag)
+      .execute()
+
+    #expect(capture.query?.contains("on_conflict=tag") == true)
+  }
+
+  @Test
+  func anExplicitConflictTargetMapsEveryColumnName() async throws {
+    // `isDone` has to reach the wire as `is_done`, so the override goes through the same
+    // `columnName(for:)` mapping every filter uses rather than interpolating property names.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .upsert(Todo.Insert(task: "buy milk"), onConflict: \.task, \.isDone)
+      .execute()
+
+    #expect(capture.query?.contains("on_conflict=task,is_done") == true)
   }
 
   @Test

--- a/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
@@ -18,10 +18,15 @@ import Testing
 /// The clause is what makes the conformance land, so it is asserted here directly.
 @Suite
 struct TableMacroSupportTests {
-  private func clause(readOnly: Bool, missing: [String]) -> String {
+  private func clause(
+    readOnly: Bool,
+    hasPrimaryKey: Bool = false,
+    missing: [String]
+  ) -> String {
     inheritanceClause(
       wanted: TableMacro.wantedConformances(
-        TableMacro.Arguments(name: "todos", schema: "public", readOnly: readOnly)
+        TableMacro.Arguments(name: "todos", schema: "public", readOnly: readOnly),
+        hasPrimaryKey: hasPrimaryKey
       ),
       missing: missing.map { TypeSyntax(stringLiteral: $0) }
     )
@@ -36,6 +41,35 @@ struct TableMacroSupportTests {
         readOnly: false,
         missing: ["Decodable", "Sendable", "PostgrestRelation", "PostgrestWritableRelation"]
       ) == ": Decodable, Sendable, PostgrestRelation, PostgrestWritableRelation"
+    )
+  }
+
+  @Test
+  func aDeclaredKeyAddsTheKeyedRelation() {
+    // What gates the derived-target `upsert`. Listed after `PostgrestRelation` for the same reason
+    // the whole chain is listed: the generated extension does not derive an inherited conformance.
+    #expect(
+      clause(
+        readOnly: false,
+        hasPrimaryKey: true,
+        missing: [
+          "Decodable", "Sendable", "PostgrestRelation", "PostgrestKeyedRelation",
+          "PostgrestWritableRelation",
+        ]
+      )
+        == ": Decodable, Sendable, PostgrestRelation, PostgrestKeyedRelation, PostgrestWritableRelation"
+    )
+  }
+
+  @Test
+  func aKeyedViewIsKeyedButNotWritable() {
+    // A view Postgres reports a key for is still read-only. The two axes are independent.
+    #expect(
+      clause(
+        readOnly: true,
+        hasPrimaryKey: true,
+        missing: ["Decodable", "Sendable", "PostgrestRelation", "PostgrestKeyedRelation"]
+      ) == ": Decodable, Sendable, PostgrestRelation, PostgrestKeyedRelation"
     )
   }
 

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -45,7 +45,7 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
             return "id"
@@ -116,7 +116,7 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
             return "id"
@@ -127,6 +127,60 @@ struct TableMacroTests {
 
         enum CodingKeys: String, CodingKey {
           case id = "id"
+        }
+      }
+      """#
+    }
+  }
+
+  @Test
+  func aWritableTableWithNoKeyOmitsPrimaryKeyColumns() {
+    // `primaryKeyColumns` is mandatory on `PostgrestKeyedRelation`, so not emitting it is what
+    // keeps this type off that protocol — and off the derived-target `upsert` with it. Emitting an
+    // empty literal would conform it and send an empty `on_conflict`, a different request.
+    assertMacro {
+      """
+      @Table("audit_events")
+      struct AuditEvent {
+        var action: String
+      }
+      """
+    } expansion: {
+      #"""
+      struct AuditEvent {
+        var action: String
+      }
+
+      extension AuditEvent {
+        static let relationName = "audit_events"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
+          switch keyPath {
+          case \Self.action:
+            return "action"
+          default:
+            fatalError("AuditEvent: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case action = "action"
+        }
+
+        struct Insert: Encodable, Sendable {
+          var action: String
+
+          enum CodingKeys: String, CodingKey {
+            case action = "action"
+          }
+
+          init(action: String) {
+            self.action = action
+          }
         }
       }
       """#
@@ -157,7 +211,7 @@ struct TableMacroTests {
 
         public static let selectString = "*"
 
-        public static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        public static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
             return "id"
@@ -220,7 +274,7 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.htmlURL:
             return "html_url"
@@ -274,7 +328,7 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
             return "id"
@@ -363,7 +417,7 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
             return "id"
@@ -428,7 +482,7 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.userID:
             return "user_id"
@@ -498,7 +552,7 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.userID:
             return "user_id"
@@ -566,7 +620,7 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
-        static func columnName<V>(for keyPath: KeyPath<Self, V>) -> String {
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
             return "id"

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -251,3 +251,7 @@ deinits
 # Term from AGENTS.md's Enum-like Values section (describing non-failable init(rawValue:)).
 failable
 memberwise
+
+# Term from PostgrestTypedMutation's upsert doc (an empty conflict target cannot be
+# written, so it is unrepresentable rather than merely invalid).
+unrepresentable

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -78,9 +78,10 @@ supporting_symbols:
   - PostgrestQueryPhase
   - PostgrestRelation
   - PostgrestRelation.columnName
-  - PostgrestRelation.primaryKeyColumns
   - PostgrestRelation.relationName
   - PostgrestRelation.schema
+  - PostgrestKeyedRelation
+  - PostgrestKeyedRelation.primaryKeyColumns
   - PostgrestRequestBuilder
   - PostgrestRequestBuilder.Operator
   - PostgrestRequestBuilder.execute


### PR DESCRIPTION
A typed upsert compiled with no conflict target. PostgREST falls back to the
primary key when `on_conflict` is absent, so on a relation with **no** key there
was nothing to merge on and every call quietly inserted another row. `onConflict`
was also a raw `String` — the one place the typed API still took a stringly-typed
column — so a typo surfaced as a runtime 400.

## Call sites

```swift
// Keyed table — was: sent no target at all. Now derives it from @PrimaryKey.
try await client.from(Todo.self)
  .upsert(Todo.Insert(id: 1, task: "buy milk"))
  .execute()                                          // on_conflict=id

// Compound key, in declaration order.
try await client.from(UserRole.self)
  .upsert(UserRole.Insert(userID: 1, roleID: 2))
  .execute()                                          // on_conflict=user_id,role_id

// Merging on a unique constraint that is not the key — was: onConflict: "email".
try await client.from(User.self)
  .upsert(User.Insert(email: "a@example.com", name: "Ada"), onConflict: \.email)
  .execute()                                          // on_conflict=email

// Multi-column override. Column names come from the same mapping filters use,
// so `isDone` reaches the wire as `is_done`.
try await client.from(Todo.self)
  .upsert(todo, onConflict: \.task, \.isDone)
  .execute()                                          // on_conflict=task,is_done
```

And the case this closes — a **keyless** writable table:

```swift
@Table("audit_events")
struct AuditEvent { var action: String; var recordedBy: String }

try client.from(AuditEvent.self).upsert(event)         // ❌ no longer compiles
// error: referencing instance method 'upsert' on 'PostgrestTypedSource'
//        requires that 'AuditEvent' conform to 'PostgrestKeyedRelation'

try client.from(AuditEvent.self).upsert(event, onConflict: \.action)   // ✅
```

## How

`primaryKeyColumns` moves onto a new `PostgrestKeyedRelation`, **mandatory**
rather than defaulting to `[]`. "Declares no key" becomes a missing conformance
instead of an empty array, so deriving an empty `on_conflict` — a different
request, not a missing one — stops being representable. `@Table` conforms a type
to it only when a property is marked `@PrimaryKey`, and the no-target `upsert` is
constrained to it.

The override takes a leading key path plus the rest, which makes an empty target
unrepresentable. Both choices follow `swift-structured-queries`, where
`PrimaryKeyedTable` is likewise a separate refinement and
`onConflict: (T1, repeat each T2)` rules out zero columns.

`columnName(for:)` drops its unused generic for `PartialKeyPath<Self>`; `KeyPath`
is a subclass, so every call site upcasts implicitly. That is what let the
override be typed at all.

**Start review at `PostgrestRelation.swift`** — making `primaryKeyColumns` a
mandatory requirement on a new protocol is the load-bearing decision; the rest
follows from it.

## Testing

Nine new tests, each watched failing first — the four wire assertions started
with `capture.query` nil, i.e. no `on_conflict` sent at all. The compile gate is
verified out-of-band, since a compile failure cannot be a runtime test.

```
━ Test run with 1293 tests in 133 suites passed after 3.950 seconds with 10 known issues.
```

`format.sh`, `spell-check.sh` and `test-docs.sh` clean.

## Out of scope, filed instead

- **SDK-1620** — a keyed relation that omits a `@Default` key still degrades to a
  plain insert. Deriving the target does not fix it (PostgREST already defaults to
  the key), and `swift-structured-queries` permits the shape deliberately as the
  insert-or-update form pattern, so it needs a decision first.
- **SDK-1621** — `from(X.self).upsert(x)` misreports as `cannot convert … to
  'String'`, blaming `from`. Pre-existing: `from(SomeView.self).delete()`
  reproduces it identically on today's read-only gate.
- **SDK-1622 / SDK-1623 / SDK-1624** — dead `named(Update)` entry, renaming
  `Insert`, and evaluating a column-expression API against the key-path one.

No `!` and no `V3_MIGRATION.md` entry: `PostgrestMacros` and `PostgrestRelation`
are both absent from v2.55.1, so nothing released changes shape — same reasoning
recorded in #1280.

Fixes SDK-1616
