### PR TITLE
feat(postgrest): add column expressions and the filter tree

### DIFF
--- a/Sources/PostgREST/Columns/PostgrestColumnExpression.swift
+++ b/Sources/PostgREST/Columns/PostgrestColumnExpression.swift
@@ -40,27 +40,45 @@ public protocol PostgrestFilterableExpression<Root, Value>: PostgrestColumnExpre
 /// embedded columns do not — PostgREST rejects all three in `order`.
 public protocol PostgrestOrderableExpression<Root, Value>: PostgrestColumnExpression {}
 
-/// A stored column, reached through a relation's generated `Columns` namespace.
-public struct PostgrestColumn<Root: PostgrestRelation, Value>: PostgrestFilterableExpression,
-  PostgrestOrderableExpression
-{
-  public let postgrestExpression: String
-
-  /// - Parameter name: The database column name.
-  public init(_ name: String) {
-    self.postgrestExpression = name
-  }
-}
-
-/// A stored column the database allows to be `NULL`.
+/// A filterable expression whose value the database allows to be `NULL`.
 ///
-/// `Value` is the **wrapped** type: `var dueDate: Date?` generates
-/// `PostgrestNullableColumn<Todo, Date>`. So every operator takes a non-optional operand — use
-/// ``PostgrestNullableColumn/isNull()`` to test for `NULL` — while an update accepts `nil` here
-/// to clear the column.
-public struct PostgrestNullableColumn<
+/// Carries ``PostgrestNullableExpression/isNull()``, which is meaningless on a `NOT NULL` column:
+/// it can never match, and a filter that silently returns nothing is worse than one that does not
+/// compile.
+///
+/// This is a protocol rather than a member of one concrete column type so that a future nullable
+/// expression — a JSON path into a nullable column, an outer-joined embed — gets `isNull()` by
+/// conforming, instead of the operator having to be redeclared on it.
+public protocol PostgrestNullableExpression<Root, Value>: PostgrestFilterableExpression {}
+
+// MARK: - Nullability
+
+/// Whether a stored column's database type admits `NULL`.
+///
+/// A phantom type on ``PostgrestStoredColumn``, never a value and never on the wire: it exists so
+/// one struct serves both column kinds while `isNull()` and an update's `nil` assignment stay
+/// available on exactly the nullable one.
+public protocol PostgrestNullability: Sendable {}
+
+/// A `NOT NULL` column.
+public enum PostgrestNotNull: PostgrestNullability {}
+
+/// A column the database allows to be `NULL`.
+public enum PostgrestNullable: PostgrestNullability {}
+
+/// A stored column, reached through a relation's generated `Columns` namespace.
+///
+/// Spell it as ``PostgrestColumn`` or ``PostgrestNullableColumn`` rather than naming this type
+/// directly; both are aliases that fix `Nullability`.
+///
+/// `Value` is always the **wrapped** type: `var dueDate: Date?` generates
+/// `PostgrestNullableColumn<Todo, Date>`, not `Optional<Date>`. So every operator takes a
+/// non-optional operand — use ``PostgrestNullableExpression/isNull()`` to test for `NULL` — while
+/// an update accepts `nil` on a nullable column to clear it.
+public struct PostgrestStoredColumn<
   Root: PostgrestRelation,
-  Value
+  Value,
+  Nullability: PostgrestNullability
 >: PostgrestFilterableExpression, PostgrestOrderableExpression {
   public let postgrestExpression: String
 
@@ -69,3 +87,15 @@ public struct PostgrestNullableColumn<
     self.postgrestExpression = name
   }
 }
+
+/// Only a nullable column can be `NULL`, so only it gets `isNull()`.
+extension PostgrestStoredColumn: PostgrestNullableExpression
+where Nullability == PostgrestNullable {}
+
+/// A stored `NOT NULL` column.
+public typealias PostgrestColumn<Root: PostgrestRelation, Value> =
+  PostgrestStoredColumn<Root, Value, PostgrestNotNull>
+
+/// A stored column the database allows to be `NULL`.
+public typealias PostgrestNullableColumn<Root: PostgrestRelation, Value> =
+  PostgrestStoredColumn<Root, Value, PostgrestNullable>

--- a/Sources/PostgREST/Columns/PostgrestColumnExpression.swift
+++ b/Sources/PostgREST/Columns/PostgrestColumnExpression.swift
@@ -1,0 +1,71 @@
+//
+//  PostgrestColumnExpression.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+/// Anything that can appear in a `select` list: a stored column, a cast, a JSON path, an
+/// aggregate, or a column projected through an embedded relation.
+///
+/// `@Table` generates the conformances. You do not conform your own types.
+public protocol PostgrestColumnExpression<Root, Value>: Sendable {
+  /// The relation this expression belongs to. Using it against another relation is a compile
+  /// error.
+  associatedtype Root: PostgrestRelation
+
+  /// The Swift type this expression produces. Operators require a matching operand, so
+  /// `.eq("seven")` on an `Int` column does not compile.
+  associatedtype Value
+
+  /// The text PostgREST expects, in a `select` list or on the left of an operator.
+  var postgrestExpression: String { get }
+}
+
+/// A column expression that can also sit on the left of a filter operator.
+///
+/// Casts, aggregates and to-many embedded columns do not conform, so filtering on one is a
+/// compile error rather than a request that misbehaves:
+///
+/// - PostgREST drops a cast from the SQL it generates, so `cost::text=eq.10` answers 200 having
+///   compared the uncast column.
+/// - There is no `HAVING`, so an aggregate cannot be filtered on.
+/// - An embedded column filters as `orders.id` but selects as `orders(id)`; filtering inside an
+///   embed is not supported yet.
+public protocol PostgrestFilterableExpression<Root, Value>: PostgrestColumnExpression {}
+
+/// A column expression that can be used as an `order` key.
+///
+/// Stored columns, JSON paths and to-one embedded columns conform. Casts, aggregates and to-many
+/// embedded columns do not — PostgREST rejects all three in `order`.
+public protocol PostgrestOrderableExpression<Root, Value>: PostgrestColumnExpression {}
+
+/// A stored column, reached through a relation's generated `Columns` namespace.
+public struct PostgrestColumn<Root: PostgrestRelation, Value>: PostgrestFilterableExpression,
+  PostgrestOrderableExpression
+{
+  public let postgrestExpression: String
+
+  /// - Parameter name: The database column name.
+  public init(_ name: String) {
+    self.postgrestExpression = name
+  }
+}
+
+/// A stored column the database allows to be `NULL`.
+///
+/// `Value` is the **wrapped** type: `var dueDate: Date?` generates
+/// `PostgrestNullableColumn<Todo, Date>`. So every operator takes a non-optional operand — use
+/// ``PostgrestNullableColumn/isNull()`` to test for `NULL` — while an update accepts `nil` here
+/// to clear the column.
+public struct PostgrestNullableColumn<
+  Root: PostgrestRelation,
+  Value
+>: PostgrestFilterableExpression, PostgrestOrderableExpression {
+  public let postgrestExpression: String
+
+  /// - Parameter name: The database column name.
+  public init(_ name: String) {
+    self.postgrestExpression = name
+  }
+}

