### PR TITLE
refactor(postgrest): collapse the embedded-column accessor shadows

### DIFF
--- a/Sources/PostgREST/Columns/PostgrestAggregate.swift
+++ b/Sources/PostgREST/Columns/PostgrestAggregate.swift
@@ -5,11 +5,17 @@
 //  Created by Guilherme Souza on 26/08/26.
 //
 
-/// An aggregate function applied to an expression — **select position only**.
+extension PostgrestDerivedExpression where Value == Int, Position == PostgrestSelectOnly {
+  /// `count()` — counts rows rather than values of a column.
+  public static var countAll: Self { Self(embed: nil, inner: "count()") }
+}
+
+/// The five aggregate functions, each declared once and correct for a stored column, a JSON path
+/// and either embed direction alike.
 ///
-/// PostgREST has no `HAVING`, and rejects an aggregate in `order`, so filtering or ordering by
-/// one is a compile error. Grouping needs nothing declared: selecting a plain column alongside an
-/// aggregate groups by it.
+/// The result is **select position only**: PostgREST has no `HAVING`, and rejects an aggregate in
+/// `order`, so filtering or ordering by one is a compile error. Grouping needs nothing declared —
+/// selecting a plain column alongside an aggregate groups by it.
 ///
 /// > Important: Requires PostgREST's `db-aggregates-enabled` setting. It is on for hosted
 /// > Supabase and off by default when self-hosting.
@@ -32,52 +38,37 @@
 /// Adding a grouping column is what removes the row entirely, so a decoder written against the
 /// grouped shape never sees the `null` and one written against the bare shape always can.
 ///
