### PR TITLE
docs(agents): document sdk-compliance.yaml and add a local check script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,25 +300,6 @@ jobs:
       - name: Test docs
         run: ./scripts/test-docs.sh
 
-  compliance:
-    name: Capability compliance
-    runs-on: blacksmith-6vcpu-macos-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Select Xcode 26.4
-        run: sudo xcode-select -s /Applications/Xcode_26.4.app
-      - name: Cache Swift build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .build
-          key: |
-            compliance-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            compliance-${{ runner.os }}-
-      - name: Check sdk-compliance.yaml
-        run: ./scripts/check-compliance.sh
-
   format-check:
     name: Format check (changed files only)
     if: github.event_name == 'pull_request'
@@ -378,7 +359,6 @@ jobs:
         examples-spm,
         spell-check,
         docs,
-        compliance,
         format-check,
       ]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,23 @@ jobs:
       - name: Test docs
         run: ./scripts/test-docs.sh
 
+  compliance:
+    name: Capability compliance
+    runs-on: blacksmith-6vcpu-macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Cache Swift build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build
+          key: |
+            compliance-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            compliance-${{ runner.os }}-
+      - name: Check sdk-compliance.yaml
+        run: ./scripts/check-compliance.sh
+
   format-check:
     name: Format check (changed files only)
     if: github.event_name == 'pull_request'
@@ -359,6 +376,7 @@ jobs:
         examples-spm,
         spell-check,
         docs,
+        compliance,
         format-check,
       ]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Select Xcode 26.4
+        run: sudo xcode-select -s /Applications/Xcode_26.4.app
       - name: Cache Swift build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,27 @@ Legitimate technical terms and project-specific words go in `dictionary.txt` at 
 
 Ensures DocC documentation builds without warnings.
 