--- a/Sources/PostgREST/Filters/PostgrestFilter+Comparison.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter+Comparison.swift
@@ -1,0 +1,94 @@
+//
+//  PostgrestFilter+Comparison.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+extension PostgrestFilterableExpression where Value: PostgrestFilterValue {
+  /// Matches rows where this column equals `value`.
+  ///
+  /// `nil` is not accepted; use ``PostgrestNullableColumn/isNull()`` to test for SQL `NULL`.
+  public func eq(_ value: Value) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "eq", value: value.rawValue)
+  }
+
+  /// Matches rows where this column is not equal to `value`.
+  public func neq(_ value: Value) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "neq", value: value.rawValue)
+  }
+
+  /// Matches rows where this column is greater than `value`.
+  public func gt(_ value: Value) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "gt", value: value.rawValue)
+  }
+
+  /// Matches rows where this column is greater than or equal to `value`.
+  public func gte(_ value: Value) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "gte", value: value.rawValue)
+  }
+
+  /// Matches rows where this column is less than `value`.
+  public func lt(_ value: Value) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "lt", value: value.rawValue)
+  }
+
+  /// Matches rows where this column is less than or equal to `value`.
+  public func lte(_ value: Value) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "lte", value: value.rawValue)
+  }
+
+  /// Matches rows where this column is distinct from `value`.
+  ///
+  /// Unlike ``neq(_:)``, a `NULL` row matches any non-null operand.
+  public func isDistinct(_ value: Value) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "isdistinct", value: value.rawValue)
+  }
+}
+
+// MARK: - Escape hatch
+
+extension PostgrestFilterableExpression {
+  /// Applies an operator this SDK has no member for — a PostgREST operator newer than this
+  /// version, for instance. The column stays compiler-checked.
+  ///
+  /// ```swift
+  /// .where { $0.tags.raw("someop.value") }   // tags=someop.value
+  /// ```
+  ///
+  /// Composes like any other filter: `!$0.tags.raw("someop.v")` renders `tags=not.someop.v`.
+  ///
+  /// - Parameter operand: Everything after the `=`, for example `"eq.10"`.
+  public func raw(_ operand: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(rawColumn: postgrestExpression, operand: operand)
+  }
+}
+
+// MARK: - Boolean IS checks
+
+extension PostgrestFilterableExpression where Value == Bool {
+  /// Matches rows where this boolean column IS true.
+  ///
+  /// On a nullable column this differs from `eq(true)`: `eq.true` is unknown for a `NULL` row,
+  /// `is.true` is false.
+  public func isTrue() -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "is", value: "true")
+  }
+
+  /// Matches rows where this boolean column IS false.
+  public func isFalse() -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "is", value: "false")
+  }
+}
+
+// MARK: - Null checks
+
+extension PostgrestNullableColumn {
+  /// Matches rows where this column is SQL `NULL`.
+  ///
+  /// There is no `isNotNull()` — negate instead: `!$0.dueDate.isNull()` renders
+  /// `due_at=not.is.null`.
+  public func isNull() -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "is", value: "null")
+  }
+}

--- a/Sources/PostgREST/Filters/PostgrestFilter+Comparison.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter+Comparison.swift
@@ -8,41 +8,49 @@
 extension PostgrestFilterableExpression where Value: PostgrestFilterValue {
   /// Matches rows where this column equals `value`.
   ///
-  /// `nil` is not accepted; use ``PostgrestNullableColumn/isNull()`` to test for SQL `NULL`.
+  /// `nil` is not accepted; use ``PostgrestNullableExpression/isNull()`` to test for SQL `NULL`.
   public func eq(_ value: Value) -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "eq", value: value.rawValue)
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.eq.rawValue, value: value.rawValue)
   }
 
   /// Matches rows where this column is not equal to `value`.
   public func neq(_ value: Value) -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "neq", value: value.rawValue)
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.neq.rawValue, value: value.rawValue)
   }
 
   /// Matches rows where this column is greater than `value`.
   public func gt(_ value: Value) -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "gt", value: value.rawValue)
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.gt.rawValue, value: value.rawValue)
   }
 
   /// Matches rows where this column is greater than or equal to `value`.
   public func gte(_ value: Value) -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "gte", value: value.rawValue)
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.gte.rawValue, value: value.rawValue)
   }
 
   /// Matches rows where this column is less than `value`.
   public func lt(_ value: Value) -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "lt", value: value.rawValue)
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.lt.rawValue, value: value.rawValue)
   }
 
   /// Matches rows where this column is less than or equal to `value`.
   public func lte(_ value: Value) -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "lte", value: value.rawValue)
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.lte.rawValue, value: value.rawValue)
   }
 
   /// Matches rows where this column is distinct from `value`.
   ///
   /// Unlike ``neq(_:)``, a `NULL` row matches any non-null operand.
   public func isDistinct(_ value: Value) -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "isdistinct", value: value.rawValue)
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.isdistinct.rawValue,
+      value: value.rawValue)
   }
 }
 
