### PR TITLE
feat(postgrest): add count and head to the typed surface

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -51,6 +51,27 @@ public struct PostgrestTypedMutation<R: PostgrestWritableRelation>: PostgrestFil
   public func execute() async throws -> PostgrestResponse<Void> {
     try await builder.execute()
   }
+
+  /// Sends the request, discarding the response body but asking how many rows it affected.
+  ///
+  /// ```swift
+  /// let removed = try await client.from(Todo.self).delete()
+  ///   .where { $0.isDone.eq(true) }
+  ///   .execute(count: .exact)
+  ///   .count
+  /// ```
+  ///
+  /// This composes with ``returning()``, which sets a different `Prefer` preference: the count is
+  /// applied when the request is sent, and each preference replaces only its own key.
+  ///
+  /// - Parameter count: The counting algorithm. See ``CountOption`` for the accuracy/speed
+  ///   trade-off.
+  /// - Returns: A ``PostgrestResponse`` whose ``PostgrestResponse/count`` is the number of rows
+  ///   affected.
+  @discardableResult
+  public func execute(count: CountOption) async throws -> PostgrestResponse<Void> {
+    try await builder.execute(options: FetchOptions(count: count))
+  }
 }
 
 extension PostgrestTypedSource where R: PostgrestWritableRelation {

--- a/Sources/PostgREST/Query/PostgrestTypedQuery.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery.swift
@@ -39,4 +39,62 @@ extension PostgrestTypedQuery where Phase: PostgrestExecutablePhase {
   public func execute() async throws -> PostgrestResponse<Output> {
     try await builder.execute()
   }
+
+  /// Sends the request and decodes the response, asking the server for a total row count as well.
+  ///
+  /// One round trip returns both the page and the total, which is what a paginated view needs:
+  ///
+  /// ```swift
+  /// let page = try await client.from(Todo.self).select()
+  ///   .where { $0.isDone.eq(false) }
+  ///   .limit(20)
+  ///   .execute(count: .exact)
+  ///
+  /// page.value  // [Todo], at most 20 of them
+  /// page.count  // every row matching the filter, ignoring the limit
+  /// ```
+  ///
+  /// The count respects the filters but ignores `limit`. Use ``count(_:)`` when the rows are not
+  /// wanted at all.
+  ///
+  /// - Parameter count: The counting algorithm. See ``CountOption`` for the accuracy/speed
+  ///   trade-off.
+  /// - Returns: A ``PostgrestResponse`` whose `value` is the decoded `Output` and whose
+  ///   ``PostgrestResponse/count`` is the total.
+  @discardableResult
+  public func execute(count: CountOption) async throws -> PostgrestResponse<Output> {
+    try await builder.execute(options: FetchOptions(count: count))
+  }
+
+  /// Asks the server how many rows match, without transferring any of them.
+  ///
+  /// This is a HEAD request: PostgREST reports the total in the `Content-Range` header and sends
+  /// no body, so counting a large table costs no rows.
+  ///
+  /// ```swift
+  /// let remaining = try await client.from(Todo.self).select()
+  ///   .where { $0.isDone.eq(false) }
+  ///   .count(.exact)
+  /// ```
+  ///
+  /// Use ``execute(count:)`` instead when the rows are wanted too — asking for both separately
+  /// is two round trips for what the server returns in one.
+  ///
+  /// - Parameter option: The counting algorithm. See ``CountOption`` for the accuracy/speed
+  ///   trade-off.
+  /// - Returns: The number of rows matching the filters.
+  /// - Throws: ``PostgrestError`` if the response carries no count, or any error thrown by the
+  ///   request itself.
+  public func count(_ option: CountOption) async throws -> Int {
+    let response = try await builder.execute(options: FetchOptions(head: true, count: option))
+    guard let count = response.count else {
+      throw PostgrestError(
+        message: """
+          The response carries no row count. Expected a `Content-Range` header for \
+          `Prefer: count=\(option.rawValue)`.
+          """
+      )
+    }
+    return count
+  }
 }

--- a/Tests/PostgRESTTests/PostgrestTypedQueryTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedQueryTests.swift
@@ -1,0 +1,112 @@
+//
+//  PostgrestTypedQueryTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 31/08/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PostgREST
+
+@Suite
+struct PostgrestTypedQueryTests {
+  struct Todo: PostgrestWritableRelation {
+    static let relationName = "todos"
+    static let schema = "public"
+    static let selectString = "*"
+
+    var id: Int
+    var task: String
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Todo, Int>("id")
+      let isDone = PostgrestColumn<Todo, Bool>("is_done")
+    }
+
+    static let columns = Columns()
+
+    struct Draft: Encodable, Sendable {
+      var task: String
+    }
+  }
+
+  @Test
+  func countAsksForTheTotalWithoutTransferringRows() async throws {
+    let capture = QueryCapture(responseHeaders: ["Content-Range": "*/42"])
+    let total = try await capture.client.from(Todo.self).select().count(.exact)
+    #expect(total == 42)
+    // `head: true` is the whole point — the body is never sent, so the count costs no rows.
+    #expect(capture.httpMethod == "HEAD")
+    #expect(capture.header("Prefer")?.contains("count=exact") == true)
+  }
+
+  @Test
+  func countRespectsFilters() async throws {
+    let capture = QueryCapture(responseHeaders: ["Content-Range": "*/3"])
+    _ = try await capture.client.from(Todo.self).select()
+      .where { $0.isDone.eq(false) }.count(.planned)
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+    #expect(capture.header("Prefer")?.contains("count=planned") == true)
+  }
+
+  @Test
+  func countThrowsWhenTheServerSendsNoTotal() async throws {
+    // No `Content-Range`, so there is no number to return and `Int` cannot be honoured.
+    let capture = QueryCapture()
+    await #expect(throws: PostgrestError.self) {
+      _ = try await capture.client.from(Todo.self).select().count(.exact)
+    }
+  }
+
+  @Test
+  func executeWithACountReturnsBothRowsAndTotal() async throws {
+    let capture = QueryCapture(
+      body: #"[{"id":1,"task":"buy milk"}]"#,
+      responseHeaders: ["Content-Range": "0-0/42"]
+    )
+    let response = try await capture.client.from(Todo.self).select().limit(1)
+      .execute(count: .exact)
+    #expect(response.value.count == 1)
+    #expect(response.count == 42)
+    // Still a GET: this is the page *and* the total from one round trip.
+    #expect(capture.httpMethod == "GET")
+    #expect(capture.header("Prefer")?.contains("count=exact") == true)
+  }
+
+  @Test
+  func executeWithoutACountAsksForNoPreference() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().execute()
+    #expect(capture.header("Prefer") == nil)
+  }
+
+  @Test
+  func aMutationCountsAffectedRowsWithoutReturningThem() async throws {
+    let capture = QueryCapture(responseHeaders: ["Content-Range": "*/7"])
+    let response = try await capture.client.from(Todo.self).delete()
+      .where { $0.isDone.eq(true) }.execute(count: .exact)
+    #expect(response.count == 7)
+    let prefer = capture.header("Prefer") ?? ""
+    #expect(prefer.contains("count=exact"))
+    #expect(prefer.contains("return=minimal"))
+  }
+
+  @Test
+  func aMutationCountComposesWithReturning() async throws {
+    // The count preference is set at send time, after `returning()` has written the header, and
+    // `appendOrUpdate` replaces only the `return=` component. So the two do not clobber.
+    let capture = QueryCapture(
+      body: #"[{"id":1,"task":"buy milk"}]"#,
+      responseHeaders: ["Content-Range": "0-0/1"]
+    )
+    let response = try await capture.client.from(Todo.self)
+      .insert(Todo.Draft(task: "buy milk")).returning().execute(count: .exact)
+    #expect(response.count == 1)
+    let prefer = capture.header("Prefer") ?? ""
+    #expect(prefer.contains("count=exact"))
+    #expect(prefer.contains("return=representation"))
+    #expect(prefer.contains("return=minimal") == false)
+  }
+}

