### PR TITLE
feat(postgrest): add the where and order closures

### DIFF
--- a/Sources/PostgREST/Columns/PostgrestOrdering.swift
+++ b/Sources/PostgREST/Columns/PostgrestOrdering.swift
@@ -32,17 +32,14 @@ public struct PostgrestOrdering<Root: PostgrestRelation>: Sendable {
       + (nullPlacement.map { ".\($0.rawValue)" } ?? "")
   }
 
-  /// Sorts `NULL`s before non-null values.
-  public func nullsFirst() -> Self {
+  /// Places `NULL`s relative to non-null values.
+  ///
+  /// ```swift
+  /// .order { $0.priority.desc().nulls(.first) }
+  /// ```
+  public func nulls(_ placement: PostgrestNullPlacement) -> Self {
     var copy = self
-    copy.nullPlacement = .first
-    return copy
-  }
-
-  /// Sorts `NULL`s after non-null values.
-  public func nullsLast() -> Self {
-    var copy = self
-    copy.nullPlacement = .last
+    copy.nullPlacement = placement
     return copy
   }
 }
@@ -65,8 +62,7 @@ public struct PostgrestNullPlacement: RawRepresentable, Hashable, Sendable {
 extension PostgrestOrderableExpression {
   /// Sorts by this expression, smallest first.
   ///
-  /// Null placement is left to the database unless you chain
-  /// ``PostgrestOrdering/nullsFirst()`` or ``PostgrestOrdering/nullsLast()``.
+  /// Null placement is left to the database unless you chain ``PostgrestOrdering/nulls(_:)``.
   public func asc() -> PostgrestOrdering<Root> {
     PostgrestOrdering(column: postgrestExpression, ascending: true)
   }
@@ -74,5 +70,19 @@ extension PostgrestOrderableExpression {
   /// Sorts by this expression, largest first.
   public func desc() -> PostgrestOrdering<Root> {
     PostgrestOrdering(column: postgrestExpression, ascending: false)
+  }
+
+  /// Sorts by this expression with an explicit `NULL` placement, leaving the direction to
+  /// PostgREST.
+  ///
+  /// ```swift
+  /// .order { $0.dueDate.nulls(.first) }   // order=due_at.nullsfirst
+  /// ```
+  ///
+  /// The two parts are independent on the wire, so a placement does not require picking a
+  /// direction: `order=name.nullsfirst` is a 200. Without this, wanting PostgREST's default
+  /// direction *and* an explicit placement would force a direction into the query anyway.
+  public func nulls(_ placement: PostgrestNullPlacement) -> PostgrestOrdering<Root> {
+    PostgrestOrdering(column: postgrestExpression, ascending: nil, nullPlacement: placement)
   }
 }

--- a/Sources/PostgREST/Columns/PostgrestOrdering.swift
+++ b/Sources/PostgREST/Columns/PostgrestOrdering.swift
@@ -1,0 +1,78 @@
+//
+//  PostgrestOrdering.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+/// One sort key: a column expression, optionally with a direction and a null placement.
+///
+/// ```swift
+/// .order { $0.priority.desc() }
+/// .order { $0.id }              // breaks ties in the first, ascending by default
+/// ```
+///
+/// Omitting the direction sends `order=id` bare, so PostgREST's own default applies rather than
+/// a value frozen into the client.
+public struct PostgrestOrdering<Root: PostgrestRelation>: Sendable {
+  let column: String
+
+  /// `nil` sends no direction, so PostgREST's default applies (ascending, `NULL`s last on 16.1).
+  let ascending: Bool?
+
+  /// `nil` sends no placement, so the database default applies.
+  ///
+  /// Deliberately unlike `PostgrestTransformBuilder.order(_:ascending:nullsFirst:)`, which always
+  /// appends one — see [SDK-1633](https://linear.app/supabase/issue/SDK-1633).
+  var nullPlacement: PostgrestNullPlacement?
+
+  var rendered: String {
+    column
+      + (ascending.map { ".\($0 ? "asc" : "desc")" } ?? "")
+      + (nullPlacement.map { ".\($0.rawValue)" } ?? "")
+  }
+
+  /// Sorts `NULL`s before non-null values.
+  public func nullsFirst() -> Self {
+    var copy = self
+    copy.nullPlacement = .first
+    return copy
+  }
+
+  /// Sorts `NULL`s after non-null values.
+  public func nullsLast() -> Self {
+    var copy = self
+    copy.nullPlacement = .last
+    return copy
+  }
+}
+
+/// Where `NULL`s sort relative to other values.
+public struct PostgrestNullPlacement: RawRepresentable, Hashable, Sendable {
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// `nullsfirst`
+  public static let first = PostgrestNullPlacement(rawValue: "nullsfirst")
+
+  /// `nullslast`
+  public static let last = PostgrestNullPlacement(rawValue: "nullslast")
+}
+
+extension PostgrestOrderableExpression {
+  /// Sorts by this expression, smallest first.
+  ///
+  /// Null placement is left to the database unless you chain
+  /// ``PostgrestOrdering/nullsFirst()`` or ``PostgrestOrdering/nullsLast()``.
+  public func asc() -> PostgrestOrdering<Root> {
+    PostgrestOrdering(column: postgrestExpression, ascending: true)
+  }
+
+  /// Sorts by this expression, largest first.
+  public func desc() -> PostgrestOrdering<Root> {
+    PostgrestOrdering(column: postgrestExpression, ascending: false)
+  }
+}

--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -13,7 +13,7 @@
 ///
 /// Like the builder it wraps, this is a value type: chaining off the same mutation twice gives
 /// two independent requests.
-public struct PostgrestTypedMutation<R: PostgrestWritableRelation>: PostgrestKeyPathFilterable,
+public struct PostgrestTypedMutation<R: PostgrestWritableRelation>: PostgrestFilterableRequest,
   Sendable
 {
   public typealias Relation = R

--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -134,7 +134,7 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   ///     $0.task = "buy oat milk"
   ///     $0.dueDate = nil
   ///   }
-  ///   .eq(\.id, 1)
+  ///   .where { $0.id.eq(1) }
   ///   .execute()
   /// ```
   ///

--- a/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery+Filters.swift
@@ -5,17 +5,18 @@
 //  Created by Guilherme Souza on 21/08/26.
 //
 
-/// A wrapper that scopes a request by key path.
+/// A request wrapper that can be scoped by filters.
 ///
-/// Both ``PostgrestTypedQuery`` and ``PostgrestTypedMutation`` conform, so the key-path filter set
-/// is declared once here rather than repeated on every wrapper. You do not conform your own types
-/// to this.
+/// Both ``PostgrestTypedQuery`` and ``PostgrestTypedMutation`` conform, so the filter set is
+/// declared once here rather than repeated on every wrapper. You do not conform your own types to
+/// this.
 ///
 /// Only filters live here. `order` and `limit` move the request into
 /// ``PostgrestTransformPhase``, so they cannot return `Self` and are declared on
 /// ``PostgrestTypedQuery`` instead.
-public protocol PostgrestKeyPathFilterable {
-  /// The relation whose key paths this wrapper accepts.
+public protocol PostgrestFilterableRequest {
+  /// The relation this wrapper queries. Its ``PostgrestRelation/Columns`` is what a filter
+  /// closure receives.
   associatedtype Relation: PostgrestRelation
 
   /// The phase of the underlying request. Filters require a filterable phase.
@@ -28,12 +29,12 @@ public protocol PostgrestKeyPathFilterable {
   init(builder: PostgrestRequestBuilder<Phase>)
 }
 
-extension PostgrestTypedQuery: PostgrestKeyPathFilterable
+extension PostgrestTypedQuery: PostgrestFilterableRequest
 where Phase: PostgrestFilterablePhase {
   public typealias Relation = R
 }
 
-extension PostgrestKeyPathFilterable {
+extension PostgrestFilterableRequest {
   /// Matches rows where the column at `column` equals `value`.
   public func eq<V: PostgrestFilterValue>(_ column: KeyPath<Relation, V>, _ value: V) -> Self {
     Self(builder: builder.eq(Relation.columnName(for: column), value: value))

--- a/Sources/PostgREST/Query/PostgrestTypedQuery+Where.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery+Where.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension PostgrestKeyPathFilterable {
+extension PostgrestFilterableRequest {
   /// Scopes the request by a filter.
   ///
   /// The closure receives the relation's column namespace. Each PostgREST operator is a method
@@ -49,7 +49,7 @@ extension PostgrestTypedQuery where Phase: PostgrestTransformablePhase {
   ///
   /// ```swift
   /// .order { $0.dueDate.asc() }
-  /// .order { $0.priority.desc().nullsFirst() }
+  /// .order { $0.priority.desc().nulls(.first) }
   /// ```
   ///
   /// Repeated calls append, so the second key breaks ties in the first. Ordering moves the
@@ -67,12 +67,12 @@ extension PostgrestTypedQuery where Phase: PostgrestTransformablePhase {
   /// ```swift
   /// .order { $0.dueDate }                  // order=due_at
   /// .order { $0.priority.desc() }          // order=priority.desc
+  /// .order { $0.dueDate.nulls(.first) }    // order=due_at.nullsfirst
   /// ```
   ///
   /// Chain ``PostgrestOrderableExpression/asc()`` or ``PostgrestOrderableExpression/desc()`` when
-  /// the direction matters, or when you need
-  /// ``PostgrestOrdering/nullsFirst()``/``PostgrestOrdering/nullsLast()`` — a placement hangs off
-  /// the direction, not off the bare column.
+  /// the direction matters. Direction and placement are independent on the wire, so
+  /// ``PostgrestOrderableExpression/nulls(_:)`` sets a placement without choosing one.
   public func order<E: PostgrestOrderableExpression>(
     _ build: (R.Columns) -> E
   ) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> where E.Root == R {
@@ -82,6 +82,10 @@ extension PostgrestTypedQuery where Phase: PostgrestTransformablePhase {
   }
 
   /// Merges one rendered sort key into the single `order` parameter PostgREST expects.
+  ///
+  /// A merge, not a second parameter: PostgREST honours only the first `order` it sees and
+  /// silently ignores the rest, so `order=name.asc&order=id.desc` sorts by name alone. Only
+  /// `order=name.asc,id.desc` applies both.
   ///
   /// Not `builder.order(_:ascending:nullsFirst:)`, which always appends a placement.
   private func appendingOrder(

--- a/Sources/PostgREST/Query/PostgrestTypedQuery+Where.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery+Where.swift
@@ -1,0 +1,102 @@
+//
+//  PostgrestTypedQuery+Where.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+
+extension PostgrestKeyPathFilterable {
+  /// Scopes the request by a filter.
+  ///
+  /// The closure receives the relation's column namespace. Each PostgREST operator is a method
+  /// on a column, and `&&`, `||` and `!` compose the results:
+  ///
+  /// ```swift
+  /// try await client.from(Todo.self)
+  ///   .select()
+  ///   .where { ($0.isDone.eq(false) && $0.priority.gt(3)) || $0.id.eq(7) }
+  ///   .execute()
+  /// ```
+  ///
+  /// A filter that depends on runtime state is assembled in the closure body like any other
+  /// value:
+  ///
+  /// ```swift
+  /// .where { c in
+  ///   var filter = c.isDone.eq(false)
+  ///   if let priority { filter = filter && c.priority.gte(priority) }
+  ///   return filter
+  /// }
+  /// ```
+  ///
+  /// > Note: Two `where` calls accumulate — they are ANDed; neither replaces the other.
+  ///
+  /// - Parameter build: Builds the filter from the relation's columns.
+  /// - Returns: A new request with the filter applied. The receiver is unchanged.
+  public func `where`(_ build: (Relation.Columns) -> PostgrestFilter<Relation>) -> Self {
+    var builder = self.builder
+    builder.request.query.append(contentsOf: build(Relation.columns).queryItems())
+    return Self(builder: builder)
+  }
+}
+
+extension PostgrestTypedQuery where Phase: PostgrestTransformablePhase {
+  /// Sorts the result.
+  ///
+  /// The direction is spelled on the column, the same way an operator is:
+  ///
+  /// ```swift
+  /// .order { $0.dueDate.asc() }
+  /// .order { $0.priority.desc().nullsFirst() }
+  /// ```
+  ///
+  /// Repeated calls append, so the second key breaks ties in the first. Ordering moves the
+  /// request into ``PostgrestTransformPhase``, after which no further filter can be applied.
+  ///
+  /// - Parameter build: Builds the sort key from the relation's columns.
+  public func order(
+    _ build: (R.Columns) -> PostgrestOrdering<R>
+  ) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> {
+    appendingOrder(build(R.columns).rendered)
+  }
+
+  /// Sorts by a column expression, leaving the direction to PostgREST.
+  ///
+  /// ```swift
+  /// .order { $0.dueDate }                  // order=due_at
+  /// .order { $0.priority.desc() }          // order=priority.desc
+  /// ```
+  ///
+  /// Chain ``PostgrestOrderableExpression/asc()`` or ``PostgrestOrderableExpression/desc()`` when
+  /// the direction matters, or when you need
+  /// ``PostgrestOrdering/nullsFirst()``/``PostgrestOrdering/nullsLast()`` — a placement hangs off
+  /// the direction, not off the bare column.
+  public func order<E: PostgrestOrderableExpression>(
+    _ build: (R.Columns) -> E
+  ) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> where E.Root == R {
+    appendingOrder(
+      PostgrestOrdering<R>(column: build(R.columns).postgrestExpression, ascending: nil).rendered
+    )
+  }
+
+  /// Merges one rendered sort key into the single `order` parameter PostgREST expects.
+  ///
+  /// Not `builder.order(_:ascending:nullsFirst:)`, which always appends a placement.
+  private func appendingOrder(
+    _ value: String
+  ) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> {
+    var request = builder.request
+    if let index = request.query.firstIndex(where: { $0.name == "order" }),
+      let existing = request.query[index].value
+    {
+      request.query[index] = URLQueryItem(name: "order", value: "\(existing),\(value)")
+    } else {
+      request.query.append(URLQueryItem(name: "order", value: value))
+    }
+    return PostgrestTypedQuery<R, Output, PostgrestTransformPhase>(
+      builder: PostgrestRequestBuilder(carryingFrom: builder, request: request)
+    )
+  }
+}

--- a/Sources/PostgREST/Query/PostgrestUpdate.swift
+++ b/Sources/PostgREST/Query/PostgrestUpdate.swift
@@ -20,7 +20,7 @@ import Foundation
 ///     $0.task = "buy oat milk"   // {"task": "buy oat milk"}
 ///     $0.dueDate = nil           // {"due_at": null}
 ///   }
-///   .eq(\.id, 1)
+///   .where { $0.id.eq(1) }
 ///   .execute()
 /// ```
 ///

--- a/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
@@ -101,10 +101,10 @@ struct PostgrestTypedMutationTests {
   }
 
   @Test
-  func updateScopesByKeyPath() async throws {
+  func updateScopesByFilter() async throws {
     let capture = QueryCapture()
     _ = try await capture.client.from(Todo.self)
-      .update { $0.task = "done" }.eq(\.id, 1).execute()
+      .update { $0.task = "done" }.where { $0.id.eq(1) }.execute()
     #expect(capture.query?.contains("id=eq.1") == true)
   }
 
@@ -113,7 +113,7 @@ struct PostgrestTypedMutationTests {
     // The whole point of SDK-1610: the body has to carry `null`, not drop the key.
     let capture = QueryCapture()
     _ = try await capture.client.from(Todo.self)
-      .update { $0.note = nil }.eq(\.id, 1).execute()
+      .update { $0.note = nil }.where { $0.id.eq(1) }.execute()
     #expect(capture.bodyString == #"{"note":null}"#)
   }
 
@@ -121,7 +121,7 @@ struct PostgrestTypedMutationTests {
   func updateOmitsAColumnItNeverNames() async throws {
     let capture = QueryCapture()
     _ = try await capture.client.from(Todo.self)
-      .update { $0.task = "done" }.eq(\.id, 1).execute()
+      .update { $0.task = "done" }.where { $0.id.eq(1) }.execute()
     #expect(capture.bodyString == #"{"task":"done"}"#)
   }
 
@@ -130,14 +130,14 @@ struct PostgrestTypedMutationTests {
     // The payload is a value, so one layer can decide the change and another can send it.
     let update = PostgrestUpdate<Todo> { $0.note = nil }
     let capture = QueryCapture()
-    _ = try await capture.client.from(Todo.self).update(update).eq(\.id, 1).execute()
+    _ = try await capture.client.from(Todo.self).update(update).where { $0.id.eq(1) }.execute()
     #expect(capture.bodyString == #"{"note":null}"#)
   }
 
   @Test
-  func deleteScopesByKeyPath() async throws {
+  func deleteScopesByFilter() async throws {
     let capture = QueryCapture()
-    _ = try await capture.client.from(Todo.self).delete().eq(\.id, 1).execute()
+    _ = try await capture.client.from(Todo.self).delete().where { $0.id.eq(1) }.execute()
     #expect(capture.query?.contains("id=eq.1") == true)
   }
 

--- a/Tests/PostgRESTTests/PostgrestTypedQueryWhereTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedQueryWhereTests.swift
@@ -1,0 +1,188 @@
+//
+//  PostgrestTypedQueryWhereTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestTypedQueryWhereTests {
+  struct Todo: PostgrestWritableRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var isDone: Bool
+    var priority: Int
+    var dueDate: Date?
+    var metadata: String
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let isDone = PostgrestColumn<Todo, Bool>("is_done")
+      let priority = PostgrestColumn<Todo, Int>("priority")
+      let dueDate = PostgrestNullableColumn<Todo, Date>("due_at")
+      let metadata = PostgrestColumn<Todo, String>("metadata")
+    }
+
+    static let columns = Columns()
+
+    static func columnName(for keyPath: PartialKeyPath<Self>) -> String {
+      switch keyPath {
+      case \Self.id: "id"
+      case \Self.isDone: "is_done"
+      case \Self.priority: "priority"
+      case \Self.dueDate: "due_at"
+      case \Self.metadata: "metadata"
+      default: fatalError("unmapped key path")
+      }
+    }
+
+    struct Draft: Encodable, Sendable {
+      var id: Int
+      var isDone: Bool
+      var priority: Int
+    }
+  }
+
+  @Test
+  func whereAppliesAFlatFilter() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select()
+      .where { $0.isDone.eq(false) && $0.priority.gt(3) }
+      .execute()
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+    #expect(capture.query?.contains("priority=gt.3") == true)
+  }
+
+  /// The target call site, verbatim.
+  @Test
+  func whereAppliesANestedGroup() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select()
+      .where { ($0.isDone.eq(false) && $0.priority.gt(3)) || $0.id.eq(7) }
+      .execute()
+    #expect(capture.query?.contains("or=(and(is_done.eq.false,priority.gt.3),id.eq.7)") == true)
+  }
+
+  /// SQL has one WHERE clause, so the singular name invites the wrong reading. Two calls AND
+  /// together.
+  @Test
+  func repeatedWhereAccumulates() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select()
+      .where { $0.isDone.eq(false) }
+      .where { $0.priority.gt(3) }
+      .execute()
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+    #expect(capture.query?.contains("priority=gt.3") == true)
+  }
+
+  @Test
+  func whereWorksOnAMutation() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).delete().where { $0.id.eq(7) }.execute()
+    #expect(capture.query?.contains("id=eq.7") == true)
+    #expect(capture.httpMethod == "DELETE")
+  }
+
+  /// A filter built conditionally inside the closure, so no second entry point is needed.
+  @Test
+  func aFilterCanBeAssembledInsideTheClosure() async throws {
+    let capture = QueryCapture()
+    let minimumPriority: Int? = 3
+    _ = try await capture.client.from(Todo.self)
+      .select()
+      .where { c in
+        var filter = c.isDone.eq(false)
+        if let minimumPriority { filter = filter && c.priority.gte(minimumPriority) }
+        return filter
+      }
+      .execute()
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+    #expect(capture.query?.contains("priority=gte.3") == true)
+  }
+
+  /// The direction is spelled on the column, so two sort keys can differ.
+  @Test
+  func orderUsesTheNamespaceColumnName() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select().order { $0.dueDate.asc() }.limit(5).execute()
+    #expect(capture.query?.contains("order=due_at.asc") == true)
+    #expect(capture.query?.contains("limit=5") == true)
+  }
+
+  /// A bare column sends no direction, rather than the SDK substituting `.asc`, so PostgREST's
+  /// own default applies.
+  @Test
+  func orderWithoutADirectionSendsTheBareColumn() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().order { $0.dueDate }.execute()
+    #expect(capture.query?.contains("order=due_at") == true)
+    #expect(capture.query?.contains("order=due_at.asc") == false)
+    #expect(capture.query?.contains("order=due_at.desc") == false)
+  }
+
+  /// The two spellings coexist as overloads, and a directionless key merges into the same single
+  /// `order` parameter as a directed one.
+  @Test
+  func directedAndDirectionlessKeysMergeInOrder() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select().order { $0.priority.desc() }.order { $0.id }.execute()
+    #expect(capture.query?.contains("order=priority.desc,id") == true)
+  }
+
+  /// An unspecified placement is not sent, so the database default applies. The string builder
+  /// always appends `.nullslast` — see
+  /// [SDK-1633](https://linear.app/supabase/issue/SDK-1633).
+  @Test
+  func nullPlacementIsOmittedUnlessAskedFor() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().order { $0.dueDate.desc() }.execute()
+    #expect(capture.query?.contains("order=due_at.desc") == true)
+    #expect(capture.query?.contains("nulls") == false)
+  }
+
+  @Test
+  func nullPlacementIsChainedWhenWanted() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select().order { $0.dueDate.desc().nullsFirst() }.execute()
+    #expect(capture.query?.contains("order=due_at.desc.nullsfirst") == true)
+  }
+
+  /// Repeated calls merge into one `order` parameter, so the second key breaks ties in the first.
+  @Test
+  func repeatedOrderAppendsASecondKey() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select().order { $0.priority.desc() }.order { $0.id.asc() }.execute()
+    #expect(capture.query?.contains("order=priority.desc,id.asc") == true)
+  }
+
+  /// Value semantics: branching two chains off one query must not leak the first chain's filter
+  /// into the second.
+  @Test
+  func branchingTwoChainsDoesNotAlias() async throws {
+    let capture = QueryCapture()
+    let base = capture.client.from(Todo.self).select()
+
+    _ = try await base.where { $0.isDone.eq(true) }.execute()
+    #expect(capture.query?.contains("is_done=eq.true") == true)
+
+    _ = try await base.where { $0.id.gt(5) }.execute()
+    #expect(capture.query?.contains("id=gt.5") == true)
+    #expect(capture.query?.contains("is_done") == false)
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestTypedQueryWhereTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedQueryWhereTests.swift
@@ -158,8 +158,20 @@ struct PostgrestTypedQueryWhereTests {
   func nullPlacementIsChainedWhenWanted() async throws {
     let capture = QueryCapture()
     _ = try await capture.client.from(Todo.self)
-      .select().order { $0.dueDate.desc().nullsFirst() }.execute()
+      .select().order { $0.dueDate.desc().nulls(.first) }.execute()
     #expect(capture.query?.contains("order=due_at.desc.nullsfirst") == true)
+  }
+
+  /// Direction and placement are independent on the wire, so asking for a placement must not
+  /// force a direction into the query — `order=due_at.nullslast` is a 200.
+  @Test
+  func aPlacementDoesNotRequireADirection() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select().order { $0.dueDate.nulls(.last) }.execute()
+    #expect(capture.query?.contains("order=due_at.nullslast") == true)
+    #expect(capture.query?.contains("asc") == false)
+    #expect(capture.query?.contains("desc") == false)
   }
 
   /// Repeated calls merge into one `order` parameter, so the second key breaks ties in the first.

--- a/Tests/PostgrestMacrosTests/SelectionIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionIntegrationTests.swift
@@ -79,7 +79,7 @@ struct SelectionIntegrationTests {
     let rows = try await capture.client
       .from(SelectionTodo.self)
       .select(TodoSummary.self)
-      .eq(\.isDone, false)
+      .where { $0.isDone.eq(false) }
       .execute()
       .value
 

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -205,7 +205,7 @@ struct TableIntegrationTests {
     _ = try await capture.client
       .from(Todo.self)
       .update { $0.dueDate = nil }
-      .eq(\.id, 1)
+      .where { $0.id.eq(1) }
       .execute()
 
     #expect(capture.bodyString == #"{"due_at":null}"#)
@@ -219,8 +219,8 @@ struct TableIntegrationTests {
     let todos = try await capture.client
       .from(Todo.self)
       .select()
-      .eq(\.isDone, false)
-      .order(\.id, ascending: false)
+      .where { $0.isDone.eq(false) }
+      .order { $0.id.desc() }
       .execute()
       .value
 
@@ -249,7 +249,7 @@ struct TableIntegrationTests {
     let rows = try await capture.client
       .from(IntegrationActiveTodo.self)
       .select()
-      .eq(\.task, "buy milk")
+      .where { $0.task.eq("buy milk") }
       .execute()
       .value
 
@@ -335,7 +335,7 @@ struct TableIntegrationTests {
     _ = try await capture.client
       .from(IntegrationUserRole.self)
       .update { $0.roleID = 3 }
-      .eq(\.userID, 1)
+      .where { $0.userID.eq(1) }
       .execute()
 
     #expect(capture.bodyString == #"{"role_id":3}"#)
@@ -348,7 +348,7 @@ struct TableIntegrationTests {
     _ = try await capture.client
       .from(Todo.self)
       .update { $0.task = "buy oat milk" }
-      .eq(\.id, 1)
+      .where { $0.id.eq(1) }
       .execute()
 
     #expect(capture.bodyString == #"{"task":"buy oat milk"}"#)

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -55,12 +55,12 @@ supporting_symbols:
   - PostgrestArrayElement
   - PostgrestArrayElement.postgrestArrayElement
   - PostgrestFilterValue.postgrestArrayElement
-  - PostgrestKeyPathFilterable
-  - PostgrestKeyPathFilterable.Phase
-  - PostgrestKeyPathFilterable.Relation
-  - PostgrestKeyPathFilterable.builder
-  - PostgrestKeyPathFilterable.init
-  - PostgrestKeyPathFilterable.where
+  - PostgrestFilterableRequest
+  - PostgrestFilterableRequest.Phase
+  - PostgrestFilterableRequest.Relation
+  - PostgrestFilterableRequest.builder
+  - PostgrestFilterableRequest.init
+  - PostgrestFilterableRequest.where
   - PostgrestTypedMutation
   - PostgrestTypedMutation.Phase
   - PostgrestTypedMutation.Relation
@@ -681,42 +681,42 @@ features:
     symbols:
       - PostgrestRequestBuilder.eq
       - PostgrestRequestBuilder.equals
-      - PostgrestKeyPathFilterable.eq
+      - PostgrestFilterableRequest.eq
       - PostgrestFilterableExpression.eq
   database.using_filters.neq:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.neq
       - PostgrestRequestBuilder.notEquals
-      - PostgrestKeyPathFilterable.neq
+      - PostgrestFilterableRequest.neq
       - PostgrestFilterableExpression.neq
   database.using_filters.gt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.gt
       - PostgrestRequestBuilder.greaterThan
-      - PostgrestKeyPathFilterable.gt
+      - PostgrestFilterableRequest.gt
       - PostgrestFilterableExpression.gt
   database.using_filters.gte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.gte
       - PostgrestRequestBuilder.greaterThanOrEquals
-      - PostgrestKeyPathFilterable.gte
+      - PostgrestFilterableRequest.gte
       - PostgrestFilterableExpression.gte
   database.using_filters.lt:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.lt
       - PostgrestRequestBuilder.lowerThan
-      - PostgrestKeyPathFilterable.lt
+      - PostgrestFilterableRequest.lt
       - PostgrestFilterableExpression.lt
   database.using_filters.lte:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.lte
       - PostgrestRequestBuilder.lowerThanOrEquals
-      - PostgrestKeyPathFilterable.lte
+      - PostgrestFilterableRequest.lte
       - PostgrestFilterableExpression.lte
   database.using_filters.like:
     status: implemented
@@ -732,8 +732,8 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.is
-      - PostgrestKeyPathFilterable.isNull
-      - PostgrestKeyPathFilterable.isNotNull
+      - PostgrestFilterableRequest.isNull
+      - PostgrestFilterableRequest.isNotNull
       - PostgrestFilterableExpression.isTrue
       - PostgrestFilterableExpression.isFalse
       - PostgrestNullableExpression.isNull
@@ -741,7 +741,7 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.in
-      - PostgrestKeyPathFilterable.in
+      - PostgrestFilterableRequest.in
       - PostgrestFilterableExpression.in
   database.using_filters.contains:
     status: implemented
@@ -905,10 +905,10 @@ features:
       - PostgrestTypedQuery.order
       - PostgrestOrderableExpression.asc
       - PostgrestOrderableExpression.desc
+      - PostgrestOrderableExpression.nulls
     supporting_symbols:
       - PostgrestOrdering
-      - PostgrestOrdering.nullsFirst
-      - PostgrestOrdering.nullsLast
+      - PostgrestOrdering.nulls
       - PostgrestNullPlacement
       - PostgrestNullPlacement.init
       - PostgrestNullPlacement.rawValue

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -60,6 +60,7 @@ supporting_symbols:
   - PostgrestKeyPathFilterable.Relation
   - PostgrestKeyPathFilterable.builder
   - PostgrestKeyPathFilterable.init
+  - PostgrestKeyPathFilterable.where
   - PostgrestTypedMutation
   - PostgrestTypedMutation.Phase
   - PostgrestTypedMutation.Relation
@@ -104,10 +105,10 @@ supporting_symbols:
   - PostgrestWritableRelation.Draft
 
   # The typed column-expression surface. A column expression is the left-hand side of every
-  # filter and every `select` entry at once, so none of these types belongs to a single
-  # capability. The operator methods declared over them are 1:1 with a capability and are
+  # filter, every `order` key and every `select` entry at once, so none of these types belongs to
+  # a single capability. The operator methods declared over them are 1:1 with a capability and are
   # attributed to that feature's own `symbols:` list instead (see database.using_filters.*
-  # below).
+  # below); `asc()`/`desc()` likewise, under database.using_modifiers.order.
   #
   # The position refinements are rules enforced by the type system rather than by the server: the
   # base protocol is select position, `PostgrestFilterableExpression` adds the left of a filter,
@@ -902,6 +903,17 @@ features:
     symbols:
       - PostgrestRequestBuilder.order
       - PostgrestTypedQuery.order
+      - PostgrestOrderableExpression.asc
+      - PostgrestOrderableExpression.desc
+    supporting_symbols:
+      - PostgrestOrdering
+      - PostgrestOrdering.nullsFirst
+      - PostgrestOrdering.nullsLast
+      - PostgrestNullPlacement
+      - PostgrestNullPlacement.init
+      - PostgrestNullPlacement.rawValue
+      - PostgrestNullPlacement.first
+      - PostgrestNullPlacement.last
   database.using_modifiers.limit:
     status: implemented
     symbols:


### PR DESCRIPTION
Stack 4/8 for SDK-1624. Base: `guilhermesouza/sdk-1624-columns-namespace`.

```swift
try await client.from(Todo.self)
  .select()
  .where { ($0.isDone.eq(false) && $0.priority.gt(3)) || $0.id.eq(7) }
  .order { $0.dueDate }
  .execute()
```

`where(_:)` takes a closure over the column namespace and returns a `PostgrestFilter`, so a whole boolean expression is one call instead of a chain of per-operator methods. Because the filter is a value, one that depends on runtime state is assembled in the closure body like any other value.

`order(_:)` is constrained to `PostgrestOrderableExpression` — a third position set that overlaps the filterable set without matching it. `order=cost::text.desc` (a cast) and `order=children(amount.sum()).desc` (an aggregate) are both 400s on PostgREST 16.1, so neither compiles.

The direction is optional: `order { $0.dueDate }` sends no direction and lets PostgREST apply its own default. `.asc()`/`.desc()` are for when it matters, and chain into `nullsFirst()`/`nullsLast()`.

Existing key-path call sites move over here; the old surface is deleted in 5/8.