@@ -58,6 +66,13 @@ extension PostgrestFilterableExpression {
   ///
   /// Composes like any other filter: `!$0.tags.raw("someop.v")` renders `tags=not.someop.v`.
   ///
+  /// > Important: The operand reaches the server unescaped, so if it is not valid in the
+  /// > `or=(…)` grammar, keep the filter out of every subtree beneath `||` or `!` — not just out
+  /// > of their immediate operands. Anything below one of those is rendered in that stricter
+  /// > grammar however deep it sits, so `($0.a.eq(1) && $0.tags.raw("someop.v")) || $0.b.eq(2)`
+  /// > routes the raw operand through it despite the immediate combinator being `&&`. See
+  /// > ``PostgrestFilter/raw(_:_:)``.
+  ///
   /// - Parameter operand: Everything after the `=`, for example `"eq.10"`.
   public func raw(_ operand: String) -> PostgrestFilter<Root> {
     PostgrestFilter(rawColumn: postgrestExpression, operand: operand)
@@ -72,23 +87,26 @@ extension PostgrestFilterableExpression where Value == Bool {
   /// On a nullable column this differs from `eq(true)`: `eq.true` is unknown for a `NULL` row,
   /// `is.true` is false.
   public func isTrue() -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "is", value: "true")
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.`is`.rawValue, value: "true")
   }
 
   /// Matches rows where this boolean column IS false.
   public func isFalse() -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "is", value: "false")
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.`is`.rawValue, value: "false")
   }
 }
 
 // MARK: - Null checks
 
