### PR TITLE
feat(postgrest): generate a Columns namespace from @Table

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -84,6 +84,11 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   /// namespace, so a column that does not exist is a compile error rather than a PostgREST 400.
   /// Taking a first column plus the rest also makes an empty target unrepresentable.
   ///
+  /// Each key path must land on a ``PostgrestStoredColumn`` of *this* relation, which is narrower
+  /// than a column expression in general: `on_conflict` names columns of a unique index, so a
+  /// derived expression — a cast, an aggregate — is not a target PostgREST can take, and neither
+  /// is a column belonging to some other relation. Both are rejected at the call site.
+  ///
   /// To merge on the primary key, use ``upsert(_:)``, which derives the target instead.
   ///
   /// - Parameters:
@@ -93,12 +98,16 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
   /// - Throws: An encoding error if `values` cannot be serialized.
   public func upsert<
-    First: PostgrestColumnExpression,
-    each Rest: PostgrestColumnExpression
+    FirstValue,
+    FirstNullability: PostgrestNullability,
+    each RestValue,
+    each RestNullability: PostgrestNullability
   >(
     _ values: R.Draft,
-    onConflict column: KeyPath<R.Columns, First>,
-    _ additional: repeat KeyPath<R.Columns, each Rest>
+    onConflict column: KeyPath<R.Columns, PostgrestStoredColumn<R, FirstValue, FirstNullability>>,
+    _ additional: repeat KeyPath<
+      R.Columns, PostgrestStoredColumn<R, each RestValue, each RestNullability>
+    >
   ) throws -> PostgrestTypedMutation<R> {
     var names = [R.columns[keyPath: column].postgrestExpression]
     repeat names.append(R.columns[keyPath: each additional].postgrestExpression)

--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -80,10 +80,9 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   ///   .execute()
   /// ```
   ///
-  /// The target is spelled as key paths, so a column that does not exist is a compile error rather
-  /// than a PostgREST 400 naming a column you cannot grep for. Splitting it into a first column
-  /// plus the rest also makes an empty target unrepresentable — `on_conflict=` with nothing after
-  /// it is a different request, not a missing one.
+  /// The target is spelled as key paths into the relation's ``PostgrestRelation/Columns``
+  /// namespace, so a column that does not exist is a compile error rather than a PostgREST 400.
+  /// Taking a first column plus the rest also makes an empty target unrepresentable.
   ///
   /// To merge on the primary key, use ``upsert(_:)``, which derives the target instead.
   ///
@@ -93,16 +92,20 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   ///   - additional: The remaining columns, for a constraint spanning more than one.
   /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
   /// - Throws: An encoding error if `values` cannot be serialized.
-  public func upsert(
+  public func upsert<
+    First: PostgrestColumnExpression,
+    each Rest: PostgrestColumnExpression
+  >(
     _ values: R.Draft,
-    onConflict column: PartialKeyPath<R>,
-    _ additional: PartialKeyPath<R>...
+    onConflict column: KeyPath<R.Columns, First>,
+    _ additional: repeat KeyPath<R.Columns, each Rest>
   ) throws -> PostgrestTypedMutation<R> {
-    let columns = CollectionOfOne(column) + additional
+    var names = [R.columns[keyPath: column].postgrestExpression]
+    repeat names.append(R.columns[keyPath: each additional].postgrestExpression)
     return PostgrestTypedMutation(
       builder: try builder.upsert(
         values,
-        onConflict: columns.map { R.columnName(for: $0) }.joined(separator: ","),
+        onConflict: names.joined(separator: ","),
         returning: .minimal
       )
     )

--- a/Sources/PostgREST/Query/PostgrestUpdate.swift
+++ b/Sources/PostgREST/Query/PostgrestUpdate.swift
@@ -47,19 +47,46 @@ public struct PostgrestUpdate<R: PostgrestWritableRelation>: Encodable, Sendable
   /// An empty update encodes to `{}`, which asks PostgREST to change nothing.
   public var isEmpty: Bool { values.isEmpty }
 
-  /// Assigns a value to the column backing a property.
+  /// Assigns a value to a column.
   ///
   /// Only the setter is meaningful. An update describes what to write, so there is nothing to
   /// read back, and the getter is marked unavailable rather than left to trap at runtime.
   ///
-  /// - Parameter keyPath: A key path to one of the relation's stored properties.
-  public subscript<V: Encodable & Sendable>(dynamicMember keyPath: KeyPath<R, V>) -> V {
+  /// This overload takes a `NOT NULL` column, so the assigned type is not optional and
+  /// `$0.task = nil` is a compile error.
+  ///
+  /// - Parameter keyPath: A key path into the relation's ``PostgrestRelation/Columns`` namespace,
+  ///   the same place a filter reads a column name from.
+  public subscript<V: Encodable & Sendable>(
+    dynamicMember keyPath: KeyPath<R.Columns, PostgrestColumn<R, V>>
+  ) -> V {
     @available(
       *, unavailable,
       message: "An update names the columns it writes; it does not read them back."
     )
     get { fatalError("PostgrestUpdate is write-only") }
-    set { values[R.columnName(for: keyPath)] = PostgrestUpdateValue(newValue) }
+    set {
+      values[R.columns[keyPath: keyPath].postgrestExpression] = PostgrestUpdateValue(newValue)
+    }
+  }
+
+  /// Assigns a value to a nullable column, or clears it.
+  ///
+  /// The assigned type is optional, so `$0.dueAt = nil` sends an explicit `null` and clears the
+  /// column, rather than omitting it from the body.
+  ///
+  /// - Parameter keyPath: A key path to one of the relation's nullable columns.
+  public subscript<V: Encodable & Sendable>(
+    dynamicMember keyPath: KeyPath<R.Columns, PostgrestNullableColumn<R, V>>
+  ) -> V? {
+    @available(
+      *, unavailable,
+      message: "An update names the columns it writes; it does not read them back."
+    )
+    get { fatalError("PostgrestUpdate is write-only") }
+    set {
+      values[R.columns[keyPath: keyPath].postgrestExpression] = PostgrestUpdateValue(newValue)
+    }
   }
 
   public func encode(to encoder: any Encoder) throws {

--- a/Sources/PostgREST/Relations/PostgrestRelation.swift
+++ b/Sources/PostgREST/Relations/PostgrestRelation.swift
@@ -33,6 +33,18 @@ public protocol PostgrestRelation: PostgrestSelection where Source == Self {
   /// The Postgres schema the relation belongs to.
   static var schema: String { get }
 
+  /// The namespace of this relation's columns.
+  ///
+  /// `@Table` generates it as a nested `Columns` struct holding one ``PostgrestColumn`` per
+  /// column. A hand-written conformance declares its own.
+  associatedtype Columns: Sendable
+
+  /// The relation's columns, for building filters and selections.
+  ///
+  /// A filter closure receives this value, so a call site names a column as `$0.isDone` rather
+  /// than spelling the relation out.
+  static var columns: Columns { get }
+
   /// The database column name backing a property.
   ///
   /// Takes a `PartialKeyPath` rather than a `KeyPath<Self, V>` because the property's type
@@ -75,9 +87,9 @@ public protocol PostgrestKeyedRelation: PostgrestRelation {
 ///
 /// There is no matching `Update` shape. A draft is a whole row, so a row type fits a write that
 /// sends one; an update sends a set of column assignments, which ``PostgrestUpdate`` builds from
-/// this relation's key paths. Modelling both as row types is what once made clearing a nullable
-/// column impossible — a single optional field cannot mean both "not assigned" and "assigned
-/// null".
+/// key paths into this relation's ``PostgrestRelation/Columns`` namespace. Modelling both as row
+/// types is what once made clearing a nullable column impossible — a single optional field cannot
+/// mean both "not assigned" and "assigned null".
 public protocol PostgrestWritableRelation: PostgrestRelation {
   /// The shape a write sends: every column, optional exactly where the database can fill it in —
   /// a nullable column, or one with a default. A primary key is included, and required unless it

--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -25,6 +25,17 @@
 /// generated `CodingKeys` and the generated column mapping come from the same input, so an insert
 /// body and a filter can never disagree about a column.
 ///
+/// The macro also generates a `Columns` namespace holding one column value per property, which
+/// filter and order closures receive:
+///
+/// ```swift
+/// .where { ($0.isDone.eq(false) && $0.priority.gt(3)) || $0.id.eq(7) }
+/// .order { $0.dueDate.desc() }
+/// ```
+///
+/// Each column carries its database name and its Swift type, so an operand of the wrong type is
+/// a compile error. Casts, JSON paths and aggregates compose onto a column and stay checked.
+///
 /// The annotated type must be declared at file scope. The macro attaches an extension, and Swift
 /// does not allow an extension of a type nested inside another type.
 ///
@@ -37,8 +48,9 @@
   extension,
   conformances: Decodable, Sendable, PostgrestRelation, PostgrestKeyedRelation,
   PostgrestWritableRelation,
-  names: named(relationName), named(schema), named(selectString), named(columnName(for:)),
-  named(primaryKeyColumns), named(CodingKeys), named(Draft)
+  names: named(relationName), named(schema), named(selectString), named(Columns),
+  named(columns), named(columnName(for:)), named(primaryKeyColumns), named(CodingKeys),
+  named(Draft)
 )
 public macro Table(
   _ name: String,

--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -77,9 +77,9 @@ public struct SelectionOfMacro: ExtensionMacro {
   /// PostgREST for `due_date`, a column that does not exist. Nothing caught it — `_columnCheck`
   /// proves the *key path* resolves, not that the name matches.
   ///
-  /// So the column comes from `Source.columnName(for:)`, which is the mapping the relation already
-  /// validated. That makes the value a runtime one rather than a literal, which is why it is
-  /// assembled with `joined(separator:)`.
+  /// So the column comes from `Source.columns`, the namespace the relation already validated.
+  /// That makes the value a runtime one rather than a literal, which is why it is assembled
+  /// with `joined(separator:)`.
   ///
   /// Each entry is emitted as a PostgREST alias, `key:column`. The alias is what keeps
   /// `CodingKeys` correct: the response comes back keyed by the selection's own name, so the
@@ -96,7 +96,7 @@ public struct SelectionOfMacro: ExtensionMacro {
     var lines = ["  \(access)static let selectString = ["]
     for property in properties {
       lines.append(
-        "    \"\(property.columnName):\\(\(relation).columnName(for: \\\(relation).\(property.name)))\","
+        "    \"\(property.columnName):\\(\(relation).columns.\(property.name).postgrestExpression)\","
       )
     }
     lines.append("  ].joined(separator: \",\")")
@@ -110,17 +110,17 @@ public struct SelectionOfMacro: ExtensionMacro {
   /// on the relation fails on the emitted line. That is what makes a declared selection fully
   /// checked rather than checked by convention.
   ///
-  /// Now that ``selectString(access:relation:properties:)`` calls `columnName(for:)` on every
-  /// property, it carries the same proof, and this array is redundant. It is kept because it says
-  /// out loud what the check is for; the diagnostic a reader gets from a bad key path is the same
-  /// either way.
+  /// Now that ``selectString(access:relation:properties:)`` reads `.postgrestExpression` off
+  /// every property's column, it carries the same proof, and this array is redundant. It is kept
+  /// because it says out loud what the check is for; the diagnostic a reader gets from a bad
+  /// property name is the same either way.
   static func columnCheck(relation: String, properties: [StoredProperty]) -> String {
     var lines = [
       "  /// Fails to compile if a property does not name a column on \(relation).",
       "  private static let _columnCheck: [String] = [",
     ]
     for property in properties {
-      lines.append("    \(relation).columnName(for: \\\(relation).\(property.name)),")
+      lines.append("    \(relation).columns.\(property.name).postgrestExpression,")
     }
     lines.append("  ]")
     return lines.joined(separator: "\n")

--- a/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
@@ -29,7 +29,7 @@ extension MacroExpansionContext {
 extension DeclGroupSyntax {
   /// The first `@Relationship` attribute on a stored property, if any.
   ///
-  /// Embeds belong to a selection, never to a relation (spec §4.5), so `@Table` rejects one.
+  /// Embeds belong to a selection, never to a relation, so `@Table` rejects one.
   ///
   /// Forward-looking: `@Relationship` itself lands in stage 3, so today a user who writes it gets
   /// "unknown attribute" from the compiler first. Matching on the attribute *name* puts the guard
@@ -50,11 +50,12 @@ extension DeclGroupSyntax {
   /// Reports every stored property whose type is left to its initializer.
   ///
   /// `postgrestStoredProperties()` reads syntax, so `var isDone = false` gives it no annotation to
-  /// read and the property is dropped from `CodingKeys`, `columnName(for:)` and `Draft`.
+  /// read and the property is dropped from `CodingKeys`, `Columns`, `columnName(for:)` and
+  /// `Draft`.
   /// Nothing about that is loud: the initializer doubles as a decoding default, so the type still
-  /// compiles, the column simply never round-trips, and the mistake surfaces only when a query
-  /// names the key path and hits the generated `fatalError`. A macro cannot recover the type from
-  /// the initializer expression, so the author is asked for an annotation instead.
+  /// compiles, the column simply never round-trips, and the mistake surfaces only much later, at
+  /// some unrelated call site that expected the column to exist. A macro cannot recover the type
+  /// from the initializer expression, so the author is asked for an annotation instead.
   ///
   /// The condition is `postgrestType(at:)` returning `nil` — the very test the reader uses to skip
   /// a binding — so the two cannot drift apart. In particular `var draft, review: String` is not

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -22,29 +22,45 @@ struct StoredProperty {
   /// The property's type made optional, or left alone if it already is.
   var optionalType: String { isOptional ? type : "\(type)?" }
 
-  /// The property's type with one layer of `Optional` removed, or left alone if it has none.
-  ///
-  /// Handles both spellings, since a generated schema can emit either.
-  var unwrappedType: String {
-    if type.hasSuffix("?") { return String(type.dropLast()) }
-    if type.hasPrefix("Optional<"), type.hasSuffix(">") {
-      return String(type.dropFirst("Optional<".count).dropLast())
-    }
-    return type
+  /// The property's type with every layer of `Optional` removed, or left alone if it has none.
+  var unwrappedType: String { postgrestUnwrapOptionalType(type) ?? type }
+}
+
+/// A written type with every layer of `Optional` stripped, or `nil` if it is not spelled as one.
+///
+/// Three spellings count, because all three mean a nullable column: `Int?`, `Optional<Int>` and
+/// `Int!`. A generated schema can emit either of the first two, and the `!` spelling reaches a
+/// generic argument where it is illegal — `PostgrestColumn<Todo, String!>` does not compile, and
+/// the error lands on macro-expanded code the author never wrote.
+///
+/// Stripping *every* layer is what keeps `Value` non-optional, which the whole wrapped-type design
+/// rests on: a column is nullable or it is not, so `Optional<Int>!` and `Int??` both describe a
+/// nullable `Int`. Leaving one layer on gives `PostgrestNullableColumn<Todo, Int?>`, and because
+/// `Optional` deliberately does not conform to `PostgrestFilterValue` that column silently loses
+/// every operator — "no member `eq`" rather than anything naming the real problem.
+///
+/// A `Swift.Optional<Int>` spelling is not matched. It is legal but vanishingly rare, and a macro
+/// cannot resolve module qualification from syntax alone.
+func postgrestUnwrapOptionalType(_ type: String) -> String? {
+  let inner: String
+  if type.hasSuffix("?") || type.hasSuffix("!") {
+    inner = String(type.dropLast())
+  } else if type.hasPrefix("Optional<"), type.hasSuffix(">") {
+    inner = String(type.dropFirst("Optional<".count).dropLast())
+  } else {
+    return nil
   }
+  return postgrestUnwrapOptionalType(inner) ?? inner
 }
 
 /// Whether a written type is spelled as an `Optional`.
 ///
-/// Both spellings have to be recognized everywhere optionality is decided: `Int?` and
-/// `Optional<Int>` are the same type, and a generated schema can emit either. Recognizing one and
-/// not the other is what let an `Optional<T>` field lose the `= nil` default in a generated
-/// initializer while a `?`-spelled one kept it.
-///
-/// A `Swift.Optional<Int>` spelling is not matched. It is legal but vanishingly rare, and a macro
-/// cannot resolve module qualification from syntax alone.
+/// Derived from ``postgrestUnwrapOptionalType(_:)`` rather than testing its own set of spellings:
+/// the two used to disagree — one accepted a bare `Optional<` prefix, the other required the
+/// closing `>` as well — and any spelling that satisfied one and not the other produced a column
+/// whose `Value` was itself optional.
 func postgrestIsOptionalType(_ type: String) -> Bool {
-  type.hasSuffix("?") || type.hasPrefix("Optional<")
+  postgrestUnwrapOptionalType(type) != nil
 }
 
 extension DeclGroupSyntax {

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -21,6 +21,17 @@ struct StoredProperty {
 
   /// The property's type made optional, or left alone if it already is.
   var optionalType: String { isOptional ? type : "\(type)?" }
+
+  /// The property's type with one layer of `Optional` removed, or left alone if it has none.
+  ///
+  /// Handles both spellings, since a generated schema can emit either.
+  var unwrappedType: String {
+    if type.hasSuffix("?") { return String(type.dropLast()) }
+    if type.hasPrefix("Optional<"), type.hasSuffix(">") {
+      return String(type.dropFirst("Optional<".count).dropLast())
+    }
+    return type
+  }
 }
 
 /// Whether a written type is spelled as an `Optional`.
@@ -39,8 +50,8 @@ func postgrestIsOptionalType(_ type: String) -> Bool {
 extension DeclGroupSyntax {
   /// Reads the stored properties, skipping computed properties and static members.
   ///
-  /// A key path to a skipped property therefore maps to no column, which is what the generated
-  /// `columnName(for:)` traps on.
+  /// A skipped property therefore has no entry in `Columns`, so a filter or a selection naming it
+  /// is a compile error, and no case in `columnName(for:)`, which traps instead.
   ///
   /// Three shapes are easy to get wrong, so each is spelled out:
   ///

--- a/Sources/PostgrestMacrosPlugin/TableMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/TableMacro.swift
@@ -79,6 +79,7 @@ public struct TableMacro: ExtensionMacro {
       "  \(access)static let relationName = \"\(arguments.name)\"",
       "  \(access)static let schema = \"\(arguments.schema)\"",
       "  \(access)static let selectString = \"*\"",
+      columnsNamespace(access: access, type: type.trimmedDescription, properties: properties),
       columnNameFunction(access: access, type: type.trimmedDescription, properties: properties),
     ]
     // The one thing `@PrimaryKey` uniquely does. Without this the marker is inert: after the key
@@ -108,9 +109,9 @@ public struct TableMacro: ExtensionMacro {
       // There is no matching `Update` shape. An update names the columns it writes, and a row
       // type cannot say that: one optional field would have to mean both "not assigned" and
       // "assigned null", so a nullable column could never be cleared. `PostgrestUpdate` builds
-      // the assignments from this type's key paths instead, and `columnName(for:)` above is all
-      // it needs from the macro. Targeting stays a separate concern — the caller filters the
-      // mutation — so the key is assignable like any other column.
+      // the assignments from key paths into the `Columns` namespace above instead, so it needs
+      // nothing further from the macro beyond that. Targeting stays a separate concern — the
+      // caller filters the mutation — so the key is assignable like any other column.
       body.append(
         writeShape(
           named: "Draft",
@@ -157,7 +158,36 @@ public struct TableMacro: ExtensionMacro {
     ].compactMap { $0 }
   }
 
-  /// The key-path-to-column mapping.
+  /// The column namespace: one stored property per column, and no `default:` arm, because a key
+  /// path to a computed property has nowhere to land.
+  ///
+  /// An optional property gets a `PostgrestNullableColumn` carrying its **wrapped** type, so
+  /// `var dueDate: Date?` emits `PostgrestNullableColumn<Todo, Date>`.
+  ///
+  /// The explicit `init()` is required: a `public` struct's memberwise initializer is internal,
+  /// so `Columns()` would not resolve from another module.
+  static func columnsNamespace(
+    access: String,
+    type: String,
+    properties: [StoredProperty]
+  ) -> String {
+    var lines = ["  \(access)struct Columns: Sendable {"]
+    for property in properties {
+      let column = property.isOptional ? "PostgrestNullableColumn" : "PostgrestColumn"
+      lines.append(
+        "    \(access)let \(property.name) = \(column)<\(type), \(property.unwrappedType)>"
+          + "(\"\(property.columnName)\")"
+      )
+    }
+    lines.append("")
+    lines.append("    \(access)init() {}")
+    lines.append("  }")
+    lines.append("")
+    lines.append("  \(access)static let columns = Columns()")
+    return lines.joined(separator: "\n")
+  }
+
+  /// The key-path-to-column mapping, for the filter surface that has not moved to `Columns` yet.
   ///
   /// Every stored property gets a case, so `default` is reachable only through a key path to a
   /// computed property — a mistake at the call site, not a query worth sending. `fatalError` says

--- a/Tests/PostgRESTTests/PostgrestRelationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestRelationTests.swift
@@ -20,6 +20,14 @@ struct PostgrestRelationTests {
     var task: String
     var isDone: Bool
 
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let task = PostgrestColumn<Todo, String>("task")
+      let isDone = PostgrestColumn<Todo, Bool>("is_done")
+    }
+
+    static let columns = Columns()
+
     static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"

--- a/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
@@ -22,14 +22,24 @@ struct PostgrestTypedMutationTests {
     var isDone: Bool
     var note: String?
 
-    /// A hand-written conformance has to keep these in step with `columnName(for:)` itself. The
-    /// `@Column` macro generates both from one input so they cannot drift.
+    /// A hand-written conformance has to keep these in step with `Columns` and
+    /// `columnName(for:)` themselves. The `@Column` macro generates them from one input so they
+    /// cannot drift.
     enum CodingKeys: String, CodingKey {
       case id
       case task
       case isDone = "is_done"
       case note
     }
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let task = PostgrestColumn<Todo, String>("task")
+      let isDone = PostgrestColumn<Todo, Bool>("is_done")
+      let note = PostgrestNullableColumn<Todo, String>("note")
+    }
+
+    static let columns = Columns()
 
     static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
@@ -54,6 +64,12 @@ struct PostgrestTypedMutationTests {
     static let selectString = "*"
 
     var id: Int
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<ActiveTodo, Int>("id")
+    }
+
+    static let columns = Columns()
 
     static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {

--- a/Tests/PostgRESTTests/PostgrestTypedQueryFilterTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedQueryFilterTests.swift
@@ -31,6 +31,15 @@ struct PostgrestTypedQueryFilterTests {
       default: fatalError("unmapped key path")
       }
     }
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let task = PostgrestColumn<Todo, String>("task")
+      let isDone = PostgrestColumn<Todo, Bool>("is_done")
+      let dueDate = PostgrestNullableColumn<Todo, Date>("due_date")
+    }
+
+    static let columns = Columns()
   }
 
   @Test

--- a/Tests/PostgRESTTests/PostgrestTypedSourceTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedSourceTests.swift
@@ -20,6 +20,13 @@ struct PostgrestTypedSourceTests {
     var id: Int
     var task: String
 
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let task = PostgrestColumn<Todo, String>("task")
+    }
+
+    static let columns = Columns()
+
     static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"

--- a/Tests/PostgRESTTests/PostgrestUpdateTests.swift
+++ b/Tests/PostgRESTTests/PostgrestUpdateTests.swift
@@ -28,6 +28,14 @@ struct PostgrestUpdateTests {
       case dueAt = "due_at"
     }
 
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let task = PostgrestColumn<Todo, String>("task")
+      let dueAt = PostgrestNullableColumn<Todo, String>("due_at")
+    }
+
+    static let columns = Columns()
+
     static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
       switch keyPath {
       case \Self.id: "id"
@@ -53,6 +61,24 @@ struct PostgrestUpdateTests {
   func assigningNilSendsAnExplicitNull() throws {
     let update = PostgrestUpdate<Todo> { $0.dueAt = nil }
     expectNoDifference(try encoded(update), ["due_at": .null])
+  }
+
+  /// The expected keys are derived from `Todo.columns` rather than hardcoded, so this fails if
+  /// the subscript ever reads a different source of truth than filters do. `dueAt` is the case
+  /// that matters: its wire name (`due_at`) differs from its Swift name.
+  @Test
+  func assignmentsResolveThroughTheColumnNamespace() throws {
+    let update = PostgrestUpdate<Todo> {
+      $0.task = "buy oat milk"
+      $0.dueAt = nil
+    }
+    expectNoDifference(
+      try encoded(update),
+      [
+        Todo.columns.task.postgrestExpression: "buy oat milk",
+        Todo.columns.dueAt.postgrestExpression: .null,
+      ]
+    )
   }
 
   @Test

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -106,7 +106,8 @@ struct DiagnosticsTests {
   @Test
   func tableRejectsAPropertyWithNoTypeAnnotation() {
     // Left alone, the property has a default, so `Decodable` synthesis still succeeds. The column
-    // never round-trips and the mistake surfaces only when `columnName(for:)` traps at runtime.
+    // never round-trips and the mistake surfaces only much later, as a compile error at some
+    // unrelated call site that expected the column to exist in `Columns` or `Draft`.
     assertMacro {
       """
       @Table("todos")
@@ -185,6 +186,16 @@ struct DiagnosticsTests {
         static let schema = "public"
 
         static let selectString = "*"
+
+        struct Columns: Sendable {
+          let id = PostgrestColumn<Todo, Int>("id")
+          let task = PostgrestColumn<Todo, String>("task")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
 
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {

--- a/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
@@ -35,8 +35,8 @@ struct SelectionOfMacroTests {
         typealias Source = Todo
 
         static let selectString = [
-          "id:\(Todo.columnName(for: \Todo.id))",
-          "due_at:\(Todo.columnName(for: \Todo.dueDate))",
+          "id:\(Todo.columns.id.postgrestExpression)",
+          "due_at:\(Todo.columns.dueDate.postgrestExpression)",
         ].joined(separator: ",")
 
         enum CodingKeys: String, CodingKey {
@@ -46,11 +46,52 @@ struct SelectionOfMacroTests {
 
         /// Fails to compile if a property does not name a column on Todo.
         private static let _columnCheck: [String] = [
-          Todo.columnName(for: \Todo.id),
-          Todo.columnName(for: \Todo.dueDate),
+          Todo.columns.id.postgrestExpression,
+          Todo.columns.dueDate.postgrestExpression,
         ]
       }
       """#
+    }
+  }
+
+  /// The select list reads the relation's namespace directly, not a key-path-to-column mapping.
+  @Test
+  func selectStringReadsTheColumnNamespace() {
+    assertMacro {
+      """
+      @SelectionOf(Todo.self)
+      struct TodoSummary {
+        var id: Int
+        var isDone: Bool
+      }
+      """
+    } expansion: {
+      """
+      struct TodoSummary {
+        var id: Int
+        var isDone: Bool
+      }
+
+      extension TodoSummary {
+        typealias Source = Todo
+
+        static let selectString = [
+          "id:\\(Todo.columns.id.postgrestExpression)",
+          "is_done:\\(Todo.columns.isDone.postgrestExpression)",
+        ].joined(separator: ",")
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case isDone = "is_done"
+        }
+
+        /// Fails to compile if a property does not name a column on Todo.
+        private static let _columnCheck: [String] = [
+          Todo.columns.id.postgrestExpression,
+          Todo.columns.isDone.postgrestExpression,
+        ]
+      }
+      """
     }
   }
 
@@ -73,7 +114,7 @@ struct SelectionOfMacroTests {
         public typealias Source = Todo
 
         public static let selectString = [
-          "is_done:\(Todo.columnName(for: \Todo.isDone))",
+          "is_done:\(Todo.columns.isDone.postgrestExpression)",
         ].joined(separator: ",")
 
         enum CodingKeys: String, CodingKey {
@@ -82,7 +123,7 @@ struct SelectionOfMacroTests {
 
         /// Fails to compile if a property does not name a column on Todo.
         private static let _columnCheck: [String] = [
-          Todo.columnName(for: \Todo.isDone),
+          Todo.columns.isDone.postgrestExpression,
         ]
       }
       """#

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -66,6 +66,18 @@ struct TableIntegrationTests {
     #expect(Todo.selectString == "*")
   }
 
+  /// `assertMacro` checks the emitted text. This checks the expansion compiles into usable
+  /// values on a real type, which the text alone does not prove.
+  @Test
+  func theGeneratedNamespaceCarriesNamesAndTypes() {
+    #expect(Todo.columns.task.postgrestExpression == "task")
+    #expect(Todo.columns.isDone.postgrestExpression == "is_done")
+    #expect(Todo.columns.dueDate.postgrestExpression == "due_at")
+    #expect(type(of: Todo.columns.isDone).Value.self == Bool.self)
+    // The nullable column carries the wrapped type.
+    #expect(type(of: Todo.columns.dueDate).Value.self == Date.self)
+  }
+
   @Test
   func macroMapsKeyPathsToColumns() {
     #expect(Todo.columnName(for: \.id) == "id")

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -49,6 +49,15 @@ struct IntegrationAuditEvent {
   var recordedBy: String
 }
 
+// An implicitly unwrapped optional. The spelling means the same nullable column as `T?`, and it
+// only ever reached a property type before `Columns` existed — a generic argument rejects `!`, so
+// the compile error landed on expanded code the author never wrote.
+@Table("drafts")
+struct IntegrationDraftNote {
+  @PrimaryKey @Default var id: Int
+  var title: String!
+}
+
 @Table("active_todos", readOnly: true)
 struct IntegrationActiveTodo {
   var id: Int
@@ -76,6 +85,16 @@ struct TableIntegrationTests {
     #expect(type(of: Todo.columns.isDone).Value.self == Bool.self)
     // The nullable column carries the wrapped type.
     #expect(type(of: Todo.columns.dueDate).Value.self == Date.self)
+  }
+
+  /// An implicitly unwrapped optional is a nullable column: the wrapped type reaches `Value`, so
+  /// the operators are there, and `isNull()` is too.
+  @Test
+  func anImplicitlyUnwrappedOptionalIsANullableColumn() {
+    #expect(IntegrationDraftNote.columns.title.postgrestExpression == "title")
+    #expect(type(of: IntegrationDraftNote.columns.title).Value.self == String.self)
+    _ = IntegrationDraftNote.columns.title.isNull()
+    _ = IntegrationDraftNote.Draft(title: nil)
   }
 
   @Test

--- a/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
@@ -100,4 +100,19 @@ struct TableMacroSupportTests {
     #expect(camelToSnakeCase("urlSession") == "url_session")
     #expect(camelToSnakeCase("id") == "id")
   }
+
+  @Test
+  func unwrapsBothOptionalSpellings() {
+    func unwrapped(_ type: String) -> String {
+      StoredProperty(
+        name: "x", type: type, isOptional: true, isPrimaryKey: false, hasDefault: false,
+        explicitColumn: nil
+      ).unwrappedType
+    }
+    #expect(unwrapped("Date?") == "Date")
+    #expect(unwrapped("Optional<Date>") == "Date")
+    #expect(unwrapped("[String]?") == "[String]")
+    #expect(unwrapped("Optional<[Int]>") == "[Int]")
+    #expect(unwrapped("String") == "String")
+  }
 }

--- a/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroSupportTests.swift
@@ -102,7 +102,7 @@ struct TableMacroSupportTests {
   }
 
   @Test
-  func unwrapsBothOptionalSpellings() {
+  func unwrapsEveryOptionalSpelling() {
     func unwrapped(_ type: String) -> String {
       StoredProperty(
         name: "x", type: type, isOptional: true, isPrimaryKey: false, hasDefault: false,
@@ -114,5 +114,25 @@ struct TableMacroSupportTests {
     #expect(unwrapped("[String]?") == "[String]")
     #expect(unwrapped("Optional<[Int]>") == "[Int]")
     #expect(unwrapped("String") == "String")
+    // An implicitly unwrapped optional is a nullable column too, and `String!` in a generic
+    // argument does not compile at all.
+    #expect(unwrapped("String!") == "String")
+    // Every layer comes off. One left on gives a column whose `Value` is optional, which loses
+    // every operator, because `Optional` does not conform to `PostgrestFilterValue`.
+    #expect(unwrapped("Optional<Int>!") == "Int")
+    #expect(unwrapped("Int??") == "Int")
+  }
+
+  /// The two used to test separate sets of spellings, and disagreed on `Optional<Int>!`.
+  @Test
+  func optionalityAgreesWithUnwrapping() {
+    for type in ["Date?", "Optional<Date>", "String!", "Optional<Int>!", "Int??"] {
+      #expect(postgrestIsOptionalType(type), "\(type) should be optional")
+      #expect(postgrestUnwrapOptionalType(type) != nil)
+    }
+    for type in ["String", "[Int]", "Dictionary<String, Int>"] {
+      #expect(!postgrestIsOptionalType(type), "\(type) should not be optional")
+      #expect(postgrestUnwrapOptionalType(type) == nil)
+    }
   }
 }

--- a/Tests/PostgrestMacrosTests/TableMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/TableMacroTests.swift
@@ -45,6 +45,18 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
+        struct Columns: Sendable {
+          let id = PostgrestColumn<Todo, Int>("id")
+          let task = PostgrestColumn<Todo, String>("task")
+          let isDone = PostgrestColumn<Todo, Bool>("is_done")
+          let dueDate = PostgrestNullableColumn<Todo, Date>("due_at")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
+
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
@@ -116,6 +128,15 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
+        struct Columns: Sendable {
+          let id = PostgrestColumn<ActiveTodo, Int>("id")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
+
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
@@ -157,6 +178,15 @@ struct TableMacroTests {
         static let schema = "public"
 
         static let selectString = "*"
+
+        struct Columns: Sendable {
+          let action = PostgrestColumn<AuditEvent, String>("action")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
 
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
@@ -210,6 +240,16 @@ struct TableMacroTests {
         public static let schema = "app"
 
         public static let selectString = "*"
+
+        public struct Columns: Sendable {
+          public let id = PostgrestColumn<Todo, Int>("id")
+          public let task = PostgrestColumn<Todo, String>("task")
+
+          public init() {
+          }
+        }
+
+        public static let columns = Columns()
 
         public static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
@@ -274,6 +314,15 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
+        struct Columns: Sendable {
+          let htmlURL = PostgrestColumn<Todo, String>("html_url")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
+
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.htmlURL:
@@ -327,6 +376,19 @@ struct TableMacroTests {
         static let schema = "public"
 
         static let selectString = "*"
+
+        struct Columns: Sendable {
+          let id = PostgrestColumn<Todo, Int>("id")
+          let task = PostgrestColumn<Todo, String>("task")
+          let note = PostgrestColumn<Todo, String>("note")
+          let draft = PostgrestColumn<Todo, String>("draft")
+          let review = PostgrestColumn<Todo, String>("review")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
 
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
@@ -417,6 +479,16 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
+        struct Columns: Sendable {
+          let id = PostgrestColumn<Todo, Int>("id")
+          let task = PostgrestColumn<Todo, String>("task")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
+
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
@@ -481,6 +553,17 @@ struct TableMacroTests {
         static let schema = "public"
 
         static let selectString = "*"
+
+        struct Columns: Sendable {
+          let userID = PostgrestColumn<UserRole, UUID>("user_id")
+          let roleID = PostgrestColumn<UserRole, UUID>("role_id")
+          let grantedAt = PostgrestColumn<UserRole, Date>("granted_at")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
 
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
@@ -552,6 +635,16 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
+        struct Columns: Sendable {
+          let userID = PostgrestColumn<UserRole, UUID>("user_id")
+          let roleID = PostgrestColumn<UserRole, UUID>("role_id")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
+
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.userID:
@@ -620,6 +713,18 @@ struct TableMacroTests {
 
         static let selectString = "*"
 
+        struct Columns: Sendable {
+          let id = PostgrestColumn<Todo, Int>("id")
+          let task = PostgrestColumn<Todo, String>("task")
+          let note = PostgrestNullableColumn<Todo, String>("note")
+          let tag = PostgrestNullableColumn<Todo, String>("tag")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
+
         static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
           switch keyPath {
           case \Self.id:
@@ -669,4 +774,72 @@ struct TableMacroTests {
     }
   }
 
+  @Test
+  func expandsAColumnsNamespace() {
+    assertMacro {
+      """
+      @Table("todos")
+      struct Todo {
+        var id: Int
+        @Column("due_at") var dueDate: Date?
+      }
+      """
+    } expansion: {
+      #"""
+      struct Todo {
+        var id: Int
+        @Column("due_at") var dueDate: Date?
+      }
+
+      extension Todo {
+        static let relationName = "todos"
+
+        static let schema = "public"
+
+        static let selectString = "*"
+
+        struct Columns: Sendable {
+          let id = PostgrestColumn<Todo, Int>("id")
+          let dueDate = PostgrestNullableColumn<Todo, Date>("due_at")
+
+          init() {
+          }
+        }
+
+        static let columns = Columns()
+
+        static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
+          switch keyPath {
+          case \Self.id:
+            return "id"
+          case \Self.dueDate:
+            return "due_at"
+          default:
+            fatalError("Todo: no column is mapped for that key path")
+          }
+        }
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case dueDate = "due_at"
+        }
+
+        struct Draft: Encodable, Sendable {
+          var id: Int
+          var dueDate: Date?
+
+          enum CodingKeys: String, CodingKey {
+            case id = "id"
+            case dueDate = "due_at"
+          }
+
+          init(id: Int, dueDate: Date? = nil) {
+            self.id = id
+            self.dueDate = dueDate
+          }
+        }
+      }
+      """#
+    }
+  }
 }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -77,6 +77,8 @@ supporting_symbols:
   - PostgrestUpdate.encode
   - PostgrestQueryPhase
   - PostgrestRelation
+  - PostgrestRelation.Columns
+  - PostgrestRelation.columns
   - PostgrestRelation.columnName
   - PostgrestRelation.relationName
   - PostgrestRelation.schema


### PR DESCRIPTION
Stack 3/8 for SDK-1624. Base: `guilhermesouza/sdk-1624-filter-operators`.

`@Table` now emits a nested `Columns` struct holding one column value per stored property, and `PostgrestRelation` gains `Columns`/`columns` so callers can reach it generically.

An optional property gets a `PostgrestNullableColumn` carrying its **wrapped** type (`var dueDate: Date?` → `PostgrestNullableColumn<Todo, Date>`). That is what lets an update accept `nil` for a nullable column and reject it for a `NOT NULL` one, while keeping every operator at one declaration — no operator takes an optional operand.

Two existing readers move onto it:

- `PostgrestUpdate`'s subscript keys off `KeyPath<R.Columns, …>` instead of the row type, so an assignment resolves the column name from the same place a filter does.
- `@SelectionOf` builds `selectString` from the namespace.

`upsert(onConflict:)` follows. It used `columnName(for:)`, which this stack removes, so it moves to key paths into `Columns` — with parameter packs, so `\.email` still infers and existing call sites are untouched.

`columnName(for:)` stays for now: the key-path filter surface still reads it, and it goes in 5/8.
