### PR TITLE
feat(postgrest): add the remaining filter operators

### DIFF
--- a/Sources/PostgREST/Filters/PostgrestFilter+Collection.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter+Collection.swift
@@ -1,0 +1,142 @@
+//
+//  PostgrestFilter+Collection.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+extension PostgrestFilter {
+  /// `{a,b}` — the Postgres array literal the array operators take.
+  static func array(_ values: [some PostgrestArrayElement]) -> String {
+    "{\(values.map(\.postgrestArrayElement).joined(separator: ","))}"
+  }
+}
+
+// MARK: - Array operands
+//
+// `cs`, `cd` and `ov` each get three methods, because the operand literal is chosen by the
+// column's Postgres type rather than by the operator: `{a,b}` for an array, `[1,3)` for a range,
+// `{"a":1}` for jsonb. Mixing them is a 400.
+//
+// Only the array shape is type-checked (`where Value == [E]`), so `contains(["a"])` on a
+// `String` column does not compile. A range and a jsonb column have no distinguishing Swift
+// type to constrain on, so the range and JSON methods sit on bare
+// `PostgrestFilterableExpression` and compile on any column; pairing one with the wrong column
+// is a server error (`42883 operator does not exist`), not a wrong answer.
+
+extension PostgrestFilterableExpression {
+  /// Matches rows where this array column contains every element of `values`.
+  ///
+  /// An empty `values` matches every row whose column is non-null — the opposite of `in` and
+  /// `likeAnyOf`, since every array contains the empty array.
+  public func contains<E: PostgrestArrayElement>(_ values: [E]) -> PostgrestFilter<Root>
+  where Value == [E] {
+    PostgrestFilter(
+      column: postgrestExpression, operator: "cs", value: PostgrestFilter<Root>.array(values))
+  }
+
+  /// Matches rows where every element of this array column is contained by `values`.
+  public func containedBy<E: PostgrestArrayElement>(_ values: [E]) -> PostgrestFilter<Root>
+  where Value == [E] {
+    PostgrestFilter(
+      column: postgrestExpression, operator: "cd", value: PostgrestFilter<Root>.array(values))
+  }
+
+  /// Matches rows where this array column shares at least one element with `values`.
+  public func overlaps<E: PostgrestArrayElement>(_ values: [E]) -> PostgrestFilter<Root>
+  where Value == [E] {
+    PostgrestFilter(
+      column: postgrestExpression, operator: "ov", value: PostgrestFilter<Root>.array(values))
+  }
+}
+
+// MARK: - Range operands
+//
+// A range literal is taken as a string, and must stay a `.comparison` so `group()` escapes its
+// `)`/`]`: bare, they close an enclosing `or=(…)` early and 400. The opposite of `in`.
+
+extension PostgrestFilterableExpression {
+  /// Matches rows where this range column contains `range`.
+  ///
+  /// - Parameter range: A Postgres range literal, for example `"[2,3)"`.
+  public func containsRange(_ range: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "cs", value: range)
+  }
+
+  /// Matches rows where this range column is contained by `range`.
+  public func containedByRange(_ range: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "cd", value: range)
+  }
+
+  /// Matches rows where this range column overlaps `range`.
+  public func overlapsRange(_ range: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "ov", value: range)
+  }
+
+  /// Matches rows where this range column is strictly to the left of `range`.
+  ///
+  /// - Parameter range: A Postgres range literal, for example `"[2024-01-01,2024-02-01)"`.
+  public func rangeLt(_ range: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "sl", value: range)
+  }
+
+  /// Matches rows where this range column is strictly to the right of `range`.
+  public func rangeGt(_ range: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "sr", value: range)
+  }
+
+  /// Matches rows where this range column does not extend to the left of `range`.
+  public func rangeGte(_ range: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "nxl", value: range)
+  }
+
+  /// Matches rows where this range column does not extend to the right of `range`.
+  public func rangeLte(_ range: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "nxr", value: range)
+  }
+
+  /// Matches rows where this range column is adjacent to `range`.
+  public func rangeAdjacent(_ range: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "adj", value: range)
+  }
+}
+
+// MARK: - JSON operands
+
+extension PostgrestFilterableExpression {
+  /// Matches rows where this `jsonb` column contains `json`.
+  ///
+  /// - Parameter json: A JSON object literal, for example `#"{"a":1}"#`.
+  public func containsJSON(_ json: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "cs", value: json)
+  }
+
+  /// Matches rows where this `jsonb` column is contained by `json`.
+  public func containedByJSON(_ json: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "cd", value: json)
+  }
+}
+
+// MARK: - Text search
+
+extension PostgrestFilterableExpression where Value == String {
+  /// Matches rows where this `text` or `tsvector` column matches the full-text `query`.
+  ///
+  /// - Parameters:
+  ///   - query: The search query.
+  ///   - config: The text-search configuration, for example `"english"`. Defaults to `nil`,
+  ///     which leaves the database default in place.
+  ///   - type: How to turn `query` into a `tsquery`. Defaults to `nil`, meaning `to_tsquery`.
+  public func textSearch(
+    _ query: String,
+    config: String? = nil,
+    type: TextSearchType? = nil
+  ) -> PostgrestFilter<Root> {
+    let configPart = config.map { "(\($0))" } ?? ""
+    return PostgrestFilter(
+      column: postgrestExpression,
+      operator: "\(type?.rawValue ?? "")fts\(configPart)",
+      value: query
+    )
+  }
+}