-extension PostgrestNullableColumn {
-  /// Matches rows where this column is SQL `NULL`.
+extension PostgrestNullableExpression {
+  /// Matches rows where this expression is SQL `NULL`.
   ///
   /// There is no `isNotNull()` — negate instead: `!$0.dueDate.isNull()` renders
   /// `due_at=not.is.null`.
   public func isNull() -> PostgrestFilter<Root> {
-    PostgrestFilter(column: postgrestExpression, operator: "is", value: "null")
+    PostgrestFilter(
+      column: postgrestExpression, operator: PostgrestOperator.`is`.rawValue, value: "null")
   }
 }

--- a/Sources/PostgREST/Filters/PostgrestFilter.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter.swift
@@ -1,0 +1,183 @@
+//
+//  PostgrestFilter.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Helpers
+
+/// A filter on a relation.
+///
+/// Built inside a `where` closure by calling an operator method on a column, then composing the
+/// results with `&&`, `||` and `!`:
+///
+/// ```swift
+/// try await client.from(Todo.self)
+///   .select()
+///   .where { ($0.isDone.eq(false) && $0.priority.gt(3)) || $0.id.eq(7) }
+///   .execute()
+/// ```
+///
+/// A top-level `&&` renders as separate query parameters, `||` as one `or=(…)`, and an `&&`
+/// nested inside an `||` as `and(…)`.
+public struct PostgrestFilter<R: PostgrestRelation>: Sendable {
+  indirect enum Node: Sendable {
+    case comparison(column: String, operator: String, value: String)
+
+    /// Everything after the `=` as one unparsed string. Separate from `comparison` because the
+    /// operator and value cannot be split.
+    case raw(column: String, operand: String)
+
+    case and([Node])
+    case or([Node])
+    case not(Node)
+  }
+
+  var node: Node
+
+  init(node: Node) {
+    self.node = node
+  }
+
+  init(column: String, operator: String, value: String) {
+    self.node = .comparison(column: column, operator: `operator`, value: value)
+  }
+
+  init(rawColumn: String, operand: String) {
+    self.node = .raw(column: rawColumn, operand: operand)
+  }
+
+  /// A filter written entirely in PostgREST syntax, for an expression the generated namespace
+  /// cannot name.
+  ///
+  /// Nothing here is checked. Prefer ``PostgrestFilterableExpression/raw(_:)``, which keeps the
+  /// column compiler-checked and takes only the operand as a string.
+  ///
+  /// ```swift
+  /// .where { $0.isDone.eq(false) && .raw("cost::text", "eq.10") }
+  /// ```
+  ///
+  /// > Important: Combine this with `&&`, not `||`. Inside the `or=(…)` an `||` produces,
+  /// > PostgREST's grammar is stricter — a `::` in the column name is a `PGRST100` there even
+  /// > though it parses at top level.
+  ///
+  /// - Parameters:
+  ///   - column: The query-parameter name, for example `"cost::text"`.
+  ///   - operand: Everything after the `=`, for example `"eq.10"`.
+  public static func raw(_ column: String, _ operand: String) -> Self {
+    Self(rawColumn: column, operand: operand)
+  }
+
+  enum Junction { case and, or }
+
+  /// Merges two nodes under one junction, absorbing a child of the same kind, so `a || b || c`
+  /// renders as one flat `or=(a,b,c)` rather than `or=(or(a,b),c)`.
+  static func flatten(_ lhs: Node, _ rhs: Node, as junction: Junction) -> [Node] {
+    func parts(_ node: Node) -> [Node] {
+      switch (junction, node) {
+      case (.and, .and(let children)): return children
+      case (.or, .or(let children)): return children
+      default: return [node]
+      }
+    }
+    return parts(lhs) + parts(rhs)
+  }
+}
+
+// MARK: - Composition
+
+/// Matches rows satisfying both filters.
+public func && <R>(lhs: PostgrestFilter<R>, rhs: PostgrestFilter<R>) -> PostgrestFilter<R> {
+  PostgrestFilter(node: .and(PostgrestFilter<R>.flatten(lhs.node, rhs.node, as: .and)))
+}
+
+/// Matches rows satisfying either filter.
+public func || <R>(lhs: PostgrestFilter<R>, rhs: PostgrestFilter<R>) -> PostgrestFilter<R> {
+  PostgrestFilter(node: .or(PostgrestFilter<R>.flatten(lhs.node, rhs.node, as: .or)))
+}
+
+/// Matches rows that do not satisfy `operand`.
+prefix public func ! <R>(operand: PostgrestFilter<R>) -> PostgrestFilter<R> {
+  PostgrestFilter(node: .not(operand.node))
+}
+
+// MARK: - Rendering
+
+extension PostgrestFilter {
+  /// The query items this filter contributes to a request.
+  func queryItems() -> [URLQueryItem] {
+    Self.queryItems(for: node)
+  }
+
+  private static func queryItems(for node: Node) -> [URLQueryItem] {
+    switch node {
+    case .comparison(let column, let `operator`, let value):
+      return [URLQueryItem(name: column, value: "\(`operator`).\(value)")]
+
+    case .raw(let column, let operand):
+      return [URLQueryItem(name: column, value: operand)]
+
+    case .and(let children):
+      // PostgREST ANDs separate parameters, so a top-level AND needs no grouping.
+      return children.flatMap { queryItems(for: $0) }
+
+    case .or(let children):
+      return [URLQueryItem(name: "or", value: "(\(children.map(group).joined(separator: ",")))")]
+
+    case .not(let inner):
+      switch inner {
+      case .and(let children):
+        return [
+          URLQueryItem(name: "not.and", value: "(\(children.map(group).joined(separator: ",")))")
+        ]
+      case .or(let children):
+        return [
+          URLQueryItem(name: "not.or", value: "(\(children.map(group).joined(separator: ",")))")
+        ]
+      case .comparison(let column, let `operator`, let value):
+        return [URLQueryItem(name: column, value: "not.\(`operator`).\(value)")]
+      case .raw(let column, let operand):
+        return [URLQueryItem(name: column, value: "not.\(operand)")]
+      case .not(let doubleNegated):
+        return queryItems(for: doubleNegated)
+      }
+    }
+  }
+
+  /// A node in the comma-separated form used inside `or=(…)`, where the grammar differs from
+  /// top level. Each rule below is a 400 or a silent zero-row answer if broken:
+  ///
+  /// - An AND is spelled `and(…)`; there is no parameter separator to carry the meaning.
+  /// - Operands must be escaped. `or=(name.eq.p(q),id.eq.3)` answers 200 with zero rows.
+  /// - A negated leaf puts `not.` after the column (`id.not.eq.2`); `not.` may only precede
+  ///   `and`/`or` here. Negating a whole group is unaffected.
+  /// - Double negation must collapse, or `!!a || b` renders `not.not.` and 400s.
+  private static func group(_ node: Node) -> String {
+    switch node {
+    case .comparison(let column, let `operator`, let value):
+      return "\(column).\(`operator`).\(escapePostgRESTFilterValue(value))"
+    case .raw(let column, let operand):
+      // Not escaped: quoting would break the caller's own syntax. The cost is that a raw node
+      // cannot always sit in a group — a `::` in the column is a parse error inside `or=(…)`.
+      return "\(column).\(operand)"
+    case .and(let children):
+      return "and(\(children.map(group).joined(separator: ",")))"
+    case .or(let children):
+      return "or(\(children.map(group).joined(separator: ",")))"
+    case .not(let inner):
+      switch inner {
+      case .not(let doubleNegated):
+        return group(doubleNegated)
+      case .and, .or:
+        // `not.` in front of a group is the only spelling PostgREST accepts here.
+        return "not.\(group(inner))"
+      case .comparison(let column, let `operator`, let value):
+        return "\(column).not.\(`operator`).\(escapePostgRESTFilterValue(value))"
+      case .raw(let column, let operand):
+        return "\(column).not.\(operand)"
+      }
+    }
+  }
+}

--- a/Sources/PostgREST/Filters/PostgrestFilter.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter.swift
@@ -59,9 +59,14 @@ public struct PostgrestFilter<R: PostgrestRelation>: Sendable {
   /// .where { $0.isDone.eq(false) && .raw("cost::text", "eq.10") }
   /// ```
   ///
-  /// > Important: Combine this with `&&`, not `||`. Inside the `or=(…)` an `||` produces,
-  /// > PostgREST's grammar is stricter — a `::` in the column name is a `PGRST100` there even
-  /// > though it parses at top level.
+  /// > Important: Keep a raw node out of every subtree beneath `||` or `!`, not merely out of
+  /// > their immediate operands. Anything below one of those renders in the stricter
+  /// > `or=(…)`/`not.and=(…)` grammar, where a `::` in the column name is a `PGRST100` even
+  /// > though it parses at top level. The immediate combinator does not decide it:
+  /// > `(a && .raw("cost::text", "eq.10")) || b` renders
+  /// > `or=(and(a,cost::text.eq.10),b)` and 400s, and `!(a && .raw("cost::text", "eq.10"))`
+  /// > renders `not.and=(a,cost::text.eq.10)` and 400s the same way. Only a node whose path to
+  /// > the root is `&&` throughout stays in the top-level grammar.
   ///
   /// - Parameters:
   ///   - column: The query-parameter name, for example `"cost::text"`.

--- a/Tests/PostgRESTTests/PostgrestColumnExpressionTests.swift
+++ b/Tests/PostgRESTTests/PostgrestColumnExpressionTests.swift
@@ -1,0 +1,68 @@
+//
+//  PostgrestColumnExpressionTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestColumnExpressionTests {
+  struct Todo: PostgrestRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var isDone: Bool
+    var dueDate: Date?
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let isDone = PostgrestColumn<Todo, Bool>("is_done")
+      let dueDate = PostgrestNullableColumn<Todo, Date>("due_at")
+    }
+
+    static let columns = Columns()
+
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.isDone: "is_done"
+      case \Self.dueDate: "due_at"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  @Test
+  func aColumnRendersItsDatabaseName() {
+    #expect(Todo.columns.isDone.postgrestExpression == "is_done")
+    #expect(Todo.columns.dueDate.postgrestExpression == "due_at")
+  }
+
+  @Test
+  func aColumnCarriesItsValueType() {
+    #expect(type(of: Todo.columns.isDone).Value.self == Bool.self)
+  }
+
+  /// `var dueDate: Date?` gives `Value == Date`, so operators take a non-optional operand.
+  @Test
+  func aNullableColumnCarriesItsWrappedType() {
+    #expect(type(of: Todo.columns.dueDate).Value.self == Date.self)
+  }
+
+  /// A plain column sits in all three positions; casts, aggregates and to-many projections are
+  /// select-only.
+  @Test
+  func bothColumnKindsAreSelectableFilterableAndOrderable() {
+    #expect((Todo.columns.id as Any) is any PostgrestFilterableExpression)
+    #expect((Todo.columns.id as Any) is any PostgrestOrderableExpression)
+    #expect((Todo.columns.dueDate as Any) is any PostgrestFilterableExpression)
+    #expect((Todo.columns.dueDate as Any) is any PostgrestOrderableExpression)
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestFilterComparisonTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterComparisonTests.swift
@@ -1,0 +1,102 @@
+//
+//  PostgrestFilterComparisonTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestFilterComparisonTests {
+  struct Todo: PostgrestRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var isDone: Bool
+    var dueDate: Date?
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let isDone = PostgrestColumn<Todo, Bool>("is_done")
+      let dueDate = PostgrestNullableColumn<Todo, Date>("due_at")
+    }
+
+    static let columns = Columns()
+
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.isDone: "is_done"
+      case \Self.dueDate: "due_at"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  private func rendered(_ filter: PostgrestFilter<Todo>) -> String {
+    filter.queryItems().map { "\($0.name)=\($0.value ?? "")" }.joined(separator: "&")
+  }
+
+  @Test
+  func everyComparisonRendersItsOperator() {
+    let c = Todo.columns
+    #expect(rendered(c.isDone.eq(false)) == "is_done=eq.false")
+    #expect(rendered(c.isDone.neq(false)) == "is_done=neq.false")
+    #expect(rendered(c.id.gt(3)) == "id=gt.3")
+    #expect(rendered(c.id.gte(3)) == "id=gte.3")
+    #expect(rendered(c.id.lt(3)) == "id=lt.3")
+    #expect(rendered(c.id.lte(3)) == "id=lte.3")
+    #expect(rendered(c.id.isDistinct(3)) == "id=isdistinct.3")
+  }
+
+  /// There is no `isNotNull()`; `!` covers it. `isNull()` does not compile on a `NOT NULL`
+  /// column — `$0.isDone.isNull()` is "has no member 'isNull'".
+  @Test
+  func nullChecksRenderTheIsOperator() {
+    #expect(rendered(Todo.columns.dueDate.isNull()) == "due_at=is.null")
+    #expect(rendered(!Todo.columns.dueDate.isNull()) == "due_at=not.is.null")
+  }
+
+  /// `is.true` is not `eq.true` on a nullable boolean, so all three values are needed.
+  @Test
+  func booleanIsChecksRenderTheIsOperator() {
+    #expect(rendered(Todo.columns.isDone.isTrue()) == "is_done=is.true")
+    #expect(rendered(Todo.columns.isDone.isFalse()) == "is_done=is.false")
+    #expect(rendered(!Todo.columns.isDone.isTrue()) == "is_done=not.is.true")
+  }
+
+  /// A nullable column takes the same operators, against a non-optional operand. `nil` must
+  /// never reach one: on a `text` column `col=eq.null` matches the literal string `'null'`.
+  @Test
+  func aNullableColumnComparesAgainstANonOptionalValue() {
+    let when = Date(timeIntervalSince1970: 0)
+    let c = Todo.columns
+    #expect(rendered(c.dueDate.eq(when)).hasPrefix("due_at=eq."))
+    #expect(rendered(c.dueDate.neq(when)).hasPrefix("due_at=neq."))
+    #expect(rendered(c.dueDate.gt(when)).hasPrefix("due_at=gt."))
+    #expect(rendered(c.dueDate.gte(when)).hasPrefix("due_at=gte."))
+    #expect(rendered(c.dueDate.lt(when)).hasPrefix("due_at=lt."))
+    #expect(rendered(c.dueDate.lte(when)).hasPrefix("due_at=lte."))
+    #expect(rendered(c.dueDate.isDistinct(when)).hasPrefix("due_at=isdistinct."))
+  }
+
+  @Test
+  func rawAppliesAnUnknownOperatorToACheckedColumn() {
+    #expect(rendered(Todo.columns.id.raw("someop.7")) == "id=someop.7")
+    #expect(rendered(!Todo.columns.id.raw("someop.7")) == "id=not.someop.7")
+  }
+
+  @Test
+  func comparisonsComposeWithTheOperators() {
+    let c = Todo.columns
+    #expect(
+      rendered((c.isDone.eq(false) && c.id.gt(3)) || c.id.eq(7))
+        == "or=(and(is_done.eq.false,id.gt.3),id.eq.7)")
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestFilterTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterTests.swift
@@ -139,6 +139,23 @@ struct PostgrestFilterTests {
     #expect(rendered(filter) == ["or=(and(a.eq.1,b.not.eq.2),c.eq.3)"])
   }
 
+  /// The group grammar reaches a raw node by ancestry, not by its immediate combinator: an `&&`
+  /// nested under `||` is still rendered by `group()`, so a `::` in the column reaches the
+  /// stricter grammar and 400s. Pinned because the rule is easy to state as "combine with `&&`",
+  /// which is not the test.
+  @Test
+  func aRawLeafUnderAndNestedInOrStillReachesTheGroupGrammar() {
+    let filter = (c("id", "eq", "1") && .raw("cost::text", "eq.10")) || c("id", "eq", "3")
+    #expect(rendered(filter) == ["or=(and(id.eq.1,cost::text.eq.10),id.eq.3)"])
+  }
+
+  /// The same by way of `not.and`, which also routes its children through `group()`.
+  @Test
+  func aRawLeafUnderAndNestedInNotStillReachesTheGroupGrammar() {
+    let filter = !(c("id", "eq", "1") && PostgrestFilter<Todo>.raw("cost::text", "eq.10"))
+    #expect(rendered(filter) == ["not.and=(id.eq.1,cost::text.eq.10)"])
+  }
+
   /// A negated `raw` leaf follows the same in-group rule as a negated comparison.
   @Test
   func negatedRawLeafInsideAGroupMovesNotNextToTheOperand() {

--- a/Tests/PostgRESTTests/PostgrestFilterTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterTests.swift
@@ -1,0 +1,170 @@
+//
+//  PostgrestFilterTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestFilterTests {
+  struct Todo: PostgrestRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+    }
+
+    static let columns = Columns()
+
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  private func rendered(_ filter: PostgrestFilter<Todo>) -> [String] {
+    filter.queryItems().map { "\($0.name)=\($0.value ?? "")" }
+  }
+
+  private func c(_ column: String, _ op: String, _ value: String) -> PostgrestFilter<Todo> {
+    PostgrestFilter<Todo>(column: column, operator: op, value: value)
+  }
+
+  /// PostgREST ANDs separate query parameters implicitly, so a top-level AND flattens.
+  @Test
+  func topLevelAndFlattensToSeparateQueryItems() {
+    #expect(rendered(c("a", "eq", "1") && c("b", "gt", "2")) == ["a=eq.1", "b=gt.2"])
+  }
+
+  @Test
+  func orRendersAsASingleParenthesisedParameter() {
+    #expect(rendered(c("a", "eq", "1") || c("b", "gt", "2")) == ["or=(a.eq.1,b.gt.2)"])
+  }
+
+  @Test
+  func anAndNestedInsideAnOrRendersAsAGroup() {
+    let filter = (c("a", "eq", "1") && c("b", "gt", "2")) || c("c", "eq", "3")
+    #expect(rendered(filter) == ["or=(and(a.eq.1,b.gt.2),c.eq.3)"])
+  }
+
+  /// Without associative flattening this renders `or=(or(a,b),c)` — accepted by PostgREST, but
+  /// not what was written.
+  @Test
+  func repeatedOrFlattens() {
+    let filter = c("a", "eq", "1") || c("b", "eq", "2") || c("c", "eq", "3")
+    #expect(rendered(filter) == ["or=(a.eq.1,b.eq.2,c.eq.3)"])
+  }
+
+  @Test
+  func repeatedAndFlattens() {
+    let filter = c("a", "eq", "1") && c("b", "eq", "2") && c("c", "eq", "3")
+    #expect(rendered(filter) == ["a=eq.1", "b=eq.2", "c=eq.3"])
+  }
+
+  @Test
+  func negationPrefixesTheGroupOperator() {
+    #expect(rendered(!(c("a", "eq", "1") && c("b", "gt", "2"))) == ["not.and=(a.eq.1,b.gt.2)"])
+    #expect(rendered(!(c("a", "eq", "1") || c("b", "gt", "2"))) == ["not.or=(a.eq.1,b.gt.2)"])
+  }
+
+  @Test
+  func negatingASingleComparisonPrefixesTheOperator() {
+    #expect(rendered(!c("a", "eq", "1")) == ["a=not.eq.1"])
+  }
+
+  @Test
+  func filtersReduceIntoOneFlatGroup() {
+    let ids = [1, 2, 3]
+    let filter = ids.dropFirst().reduce(c("id", "eq", "1")) { $0 || c("id", "eq", "\($1)") }
+    #expect(rendered(filter) == ["or=(id.eq.1,id.eq.2,id.eq.3)"])
+  }
+
+  @Test
+  func rawPassesAnOperandThroughUntouched() {
+    #expect(rendered(.raw("cost::text", "eq.10")) == ["cost::text=eq.10"])
+    #expect(rendered(!PostgrestFilter<Todo>.raw("x", "eq.1")) == ["x=not.eq.1"])
+    #expect(rendered(c("id", "eq", "1") || .raw("x", "eq.2")) == ["or=(id.eq.1,x.eq.2)"])
+  }
+
+  /// Unescaped, `or=(name.eq.p(q),id.eq.3)` answers 200 with zero rows. Top level must *not* be
+  /// quoted — `name=eq.a,b` is already correct there.
+  @Test
+  func groupOperandsAreEscapedAndTopLevelOnesAreNot() {
+    #expect(rendered(c("name", "eq", "a,b")) == ["name=eq.a,b"])
+    #expect(
+      rendered(c("name", "eq", "a,b") || c("id", "eq", "3"))
+        == ["or=(name.eq.\"a,b\",id.eq.3)"])
+    #expect(
+      rendered(c("name", "eq", "p(q)") || c("id", "eq", "3"))
+        == ["or=(name.eq.\"p(q)\",id.eq.3)"])
+  }
+
+  /// `group` must collapse too, or `!!a || b` renders `not.not.` and 400s.
+  @Test
+  func doubleNegationCollapsesInBothPositions() {
+    #expect(rendered(!(!c("id", "eq", "2"))) == ["id=eq.2"])
+    #expect(rendered(!(!c("id", "eq", "2")) || c("id", "eq", "3")) == ["or=(id.eq.2,id.eq.3)"])
+  }
+
+  /// `or=(not.id.eq.2,…)` is a `PGRST100`; `or=(id.not.eq.2,…)` is the accepted form.
+  ///
+  /// A negated leaf takes a different `group()` branch than a plain one, so the escaping is
+  /// pinned here too rather than assumed from the plain case.
+  @Test
+  func negatedLeafInsideAGroupMovesNotNextToTheOperator() {
+    #expect(rendered(!c("a", "eq", "1") || c("b", "eq", "2")) == ["or=(a.not.eq.1,b.eq.2)"])
+    #expect(
+      rendered(!c("name", "eq", "p(q)") || c("id", "eq", "3"))
+        == ["or=(name.not.eq.\"p(q)\",id.eq.3)"])
+    #expect(
+      rendered(!c("name", "eq", "a,b") || c("id", "eq", "3"))
+        == ["or=(name.not.eq.\"a,b\",id.eq.3)"])
+  }
+
+  /// The same rule one level deeper.
+  @Test
+  func negatedLeafInsideANestedAndRendersInPlace() {
+    let filter = (c("a", "eq", "1") && !c("b", "eq", "2")) || c("c", "eq", "3")
+    #expect(rendered(filter) == ["or=(and(a.eq.1,b.not.eq.2),c.eq.3)"])
+  }
+
+  /// A negated `raw` leaf follows the same in-group rule as a negated comparison.
+  @Test
+  func negatedRawLeafInsideAGroupMovesNotNextToTheOperand() {
+    #expect(
+      rendered(c("id", "eq", "1") || !PostgrestFilter<Todo>.raw("x", "eq.2"))
+        == ["or=(id.eq.1,x.not.eq.2)"])
+  }
+
+  /// The leaf rule above does not affect a negated group: `not.` stays in front of `and(…)`.
+  @Test
+  func negatingANestedGroupStillPrefixesTheGroupOperator() {
+    let filter = !(c("a", "eq", "1") && c("b", "eq", "2")) || c("c", "eq", "3")
+    #expect(rendered(filter) == ["or=(not.and(a.eq.1,b.eq.2),c.eq.3)"])
+  }
+
+  @Test
+  func groupEscapingAppliesTwoLevelsDeep() {
+    let filter = (c("a", "eq", "1") && c("name", "eq", "p(q)")) || c("id", "eq", "3")
+    #expect(rendered(filter) == ["or=(and(a.eq.1,name.eq.\"p(q)\"),id.eq.3)"])
+  }
+
+  /// The three global operators must not make ordinary Boolean logic ambiguous.
+  @Test
+  func ordinaryBooleanLogicStillWorks() {
+    func check(_ a: Bool, _ b: Bool, _ d: Bool) -> Bool { (a && b) || (!d && a) || (b && !a) }
+    #expect(check(true, true, false) == true)
+    #expect(check(false, false, true) == false)
+  }
+}

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -258,3 +258,10 @@ memberwise
 # Term from PostgrestTypedMutation's upsert doc (an empty conflict target cannot be
 # written, so it is unrepresentable rather than merely invalid).
 unrepresentable