-/// The `Value` type parameter is the *non-optional* result type. It types the expression, not the
-/// response — nothing in the SDK decodes through it — so it stays non-optional for the same reason
-/// a nullable column's ``PostgrestColumn`` does: an optional `Value` would strip the operators from
-/// anything chained off it.
-public struct PostgrestAggregate<Root: PostgrestRelation, Value>: PostgrestColumnExpression {
-  public let postgrestExpression: String
-
-  init(_ expression: String) {
-    self.postgrestExpression = expression
-  }
-}
-
-extension PostgrestAggregate where Value == Int {
-  /// `count()` — counts rows rather than values of a column.
-  public static var countAll: Self { Self("count()") }
-}
-
+/// The result's `Value` is the *non-optional* type. It types the expression, not the response —
+/// nothing in the SDK decodes through it — so it stays non-optional for the same reason a nullable
+/// column's ``PostgrestColumn`` does: an optional `Value` would strip the operators from anything
+/// chained off it.
 extension PostgrestColumnExpression {
   /// The sum of this expression across the group, typed `Double` whatever the column's type.
   ///
   /// > Important: The wire value is a JSON integer, so past 2^53 a `Double` rounds it silently.
   /// > When a total can get that large, alias the aggregate in `select` and decode that field as
   /// > `Int` or `Decimal`.
-  public func sum() -> PostgrestAggregate<Root, Double> {
-    PostgrestAggregate("\(postgrestExpression).sum()")
+  public func sum() -> PostgrestDerivedExpression<Root, Double, PostgrestSelectOnly> {
+    _deriving(".sum()")
   }
 
   /// The mean of this expression across the group.
-  public func avg() -> PostgrestAggregate<Root, Double> {
-    PostgrestAggregate("\(postgrestExpression).avg()")
+  public func avg() -> PostgrestDerivedExpression<Root, Double, PostgrestSelectOnly> {
+    _deriving(".avg()")
   }
 
   /// The smallest value of this expression in the group, keeping the expression's own type.
-  public func min() -> PostgrestAggregate<Root, Value> {
-    PostgrestAggregate("\(postgrestExpression).min()")
+  public func min() -> PostgrestDerivedExpression<Root, Value, PostgrestSelectOnly> {
+    _deriving(".min()")
   }
 
   /// The largest value of this expression in the group.
-  public func max() -> PostgrestAggregate<Root, Value> {
-    PostgrestAggregate("\(postgrestExpression).max()")
+  public func max() -> PostgrestDerivedExpression<Root, Value, PostgrestSelectOnly> {
+    _deriving(".max()")
   }
 
   /// How many non-null values of this expression are in the group.
-  ///
-  /// For a count of rows rather than of values, use ``PostgrestAggregate/countAll``.
-  public func count() -> PostgrestAggregate<Root, Int> {
-    PostgrestAggregate("\(postgrestExpression).count()")
+  public func count() -> PostgrestDerivedExpression<Root, Int, PostgrestSelectOnly> {
+    _deriving(".count()")
   }
 }

--- a/Sources/PostgREST/Columns/PostgrestColumnExpression.swift
+++ b/Sources/PostgREST/Columns/PostgrestColumnExpression.swift
@@ -5,6 +5,29 @@
 //  Created by Guilherme Souza on 26/08/26.
 //
 
+// MARK: - Positions
+
+/// Where an expression is allowed to appear. Carried as a phantom type so a derived expression
+/// inherits its receiver's positions instead of restating them.
+public protocol PostgrestPosition: Sendable {}
+
+/// A position set that includes `order`.
+public protocol PostgrestOrderablePosition: PostgrestPosition {}
+
+/// A position set that includes the left of a filter operator.
+public protocol PostgrestFilterablePosition: PostgrestPosition {}
+
+/// `select` only — a cast, an aggregate, or any projection of a to-many embed.
+public enum PostgrestSelectOnly: PostgrestPosition {}
+
+/// `select` and `order`, but not a filter — a to-one embedded projection.
+public enum PostgrestSelectAndOrder: PostgrestOrderablePosition {}
+
+/// Every position — a stored column, or a JSON path on one.
+public enum PostgrestEveryPosition: PostgrestOrderablePosition, PostgrestFilterablePosition {}
+
+// MARK: - Expressions
+
 /// Anything that can appear in a `select` list: a stored column, a cast, a JSON path, an
 /// aggregate, or a column projected through an embedded relation.
 ///
@@ -18,8 +41,31 @@ public protocol PostgrestColumnExpression<Root, Value>: Sendable {
   /// `.eq("seven")` on an `Int` column does not compile.
   associatedtype Value
 
+  /// Where this expression may appear. A derivation of it inherits this, so a JSON path on a
+  /// to-many embed is select-only without that rule being written per embed kind.
+  associatedtype Position: PostgrestPosition
+
   /// The text PostgREST expects, in a `select` list or on the left of an operator.
   var postgrestExpression: String { get }
+
+  /// Applies `derivation` where PostgREST expects it, which is not always at the end: an
+  /// embedded projection renders `parent(title)`, and a cast or aggregate has to land inside
+  /// those parentheses or the server drops it.
+  ///
+  /// This is the single hook each expression kind implements. Every accessor — `cast(to:)`,
+  /// `jsonText(_:)`, `sum()` and the rest — is declared once against it.
+  func _deriving<V, P: PostgrestPosition>(
+    _ derivation: String
+  ) -> PostgrestDerivedExpression<Root, V, P>
+}
+
+extension PostgrestColumnExpression {
+  /// Appends, which is correct for everything that is not an embedded projection.
+  public func _deriving<V, P: PostgrestPosition>(
+    _ derivation: String
+  ) -> PostgrestDerivedExpression<Root, V, P> {
+    PostgrestDerivedExpression(embed: nil, inner: postgrestExpression + derivation)
+  }
 }
 
 /// A column expression that can also sit on the left of a filter operator.
@@ -80,6 +126,8 @@ public struct PostgrestStoredColumn<
   Value,
   Nullability: PostgrestNullability
 >: PostgrestFilterableExpression, PostgrestOrderableExpression {
+  public typealias Position = PostgrestEveryPosition
+
   public let postgrestExpression: String
 
   /// - Parameter name: The database column name.

--- a/Sources/PostgREST/Columns/PostgrestDerivedColumn.swift
+++ b/Sources/PostgREST/Columns/PostgrestDerivedColumn.swift
@@ -5,42 +5,6 @@
 //  Created by Guilherme Souza on 26/08/26.
 //
 
-/// A column with a cast applied — **select position only**.
-///
-/// PostgREST accepts `cost::text=eq.10` and then drops the cast, so a filter on a cast silently
-/// compares the uncast column; ordering by one is a 400. Only `select=cost::text` behaves as
-/// written, so this conforms to ``PostgrestColumnExpression`` and neither refinement.
-///
-/// To *filter* on a cast, expose it from the database as a generated column or a view; it is then
-/// an ordinary column, usable in every position.
-public struct PostgrestCastColumn<
-  Root: PostgrestRelation,
-  Value
->: PostgrestColumnExpression {
-  public let postgrestExpression: String
-
-  init(_ expression: String) {
-    self.postgrestExpression = expression
-  }
-}
-
-/// A JSON path into a `json`/`jsonb` column. Unlike a cast, usable in select, filter and order
-/// position alike.
-///
-/// > Important: The arrow decides the comparison semantics. `->>` yields `text`, so
-/// > `data->>n=gt.2` compares as text and excludes `10`; `->` yields `jsonb`, which compares
-/// > numerically and includes it.
-public struct PostgrestJSONPath<
-  Root: PostgrestRelation,
-  Value
->: PostgrestFilterableExpression, PostgrestOrderableExpression {
-  public let postgrestExpression: String
-
-  init(_ expression: String) {
-    self.postgrestExpression = expression
-  }
-}
-
 /// A Postgres type to cast to, paired with the Swift type that cast produces so the two cannot
 /// disagree.
 ///
@@ -83,18 +47,21 @@ extension PostgrestColumnExpression {
   /// Casts this expression to another Postgres type.
   ///
   /// ```swift
-  /// Item.columns.cost.cast(to: .text).postgrestExpression   // "cost::text", valid in a select list
+  /// Item.columns.cost.cast(to: .text).postgrestExpression   // "cost::text"
   /// ```
   ///
-  /// > Important: The result is **select position only** — it cannot be filtered or ordered by.
+  /// PostgREST accepts `cost::text=eq.10` and then drops the cast, so a filter on a cast silently
+  /// compares the uncast column; ordering by one is a 400. The result is therefore **select
+  /// position only**, whatever it was applied to.
   ///
   /// > Note: Make a cast the **last** step in a chain. PostgREST applies only the first cast in
   /// > `cost::text::int`, and rejects a JSON path applied to a cast (`cost::text->>k`).
   ///
   /// - Parameter target: The Postgres type to cast to.
-  /// - Returns: A select-only cast column rendering `expression::sqlType`.
-  public func cast<T>(to target: PostgrestCastTarget<T>) -> PostgrestCastColumn<Root, T> {
-    PostgrestCastColumn("\(postgrestExpression)::\(target.sqlType)")
+  public func cast<T>(
+    to target: PostgrestCastTarget<T>
+  ) -> PostgrestDerivedExpression<Root, T, PostgrestSelectOnly> {
+    _deriving("::\(target.sqlType)")
   }
 
   /// Reads a `json`/`jsonb` path as text, with `->>`.
@@ -106,10 +73,12 @@ extension PostgrestColumnExpression {
   /// Comparison is textual, so `data->>n=gt.2` excludes a row where `n` is `10`. Use
   /// ``jsonObject(_:)`` for numeric comparison.
   ///
+  /// Keeps the receiver's positions: a JSON path on a stored column filters and orders, one on a
+  /// to-many embed does neither.
+  ///
   /// - Parameter path: The key or index to read.
-  /// - Returns: A JSON path typed `String`, because `->>` always yields text.
-  public func jsonText(_ path: String) -> PostgrestJSONPath<Root, String> {
-    PostgrestJSONPath("\(postgrestExpression)->>\(path)")
+  public func jsonText(_ path: String) -> PostgrestDerivedExpression<Root, String, Position> {
+    _deriving("->>\(path)")
   }
 
   /// Reads a `json`/`jsonb` path as JSON, with `->`.
@@ -121,8 +90,7 @@ extension PostgrestColumnExpression {
   /// > chain ``jsonText(_:)`` or ``cast(to:)`` to reach a scalar.
   ///
   /// - Parameter path: The key or index to read.
-  /// - Returns: A JSON path rendering `expression->path`.
-  public func jsonObject(_ path: String) -> PostgrestJSONPath<Root, Value> {
-    PostgrestJSONPath("\(postgrestExpression)->\(path)")
+  public func jsonObject(_ path: String) -> PostgrestDerivedExpression<Root, Value, Position> {
+    _deriving("->\(path)")
   }
 }

--- a/Sources/PostgREST/Columns/PostgrestDerivedExpression.swift
+++ b/Sources/PostgREST/Columns/PostgrestDerivedExpression.swift
@@ -1,0 +1,55 @@
+//
+//  PostgrestDerivedExpression.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 27/08/26.
+//
+
+/// A cast, JSON path or aggregate applied to another expression.
+///
+/// One type for all of them, replacing `PostgrestCastColumn`, `PostgrestJSONPath`,
+/// `PostgrestAggregate` and `PostgrestToOneDerivedColumn`. It keeps the embed name and the inner
+/// expression apart, so a further derivation lands inside the embed's parentheses:
+/// `Order.columns.todo.amount.sum().cast(to: .text)` renders `todo(amount.sum()::text)`, with the
+/// cast applied — the flattened form returns the value uncast.
+///
+/// `Position` is inherited from whatever the derivation was applied to, so a JSON path on a
+/// to-many embed is select-only without that rule being restated per embed kind.
+public struct PostgrestDerivedExpression<
+  Root: PostgrestRelation,
+  Value,
+  Position: PostgrestPosition
+>: PostgrestColumnExpression {
+  let embed: String?
+  let inner: String
+
+  init(embed: String?, inner: String) {
+    self.embed = embed
+    self.inner = inner
+  }
+
+  public var postgrestExpression: String {
+    embed.map { "\($0)(\(inner))" } ?? inner
+  }
+
+  /// Keeps the embed, so a chained derivation stays inside the parentheses.
+  public func _deriving<V, P: PostgrestPosition>(
+    _ derivation: String
+  ) -> PostgrestDerivedExpression<Root, V, P> {
+    PostgrestDerivedExpression<Root, V, P>(embed: embed, inner: inner + derivation)
+  }
+}
+
+extension PostgrestDerivedExpression: PostgrestFilterableExpression
+where Position: PostgrestFilterablePosition {}
+
+extension PostgrestDerivedExpression: PostgrestOrderableExpression
+where Position: PostgrestOrderablePosition {}
+
+/// A cast is select position only, whatever it was applied to.
+public typealias PostgrestCastColumn<Root: PostgrestRelation, Value> =
+  PostgrestDerivedExpression<Root, Value, PostgrestSelectOnly>
+
+/// An aggregate is select position only, whatever it was applied to.
+public typealias PostgrestAggregate<Root: PostgrestRelation, Value> =
+  PostgrestDerivedExpression<Root, Value, PostgrestSelectOnly>

--- a/Sources/PostgREST/Columns/PostgrestRelatedColumns.swift
+++ b/Sources/PostgREST/Columns/PostgrestRelatedColumns.swift
@@ -1,0 +1,326 @@
+//
+//  PostgrestRelatedColumns.swift
+//  PostgREST
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+// MARK: - Relations
+
+/// A to-**one** embedded relation (many-to-one or one-to-one), reached from its parent's column
+/// namespace.
+///
+/// Projecting a column through it gives one checked chain:
+///
+/// ```swift
+/// Order.columns.todo.title   // todo(title)
+/// ```
+///
+/// The relationship is declared once, here on the namespace, by the generator that has the
+/// foreign key from `postgres-meta`. `@Table` cannot emit one: a macro sees syntax only.
+///
+/// Projections of a to-one embed are orderable, unlike ``PostgrestToManyRelation``'s.
+@dynamicMemberLookup
+public struct PostgrestToOneRelation<
+  Root: PostgrestRelation,
+  Target: PostgrestRelation
+>: Sendable {
+  /// The name PostgREST addresses the embed by, including any disambiguating foreign-key hint.
+  ///
+  /// Prefixed because every public member of this type shadows a projected column of the same
+  /// name: `@dynamicMemberLookup` only fires when no real member matches, so a plain `name` here
+  /// would make `orders.name` return this string instead of the embedded `name` column.
+  public let postgrestEmbedName: String
+
+  /// - Parameter name: The embed name.
+  public init(_ name: String) {
+    self.postgrestEmbedName = name
+  }
+
+  /// Projects a column of the embedded relation into the parent's frame.
+  ///
+  /// The result is rooted on `Root`, so it belongs in the parent's `select` list, while its
+  /// `Value` still comes from `Target`.
+  public subscript<C: PostgrestColumnExpression>(
+    dynamicMember keyPath: KeyPath<Target.Columns, C>
+  ) -> PostgrestToOneColumn<Root, Target, C.Value> where C.Root == Target {
+    PostgrestToOneColumn(
+      embed: postgrestEmbedName,
+      inner: Target.columns[keyPath: keyPath].postgrestExpression
+    )
+  }
+}
+
+/// A to-**many** embedded relation (one-to-many or many-to-many), reached from its parent's
+/// column namespace. Declared once by the generator, as ``PostgrestToOneRelation`` is.
+///
+/// Its projections are select position only: PostgREST answers `order=children(amount).desc` with
+/// `PGRST118` ("do not form a many-to-one or one-to-one relationship").
+@dynamicMemberLookup
+public struct PostgrestToManyRelation<
+  Root: PostgrestRelation,
+  Target: PostgrestRelation
+>: Sendable {
+  /// The name PostgREST addresses the embed by, including any disambiguating foreign-key hint.
+  ///
+  /// Prefixed for the same reason as ``PostgrestToOneRelation/postgrestEmbedName``.
+  public let postgrestEmbedName: String
+
+  /// - Parameter name: The embed name.
+  public init(_ name: String) {
+    self.postgrestEmbedName = name
+  }
+
+  /// Projects a column of the embedded relation into the parent's frame.
+  public subscript<C: PostgrestColumnExpression>(
+    dynamicMember keyPath: KeyPath<Target.Columns, C>
+  ) -> PostgrestToManyColumn<Root, Target, C.Value> where C.Root == Target {
+    PostgrestToManyColumn(
+      embed: postgrestEmbedName,
+      inner: Target.columns[keyPath: keyPath].postgrestExpression
+    )
+  }
+}
+
+// MARK: - Columns
+
+/// A column of a to-**one** embedded relation, seen from the parent.
+///
+/// Selectable and orderable, not filterable: an embedded column renders `parent(title)` in a
+/// `select` list but `parent.title` on the left of a filter, and the filter form also needs an
+/// `!inner` decision. Filtering inside an embed is scoped separately (SDK-1575), and reads
+/// ``embeddedFilterName``.
+public struct PostgrestToOneColumn<
+  Root: PostgrestRelation,
+  Target: PostgrestRelation,
+  Value
+>: PostgrestColumnExpression, PostgrestOrderableExpression {
+  let embed: String
+  let inner: String
+
+  /// The `select`-list form, `parent(title)`. Also the form `order` accepts for a to-one embed.
+  public var postgrestExpression: String { "\(embed)(\(inner))" }
+
+  /// The filter form, `parent.title`.
+  public var embeddedFilterName: String { "\(embed).\(inner)" }
+
+  init(embed: String, inner: String) {
+    self.embed = embed
+    self.inner = inner
+  }
+}
+
+/// A column of a to-**many** embedded relation, seen from the parent.
+///
+/// Select position only — `order=children(amount).desc` is `PGRST118` — and an embedded filter is
+/// scoped rather than written inline (SDK-1575).
+public struct PostgrestToManyColumn<
+  Root: PostgrestRelation,
+  Target: PostgrestRelation,
+  Value
+>: PostgrestColumnExpression {
+  let embed: String
+  let inner: String
+
+  /// The `select`-list form, `children(amount)`.
+  public var postgrestExpression: String { "\(embed)(\(inner))" }
+
+  /// The filter form, `children.amount`.
+  public var embeddedFilterName: String { "\(embed).\(inner)" }
+
+  init(embed: String, inner: String) {
+    self.embed = embed
+    self.inner = inner
+  }
+}
+
+/// A cast, JSON path or aggregate applied to a to-**one** embedded column — **select position
+/// only**.
+///
+/// A to-one projection is orderable but a cast or an aggregate of one is not, so those methods
+/// return this type instead of `Self`. It keeps `embed` and `inner` apart, so anything chained
+/// onward also lands inside the embed's parentheses:
+/// `Order.columns.todo.amount.sum().cast(to: .text)` renders `todo(amount.sum()::text)`, with the
+/// cast applied — the flattened form `todo(amount.sum())::text` returns the value uncast.
+///
+/// > Note: Landing inside the parentheses makes an invalid chain loud rather than silent.
+/// > PostgREST accepts only `::` after an aggregate, so a second aggregate or a JSON path is a
+/// > 400. The to-many side behaves the same way.
+///
+/// > Important: When the operation is an aggregate, everything ``PostgrestAggregate`` documents
+/// > still applies — the `db-aggregates-enabled` requirement, and the response being an array of
+/// > objects keyed by the function name.
+public struct PostgrestToOneDerivedColumn<
+  Root: PostgrestRelation,
+  Target: PostgrestRelation,
+  Value
+>: PostgrestColumnExpression {
+  let embed: String
+  let inner: String
+
+  /// The `select`-list form, `parent(title::text)`. There is no `order` or filter form.
+  public var postgrestExpression: String { "\(embed)(\(inner))" }
+
+  init(embed: String, inner: String) {
+    self.embed = embed
+    self.inner = inner
+  }
+}
+
+// Every embedded column type shadows the eight accessors it would otherwise inherit from
+// `PostgrestColumnExpression`. The inherited versions render *outside* the embed's parentheses —
+// `parent(title)::text` rather than `parent(title::text)` — and PostgREST does not reject that:
+// it answers 200 and silently drops whatever sits outside. The shadows put the operation inside.
+
+// MARK: - Shadowed accessors (to-one derived)
+
+extension PostgrestToOneDerivedColumn {
+  /// Casts this derived projection to another Postgres type.
+  ///
+  /// > Note: Make a cast the last step. PostgREST applies only the first cast in
+  /// > `parent(id::text::int)`, returning a JSON string while the Swift type says `Int`.
+  ///
+  /// - Returns: A derived projection rendering `embed(inner::sqlType)`.
+  public func cast<T>(
+    to target: PostgrestCastTarget<T>
+  ) -> PostgrestToOneDerivedColumn<Root, Target, T> {
+    PostgrestToOneDerivedColumn<Root, Target, T>(
+      embed: embed, inner: "\(inner)::\(target.sqlType)")
+  }
+
+  /// Reads a `json`/`jsonb` path on this derived projection as text, with `->>`.
+  public func jsonText(_ path: String) -> PostgrestToOneDerivedColumn<Root, Target, String> {
+    PostgrestToOneDerivedColumn<Root, Target, String>(embed: embed, inner: "\(inner)->>\(path)")
+  }
+
+  /// Reads a `json`/`jsonb` path on this derived projection as JSON, with `->`.
+  public func jsonObject(_ path: String) -> PostgrestToOneDerivedColumn<Root, Target, Value> {
+    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner)->\(path)")
+  }
+
+  /// The sum of this derived projection.
+  public func sum() -> PostgrestToOneDerivedColumn<Root, Target, Double> {
+    PostgrestToOneDerivedColumn<Root, Target, Double>(embed: embed, inner: "\(inner).sum()")
+  }
+
+  /// The mean of this derived projection.
+  public func avg() -> PostgrestToOneDerivedColumn<Root, Target, Double> {
+    PostgrestToOneDerivedColumn<Root, Target, Double>(embed: embed, inner: "\(inner).avg()")
+  }
+
+  /// The smallest value of this derived projection.
+  public func min() -> PostgrestToOneDerivedColumn<Root, Target, Value> {
+    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner).min()")
+  }
+
+  /// The largest value of this derived projection.
+  public func max() -> PostgrestToOneDerivedColumn<Root, Target, Value> {
+    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner).max()")
+  }
+
+  /// How many non-null values of this derived projection there are.
+  public func count() -> PostgrestToOneDerivedColumn<Root, Target, Int> {
+    PostgrestToOneDerivedColumn<Root, Target, Int>(embed: embed, inner: "\(inner).count()")
+  }
+}
+
+// MARK: - Shadowed accessors (to-one)
+
+extension PostgrestToOneColumn {
+  /// Casts this projection to another Postgres type.
+  ///
+  /// Returns ``PostgrestToOneDerivedColumn``, not `Self`: a to-one projection is orderable and a
+  /// cast of one is not.
+  ///
+  /// - Returns: A select-only derived projection rendering `embed(inner::sqlType)`.
+  public func cast<T>(
+    to target: PostgrestCastTarget<T>
+  ) -> PostgrestToOneDerivedColumn<Root, Target, T> {
+    PostgrestToOneDerivedColumn<Root, Target, T>(
+      embed: embed, inner: "\(inner)::\(target.sqlType)")
+  }
+
+  /// Reads a `json`/`jsonb` path on this projection as text, with `->>`.
+  ///
+  /// Keeps this type, unlike ``cast(to:)``: an arrow path inside an embed is still orderable.
+  public func jsonText(_ path: String) -> PostgrestToOneColumn<Root, Target, String> {
+    PostgrestToOneColumn<Root, Target, String>(embed: embed, inner: "\(inner)->>\(path)")
+  }
+
+  /// Reads a `json`/`jsonb` path on this projection as JSON, with `->`.
+  public func jsonObject(_ path: String) -> PostgrestToOneColumn<Root, Target, Value> {
+    PostgrestToOneColumn(embed: embed, inner: "\(inner)->\(path)")
+  }
+
+  /// The sum of this projection, over the single related row.
+  ///
+  /// Returns ``PostgrestToOneDerivedColumn``, not `Self`: a to-one projection is orderable and an
+  /// aggregate of one is not.
+  public func sum() -> PostgrestToOneDerivedColumn<Root, Target, Double> {
+    PostgrestToOneDerivedColumn<Root, Target, Double>(embed: embed, inner: "\(inner).sum()")
+  }
+
+  /// The mean of this projection, over the single related row.
+  public func avg() -> PostgrestToOneDerivedColumn<Root, Target, Double> {
+    PostgrestToOneDerivedColumn<Root, Target, Double>(embed: embed, inner: "\(inner).avg()")
+  }
+
+  /// The smallest value of this projection, over the single related row.
+  public func min() -> PostgrestToOneDerivedColumn<Root, Target, Value> {
+    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner).min()")
+  }
+
+  /// The largest value of this projection, over the single related row.
+  public func max() -> PostgrestToOneDerivedColumn<Root, Target, Value> {
+    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner).max()")
+  }
+
+  /// How many non-null values of this projection are in the single related row.
+  public func count() -> PostgrestToOneDerivedColumn<Root, Target, Int> {
+    PostgrestToOneDerivedColumn<Root, Target, Int>(embed: embed, inner: "\(inner).count()")
+  }
+}
+
+// MARK: - Shadowed accessors (to-many)
+
+extension PostgrestToManyColumn {
+  /// Casts this projection to another Postgres type, rendering `children(amount::text)`.
+  public func cast<T>(to target: PostgrestCastTarget<T>) -> PostgrestToManyColumn<Root, Target, T> {
+    PostgrestToManyColumn<Root, Target, T>(embed: embed, inner: "\(inner)::\(target.sqlType)")
+  }
+
+  /// Reads a `json`/`jsonb` path on this projection as text, with `->>`.
+  public func jsonText(_ path: String) -> PostgrestToManyColumn<Root, Target, String> {
+    PostgrestToManyColumn<Root, Target, String>(embed: embed, inner: "\(inner)->>\(path)")
+  }
+
+  /// Reads a `json`/`jsonb` path on this projection as JSON, with `->`.
+  public func jsonObject(_ path: String) -> PostgrestToManyColumn<Root, Target, Value> {
+    PostgrestToManyColumn(embed: embed, inner: "\(inner)->\(path)")
+  }
+
+  /// The sum of this embedded column across the group, rendering `orders(amount.sum())`.
+  public func sum() -> PostgrestToManyColumn<Root, Target, Double> {
+    PostgrestToManyColumn<Root, Target, Double>(embed: embed, inner: "\(inner).sum()")
+  }
+
+  /// The mean of this embedded column across the group.
+  public func avg() -> PostgrestToManyColumn<Root, Target, Double> {
+    PostgrestToManyColumn<Root, Target, Double>(embed: embed, inner: "\(inner).avg()")
+  }
+
+  /// The smallest value of this embedded column in the group.
+  public func min() -> PostgrestToManyColumn<Root, Target, Value> {
+    PostgrestToManyColumn(embed: embed, inner: "\(inner).min()")
+  }
+
+  /// The largest value of this embedded column in the group.
+  public func max() -> PostgrestToManyColumn<Root, Target, Value> {
+    PostgrestToManyColumn(embed: embed, inner: "\(inner).max()")
+  }
+
+  /// How many non-null values of this embedded column are in the group.
+  public func count() -> PostgrestToManyColumn<Root, Target, Int> {
+    PostgrestToManyColumn<Root, Target, Int>(embed: embed, inner: "\(inner).count()")
+  }
+}

--- a/Sources/PostgREST/Columns/PostgrestRelatedColumns.swift
+++ b/Sources/PostgREST/Columns/PostgrestRelatedColumns.swift
@@ -83,6 +83,11 @@ public struct PostgrestToManyRelation<
 }
 
 // MARK: - Columns
+//
+// Each embedded column implements `_deriving(_:)` to place a derivation inside its parentheses,
+// and declares its `Position`. Those two lines are all either kind contributes: `cast(to:)`,
+// `jsonText(_:)`, `jsonObject(_:)` and the five aggregates are declared once on
+// `PostgrestColumnExpression` and are correct here for free.
 
 /// A column of a to-**one** embedded relation, seen from the parent.
 ///
@@ -95,6 +100,8 @@ public struct PostgrestToOneColumn<
   Target: PostgrestRelation,
   Value
 >: PostgrestColumnExpression, PostgrestOrderableExpression {
+  public typealias Position = PostgrestSelectAndOrder
+
   let embed: String
   let inner: String
 
@@ -108,6 +115,12 @@ public struct PostgrestToOneColumn<
     self.embed = embed
     self.inner = inner
   }
+
+  public func _deriving<V, P: PostgrestPosition>(
+    _ derivation: String
+  ) -> PostgrestDerivedExpression<Root, V, P> {
+    PostgrestDerivedExpression<Root, V, P>(embed: embed, inner: inner + derivation)
+  }
 }
 
 /// A column of a to-**many** embedded relation, seen from the parent.
@@ -119,6 +132,8 @@ public struct PostgrestToManyColumn<
   Target: PostgrestRelation,
   Value
 >: PostgrestColumnExpression {
+  public typealias Position = PostgrestSelectOnly
+
   let embed: String
   let inner: String
 
@@ -132,195 +147,10 @@ public struct PostgrestToManyColumn<
     self.embed = embed
     self.inner = inner
   }
-}
 
-/// A cast, JSON path or aggregate applied to a to-**one** embedded column — **select position
-/// only**.
-///
-/// A to-one projection is orderable but a cast or an aggregate of one is not, so those methods
-/// return this type instead of `Self`. It keeps `embed` and `inner` apart, so anything chained
-/// onward also lands inside the embed's parentheses:
-/// `Order.columns.todo.amount.sum().cast(to: .text)` renders `todo(amount.sum()::text)`, with the
-/// cast applied — the flattened form `todo(amount.sum())::text` returns the value uncast.
-///
-/// > Note: Landing inside the parentheses makes an invalid chain loud rather than silent.
-/// > PostgREST accepts only `::` after an aggregate, so a second aggregate or a JSON path is a
-/// > 400. The to-many side behaves the same way.
-///
-/// > Important: When the operation is an aggregate, everything ``PostgrestAggregate`` documents
-/// > still applies — the `db-aggregates-enabled` requirement, and the response being an array of
-/// > objects keyed by the function name.
-public struct PostgrestToOneDerivedColumn<
-  Root: PostgrestRelation,
-  Target: PostgrestRelation,
-  Value
->: PostgrestColumnExpression {
-  let embed: String
-  let inner: String
-
-  /// The `select`-list form, `parent(title::text)`. There is no `order` or filter form.
-  public var postgrestExpression: String { "\(embed)(\(inner))" }
-
-  init(embed: String, inner: String) {
-    self.embed = embed
-    self.inner = inner
-  }
-}
-
-// Every embedded column type shadows the eight accessors it would otherwise inherit from
-// `PostgrestColumnExpression`. The inherited versions render *outside* the embed's parentheses —
-// `parent(title)::text` rather than `parent(title::text)` — and PostgREST does not reject that:
-// it answers 200 and silently drops whatever sits outside. The shadows put the operation inside.
-
-// MARK: - Shadowed accessors (to-one derived)
-
-extension PostgrestToOneDerivedColumn {
-  /// Casts this derived projection to another Postgres type.
-  ///
-  /// > Note: Make a cast the last step. PostgREST applies only the first cast in
-  /// > `parent(id::text::int)`, returning a JSON string while the Swift type says `Int`.
-  ///
-  /// - Returns: A derived projection rendering `embed(inner::sqlType)`.
-  public func cast<T>(
-    to target: PostgrestCastTarget<T>
-  ) -> PostgrestToOneDerivedColumn<Root, Target, T> {
-    PostgrestToOneDerivedColumn<Root, Target, T>(
-      embed: embed, inner: "\(inner)::\(target.sqlType)")
-  }
-
-  /// Reads a `json`/`jsonb` path on this derived projection as text, with `->>`.
-  public func jsonText(_ path: String) -> PostgrestToOneDerivedColumn<Root, Target, String> {
-    PostgrestToOneDerivedColumn<Root, Target, String>(embed: embed, inner: "\(inner)->>\(path)")
-  }
-
-  /// Reads a `json`/`jsonb` path on this derived projection as JSON, with `->`.
-  public func jsonObject(_ path: String) -> PostgrestToOneDerivedColumn<Root, Target, Value> {
-    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner)->\(path)")
-  }
-
-  /// The sum of this derived projection.
-  public func sum() -> PostgrestToOneDerivedColumn<Root, Target, Double> {
-    PostgrestToOneDerivedColumn<Root, Target, Double>(embed: embed, inner: "\(inner).sum()")
-  }
-
-  /// The mean of this derived projection.
-  public func avg() -> PostgrestToOneDerivedColumn<Root, Target, Double> {
-    PostgrestToOneDerivedColumn<Root, Target, Double>(embed: embed, inner: "\(inner).avg()")
-  }
-
-  /// The smallest value of this derived projection.
-  public func min() -> PostgrestToOneDerivedColumn<Root, Target, Value> {
-    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner).min()")
-  }
-
-  /// The largest value of this derived projection.
-  public func max() -> PostgrestToOneDerivedColumn<Root, Target, Value> {
-    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner).max()")
-  }
-
-  /// How many non-null values of this derived projection there are.
-  public func count() -> PostgrestToOneDerivedColumn<Root, Target, Int> {
-    PostgrestToOneDerivedColumn<Root, Target, Int>(embed: embed, inner: "\(inner).count()")
-  }
-}
-
-// MARK: - Shadowed accessors (to-one)
-
-extension PostgrestToOneColumn {
-  /// Casts this projection to another Postgres type.
-  ///
-  /// Returns ``PostgrestToOneDerivedColumn``, not `Self`: a to-one projection is orderable and a
-  /// cast of one is not.
-  ///
-  /// - Returns: A select-only derived projection rendering `embed(inner::sqlType)`.
-  public func cast<T>(
-    to target: PostgrestCastTarget<T>
-  ) -> PostgrestToOneDerivedColumn<Root, Target, T> {
-    PostgrestToOneDerivedColumn<Root, Target, T>(
-      embed: embed, inner: "\(inner)::\(target.sqlType)")
-  }
-
-  /// Reads a `json`/`jsonb` path on this projection as text, with `->>`.
-  ///
-  /// Keeps this type, unlike ``cast(to:)``: an arrow path inside an embed is still orderable.
-  public func jsonText(_ path: String) -> PostgrestToOneColumn<Root, Target, String> {
-    PostgrestToOneColumn<Root, Target, String>(embed: embed, inner: "\(inner)->>\(path)")
-  }
-
-  /// Reads a `json`/`jsonb` path on this projection as JSON, with `->`.
-  public func jsonObject(_ path: String) -> PostgrestToOneColumn<Root, Target, Value> {
-    PostgrestToOneColumn(embed: embed, inner: "\(inner)->\(path)")
-  }
-
-  /// The sum of this projection, over the single related row.
-  ///
-  /// Returns ``PostgrestToOneDerivedColumn``, not `Self`: a to-one projection is orderable and an
-  /// aggregate of one is not.
-  public func sum() -> PostgrestToOneDerivedColumn<Root, Target, Double> {
-    PostgrestToOneDerivedColumn<Root, Target, Double>(embed: embed, inner: "\(inner).sum()")
-  }
-
-  /// The mean of this projection, over the single related row.
-  public func avg() -> PostgrestToOneDerivedColumn<Root, Target, Double> {
-    PostgrestToOneDerivedColumn<Root, Target, Double>(embed: embed, inner: "\(inner).avg()")
-  }
-
-  /// The smallest value of this projection, over the single related row.
-  public func min() -> PostgrestToOneDerivedColumn<Root, Target, Value> {
-    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner).min()")
-  }
-
-  /// The largest value of this projection, over the single related row.
-  public func max() -> PostgrestToOneDerivedColumn<Root, Target, Value> {
-    PostgrestToOneDerivedColumn(embed: embed, inner: "\(inner).max()")
-  }
-
-  /// How many non-null values of this projection are in the single related row.
-  public func count() -> PostgrestToOneDerivedColumn<Root, Target, Int> {
-    PostgrestToOneDerivedColumn<Root, Target, Int>(embed: embed, inner: "\(inner).count()")
-  }
-}
-
-// MARK: - Shadowed accessors (to-many)
-
-extension PostgrestToManyColumn {
-  /// Casts this projection to another Postgres type, rendering `children(amount::text)`.
-  public func cast<T>(to target: PostgrestCastTarget<T>) -> PostgrestToManyColumn<Root, Target, T> {
-    PostgrestToManyColumn<Root, Target, T>(embed: embed, inner: "\(inner)::\(target.sqlType)")
-  }
-
-  /// Reads a `json`/`jsonb` path on this projection as text, with `->>`.
-  public func jsonText(_ path: String) -> PostgrestToManyColumn<Root, Target, String> {
-    PostgrestToManyColumn<Root, Target, String>(embed: embed, inner: "\(inner)->>\(path)")
-  }
-
-  /// Reads a `json`/`jsonb` path on this projection as JSON, with `->`.
-  public func jsonObject(_ path: String) -> PostgrestToManyColumn<Root, Target, Value> {
-    PostgrestToManyColumn(embed: embed, inner: "\(inner)->\(path)")
-  }
-
-  /// The sum of this embedded column across the group, rendering `orders(amount.sum())`.
-  public func sum() -> PostgrestToManyColumn<Root, Target, Double> {
-    PostgrestToManyColumn<Root, Target, Double>(embed: embed, inner: "\(inner).sum()")
-  }
-
-  /// The mean of this embedded column across the group.
-  public func avg() -> PostgrestToManyColumn<Root, Target, Double> {
-    PostgrestToManyColumn<Root, Target, Double>(embed: embed, inner: "\(inner).avg()")
-  }
-
-  /// The smallest value of this embedded column in the group.
-  public func min() -> PostgrestToManyColumn<Root, Target, Value> {
-    PostgrestToManyColumn(embed: embed, inner: "\(inner).min()")
-  }
-
-  /// The largest value of this embedded column in the group.
-  public func max() -> PostgrestToManyColumn<Root, Target, Value> {
-    PostgrestToManyColumn(embed: embed, inner: "\(inner).max()")
-  }
-
-  /// How many non-null values of this embedded column are in the group.
-  public func count() -> PostgrestToManyColumn<Root, Target, Int> {
-    PostgrestToManyColumn<Root, Target, Int>(embed: embed, inner: "\(inner).count()")
+  public func _deriving<V, P: PostgrestPosition>(
+    _ derivation: String
+  ) -> PostgrestDerivedExpression<Root, V, P> {
+    PostgrestDerivedExpression<Root, V, P>(embed: embed, inner: inner + derivation)
   }
 }

--- a/Tests/PostgRESTTests/PostgrestDerivedColumnTests.swift
+++ b/Tests/PostgRESTTests/PostgrestDerivedColumnTests.swift
@@ -50,14 +50,16 @@ struct PostgrestDerivedColumnTests {
     #expect((costText as Any) is any PostgrestOrderableExpression == false)
   }
 
-  /// A JSON path chained onto a cast **compiles**, since both are declared on the base protocol,
-  /// but PostgREST rejects the result. The rendering pinned here is therefore not a form to send
-  /// — it records the compiling-but-rejected shape so a change to the hierarchy surfaces here.
+  /// A JSON path chained onto a cast still compiles — both are declared on the base protocol —
+  /// but it inherits the cast's select-only position, so it can no longer be filtered on.
+  /// PostgREST rejects `cost::text->>k` in every position, so select-only is as tight as the
+  /// type system can get here without forbidding the chain outright.
   @Test
-  func castingThenJSONPathCompilesButPostgRESTRejectsIt() {
+  func castingThenJSONPathInheritsTheCastsSelectOnlyPosition() {
     let composed = Item.columns.cost.cast(to: .text).jsonText("k")
     #expect(composed.postgrestExpression == "cost::text->>k")
-    #expect((composed as Any) is any PostgrestFilterableExpression)
+    #expect((composed as Any) is any PostgrestFilterableExpression == false)
+    #expect((composed as Any) is any PostgrestOrderableExpression == false)
   }
 
   /// A Postgres type with no shipped target is still reachable, and still says what it produces.

--- a/Tests/PostgRESTTests/PostgrestRelatedColumnsTests.swift
+++ b/Tests/PostgRESTTests/PostgrestRelatedColumnsTests.swift
@@ -1,0 +1,275 @@
+//
+//  PostgrestRelatedColumnsTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 26/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestRelatedColumnsTests {
+  struct Order: PostgrestRelation {
+    static let relationName = "orders"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var todoID: Int
+    var amount: Double
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Order, Int>("id")
+      let todoID = PostgrestColumn<Order, Int>("todo_id")
+      let amount = PostgrestColumn<Order, Double>("amount")
+      let shippedAt = PostgrestNullableColumn<Order, Date>("shipped_at")
+      // The to-one direction of the same pair: many orders per todo, one todo per order.
+      let todo = PostgrestToOneRelation<Order, Todo>("todo")
+    }
+
+    static let columns = Columns()
+  }
+
+  struct Todo: PostgrestRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var title: String
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let title = PostgrestColumn<Todo, String>("title")
+      // Deliberately named `name`: every public member of the relation type shadows a projected
+      // column of the same name, so this is the case that regressed.
+      let name = PostgrestColumn<Todo, String>("name")
+      // Numeric, so an aggregate over the to-one direction has something meaningful to sum.
+      let amount = PostgrestColumn<Todo, Double>("amount")
+      // What the generator emits from postgres-meta's foreign-key metadata: the relationship,
+      // declared once, checked at every use.
+      let orders = PostgrestToManyRelation<Todo, Order>("orders")
+    }
+
+    static let columns = Columns()
+  }
+
+  @Test
+  func aProjectedColumnWrapsInTheEmbedName() {
+    #expect(Todo.columns.orders.amount.postgrestExpression == "orders(amount)")
+  }
+
+  /// `@dynamicMemberLookup` only fires when no real member matches, so any public member of the
+  /// relation type wins over a projected column spelled the same way. With the property named
+  /// `name`, `Order.columns.todo.name` type-checked as the embed's own name string and the
+  /// column was unreachable — a silently wrong `select`, not an error.
+  @Test
+  func aProjectedColumnNamedLikeARelationMemberStillProjects() {
+    let projected = Order.columns.todo.name
+    #expect(projected.postgrestExpression == "todo(name)")
+    #expect(type(of: projected).Value.self == String.self)
+    // The embed name is still readable, under a name no column will collide with.
+    #expect(Order.columns.todo.postgrestEmbedName == "todo")
+  }
+
+  /// The aggregate goes inside the parentheses — `orders(amount.sum())`, never
+  /// `orders(amount).sum()`. PostgREST answers 200 for the latter and silently ignores the
+  /// `.sum()`, so every aggregate is shadowed to keep the function inside.
+  @Test
+  func anAggregateOverAnEmbedRendersInsideTheParentheses() {
+    #expect(Todo.columns.orders.amount.sum().postgrestExpression == "orders(amount.sum())")
+    #expect(Todo.columns.orders.id.count().postgrestExpression == "orders(id.count())")
+    #expect(Todo.columns.orders.amount.avg().postgrestExpression == "orders(amount.avg())")
+    #expect(Todo.columns.orders.id.min().postgrestExpression == "orders(id.min())")
+    #expect(Todo.columns.orders.id.max().postgrestExpression == "orders(id.max())")
+  }
+
+  /// Same for a cast: unshadowed it would render `orders(amount)::text`, which PostgREST answers
+  /// 200 with the cast dropped.
+  @Test
+  func aCastOverAnEmbedRendersInsideTheParentheses() {
+    #expect(
+      Todo.columns.orders.amount.cast(to: .text).postgrestExpression == "orders(amount::text)")
+  }
+
+  /// `jsonText(_:)` is declared on the base protocol too, so it needs the same shadow.
+  @Test
+  func aJSONTextPathOverAnEmbedRendersInsideTheParentheses() {
+    #expect(
+      Todo.columns.orders.amount.jsonText("k").postgrestExpression == "orders(amount->>k)")
+  }
+
+  /// `jsonObject(_:)` is declared on the base protocol too, so it needs the same shadow.
+  @Test
+  func aJSONObjectPathOverAnEmbedRendersInsideTheParentheses() {
+    #expect(
+      Todo.columns.orders.amount.jsonObject("k").postgrestExpression == "orders(amount->k)")
+  }
+
+  @Test
+  func aProjectedColumnKeepsItsValueType() {
+    #expect(type(of: Todo.columns.orders.amount).Value.self == Double.self)
+    #expect(type(of: Todo.columns.orders.amount.sum()).Value.self == Double.self)
+  }
+
+  /// One subscript, generic over the column kind, so a nullable embedded column needs no
+  /// second declaration.
+  @Test
+  func aNullableEmbeddedColumnProjectsThroughTheSameSubscript() {
+    #expect(Todo.columns.orders.shippedAt.postgrestExpression == "orders(shipped_at)")
+    #expect(type(of: Todo.columns.orders.shippedAt).Value.self == Date.self)
+  }
+
+  /// An embedded column filters with dot notation, a different string from the select form. It is
+  /// not filterable directly — SDK-1575's embed scope uses this:
+  ///
+  ///     .where { $0.orders.id.eq(7) }
+  ///     -> value of type 'PostgrestToManyColumn<…>' has no member 'eq'
+  ///
+  /// Nor orderable. Checked on an erased value, since a positive `is` on the concrete type would
+  /// be a compile-time truism.
+  @Test
+  func theFilterFormIsDottedAndSeparate() {
+    #expect(Todo.columns.orders.id.embeddedFilterName == "orders.id")
+    #expect(Todo.columns.orders.id.postgrestExpression == "orders(id)")
+    #expect((Todo.columns.orders.id as Any) is any PostgrestFilterableExpression == false)
+    #expect((Todo.columns.orders.id as Any) is any PostgrestOrderableExpression == false)
+  }
+
+  /// A to-one projection renders and filters exactly like a to-many one — the difference between
+  /// them is orderability, not selection.
+  @Test
+  func aToOneProjectionWrapsInTheEmbedNameAndFilterForm() {
+    #expect(Order.columns.todo.title.postgrestExpression == "todo(title)")
+    #expect(Order.columns.todo.title.embeddedFilterName == "todo.title")
+    #expect((Order.columns.todo.title as Any) is any PostgrestFilterableExpression == false)
+  }
+
+  /// The reason `PostgrestToOneRelation` is a separate type: its projections are orderable, while
+  /// a to-many projection's `order` is a 400 PGRST118. Proven behaviorally, by rendering
+  /// `asc()`/`desc()`, rather than with an `is` check that asserts nothing on a concrete type.
+  @Test
+  func aToOneProjectionIsOrderableButAToManyProjectionIsNot() {
+    #expect(Order.columns.todo.title.asc().rendered == "todo(title).asc")
+    // A direction is optional here too.
+    #expect(
+      PostgrestOrdering<Order>(
+        column: Order.columns.todo.title.postgrestExpression, ascending: nil
+      ).rendered == "todo(title)")
+    #expect(Order.columns.todo.title.desc().rendered == "todo(title).desc")
+    #expect((Todo.columns.orders.amount as Any) is any PostgrestOrderableExpression == false)
+  }
+
+  /// A to-one embed needs the same shadowing as a to-many one; both would otherwise render
+  /// `todo(amount)::text` instead of `todo(amount::text)`.
+  @Test
+  func aToOneProjectionShadowsCastAndJSONPathToo() {
+    #expect(Order.columns.todo.id.cast(to: .text).postgrestExpression == "todo(id::text)")
+    #expect(Order.columns.todo.id.jsonText("k").postgrestExpression == "todo(id->>k)")
+    #expect(Order.columns.todo.id.jsonObject("k").postgrestExpression == "todo(id->k)")
+  }
+
+  /// A cast of a to-one projection must not be orderable even though the projection is, which is
+  /// why ``PostgrestToOneColumn/cast(to:)`` returns `PostgrestToOneDerivedColumn` rather than
+  /// `Self`. A JSON path stays orderable. Proven behaviorally by calling `asc()`.
+  @Test
+  func aToOneCastIsNotOrderableButAToOneJSONPathIs() {
+    #expect(
+      (Order.columns.todo.id.cast(to: .text) as Any) is any PostgrestOrderableExpression == false)
+    #expect(Order.columns.todo.id.jsonText("k").asc().rendered == "todo(id->>k).asc")
+  }
+
+  /// A to-one projection has the identical rendering bug if unshadowed: PostgREST answers 200 for
+  /// `probe_parent(id).sum()` and ignores the `.sum()`, while `probe_parent(id.sum())` applies it.
+  @Test
+  func anAggregateOverAToOneProjectionRendersInsideTheParentheses() {
+    #expect(Order.columns.todo.id.sum().postgrestExpression == "todo(id.sum())")
+    #expect(Order.columns.todo.id.avg().postgrestExpression == "todo(id.avg())")
+    #expect(Order.columns.todo.id.min().postgrestExpression == "todo(id.min())")
+    #expect(Order.columns.todo.id.max().postgrestExpression == "todo(id.max())")
+    #expect(Order.columns.todo.id.count().postgrestExpression == "todo(id.count())")
+  }
+
+  /// Both halves have to hold at once: the projection stays orderable, an aggregate of it does
+  /// not. That is why `sum()` and its siblings return `PostgrestToOneDerivedColumn`. The negative
+  /// half uses the erased form, since a positive `is` on a concrete type is a truism.
+  @Test
+  func aToOneAggregateIsNotOrderableEvenThoughTheProjectionIs() {
+    #expect(Order.columns.todo.id.asc().rendered == "todo(id).asc")
+    #expect((Order.columns.todo.id.sum() as Any) is any PostgrestOrderableExpression == false)
+    #expect((Order.columns.todo.id.count() as Any) is any PostgrestOrderableExpression == false)
+  }
+
+  /// The point of `PostgrestToOneDerivedColumn`: it keeps `embed` and `inner` apart, so anything
+  /// chained onto a cast or aggregate lands inside the embed's parentheses. Returning a flat
+  /// `PostgrestCastColumn`/`PostgrestAggregate` put it outside, where PostgREST answers 200 and
+  /// silently discards it — measured for all six outside forms. The inside form applies:
+  /// `probe_parent(id.sum()::text)` returns `{"sum": "1"}`.
+  @Test
+  func aDerivedToOneChainStaysInsideTheEmbedParentheses() {
+    #expect(
+      Order.columns.todo.amount.sum().cast(to: .text).postgrestExpression
+        == "todo(amount.sum()::text)")
+    #expect(
+      Order.columns.todo.id.cast(to: .text).jsonText("k").postgrestExpression
+        == "todo(id::text->>k)")
+    #expect(
+      Order.columns.todo.id.sum().jsonObject("k").postgrestExpression == "todo(id.sum()->k)")
+    #expect(Order.columns.todo.id.sum().sum().postgrestExpression == "todo(id.sum().sum())")
+    #expect(
+      Order.columns.todo.id.cast(to: .text).cast(to: .int).postgrestExpression
+        == "todo(id::text::int)")
+    #expect(
+      Order.columns.todo.id.cast(to: .text).sum().postgrestExpression == "todo(id::text.sum())")
+  }
+
+  /// Landing the operation inside the parentheses does not make every chain valid — it makes an
+  /// invalid one loud instead of silent. PostgREST accepts only `::` after an aggregate, so a
+  /// second aggregate or a JSON path is a 400 rather than a quietly dropped operation. Nothing to
+  /// assert against the server here; the point is that the SDK no longer renders a string
+  /// PostgREST accepts and ignores.
+  @Test
+  func theSingleAppliedDerivedFormIsACastAfterAnAggregate() {
+    #expect(
+      Order.columns.todo.amount.avg().cast(to: .text).postgrestExpression
+        == "todo(amount.avg()::text)")
+    #expect(
+      Order.columns.todo.id.min().cast(to: .text).postgrestExpression == "todo(id.min()::text)")
+    #expect(
+      Order.columns.todo.id.max().cast(to: .text).postgrestExpression == "todo(id.max()::text)")
+    #expect(
+      Order.columns.todo.id.count().cast(to: .text).postgrestExpression
+        == "todo(id.count()::text)")
+  }
+
+  /// `PostgrestToOneDerivedColumn` is select position only, and has to stay that way: a cast and
+  /// an aggregate are both 400 in `order`, and there is no `HAVING`. Asserted on an erased value,
+  /// so it keeps failing if a later change adds either conformance.
+  @Test
+  func aDerivedToOneProjectionIsNeitherOrderableNorFilterable() {
+    let fromCast = Order.columns.todo.id.cast(to: .text)
+    let fromAggregate = Order.columns.todo.amount.sum()
+    let chained = Order.columns.todo.amount.sum().cast(to: .text)
+
+    for value in [fromCast as Any, fromAggregate as Any, chained as Any] {
+      #expect(value is any PostgrestOrderableExpression == false)
+      #expect(value is any PostgrestFilterableExpression == false)
+      #expect(value is any PostgrestColumnExpression)
+    }
+  }
+
+  /// A derived projection carries the `Value` the operation produces, not the column's: `sum()`
+  /// widens to `Double`, `count()` is `Int`, `min()`/`max()` keep the column's type, and a cast
+  /// takes its target's. That is what makes a wrong operand a compile error, not a decode failure.
+  @Test
+  func aDerivedToOneProjectionCarriesTheOperationsValueType() {
+    #expect(type(of: Order.columns.todo.id.sum()).Value.self == Double.self)
+    #expect(type(of: Order.columns.todo.id.count()).Value.self == Int.self)
+    #expect(type(of: Order.columns.todo.id.min()).Value.self == Int.self)
+    #expect(type(of: Order.columns.todo.id.cast(to: .text)).Value.self == String.self)
+    #expect(type(of: Order.columns.todo.amount.sum().cast(to: .int)).Value.self == Int.self)
+  }
+}

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -268,3 +268,7 @@ someop
 
 # Term from the cast target list (PostgrestDerivedColumn.swift).
 citext