--- a/Sources/PostgREST/Filters/PostgrestFilter+Collection.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter+Collection.swift
@@ -5,11 +5,12 @@
 //  Created by Guilherme Souza on 26/08/26.
 //
 
-extension PostgrestFilter {
-  /// `{a,b}` — the Postgres array literal the array operators take.
-  static func array(_ values: [some PostgrestArrayElement]) -> String {
-    "{\(values.map(\.postgrestArrayElement).joined(separator: ","))}"
-  }
+/// `{a,b}` — the Postgres array literal the array and multi-pattern operators take.
+///
+/// Members go through the array escaper: a raw join splits any element containing a comma into
+/// two, and a stray `{`/`}` corrupts the literal's delimiters.
+func postgrestArray(_ values: [some PostgrestArrayElement]) -> String {
+  "{\(values.map(\.postgrestArrayElement).joined(separator: ","))}"
 }
 
 // MARK: - Array operands
@@ -32,21 +33,21 @@ extension PostgrestFilterableExpression {
   public func contains<E: PostgrestArrayElement>(_ values: [E]) -> PostgrestFilter<Root>
   where Value == [E] {
     PostgrestFilter(
-      column: postgrestExpression, operator: "cs", value: PostgrestFilter<Root>.array(values))
+      column: postgrestExpression, operator: "cs", value: postgrestArray(values))
   }
 
   /// Matches rows where every element of this array column is contained by `values`.
   public func containedBy<E: PostgrestArrayElement>(_ values: [E]) -> PostgrestFilter<Root>
   where Value == [E] {
     PostgrestFilter(
-      column: postgrestExpression, operator: "cd", value: PostgrestFilter<Root>.array(values))
+      column: postgrestExpression, operator: "cd", value: postgrestArray(values))
   }
 
   /// Matches rows where this array column shares at least one element with `values`.
   public func overlaps<E: PostgrestArrayElement>(_ values: [E]) -> PostgrestFilter<Root>
   where Value == [E] {
     PostgrestFilter(
-      column: postgrestExpression, operator: "ov", value: PostgrestFilter<Root>.array(values))
+      column: postgrestExpression, operator: "ov", value: postgrestArray(values))
   }
 }
 

--- a/Sources/PostgREST/Filters/PostgrestFilter+Pattern.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter+Pattern.swift
@@ -5,23 +5,13 @@
 //  Created by Guilherme Souza on 26/08/26.
 //
 