+
+# Terms from the typed column-expression surface (Sources/PostgREST/Columns).
+associatedtype
+uncast
+
+# Term from the comparison operators' documentation (PostgrestFilter+Comparison.swift).
+someop

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -101,6 +101,34 @@ supporting_symbols:
   - PostgrestWritableRelation
   - PostgrestWritableRelation.Draft
 
+  # The typed column-expression surface. A column expression is the left-hand side of every
+  # filter and every `select` entry at once, so none of these types belongs to a single
+  # capability. The operator methods declared over them are 1:1 with a capability and are
+  # attributed to that feature's own `symbols:` list instead (see database.using_filters.*
+  # below).
+  #
+  # The two refinements are position rules, enforced by the type system rather than by the
+  # server: the base protocol is select position, `PostgrestFilterableExpression` adds the left of
+  # a filter, `PostgrestOrderableExpression` adds an `order` key.
+  - PostgrestColumnExpression
+  - PostgrestColumnExpression.Root
+  - PostgrestColumnExpression.Value
+  - PostgrestColumnExpression.postgrestExpression
+  - PostgrestFilterableExpression
+  - PostgrestOrderableExpression
+  - PostgrestColumn
+  - PostgrestColumn.init
+  - PostgrestColumn.postgrestExpression
+  - PostgrestNullableColumn
+  - PostgrestNullableColumn.init
+  - PostgrestNullableColumn.postgrestExpression
+  # The filter value itself, and the AND junction. `||` and `!` map onto
+  # database.using_filters.or and .not; `&&` has no capability of its own — PostgREST ANDs
+  # top-level query parameters already, so conjunction is the default rather than a feature — and
+  # sits here instead of being attributed to a capability it does not implement.
+  - PostgrestFilter
+  - "&&"
+
   # The `PostgrestMacros` attributes. `@Table` synthesizes the relation
   # conformance used by every database.* typed entry point, and the three
   # markers are inputs to that one expansion rather than capabilities of their