--- a/Tests/PostgRESTTests/QueryCapture.swift
+++ b/Tests/PostgRESTTests/QueryCapture.swift
@@ -23,7 +23,11 @@ struct QueryCapture {
   let client: PostgrestClient
   private let captured = LockIsolated(URLRequest?.none)
 
-  init(body: String = "[]") {
+  /// - Parameters:
+  ///   - body: The response body to hand back to every request.
+  ///   - responseHeaders: Extra response header fields, merged over `Content-Type`. Use this to
+  ///     stub the `Content-Range` header a count request reads its total from.
+  init(body: String = "[]", responseHeaders: [String: String] = [:]) {
     let captured = self.captured
     client = PostgrestClient(
       url: URL(string: "https://example.supabase.co")!,
@@ -34,7 +38,7 @@ struct QueryCapture {
           url: request.url!,
           statusCode: 200,
           httpVersion: nil,
-          headerFields: ["Content-Type": "application/json"]
+          headerFields: ["Content-Type": "application/json"].merging(responseHeaders) { $1 }
         )!
         return (Data(body.utf8), response)
       }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -670,6 +670,10 @@ features:
       - PostgrestTypedQuery.builder
       - PostgrestTypedQuery.init
       - PostgrestTypedQuery.execute
+      # Row counting. `capabilities/database.yaml` has no id for it — it is an option on every
+      # verb in supabase-js rather than a modifier — so it is registered against `select`, the
+      # verb the count-only HEAD form belongs to, instead of claiming a capability of its own.
+      - PostgrestTypedQuery.count
       - CountOption
       - CountOption.init
       - CountOption.rawValue


### PR DESCRIPTION
Adds row counting to the typed PostgREST surface, which had neither of supabase-js's `count` and `head` options.

- `count(_:)` on the typed query is the `head: true` case: a HEAD request that returns the matching total without transferring rows.
- `execute(count:)` on the typed query returns the page and the total from one round trip, which is what a paginated view needs.
- `execute(count:)` on the typed mutation answers "how many rows did that affect".

Fixes SDK-1639