-extension PostgrestFilter {
-  /// `(a,b,c)` — the parenthesised form `in` takes.
-  ///
-  /// Must use the filter escaper, not the array one: they reserve different characters, and an
-  /// `in.(…)` list is filter-value syntax. With the array escaper, `name=in.(p(q),Ada)` answers
-  /// 200 with zero rows.
-  static func list(_ values: [some PostgrestFilterValue]) -> String {
-    "(\(values.map { escapePostgRESTFilterValue($0.rawValue) }.joined(separator: ",")))"
-  }
-
-  /// `{a,b}` — the braced form the multi-pattern operators take.
-  ///
-  /// Array-literal syntax, so members need the array escaper: a raw join splits any pattern
-  /// containing a comma into two, and a stray `{`/`}` corrupts the literal's delimiters.
-  static func braced(_ patterns: [String]) -> String {
-    "{\(patterns.map(escapePostgRESTArrayLiteralElement).joined(separator: ","))}"
-  }
+/// `(a,b,c)` — the parenthesised form `in` takes.
+///
+/// Must use the filter escaper, not the array one: they reserve different characters, and an
+/// `in.(…)` list is filter-value syntax. With the array escaper, `name=in.(p(q),Ada)` answers
+/// 200 with zero rows.
+func postgrestList(_ values: [some PostgrestFilterValue]) -> String {
+  "(\(values.map { escapePostgRESTFilterValue($0.rawValue) }.joined(separator: ",")))"
 }
 
 extension PostgrestFilterableExpression where Value == String {
@@ -54,11 +44,13 @@ extension PostgrestFilterableExpression where Value == String {
 
   /// Matches rows where this column matches every one of `patterns`, case-sensitively.
   ///
-  /// An empty `patterns` matches no rows — PostgREST accepts `like(all).{}` without error.
+  /// An empty `patterns` matches **every** row, including rows where the column is `NULL`:
+  /// PostgREST renders this as `LIKE ALL('{}')`, and a quantified `ALL` over an empty array is
+  /// vacuously true. `likeAnyOf`/`ilikeAnyOf` are the reverse — empty matches no rows.
   public func likeAllOf(_ patterns: [String]) -> PostgrestFilter<Root> {
     PostgrestFilter(
       column: postgrestExpression, operator: "like(all)",
-      value: PostgrestFilter<Root>.braced(patterns))
+      value: postgrestArray(patterns))
   }
 
   /// Matches rows where this column matches at least one of `patterns`, case-sensitively.
@@ -67,16 +59,18 @@ extension PostgrestFilterableExpression where Value == String {
   public func likeAnyOf(_ patterns: [String]) -> PostgrestFilter<Root> {
     PostgrestFilter(
       column: postgrestExpression, operator: "like(any)",
-      value: PostgrestFilter<Root>.braced(patterns))
+      value: postgrestArray(patterns))
   }
 
   /// Matches rows where this column matches every one of `patterns`, case-insensitively.
   ///
-  /// An empty `patterns` matches no rows.
+  /// An empty `patterns` matches **every** row, including rows where the column is `NULL`:
+  /// PostgREST renders this as `ILIKE ALL('{}')`, and a quantified `ALL` over an empty array is
+  /// vacuously true. `likeAnyOf`/`ilikeAnyOf` are the reverse — empty matches no rows.
   public func ilikeAllOf(_ patterns: [String]) -> PostgrestFilter<Root> {
     PostgrestFilter(
       column: postgrestExpression, operator: "ilike(all)",
-      value: PostgrestFilter<Root>.braced(patterns))
+      value: postgrestArray(patterns))
   }
 
   /// Matches rows where this column matches at least one of `patterns`, case-insensitively.
@@ -85,7 +79,7 @@ extension PostgrestFilterableExpression where Value == String {
   public func ilikeAnyOf(_ patterns: [String]) -> PostgrestFilter<Root> {
     PostgrestFilter(
       column: postgrestExpression, operator: "ilike(any)",
-      value: PostgrestFilter<Root>.braced(patterns))
+      value: postgrestArray(patterns))
   }
 }
 
@@ -102,6 +96,6 @@ extension PostgrestFilterableExpression where Value: PostgrestFilterValue {
   /// opposite case and needs that escaping to survive a group.
   public func `in`(_ values: [Value]) -> PostgrestFilter<Root> {
     PostgrestFilter(
-      rawColumn: postgrestExpression, operand: "in.\(PostgrestFilter<Root>.list(values))")
+      rawColumn: postgrestExpression, operand: "in.\(postgrestList(values))")
   }
 }