@@ -644,36 +672,42 @@ features:
       - PostgrestRequestBuilder.eq
       - PostgrestRequestBuilder.equals
       - PostgrestKeyPathFilterable.eq
+      - PostgrestFilterableExpression.eq
   database.using_filters.neq:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.neq
       - PostgrestRequestBuilder.notEquals
       - PostgrestKeyPathFilterable.neq
+      - PostgrestFilterableExpression.neq
   database.using_filters.gt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.gt
       - PostgrestRequestBuilder.greaterThan
       - PostgrestKeyPathFilterable.gt
+      - PostgrestFilterableExpression.gt
   database.using_filters.gte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.gte
       - PostgrestRequestBuilder.greaterThanOrEquals
       - PostgrestKeyPathFilterable.gte
+      - PostgrestFilterableExpression.gte
   database.using_filters.lt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.lt
       - PostgrestRequestBuilder.lowerThan
       - PostgrestKeyPathFilterable.lt
+      - PostgrestFilterableExpression.lt
   database.using_filters.lte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.lte
       - PostgrestRequestBuilder.lowerThanOrEquals
       - PostgrestKeyPathFilterable.lte
+      - PostgrestFilterableExpression.lte
   database.using_filters.like:
     status: implemented
     symbols:
@@ -688,6 +722,9 @@ features:
       - PostgrestRequestBuilder.is
       - PostgrestKeyPathFilterable.isNull
       - PostgrestKeyPathFilterable.isNotNull