+
+# Terms from the embedded-relations column namespace (PostgrestRelatedColumns.swift).
+unshadowed
+orderability

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -108,8 +108,8 @@ supporting_symbols:
 
   # The typed column-expression surface. A column expression is the left-hand side of every
   # filter, every `order` key and every `select` entry at once, so none of these types belongs to
-  # a single capability. The operator methods declared over them are 1:1 with a capability and are
-  # attributed to that feature's own `symbols:` list instead (see database.using_filters.*
+  # a single capability. The ~34 operator methods declared over them are 1:1 with a capability and
+  # are attributed to that feature's own `symbols:` list instead (see database.using_filters.*
   # below); `asc()`/`desc()` likewise, under database.using_modifiers.order.
   #
   # The position refinements are rules enforced by the type system rather than by the server: the
@@ -976,7 +976,57 @@ features:
   database.using_modifiers.request_cancellation: implemented
   database.using_modifiers.relationship_embed:
     status: partially_implemented
-    note: "Supported via query-string syntax in select() (e.g. 'user(*)'); no dedicated relationship builder API."
+    note: "Two spellings. The string builder takes query-string syntax in select() (e.g. 'user(*)'). The typed surface has a dedicated relationship API: `PostgrestToOneRelation`/`PostgrestToManyRelation`, declared on a relation's `Columns` namespace (emitted by the postgres-meta-backed generator, or hand-written; `@Table` does not synthesize them, since a macro cannot see foreign-key metadata), and projecting a column through one is compiler-checked in select position, and in order position for the to-one direction only (a to-many order key is PGRST118 on the server). Still partial: filtering *inside* an embed needs the `parent.title` rendering and an `!inner` decision, which is scoped separately (SDK-1575) — `embeddedFilterName` is what it will read."
+    symbols:
+      - PostgrestToOneRelation.subscript
+      - PostgrestToManyRelation.subscript
+    supporting_symbols:
+      - PostgrestToOneRelation
+      - PostgrestToOneRelation.init
+      - PostgrestToOneRelation.postgrestEmbedName
+      - PostgrestToManyRelation
+      - PostgrestToManyRelation.init
+      - PostgrestToManyRelation.postgrestEmbedName
+      # An embedded projection renders `parent(title)`, so a cast, JSON path or aggregate on one
+      # has to land *inside* the parentheses — PostgREST 16.1 answers 200 and silently drops
+      # anything outside them. Each embedded column type therefore shadows all eight inherited
+      # accessors rather than inheriting them from PostgrestColumnExpression.
+      - PostgrestToOneColumn
+      - PostgrestToOneColumn.postgrestExpression
+      - PostgrestToOneColumn.embeddedFilterName
+      - PostgrestToOneColumn.cast
+      - PostgrestToOneColumn.jsonText
+      - PostgrestToOneColumn.jsonObject
+      - PostgrestToOneColumn.sum
+      - PostgrestToOneColumn.avg
+      - PostgrestToOneColumn.min
+      - PostgrestToOneColumn.max
+      - PostgrestToOneColumn.count
+      - PostgrestToManyColumn
+      - PostgrestToManyColumn.postgrestExpression
+      - PostgrestToManyColumn.embeddedFilterName
+      - PostgrestToManyColumn.cast
+      - PostgrestToManyColumn.jsonText
+      - PostgrestToManyColumn.jsonObject
+      - PostgrestToManyColumn.sum
+      - PostgrestToManyColumn.avg
+      - PostgrestToManyColumn.min
+      - PostgrestToManyColumn.max
+      - PostgrestToManyColumn.count
+      # The to-one direction needs a fifth type to reach the same place. A to-many projection can
+      # return itself from a cast or an aggregate, because it was never orderable; a to-one
+      # projection is orderable and a cast or aggregate of it is not, so it has to move to a
+      # select-only type that still keeps the embed name and the inner expression apart.
+      - PostgrestToOneDerivedColumn
+      - PostgrestToOneDerivedColumn.postgrestExpression
+      - PostgrestToOneDerivedColumn.cast
+      - PostgrestToOneDerivedColumn.jsonText
+      - PostgrestToOneDerivedColumn.jsonObject
+      - PostgrestToOneDerivedColumn.sum
+      - PostgrestToOneDerivedColumn.avg
+      - PostgrestToOneDerivedColumn.min
+      - PostgrestToOneDerivedColumn.max
+      - PostgrestToOneDerivedColumn.count
   database.using_modifiers.dry_run:
     status: implemented
     symbols:


### PR DESCRIPTION
Stack 9/9 for SDK-1624. Base: `guilhermesouza/sdk-1624-embedded-relations` (#1295).

> **Why not on top of #1290, as asked.** Three of the four files this rewrites do not exist there: `PostgrestDerivedColumn.swift` arrives in #1293, `PostgrestAggregate.swift` in #1294, `PostgrestRelatedColumns.swift` in #1295. At #1290 there is nothing to collapse. See "Alternative" at the bottom for the version that *does* start at #1290.

## The problem

Each embedded column type shadows the eight accessors it inherits from `PostgrestColumnExpression`, because an embedded projection renders `parent(title)` and a cast or aggregate has to land **inside** those parentheses — PostgREST answers 200 and silently drops anything outside. That is **24 declarations across three types**, and nothing makes a ninth accessor's missing shadows an error: it would be inherited, render outside, and return wrong rows quietly.

## The change

The shadows exist because a derived expression stores an already-flattened string, so nothing can be inserted after the fact.

```swift
// one hook: place a derivation where the server expects it
func _deriving<V, P: PostgrestPosition>(_ d: String) -> PostgrestDerivedExpression<Root, V, P>
// default appends; each embed kind overrides it once

// a phantom Position, so a derivation inherits its receiver's positions
associatedtype Position: PostgrestPosition
extension PostgrestDerivedExpression: PostgrestOrderableExpression
  where Position: PostgrestOrderablePosition {}
```

One `PostgrestDerivedExpression` replaces `PostgrestCastColumn`, `PostgrestJSONPath`, `PostgrestAggregate` and `PostgrestToOneDerivedColumn`. The last existed *only* to keep a chain inside the parentheses; that now falls out of the hook.

| | before | after |
| --- | --- | --- |
| shadows in `PostgrestRelatedColumns.swift` | 24 | 2 |
| public accessor declarations in `Columns/` | 32 | 11 |
| public types for derived expressions | 4 | 1 |

## Verification

- **1397 tests pass.** One test changed, and it *tightens* a guarantee: a JSON path chained onto a cast now inherits the cast's select-only position, so filtering `cost::text->>k` — a 400 the current design lets you write — no longer compiles.
- **Position matrix re-checked by compile probe.** Rejected: cast-of-a-to-one isn't orderable; to-many JSON path isn't orderable; to-many column isn't orderable; aggregate isn't filterable; to-one column isn't filterable; JSON-path-on-a-cast isn't filterable (new). Compiles: to-one JSON path is orderable; plain JSON path is filterable.
- **Drift scenario demonstrated.** Added a ninth accessor as one declaration with no shadows: it rendered `parent(name.lower())` and `kids(name.lower())`, and composed to `parent(name.lower()::text)`.

## Costs, stated plainly

- Merges four public types into one generic. 37 lines of `sdk-compliance.yaml` reference symbols this changes (not yet updated here).
- `_deriving(_:)` is public-for-protocol-reasons — underscored, but visible.
- Diagnostics regress in one way: a mispositioned expression fails as "does not conform to `PostgrestOrderableExpression`" rather than "has no member `asc`".
- As stacked, the reviewer reads "add 24 shadows" in #1293–#1295 and "delete them" here.

## Alternative, if that last point bothers you

Fold the `Position`/`_deriving` machinery into #1288 and re-author #1293/#1294/#1295 on top of it, so the shadows are never written. That is the version that begins near #1290. It is strictly better history and strictly more work — three pushed PRs rewritten instead of one added. Happy to do it that way instead; this PR is the cheap way to evaluate the design first.
