### PR TITLE
feat(postgrest): add aggregate functions as select-only expressions

### DIFF
--- a/Sources/PostgREST/Columns/PostgrestAggregate.swift
+++ b/Sources/PostgREST/Columns/PostgrestAggregate.swift
@@ -16,6 +16,26 @@
 ///
 /// > Important: The response is an array of objects keyed by the function name, not a scalar —
 /// > `{"total":[{"sum":150}]}` for `select=total:children(amount.sum())`. Decode accordingly.
+///
+/// ## Decoding an empty result
+///
+/// `sum`, `avg`, `min` and `max` come back `null` when no rows match, so decode them as optionals.
+/// Only `count` is exempt — it is `0`. Selecting the aggregate on its own still returns one row,
+/// because a query with no grouping column has nothing to group by:
+///
+/// ```
+/// ?select=amount.sum(),amount.count()&id=eq.99999   -> [{"sum":null,"count":0}]
+/// ?select=count()&id=eq.99999                       -> [{"count":0}]
+/// ?select=category,amount.sum()&id=eq.99999         -> []
+/// ```
+///
+/// Adding a grouping column is what removes the row entirely, so a decoder written against the
+/// grouped shape never sees the `null` and one written against the bare shape always can.
+///
+/// The `Value` type parameter is the *non-optional* result type. It types the expression, not the
+/// response — nothing in the SDK decodes through it — so it stays non-optional for the same reason
+/// a nullable column's ``PostgrestColumn`` does: an optional `Value` would strip the operators from
+/// anything chained off it.
 public struct PostgrestAggregate<Root: PostgrestRelation, Value>: PostgrestColumnExpression {
   public let postgrestExpression: String
 

--- a/Sources/PostgREST/Columns/PostgrestAggregate.swift
+++ b/Sources/PostgREST/Columns/PostgrestAggregate.swift
@@ -1,0 +1,63 @@
+//
+//  PostgrestAggregate.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+/// An aggregate function applied to an expression — **select position only**.
+///
+/// PostgREST has no `HAVING`, and rejects an aggregate in `order`, so filtering or ordering by
+/// one is a compile error. Grouping needs nothing declared: selecting a plain column alongside an
+/// aggregate groups by it.
+///
+/// > Important: Requires PostgREST's `db-aggregates-enabled` setting. It is on for hosted
+/// > Supabase and off by default when self-hosting.
+///
+/// > Important: The response is an array of objects keyed by the function name, not a scalar —
+/// > `{"total":[{"sum":150}]}` for `select=total:children(amount.sum())`. Decode accordingly.
+public struct PostgrestAggregate<Root: PostgrestRelation, Value>: PostgrestColumnExpression {
+  public let postgrestExpression: String
+
+  init(_ expression: String) {
+    self.postgrestExpression = expression
+  }
+}
+
+extension PostgrestAggregate where Value == Int {
+  /// `count()` — counts rows rather than values of a column.
+  public static var countAll: Self { Self("count()") }
+}
+
+extension PostgrestColumnExpression {
+  /// The sum of this expression across the group, typed `Double` whatever the column's type.
+  ///
+  /// > Important: The wire value is a JSON integer, so past 2^53 a `Double` rounds it silently.
+  /// > When a total can get that large, alias the aggregate in `select` and decode that field as
+  /// > `Int` or `Decimal`.
+  public func sum() -> PostgrestAggregate<Root, Double> {
+    PostgrestAggregate("\(postgrestExpression).sum()")
+  }
+
+  /// The mean of this expression across the group.
+  public func avg() -> PostgrestAggregate<Root, Double> {
+    PostgrestAggregate("\(postgrestExpression).avg()")
+  }
+
+  /// The smallest value of this expression in the group, keeping the expression's own type.
+  public func min() -> PostgrestAggregate<Root, Value> {
+    PostgrestAggregate("\(postgrestExpression).min()")
+  }
+
+  /// The largest value of this expression in the group.
+  public func max() -> PostgrestAggregate<Root, Value> {
+    PostgrestAggregate("\(postgrestExpression).max()")
+  }
+
+  /// How many non-null values of this expression are in the group.
+  ///
+  /// For a count of rows rather than of values, use ``PostgrestAggregate/countAll``.
+  public func count() -> PostgrestAggregate<Root, Int> {
+    PostgrestAggregate("\(postgrestExpression).count()")
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestAggregateTests.swift
+++ b/Tests/PostgRESTTests/PostgrestAggregateTests.swift
@@ -1,0 +1,68 @@
+//
+//  PostgrestAggregateTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestAggregateTests {
+  struct Order: PostgrestRelation {
+    static let relationName = "orders"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var amount: Double
+    var quantity: Int
+
+    struct Columns: Sendable {
+      let amount = PostgrestColumn<Order, Double>("amount")
+      let quantity = PostgrestColumn<Order, Int>("quantity")
+    }
+
+    static let columns = Columns()
+  }
+
+  @Test
+  func aggregatesRenderTheirFunctionSuffix() {
+    let amount = Order.columns.amount
+    #expect(amount.sum().postgrestExpression == "amount.sum()")
+    #expect(amount.avg().postgrestExpression == "amount.avg()")
+    #expect(amount.min().postgrestExpression == "amount.min()")
+    #expect(amount.max().postgrestExpression == "amount.max()")
+    #expect(amount.count().postgrestExpression == "amount.count()")
+  }
+
+  /// `sum` and `avg` widen to `Double` whatever the column's type; `min` and `max` keep it, and
+  /// `count` is always an `Int`.
+  @Test
+  func aggregatesCarryTheRightResultType() {
+    #expect(type(of: Order.columns.quantity.sum()).Value.self == Double.self)
+    #expect(type(of: Order.columns.quantity.avg()).Value.self == Double.self)
+    #expect(type(of: Order.columns.quantity.min()).Value.self == Int.self)
+    #expect(type(of: Order.columns.quantity.max()).Value.self == Int.self)
+    #expect(type(of: Order.columns.quantity.count()).Value.self == Int.self)
+  }
+
+  /// `count()` with no column counts rows, so it takes no argument and is a static.
+  @Test
+  func countAllRendersWithNoColumn() {
+    #expect(PostgrestAggregate<Order, Int>.countAll.postgrestExpression == "count()")
+  }
+
+  /// PostgREST has no `HAVING` and cannot order by an aggregate. Neither call must compile:
+  ///
+  ///     .where { $0.amount.sum().gt(100.0) }   // no member 'gt'
+  ///     .order { $0.amount.sum().desc() }      // no member 'desc'
+  @Test
+  func anAggregateIsSelectableAndNothingElse() {
+    let sum = Order.columns.amount.sum()
+    #expect((sum as Any) is any PostgrestFilterableExpression == false)
+    #expect((sum as Any) is any PostgrestOrderableExpression == false)
+  }
+}

--- a/Tests/PostgRESTTests/PostgrestAggregateTests.swift
+++ b/Tests/PostgRESTTests/PostgrestAggregateTests.swift
@@ -49,6 +49,17 @@ struct PostgrestAggregateTests {
     #expect(type(of: Order.columns.quantity.count()).Value.self == Int.self)
   }
 
+  /// `Value` is the non-optional result type: it types the expression, not the response. An
+  /// aggregate over zero matching rows comes back `null` on the wire (`count` excepted), and the
+  /// caller decodes that as an optional — the wrapped-type invariant here matches
+  /// ``PostgrestColumn``'s, where an optional `Value` strips the operators from anything chained
+  /// off it.
+  @Test
+  func theResultTypeStaysNonOptional() {
+    #expect(type(of: Order.columns.amount.sum()).Value.self != Double?.self)
+    #expect(type(of: Order.columns.amount.min()).Value.self != Double?.self)
+  }
+
   /// `count()` with no column counts rows, so it takes no argument and is a static.
   @Test
   func countAllRendersWithNoColumn() {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -141,9 +141,9 @@ supporting_symbols:
   - PostgrestFilter
   - "&&"
 
-  # Casts and JSON paths. These are absent from `capabilities/database.yaml` in every SDK — there
-  # is no `database.*` id to attribute them to yet — so they are registered here, which accounts
-  # for them without claiming a capability.
+  # Casts, JSON paths and aggregates. These are absent from `capabilities/database.yaml` in every
+  # SDK — there is no `database.*` id to attribute them to yet — so they are registered here,
+  # which accounts for them without claiming a capability.
   - PostgrestCastColumn
   - PostgrestCastColumn.postgrestExpression
   - PostgrestCastTarget
@@ -158,6 +158,14 @@ supporting_symbols:
   - PostgrestJSONPath.postgrestExpression
   - PostgrestColumnExpression.jsonText
   - PostgrestColumnExpression.jsonObject
+  - PostgrestAggregate
+  - PostgrestAggregate.postgrestExpression
+  - PostgrestAggregate.countAll
+  - PostgrestColumnExpression.sum
+  - PostgrestColumnExpression.avg
+  - PostgrestColumnExpression.min
+  - PostgrestColumnExpression.max
+  - PostgrestColumnExpression.count
 
   # The `PostgrestMacros` attributes. `@Table` synthesizes the relation
   # conformance used by every database.* typed entry point, and the three


### PR DESCRIPTION
Stack 7/8 for SDK-1624. Base: `guilhermesouza/sdk-1624-casts-json-paths`.

`sum()`, `avg()`, `min()`, `max()`, `count()` and `PostgrestAggregate.countAll` render `amount.sum()` and `count()` in a `select` list.

`PostgrestAggregate` conforms to `PostgrestColumnExpression` and to neither refinement, because PostgREST has no `HAVING`: filtering on an aggregate is not a request it can serve, and `order=children(amount.sum()).desc` is a PGRST100 "failed to parse order" — aliasing it in `select` first, dotting the path and dropping the parentheses all fail too. So `$0.amount.sum().gt(100)` does not compile.

`min()`/`max()` keep the column's type while `sum()`/`avg()` do not: a min of an `Int` column is an `Int`, but a sum can overflow it and an average is rarely integral.

Aggregates need `db-aggregates-enabled`, which is on for hosted Supabase and off by default in self-hosted PostgREST.