+      - PostgrestFilterableExpression.isTrue
+      - PostgrestFilterableExpression.isFalse
+      - PostgrestNullableColumn.isNull
   database.using_filters.in:
     status: implemented
     symbols:
@@ -749,6 +786,7 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.not
+      - "!"
     supporting_symbols:
       - PostgrestOperator
       - PostgrestOperator.init
@@ -782,10 +820,14 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.or
+      - "||"
   database.using_filters.raw:
     status: implemented
+    note: "Two escape hatches on the typed surface, at different strengths. `PostgrestFilterableExpression.raw(_:)` keeps the column compiler-checked and leaves only the operand as a string; `PostgrestFilter.raw(_:_:)` takes both as strings, for an expression the generated namespace cannot name at all."
     symbols:
       - PostgrestRequestBuilder.filter
+      - PostgrestFilterableExpression.raw
+      - PostgrestFilter.raw
   database.using_filters.regex:
     status: implemented
     note: "PostgrestRequestBuilder.match(_:pattern:) — the PostgrestFilterValue-typed overload backing the `~` operator, distinct from the dictionary-based overload used by database.using_filters.match above."
@@ -799,6 +841,7 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.isDistinct
+      - PostgrestFilterableExpression.isDistinct
   database.using_filters.not_in:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -107,21 +107,28 @@ supporting_symbols:
   # attributed to that feature's own `symbols:` list instead (see database.using_filters.*
   # below).
   #