+### Capability Compliance
+
+`sdk-compliance.yaml` declares this SDK's public API against the
+[supabase/sdk](https://github.com/supabase/sdk) capability matrix, and is
+CI-gated: `.github/workflows/validate-capabilities.yml` fails a PR that adds
+public API not listed there. **Any change to public API — adding, removing,
+renaming, or moving a symbol — updates `sdk-compliance.yaml` in the same
+commit.** This includes symbols a refactor deletes: a stale entry for a
+symbol that no longer exists is as much a compliance failure as a missing
+one, and CI does not check for it. See the file's own comments and
+`https://github.com/supabase/sdk/blob/main/CONTRIBUTING.md` for the format.
+
+```bash
+# Check sdk-compliance.yaml against the current public API
+./scripts/check-compliance.sh
+```
+
+This reproduces the gate's stale-entry check locally: it fails if the
+manifest still lists a symbol the public API no longer has. It does not
+require network access or a checkout of `supabase/sdk`.
+
 ## Code Style and Conventions
 
 ### Swift Style
@@ -321,19 +342,25 @@ Dropping support for older versions is NOT considered a breaking change and happ
 
 1. Create feature branch from `main`
 2. Implement feature with tests
-3. Run `./scripts/format.sh` to format code
-4. Run `swift test` to verify tests pass
-5. Add documentation if needed
-6. Create PR with conventional commit title
-7. Ensure CI passes
+3. If the feature adds or changes public API, update `sdk-compliance.yaml`
+   in the same commit (see "Capability Compliance" above) and run
+   `./scripts/check-compliance.sh`
+4. Run `./scripts/format.sh` to format code
+5. Run `swift test` to verify tests pass
+6. Add documentation if needed
+7. Create PR with conventional commit title
+8. Ensure CI passes
 
 ### Fixing a Bug
 
 1. Add a failing test that reproduces the bug
 2. Fix the bug
-3. Verify test now passes
-4. Run full test suite
-5. Create PR with `fix:` prefix
+3. If the fix adds, removes, or renames public API, update
+   `sdk-compliance.yaml` in the same commit and run
+   `./scripts/check-compliance.sh`
+4. Verify test now passes
+5. Run full test suite
+6. Create PR with `fix:` prefix
 
 ### Updating Dependencies
 
@@ -370,6 +397,9 @@ supabase stop
 ## Important Notes for AI Coding Agents
 
 - Always run `./scripts/format.sh` before committing Swift code
+- Any change to public API (add, remove, rename, or move a symbol) updates
+  `sdk-compliance.yaml` in the same commit — run `./scripts/check-compliance.sh`
+  to check for stale entries before committing (see "Capability Compliance")
 - Ensure new public APIs have DocC documentation comments
 - Add tests for all new functionality
 - Keep changes minimal and focused

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,23 +98,32 @@ Ensures DocC documentation builds without warnings.
 ### Capability Compliance
 
 `sdk-compliance.yaml` declares this SDK's public API against the
-[supabase/sdk](https://github.com/supabase/sdk) capability matrix, and is
-CI-gated: `.github/workflows/validate-capabilities.yml` fails a PR that adds
-public API not listed there. **Any change to public API — adding, removing,
-renaming, or moving a symbol — updates `sdk-compliance.yaml` in the same
-commit.** This includes symbols a refactor deletes: a stale entry for a
-symbol that no longer exists is as much a compliance failure as a missing
-one, and CI does not check for it. See the file's own comments and
-`https://github.com/supabase/sdk/blob/main/CONTRIBUTING.md` for the format.
+[supabase/sdk](https://github.com/supabase/sdk) capability matrix.
+`.github/workflows/validate-capabilities.yml` calls supabase/sdk's reusable
+compliance workflow on every PR, and it does check for both newly added
+public API not listed in the manifest and registered symbols the code no
+longer has. But that workflow is not a required status check on `main` —
+only `CI Success` (this repo's own `ci.yml`) and the WIP/draft gate are —
+so a failing compliance check does not, by itself, block a merge. That is
+how a 15-symbol manifest drift shipped unnoticed.
+
+**Any change to public API — adding, removing, renaming, or moving a
+symbol — updates `sdk-compliance.yaml` in the same commit.** This includes
+symbols a refactor deletes: a stale entry for a symbol that no longer
+exists is as much a compliance failure as a missing one. See the file's
+own comments and
+`https://github.com/supabase/sdk/blob/main/CONTRIBUTING.md` for the
+format.
 
 ```bash
 # Check sdk-compliance.yaml against the current public API
 ./scripts/check-compliance.sh
 ```
 
-This reproduces the gate's stale-entry check locally: it fails if the
-manifest still lists a symbol the public API no longer has. It does not
-require network access or a checkout of `supabase/sdk`.
+This runs the same stale-entry check locally, without network access or a
+checkout of `supabase/sdk`, and also runs as part of `ci.yml`'s `compliance`
+job — which, unlike `validate-capabilities.yml`, feeds into the required
+`CI Success` check.
 
 ## Code Style and Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,9 +121,9 @@ format.
 ```
 
 This runs the same stale-entry check locally, without network access or a
-checkout of `supabase/sdk`, and also runs as part of `ci.yml`'s `compliance`
-job — which, unlike `validate-capabilities.yml`, feeds into the required
-`CI Success` check.
+checkout of `supabase/sdk`. Run it yourself before pushing a public-API
+change — `validate-capabilities.yml` will eventually catch it too, but
+since it isn't a required check, nothing stops a merge if you don't.
 
 ## Code Style and Conventions
 

--- a/scripts/check-compliance.sh
+++ b/scripts/check-compliance.sh
@@ -46,9 +46,15 @@ if [ -f "$RESOLVED_FILE" ]; then
 fi
 
 echo "Dumping public symbol graph..." >&2
-# || true: test targets may fail to extract; library targets land first
-# (same rationale as supabase/sdk's own extraction step).
-swift package dump-symbol-graph --minimum-access-level public --skip-synthesized-members >/dev/null || true
+# A failing exit here isn't necessarily fatal: test targets can fail to
+# extract while library targets already landed first (same rationale as
+# supabase/sdk's own extraction step). But it can also mean extraction
+# aborted partway through a library target, silently dropping real public
+# symbols and producing bogus stale-entry reports below — so warn instead
+# of swallowing it outright.
+if ! swift package dump-symbol-graph --minimum-access-level public --skip-synthesized-members >/dev/null; then
+  echo "⚠️  dump-symbol-graph exited non-zero; results below may be incomplete." >&2
+fi
 
 SGFILES_LIST="$(mktemp)"
 find .build -maxdepth 4 -name "*.symbols.json" > "$SGFILES_LIST"

--- a/scripts/check-compliance.sh
+++ b/scripts/check-compliance.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Checks sdk-compliance.yaml against the package's current public API.
+#
+# Reproduces, locally and without a base ref, the part of supabase/sdk's
+# capability-matrix gate (validate-sdk-compliance-swift.yml) that CI only
+# catches remotely: it dumps the current public symbol graph, normalizes it
+# the same way upstream's normalize-symbolgraph.ts does (pathComponents
+# joined with ".", everything from the first "(" in the last component
+# stripped), and does a comm-style diff against every symbol
+# sdk-compliance.yaml declares (`symbols` + `supporting_symbols`, top level
+# and per feature).
+#
+# This only fails the build on STALE entries: symbols the manifest still
+# declares after the code that implemented them was deleted, moved, or
+# renamed. That's the exact failure mode from SDK-1624/SDK-1643 — 15 symbols
+# were dropped across 43 commits and nothing local caught that the manifest
+# still listed them, because the remote gate only ever reports on *new*
+# symbols.
+#
+# Symbols present in code but missing from the manifest are reported too,
+# but are advisory only here, not fatal: the manifest carries a large
+# backlog of pre-existing supporting types (structs, DTO properties, etc.)
+# it never enumerated, predating this script, and upstream's CI already
+# gates genuinely new public API against the matrix on every PR diff.
+# Making that backlog fatal here would fail on a clean main and train
+# whoever runs this to ignore or disable it. Register new public API in
+# sdk-compliance.yaml as you add it — see AGENTS.md.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+COMPLIANCE_FILE="sdk-compliance.yaml"
+
+# dump-symbol-graph re-resolves the package graph as a side effect and
+# rewrites Package.resolved. Back it up and restore it so this check doesn't
+# leave unrelated churn behind.
+RESOLVED_FILE="Package.resolved"
+RESOLVED_BACKUP=""
+if [ -f "$RESOLVED_FILE" ]; then
+  RESOLVED_BACKUP="$(mktemp)"
+  cp "$RESOLVED_FILE" "$RESOLVED_BACKUP"
+  trap 'cp "$RESOLVED_BACKUP" "$RESOLVED_FILE"; rm -f "$RESOLVED_BACKUP"' EXIT
+fi
+
+echo "Dumping public symbol graph..." >&2
+# || true: test targets may fail to extract; library targets land first
+# (same rationale as supabase/sdk's own extraction step).
+swift package dump-symbol-graph --minimum-access-level public --skip-synthesized-members >/dev/null || true
+
+SGFILES_LIST="$(mktemp)"
+find .build -maxdepth 4 -name "*.symbols.json" > "$SGFILES_LIST"
+if [ ! -s "$SGFILES_LIST" ]; then
+  echo "error: no symbol graphs emitted" >&2
+  exit 1
+fi
+
+# Kind identifiers that count as public API. Matches supabase/sdk's
+# normalize-symbolgraph.ts KIND_MAP, plus swift.macro — which that map
+# omits (a separate known gap, see SDK-1647) but which this repo's `@Table`
+# family of attached macros needs in order to round-trip at all.
+CODE_SYMBOLS="$(mktemp)"
+jq -s '[.[] | .symbols[]]' $(cat "$SGFILES_LIST") | jq -r '
+  .[]
+  | select(.kind.identifier as $k |
+      ["swift.class","swift.struct","swift.enum","swift.protocol","swift.actor",
+       "swift.func","swift.func.op","swift.method","swift.type.method","swift.init",
+       "swift.subscript","swift.type.subscript","swift.property","swift.type.property",
+       "swift.enum.case","swift.typealias","swift.associatedtype","swift.var","swift.macro"
+      ] | index($k) != null)
+  | .pathComponents as $p
+  | ($p[:-1] + [($p[-1] | sub("\\(.*"; ""))]) | join(".")
+' | LC_ALL=C sort -u > "$CODE_SYMBOLS"
+
+# sdk-compliance.yaml only ever holds plain "- Symbol.Name" list items under
+# `symbols:`/`supporting_symbols:` (top level or per feature) — there's no
+# other array in the schema — so grepping for list items is a safe
+# substitute for a real YAML parser here.
+#
+# Names swift package dump-symbol-graph can't see at all (currently just
+# leading-underscore members, e.g. FunctionsClient._invokeWithStreamedResponse)
+# are excluded from the manifest side too: they can never match, so leaving
+# them in would always misreport as stale.
+MANIFEST_SYMBOLS="$(mktemp)"
+grep -E '^[[:space:]]*-[[:space:]]+[A-Za-z_]' "$COMPLIANCE_FILE" \
+  | sed -E 's/^[[:space:]]*-[[:space:]]+//' \
+  | grep -vE '(^|\.)_[A-Za-z_]*$' \
+  | LC_ALL=C sort -u > "$MANIFEST_SYMBOLS"
+
+UNCOVERED="$(comm -23 "$CODE_SYMBOLS" "$MANIFEST_SYMBOLS")"
+STALE="$(comm -13 "$CODE_SYMBOLS" "$MANIFEST_SYMBOLS")"
+
+rm -f "$SGFILES_LIST" "$CODE_SYMBOLS" "$MANIFEST_SYMBOLS"
+
+if [ -n "$UNCOVERED" ]; then
+  echo "ℹ️  Public API not declared in $COMPLIANCE_FILE (pre-existing backlog, not fatal):"
+  echo "$UNCOVERED" | sed 's/^/  - /'
+  echo
+fi
+
+if [ -n "$STALE" ]; then
+  echo "❌ $COMPLIANCE_FILE declares symbols the public API no longer has:"
+  echo "$STALE" | sed 's/^/  - /'
+  echo
+  echo "Remove them from sdk-compliance.yaml, or update the entry if the symbol moved or was renamed."
+  exit 1
+fi
+
+echo "✅ sdk-compliance.yaml has no stale entries."

--- a/scripts/check-compliance.sh
+++ b/scripts/check-compliance.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 # Checks sdk-compliance.yaml against the package's current public API.
 #
-# Reproduces, locally and without a base ref, the part of supabase/sdk's
-# capability-matrix gate (validate-sdk-compliance-swift.yml) that CI only
-# catches remotely: it dumps the current public symbol graph, normalizes it
-# the same way upstream's normalize-symbolgraph.ts does (pathComponents
-# joined with ".", everything from the first "(" in the last component
-# stripped), and does a comm-style diff against every symbol
-# sdk-compliance.yaml declares (`symbols` + `supporting_symbols`, top level
-# and per feature).
+# supabase/sdk's capability-matrix gate (validate-sdk-compliance-swift.yml,
+# run via .github/workflows/validate-capabilities.yml) already detects both
+# newly added public API and registered symbols the code no longer has. But
+# that workflow is not a required status check on `main` — only `CI Success`
+# (this repo's own ci.yml) is — so a failing compliance check does not, by
+# itself, block a merge. This script reproduces the stale-entry half of that
+# check locally and without a base ref, so it can run as part of `CI
+# Success` (the "compliance" job in ci.yml) and actually gate merges: it
+# dumps the current public symbol graph, normalizes it the same way
+# upstream's normalize-symbolgraph.ts does (pathComponents joined with ".",
+# everything from the first "(" in the last component stripped), and does a
+# comm-style diff against every symbol sdk-compliance.yaml declares
+# (`symbols` + `supporting_symbols`, top level and per feature).
 #
 # This only fails the build on STALE entries: symbols the manifest still
 # declares after the code that implemented them was deleted, moved, or
-# renamed. That's the exact failure mode from SDK-1624/SDK-1643 — 15 symbols
-# were dropped across 43 commits and nothing local caught that the manifest
-# still listed them, because the remote gate only ever reports on *new*
-# symbols.
+# renamed.
 #
 # Symbols present in code but missing from the manifest are reported too,
 # but are advisory only here, not fatal: the manifest carries a large

--- a/scripts/check-compliance.sh
+++ b/scripts/check-compliance.sh
@@ -6,14 +6,14 @@
 # newly added public API and registered symbols the code no longer has. But
 # that workflow is not a required status check on `main` — only `CI Success`
 # (this repo's own ci.yml) is — so a failing compliance check does not, by
-# itself, block a merge. This script reproduces the stale-entry half of that
-# check locally and without a base ref, so it can run as part of `CI
-# Success` (the "compliance" job in ci.yml) and actually gate merges: it
-# dumps the current public symbol graph, normalizes it the same way
-# upstream's normalize-symbolgraph.ts does (pathComponents joined with ".",
-# everything from the first "(" in the last component stripped), and does a
-# comm-style diff against every symbol sdk-compliance.yaml declares
-# (`symbols` + `supporting_symbols`, top level and per feature).
+# itself, block a merge, and nothing else runs it locally before a push.
+# This script reproduces the stale-entry half of that check locally and
+# without a base ref: it dumps the current public symbol graph, normalizes
+# it the same way upstream's normalize-symbolgraph.ts does (pathComponents
+# joined with ".", everything from the first "(" in the last component
+# stripped), and does a comm-style diff against every symbol
+# sdk-compliance.yaml declares (`symbols` + `supporting_symbols`, top level
+# and per feature).
 #
 # This only fails the build on STALE entries: symbols the manifest still
 # declares after the code that implemented them was deleted, moved, or

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -547,9 +547,9 @@ features:
       - AuthLocalStorage
   client.session_management.persist_session:
     status: implemented
-    note: "Sessions persist by default via AuthLocalStorage.defaultLocalStorage (KeychainLocalStorage on Apple platforms). There's no separate boolean toggle to disable persistence — that's done by swapping in a custom, non-persisting AuthLocalStorage via client.session_management.custom_storage."
+    note: "Sessions persist by default via AuthClient.Configuration.defaultLocalStorage (KeychainLocalStorage on Apple platforms). There's no separate boolean toggle to disable persistence — that's done by swapping in a custom, non-persisting AuthLocalStorage via client.session_management.custom_storage."
     symbols:
-      - AuthLocalStorage.defaultLocalStorage
+      - AuthClient.Configuration.defaultLocalStorage
 
   client.request_configuration.custom_http_client:
     status: partially_implemented


### PR DESCRIPTION
## Summary

- Document `sdk-compliance.yaml` in AGENTS.md (new "Capability Compliance" section, plus references from "Adding a New Feature", "Fixing a Bug", and the AI-agent checklist): any public API change updates the manifest in the same commit, including symbols a refactor deletes.
- Add `scripts/check-compliance.sh`: a local developer tool that dumps the current public symbol graph via `swift package dump-symbol-graph`, normalizes it the same way upstream's `normalize-symbolgraph.ts` does, and diffs it against everything `sdk-compliance.yaml` declares. It fails on stale entries (manifest symbols the code no longer has) and reports never-declared symbols as advisory only, since that backlog predates this script and is already covered by the remote gate's new-symbol check. It backs up and restores `Package.resolved`, since `dump-symbol-graph` dirties it as a side effect.
- Fix a real latent bug the script found while being validated against `main`: `sdk-compliance.yaml` declared `AuthLocalStorage.defaultLocalStorage`, which was never a real symbol — the static property actually lives on `AuthClient.Configuration.defaultLocalStorage`.

## Why this isn't wired into ci.yml

`.github/workflows/validate-capabilities.yml` already calls supabase/sdk's reusable compliance workflow on every PR, and that workflow already detects both newly added public API and registered symbols the code no longer has. The real gap is that this workflow isn't a required status check on `main` (branch protection only requires `CI Success` and the WIP/draft gate), so a failing compliance check doesn't block a merge.

I initially tried closing that gap by adding a `compliance` job to `ci.yml` that runs this script as part of the required `CI Success` check. That turned out to be unreliable on this repo's `blacksmith-6vcpu-macos-latest` runner: `swift package dump-symbol-graph` crashes there while extracting the synthetic `SupabasePackageTests` aggregate test target ("Couldn't load module ... in the current SDK and search paths"), even pinned to the same Xcode version used locally, silently dropping scattered real public symbols and producing false stale-entry failures. Rather than ship a required check that's less reliable than the one it's meant to backstop, I dropped that job and kept the script local-only — run it yourself before pushing a public-API change.

## Test plan

- `./scripts/check-compliance.sh` passes on `main`; verified it actually catches drift by injecting a fake stale symbol and confirming a non-zero exit.
- `./scripts/format.sh` — no changes.
- `./scripts/spell-check.sh` — 389 files checked, 0 issues.
- `swift test` — 1313 tests in 138 suites passed (12 known issues, pre-existing).
- `ci.yml` is now identical to `main`.

Fixes SDK-1643