--- a/Sources/PostgREST/Filters/PostgrestFilter+Pattern.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter+Pattern.swift
@@ -1,0 +1,107 @@
+//
+//  PostgrestFilter+Pattern.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+extension PostgrestFilter {
+  /// `(a,b,c)` — the parenthesised form `in` takes.
+  ///
+  /// Must use the filter escaper, not the array one: they reserve different characters, and an
+  /// `in.(…)` list is filter-value syntax. With the array escaper, `name=in.(p(q),Ada)` answers
+  /// 200 with zero rows.
+  static func list(_ values: [some PostgrestFilterValue]) -> String {
+    "(\(values.map { escapePostgRESTFilterValue($0.rawValue) }.joined(separator: ",")))"
+  }
+
+  /// `{a,b}` — the braced form the multi-pattern operators take.
+  ///
+  /// Array-literal syntax, so members need the array escaper: a raw join splits any pattern
+  /// containing a comma into two, and a stray `{`/`}` corrupts the literal's delimiters.
+  static func braced(_ patterns: [String]) -> String {
+    "{\(patterns.map(escapePostgRESTArrayLiteralElement).joined(separator: ","))}"
+  }
+}
+
+extension PostgrestFilterableExpression where Value == String {
+  /// Matches rows where this column matches the `LIKE` `pattern`, case-sensitively.
+  ///
+  /// `%` matches any run of characters, `_` matches exactly one.
+  public func like(_ pattern: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "like", value: pattern)
+  }
+
+  /// Matches rows where this column matches the `LIKE` `pattern`, case-insensitively.
+  public func ilike(_ pattern: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "ilike", value: pattern)
+  }
+
+  /// Matches rows where this column matches the POSIX regular expression `pattern`,
+  /// case-sensitively.
+  ///
+  /// Named `regexMatch`, not `match`: across Supabase SDKs `match` means a multi-column equality
+  /// shorthand.
+  public func regexMatch(_ pattern: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "match", value: pattern)
+  }
+
+  /// Matches rows where this column matches the POSIX regular expression `pattern`,
+  /// case-insensitively.
+  public func regexIMatch(_ pattern: String) -> PostgrestFilter<Root> {
+    PostgrestFilter(column: postgrestExpression, operator: "imatch", value: pattern)
+  }
+
+  /// Matches rows where this column matches every one of `patterns`, case-sensitively.
+  ///
+  /// An empty `patterns` matches no rows — PostgREST accepts `like(all).{}` without error.
+  public func likeAllOf(_ patterns: [String]) -> PostgrestFilter<Root> {
+    PostgrestFilter(
+      column: postgrestExpression, operator: "like(all)",
+      value: PostgrestFilter<Root>.braced(patterns))
+  }
+
+  /// Matches rows where this column matches at least one of `patterns`, case-sensitively.
+  ///
+  /// An empty `patterns` matches no rows.
+  public func likeAnyOf(_ patterns: [String]) -> PostgrestFilter<Root> {
+    PostgrestFilter(
+      column: postgrestExpression, operator: "like(any)",
+      value: PostgrestFilter<Root>.braced(patterns))
+  }
+
+  /// Matches rows where this column matches every one of `patterns`, case-insensitively.
+  ///
+  /// An empty `patterns` matches no rows.
+  public func ilikeAllOf(_ patterns: [String]) -> PostgrestFilter<Root> {
+    PostgrestFilter(
+      column: postgrestExpression, operator: "ilike(all)",
+      value: PostgrestFilter<Root>.braced(patterns))
+  }
+
+  /// Matches rows where this column matches at least one of `patterns`, case-insensitively.
+  ///
+  /// An empty `patterns` matches no rows.
+  public func ilikeAnyOf(_ patterns: [String]) -> PostgrestFilter<Root> {
+    PostgrestFilter(
+      column: postgrestExpression, operator: "ilike(any)",
+      value: PostgrestFilter<Root>.braced(patterns))
+  }
+}
+
+extension PostgrestFilterableExpression where Value: PostgrestFilterValue {
+  /// Matches rows where this column is one of `values`.
+  ///
+  /// There is no `notIn` — negate instead: `!$0.id.in([1, 2])` renders `id=not.in.(1,2)`.
+  ///
+  /// An empty `values` matches no rows.
+  ///
+  /// Built as a raw node so `group()` leaves the operand alone: `in.(…)`'s parens belong to the
+  /// operator's grammar, and re-quoting them gives `or=(id.in."(2,3)",…)`, a `PGRST100`. Members
+  /// are still escaped, by `list(_:)`. This applies to `in.(…)` alone — a range literal is the
+  /// opposite case and needs that escaping to survive a group.
+  public func `in`(_ values: [Value]) -> PostgrestFilter<Root> {
+    PostgrestFilter(
+      rawColumn: postgrestExpression, operand: "in.\(PostgrestFilter<Root>.list(values))")
+  }
+}