-  # The two refinements are position rules, enforced by the type system rather than by the
-  # server: the base protocol is select position, `PostgrestFilterableExpression` adds the left of
-  # a filter, `PostgrestOrderableExpression` adds an `order` key.
+  # The position refinements are rules enforced by the type system rather than by the server: the
+  # base protocol is select position, `PostgrestFilterableExpression` adds the left of a filter,
+  # `PostgrestOrderableExpression` adds an `order` key. `PostgrestNullableExpression` is not a
+  # position but a nullability refinement, and it is where `isNull()` lives so that any future
+  # nullable expression gets the operator by conforming rather than by redeclaring it.
   - PostgrestColumnExpression
   - PostgrestColumnExpression.Root
   - PostgrestColumnExpression.Value
   - PostgrestColumnExpression.postgrestExpression
   - PostgrestFilterableExpression
   - PostgrestOrderableExpression
+  - PostgrestNullableExpression
+  # One stored-column struct with a nullability phantom, plus the two aliases callers and the
+  # generator spell it as. The members are on the struct, so they are registered there.
+  - PostgrestStoredColumn
+  - PostgrestStoredColumn.init
+  - PostgrestStoredColumn.postgrestExpression
   - PostgrestColumn
-  - PostgrestColumn.init
-  - PostgrestColumn.postgrestExpression
   - PostgrestNullableColumn
-  - PostgrestNullableColumn.init
-  - PostgrestNullableColumn.postgrestExpression
+  - PostgrestNullability
+  - PostgrestNotNull
+  - PostgrestNullable
   # The filter value itself, and the AND junction. `||` and `!` map onto
   # database.using_filters.or and .not; `&&` has no capability of its own — PostgREST ANDs
   # top-level query parameters already, so conjunction is the default rather than a feature — and
@@ -724,7 +731,7 @@ features:
       - PostgrestKeyPathFilterable.isNotNull
       - PostgrestFilterableExpression.isTrue
       - PostgrestFilterableExpression.isFalse
-      - PostgrestNullableColumn.isNull
+      - PostgrestNullableExpression.isNull
   database.using_filters.in:
     status: implemented
     symbols:


### PR DESCRIPTION
Stack 1/8 for SDK-1624. Base: `main`.

Replaces the key-path filter surface with a generated `Columns` namespace, so casts, JSON paths, aggregates and embedded relations are all expressible and compiler-checked. This PR is the vocabulary; nothing consumes it yet.

**`PostgrestColumnExpression`** is anything valid in a `select` list, with two independent refinements — `PostgrestFilterableExpression` (left of an operator) and `PostgrestOrderableExpression` (an `order` key) — because live PostgREST accepts a different expression set in each position. `Root` stops an expression from one relation being used against another; `Value` makes `.eq("seven")` on an `Int` column a compile error.

**`PostgrestFilter`** is the tree: `&&`, `||`, `!`, rendered to query items. Rendering is position-dependent and was corrected against PostgREST 16.1:

- a top-level operand goes unescaped, the same operand inside `or=(…)` must be escaped;
- a negated leaf in a group is `id.not.eq.2` — `not.id.eq.2` is a PGRST100 parse error.

Comparison, null and `raw` operators come with it.

`where(_:)` arrives in 4/8, so the doc examples here reference it ahead of time.
