### PR TITLE
chore: ignore root-level compiler intermediates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,24 @@ playground.xcworkspace
 
 .build/
 
+# Per-file compiler intermediates leaked into the working directory.
+#
+# These belong in .build/ (SwiftPM) or DerivedData (Xcode), and both are configured correctly —
+# nothing here overrides the build location. SwiftPM bug #7930 writes them relative to the build
+# process's working directory instead, for a target whose sources come from a build-tool plugin's
+# output directory. swift-secp256k1's `P256K` is such a target: its 63 shared sources are copied
+# in by SharedSourcesPlugin, and its own plugin header documents the leak. One observed run left
+# 252 files (63 basenames x 4 extensions) in the repository root, where a `git add -A` committed
+# them.
+#
+# Root-anchored on purpose. A bare `*.o` would silently hide a file anywhere in the tree; these
+# only ever appear beside Package.swift.
+/*.o
+/*.d
+/*.dia
+/*.swiftdeps
+/*.swiftmodule
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However


### PR DESCRIPTION
A build once left 252 files in the repository root — `ASN1.o`, `ASN1.dia`, `MuSig+Nonces.swiftdeps` and the like, 63 basenames × 4 extensions. The 63 match the shared sources of `swift-secp256k1`'s `P256K` target one for one. Nothing ignored them, so a `git add -A` committed them and the commit had to be rewritten.

**Cause is upstream, not a misconfiguration here.** These belong in `.build/` or DerivedData, and both are configured correctly: there is no `WorkspaceSettings.xcsettings` overriding the build location, and Xcode's `IDEBuildLocationStyle` / `IDECustomBuildLocationType` defaults are unset. `P256K` takes its sources from a build-tool plugin's output directory, and SwiftPM bug #7930 then writes the per-file intermediates relative to the build process's working directory. `SharedSourcesPlugin`'s own header documents the leak and suggests a cleanup `find`.

**Root-anchored, not bare globs.** `*.o` would hide a file anywhere in the tree; these only ever appear beside `Package.swift`. `git ls-files | grep -E '\.(o|d|dia|swiftdeps|swiftmodule)$'` is empty, so nothing tracked is masked.

Verified both directions:

| Path | Result |
| --- | --- |
| `ASN1.o`, `ASN1.d`, `ASN1.dia`, `ASN1.swiftdeps`, `MuSig+Nonces.swiftdeps`, `Foo.swiftmodule` | ignored, each attributed to its rule by `git check-ignore -v` |
| `Sources/Probe/Nested.{o,d,dia,swiftdeps}` | **not** ignored (exit 1); `git status` still reports the directory |

**No cleanup trap added to `scripts/test-docs.sh` or `scripts/xcodebuild.sh`**, deliberately. Neither compiles `P256K` — a `-dry-run` plan for `-scheme Supabase` contains no `P256K`, `libsecp256k1` or `SharedSourcesPlugin` entry — so a trap there would look like a fix while never firing on the real cause. And the upstream command deletes on globs as generic as `*.d` at the repo root; a docs script silently removing untracked files it never created is a bad trade once these are ignored.

**The exact trigger is still not reproducible on demand**, which is the one loose end here. Everything tried, none of which leaked a single file:

| Attempt | Result |
| --- | --- |
| `swift build --build-tests`, recompiling all 63 `P256K` sources | no leak |
| wiping the plugin output directory to re-run its `prebuildCommand` | no leak |
| `swift package dump-symbol-graph` | no leak |
| `./scripts/test-docs.sh` in isolation | no leak |
| `swift build` with `.build/…/debug/P256K.build` deleted (cold `P256K`) | no leak |
| `dump-symbol-graph` with the `index-build` and `swift-dce-index` `P256K.build` dirs deleted | no leak |

So the ignore rules are the fix that holds regardless: the leak is real and has recurred several times during unrelated work, but nothing identifies a command to hang a targeted cleanup off. That is also the second reason not to add a trap to a specific script — there is no evidence any particular script is the one that leaks.