--- a/Sources/PostgREST/Filters/PostgrestFilter.swift
+++ b/Sources/PostgREST/Filters/PostgrestFilter.swift
@@ -27,7 +27,8 @@ public struct PostgrestFilter<R: PostgrestRelation>: Sendable {
     case comparison(column: String, operator: String, value: String)
 
     /// Everything after the `=` as one unparsed string. Separate from `comparison` because the
-    /// operator and value cannot be split.
+    /// operator and value cannot be split, and because `in`'s own `in.(…)` delimiters must
+    /// survive `group()` unescaped.
     case raw(column: String, operand: String)
 
     case and([Node])
@@ -164,8 +165,9 @@ extension PostgrestFilter {
     case .comparison(let column, let `operator`, let value):
       return "\(column).\(`operator`).\(escapePostgRESTFilterValue(value))"
     case .raw(let column, let operand):
-      // Not escaped: quoting would break the caller's own syntax. The cost is that a raw node
-      // cannot always sit in a group — a `::` in the column is a parse error inside `or=(…)`.
+      // Not escaped: quoting would break the caller's own syntax, and `in`'s own `in.(…)`
+      // delimiters must stay literal. The cost is that a raw node cannot always sit in a group —
+      // a `::` in the column is a parse error inside `or=(…)`.
       return "\(column).\(operand)"
     case .and(let children):
       return "and(\(children.map(group).joined(separator: ",")))"

--- a/Tests/PostgRESTTests/PostgrestFilterCollectionTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterCollectionTests.swift
@@ -1,0 +1,122 @@
+//
+//  PostgrestFilterCollectionTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestFilterCollectionTests {
+  struct Post: PostgrestRelation {
+    static let relationName = "posts"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var tags: [String]
+    var scheduled: String
+    var content: String
+
+    struct Columns: Sendable {
+      let tags = PostgrestColumn<Post, [String]>("tags")
+      let scheduled = PostgrestColumn<Post, String>("scheduled")
+      let content = PostgrestColumn<Post, String>("content")
+    }
+
+    static let columns = Columns()
+
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
+      switch keyPath {
+      case \Self.tags: "tags"
+      case \Self.scheduled: "scheduled"
+      case \Self.content: "content"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  private func rendered(_ filter: PostgrestFilter<Post>) -> String {
+    filter.queryItems().map { "\($0.name)=\($0.value ?? "")" }.joined(separator: "&")
+  }
+
+  @Test
+  func arrayOperatorsRenderABracedArray() {
+    let tags = Post.columns.tags
+    #expect(rendered(tags.contains(["swift"])) == "tags=cs.{swift}")
+    #expect(rendered(tags.containedBy(["swift", "ios"])) == "tags=cd.{swift,ios}")
+    #expect(rendered(tags.overlaps(["swift"])) == "tags=ov.{swift}")
+  }
+
+  /// A member containing a literal brace is what tells the two escapers apart: the array escaper
+  /// quotes it, the filter escaper would let it through and corrupt the literal's delimiters.
+  @Test
+  func arrayOperatorMembersAreEscaped() {
+    let tags = Post.columns.tags
+    #expect(rendered(tags.contains(["a{b"])) == "tags=cs.{\"a{b\"}")
+    #expect(rendered(tags.containedBy(["a,b"])) == "tags=cd.{\"a,b\"}")
+  }
+
+  /// `tags=cs.{}` matches every row whose column is non-null; a `NULL` column never matches.
+  @Test
+  func arrayOperatorsRenderAnEmptyArray() {
+    let tags = Post.columns.tags
+    #expect(rendered(tags.contains([])) == "tags=cs.{}")
+  }
+
+  @Test
+  func rangeOperatorsRenderTheirAbbreviation() {
+    let s = Post.columns.scheduled
+    #expect(
+      rendered(s.rangeLt("[2024-01-01,2024-02-01)")) == "scheduled=sl.[2024-01-01,2024-02-01)")
+    #expect(rendered(s.rangeGt("[2024-01-01,)")) == "scheduled=sr.[2024-01-01,)")
+    #expect(rendered(s.rangeGte("[2024-01-01,)")) == "scheduled=nxl.[2024-01-01,)")
+    #expect(rendered(s.rangeLte("[2024-01-01,)")) == "scheduled=nxr.[2024-01-01,)")
+    #expect(rendered(s.rangeAdjacent("[2024-01-01,)")) == "scheduled=adj.[2024-01-01,)")
+  }
+
+  /// Same wire operators as the array trio, but taking a range literal. Crossing the two shapes
+  /// (`span=ov.{1,20}`) is a 400.
+  @Test
+  func containmentOperatorsTakeARangeLiteral() {
+    let s = Post.columns.scheduled
+    #expect(rendered(s.containsRange("[21,22)")) == "scheduled=cs.[21,22)")
+    #expect(rendered(s.containedByRange("[21,22)")) == "scheduled=cd.[21,22)")
+    #expect(rendered(s.overlapsRange("[25,35)")) == "scheduled=ov.[25,35)")
+  }
+
+  /// The third operand shape `cs`/`cd` take: a JSON object literal, on a `jsonb` column.
+  @Test
+  func containmentOperatorsTakeJSONLiteral() {
+    let content = Post.columns.content
+    #expect(rendered(content.containsJSON(#"{"a":1}"#)) == #"content=cs.{"a":1}"#)
+    #expect(rendered(content.containedByJSON(#"{"a":1}"#)) == #"content=cd.{"a":1}"#)
+  }
+
+  @Test
+  func textSearchRendersConfigAndType() {
+    let content = Post.columns.content
+    #expect(rendered(content.textSearch("swift")) == "content=fts.swift")
+    #expect(
+      rendered(content.textSearch("swift", config: "english")) == "content=fts(english).swift")
+    #expect(
+      rendered(content.textSearch("swift", config: "english", type: .websearch))
+        == "content=wfts(english).swift")
+    #expect(rendered(content.textSearch("swift", type: .plain)) == "content=plfts.swift")
+  }
+
+  /// A range literal is the case that *needs* `group()`'s escaping: bare, the `)` in
+  /// `or=(span.ov.[25,35),id.eq.3)` closes the logic group early and 400s. Routing these through
+  /// `.raw` the way `in` does would produce exactly that.
+  @Test
+  func rangeOperandIsEscapedInsideOr() {
+    let s = Post.columns.scheduled
+    let content = Post.columns.content
+    #expect(
+      rendered(s.overlapsRange("[25,35)") || content.eq("x"))
+        == #"or=(scheduled.ov."[25,35)",content.eq.x)"#)
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestFilterPatternTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterPatternTests.swift
@@ -1,0 +1,135 @@
+//
+//  PostgrestFilterPatternTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestFilterPatternTests {
+  struct Todo: PostgrestRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+    var note: String?
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let task = PostgrestColumn<Todo, String>("task")
+      let note = PostgrestNullableColumn<Todo, String>("note")
+    }
+
+    static let columns = Columns()
+
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.task: "task"
+      case \Self.note: "note"
+      default: fatalError("unmapped key path")
+      }
+    }
+  }
+
+  private func rendered(_ filter: PostgrestFilter<Todo>) -> String {
+    filter.queryItems().map { "\($0.name)=\($0.value ?? "")" }.joined(separator: "&")
+  }
+
+  @Test
+  func patternOperatorsRenderTheirPrefix() {
+    let task = Todo.columns.task
+    #expect(rendered(task.like("Jo%")) == "task=like.Jo%")
+    #expect(rendered(task.ilike("jo%")) == "task=ilike.jo%")
+    #expect(rendered(task.regexMatch("^Jo")) == "task=match.^Jo")
+    #expect(rendered(task.regexIMatch("^jo")) == "task=imatch.^jo")
+  }
+
+  /// The multi-pattern forms take a braced array literal, not a parenthesised list.
+  @Test
+  func multiPatternOperatorsRenderABracedArray() {
+    let task = Todo.columns.task
+    #expect(rendered(task.likeAllOf(["A%", "%z"])) == "task=like(all).{A%,%z}")
+    #expect(rendered(task.likeAnyOf(["A%", "%z"])) == "task=like(any).{A%,%z}")
+    #expect(rendered(task.ilikeAllOf(["a%"])) == "task=ilike(all).{a%}")
+    #expect(rendered(task.ilikeAnyOf(["a%"])) == "task=ilike(any).{a%}")
+  }
+
+  /// There is no `notIn`; `!` covers it.
+  @Test
+  func listOperatorsRenderAParenthesisedList() {
+    #expect(rendered(Todo.columns.id.in([1, 2, 3])) == "id=in.(1,2,3)")
+    #expect(rendered(!Todo.columns.id.in([1, 2])) == "id=not.in.(1,2)")
+  }
+
+  /// List operands are escaped, unlike single values at top level: a comma splits the list, and a
+  /// parenthesis silently matches nothing.
+  @Test
+  func listMembersAreEscaped() {
+    #expect(rendered(Todo.columns.task.in(["a,b"])) == "task=in.(\"a,b\")")
+    #expect(rendered(Todo.columns.task.in(["p(q)", "Ada"])) == "task=in.(\"p(q)\",Ada)")
+  }
+
+  /// A comma splits one pattern into two, and a brace corrupts the literal's delimiters. The
+  /// brace case is what distinguishes the array escaper from the filter escaper here — swapping
+  /// them would leave a stray `{` unquoted while the paren case still passed.
+  @Test
+  func multiPatternMembersAreEscaped() {
+    #expect(rendered(Todo.columns.task.likeAnyOf(["a,%"])) == "task=like(any).{\"a,%\"}")
+    #expect(rendered(Todo.columns.task.likeAnyOf(["a{b"])) == "task=like(any).{\"a{b\"}")
+  }
+
+  /// A nullable text column reaches the same declarations: its `Value` is the wrapped `String`.
+  @Test
+  func nullableColumnsTakePatternAndListOperators() {
+    #expect(rendered(Todo.columns.note.like("Jo%")) == "note=like.Jo%")
+    #expect(rendered(Todo.columns.note.in(["a", "b"])) == "note=in.(a,b)")
+  }
+
+  /// `in`'s own `(…)` must not be re-escaped inside a group: `or=(id.in."(2,3)",id.eq.4)` is
+  /// a `PGRST100`. Reproduces with no special characters at all.
+  @Test
+  func inKeepsItsListParensBareInsideAGroup() {
+    #expect(
+      rendered(Todo.columns.id.in([2, 3]) || Todo.columns.id.eq(4))
+        == "or=(id.in.(2,3),id.eq.4)")
+  }
+
+  /// Members are still escaped inside a group. Only the list's own outer parens stay bare.
+  @Test
+  func inEscapesItsListMembersInsideAGroup() {
+    #expect(
+      rendered(Todo.columns.task.in(["p(q)", "Ada"]) || Todo.columns.id.eq(4))
+        == "or=(task.in.(\"p(q)\",Ada),id.eq.4)")
+  }
+
+  /// PostgREST tolerates the redundant quoting `group()` adds around a `{…}` operand, so the
+  /// multi-pattern operators need no exemption. Pinned so the escaping path cannot change it.
+  @Test
+  func multiPatternOperatorsComposeWithOr() {
+    let task = Todo.columns.task
+    let id = Todo.columns.id
+    #expect(
+      rendered(task.likeAllOf(["A%", "%z"]) || id.eq(4))
+        == "or=(task.like(all).\"{A%,%z}\",id.eq.4)")
+    #expect(
+      rendered(task.likeAnyOf(["A%", "%z"]) || id.eq(4))
+        == "or=(task.like(any).\"{A%,%z}\",id.eq.4)")
+    #expect(
+      rendered(task.ilikeAllOf(["a%"]) || id.eq(4))
+        == "or=(task.ilike(all).{a%},id.eq.4)")
+    #expect(
+      rendered(task.ilikeAnyOf(["a%"]) || id.eq(4))
+        == "or=(task.ilike(any).{a%},id.eq.4)")
+    #expect(
+      rendered(task.likeAnyOf(["a,%"]) || id.eq(3))
+        == "or=(task.like(any).\"{\\\"a,%\\\"}\",id.eq.3)")
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestFilterPatternTests.swift
+++ b/Tests/PostgRESTTests/PostgrestFilterPatternTests.swift
@@ -62,6 +62,15 @@ struct PostgrestFilterPatternTests {
     #expect(rendered(task.ilikeAnyOf(["a%"])) == "task=ilike(any).{a%}")
   }
 
+  /// An empty list reaches the server as an empty literal rather than being short-circuited: for
+  /// `all` that is vacuously true and matches every row, for `any`/`in` it matches none.
+  @Test
+  func emptyListsRenderAnEmptyLiteral() {
+    #expect(rendered(Todo.columns.task.likeAllOf([])) == "task=like(all).{}")
+    #expect(rendered(Todo.columns.task.likeAnyOf([])) == "task=like(any).{}")
+    #expect(rendered(Todo.columns.id.in([])) == "id=in.()")
+  }
+
   /// There is no `notIn`; `!` covers it.
   @Test
   func listOperatorsRenderAParenthesisedList() {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -719,10 +719,12 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.like
+      - PostgrestFilterableExpression.like
   database.using_filters.ilike:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.ilike
+      - PostgrestFilterableExpression.ilike
   database.using_filters.is:
     status: implemented
     symbols:
@@ -737,46 +739,62 @@ features:
     symbols:
       - PostgrestRequestBuilder.in
       - PostgrestKeyPathFilterable.in
+      - PostgrestFilterableExpression.in
   database.using_filters.contains:
     status: implemented
+    note: "The operand literal is chosen by the column's Postgres type, not by the operator — `cs.{a,b}` for an array, `cs.[1,3)` for a range, `cs.{\"a\":1}` for jsonb. The typed surface spells the three as separate methods so each takes the operand shape it needs; the string builder takes one dictionary/array argument."
     symbols:
       - PostgrestRequestBuilder.contains
+      - PostgrestFilterableExpression.contains
+      - PostgrestFilterableExpression.containsRange
+      - PostgrestFilterableExpression.containsJSON
   database.using_filters.contained_by:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.containedBy
+      - PostgrestFilterableExpression.containedBy
+      - PostgrestFilterableExpression.containedByRange
+      - PostgrestFilterableExpression.containedByJSON
   database.using_filters.range_gt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.rangeGt
       - PostgrestRequestBuilder.rangeGreaterThan
+      - PostgrestFilterableExpression.rangeGt
   database.using_filters.range_gte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.rangeGte
       - PostgrestRequestBuilder.rangeGreaterThanOrEquals
+      - PostgrestFilterableExpression.rangeGte
   database.using_filters.range_lt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.rangeLt
       - PostgrestRequestBuilder.rangeLowerThan
+      - PostgrestFilterableExpression.rangeLt
   database.using_filters.range_lte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.rangeLte
       - PostgrestRequestBuilder.rangeLowerThanOrEquals
+      - PostgrestFilterableExpression.rangeLte
   database.using_filters.range_adjacent:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.rangeAdjacent
+      - PostgrestFilterableExpression.rangeAdjacent
   database.using_filters.overlaps:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.overlaps
+      - PostgrestFilterableExpression.overlaps
+      - PostgrestFilterableExpression.overlapsRange
   database.using_filters.text_search:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.textSearch
+      - PostgrestFilterableExpression.textSearch
     supporting_symbols:
       - TextSearchType
       - TextSearchType.init
@@ -840,10 +858,12 @@ features:
     note: "PostgrestRequestBuilder.match(_:pattern:) — the PostgrestFilterValue-typed overload backing the `~` operator, distinct from the dictionary-based overload used by database.using_filters.match above."
     symbols:
       - PostgrestRequestBuilder.match
+      - PostgrestFilterableExpression.regexMatch
   database.using_filters.regex_icase:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.imatch
+      - PostgrestFilterableExpression.regexIMatch
   database.using_filters.is_distinct:
     status: implemented
     symbols:
@@ -857,19 +877,23 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.likeAllOf
+      - PostgrestFilterableExpression.likeAllOf
   database.using_filters.like_any:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.likeAnyOf
+      - PostgrestFilterableExpression.likeAnyOf
   database.using_filters.ilike_all:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.iLikeAllOf
+      - PostgrestFilterableExpression.ilikeAllOf
   database.using_filters.ilike_any:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.iLikeAnyOf
 
+      - PostgrestFilterableExpression.ilikeAnyOf
   database.using_modifiers.order:
     status: implemented
     symbols:

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -871,6 +871,7 @@ features:
       - PostgrestFilterableExpression.isDistinct
   database.using_filters.not_in:
     status: implemented
+    note: "The typed surface has no dedicated `notIn`: negation is the `!` operator on the filter tree, so `!$0.id.in([1, 2])` renders `id=not.in.(1,2)`."
     symbols:
       - PostgrestRequestBuilder.notIn
   database.using_filters.like_all:
@@ -892,8 +893,8 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.iLikeAnyOf
-
       - PostgrestFilterableExpression.ilikeAnyOf
+
   database.using_modifiers.order:
     status: implemented
     symbols:


### PR DESCRIPTION
Stack 2/8 for SDK-1624. Base: `guilhermesouza/sdk-1624-column-expressions`.

Pattern, list, array, range, jsonb and text-search operators, completing the operator surface.

Two details are wire-verified rather than inferred:

- `contains`/`containedBy`/`overlaps` each get three methods, because the operand literal is chosen by the column's Postgres type and not by the operator: `{a,b}` for an array, `[1,3)` for a range, `{"a":1}` for jsonb. One method taking one argument cannot spell all three.
- `in` renders its own `in.(…)` delimiters, which must reach the server literal. It therefore builds a `raw` node so `group()` leaves it alone — escaping it gives `or=(id.in."(2,3)",…)`, a 400. Members are still escaped.

`in` is declared as `` func `in` `` — the keyword needs backticks in the declaration, but **not at the call site**: `$0.id.in([1, 2])` parses, and so does `{ c in c.id.in([1, 2]) }` with both meanings of `in` on one line. The name matches the wire token, supabase-js, the legacy builder's `in(_:values:)`, and the `database.using_filters.in` capability id.

`regexMatch`/`regexIMatch` deliberately avoid the name `match`: supabase-js binds `match` to a multi-column equality shorthand, and the capability matrix has separate ids for the three meanings.
