### PR TITLE
feat(postgrest): accept a collection of rows in typed insert and upsert

### DIFF
--- a/Sources/PostgREST/Legacy/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/Legacy/PostgrestQueryBuilder.swift
@@ -117,17 +117,8 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
     if !prefersHeaders.isEmpty {
       request.headers[.prefer] = prefersHeaders.joined(separator: ",")
     }
-    if let body = request.body,
-      let jsonObject = try JSONSerialization.jsonObject(with: body) as? [[String: Any]]
-    {
-      let allKeys = jsonObject.flatMap(\.keys)
-      let uniqueKeys = Set(allKeys).sorted()
-      request.query.appendOrUpdate(
-        URLQueryItem(
-          name: "columns",
-          value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
-        )
-      )
+    if let body = request.body, let columns = try columnsQueryItem(forBody: body) {
+      request.query.appendOrUpdate(columns)
     }
 
     return PostgrestFilterBuilder(carryingFrom: self, request: request)
@@ -194,17 +185,8 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
       request.headers[.prefer] = prefersHeaders.joined(separator: ",")
     }
 
-    if let body = request.body,
-      let jsonObject = try JSONSerialization.jsonObject(with: body) as? [[String: Any]]
-    {
-      let allKeys = jsonObject.flatMap(\.keys)
-      let uniqueKeys = Set(allKeys).sorted()
-      request.query.appendOrUpdate(
-        URLQueryItem(
-          name: "columns",
-          value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
-        )
-      )
+    if let body = request.body, let columns = try columnsQueryItem(forBody: body) {
+      request.query.appendOrUpdate(columns)
     }
 
     return PostgrestFilterBuilder(carryingFrom: self, request: request)
@@ -300,4 +282,29 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
 
     return PostgrestFilterBuilder(carryingFrom: self, request: request)
   }
+}
+
+/// The `columns` query parameter for an array request body: the union of the keys across every
+/// row, quoted and comma-separated.
+///
+/// PostgREST otherwise derives the column list from the first object alone and silently drops keys
+/// a later row added. Rows in one batch legitimately differ, because a nil optional is omitted from
+/// the payload rather than encoded as `null`, so the union has to be sent explicitly.
+///
+/// - Parameter body: The encoded request body.
+/// - Returns: The query item, or `nil` when the body is not an array of objects, or is an array
+///   that contributes no keys at all. An empty union would spell `columns=`, which names one
+///   column called `""` and makes PostgREST reject the request — so an empty batch sends no
+///   parameter and writes nothing, rather than failing.
+/// - Throws: An error if `body` is not valid JSON.
+private func columnsQueryItem(forBody body: Data) throws -> URLQueryItem? {
+  guard let rows = try JSONSerialization.jsonObject(with: body) as? [[String: Any]] else {
+    return nil
+  }
+  let uniqueKeys = Set(rows.flatMap(\.keys)).sorted()
+  guard !uniqueKeys.isEmpty else { return nil }
+  return URLQueryItem(
+    name: "columns",
+    value: uniqueKeys.map { "\"\($0)\"" }.joined(separator: ",")
+  )
 }

--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -71,6 +71,32 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
     PostgrestTypedMutation(builder: try builder.insert(values, returning: .minimal))
   }
 
+  /// Inserts a collection of rows, in a single request.
+  ///
+  /// ```swift
+  /// try await client.from(Todo.self)
+  ///   .insert(tasks.map { Todo.Draft(task: $0) })
+  ///   .execute()
+  /// ```
+  ///
+  /// The rows do not have to encode the same columns. A draft omits a nil optional rather than
+  /// sending `null`, so a batch built by `map` routinely has ragged shapes; the request names the
+  /// union of the columns explicitly, which is what stops the database from taking the column list
+  /// from the first row alone and dropping what the later ones added.
+  ///
+  /// > Note: An empty collection is not an error. It sends a request that writes nothing, and
+  /// > ``PostgrestTypedMutation/returning()`` on it decodes an empty array. A batch computed from a
+  /// > filter or a `map` may legitimately have no rows, and making every caller guard for that is a
+  /// > worse trade than one wasted round trip.
+  ///
+  /// - Parameter values: The rows to insert, in the relation's
+  ///   ``PostgrestWritableRelation/Draft`` shape.
+  /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func insert(_ values: some Collection<R.Draft>) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(builder: try builder.insert(Array(values), returning: .minimal))
+  }
+
   /// Inserts a row, updating it instead if it conflicts on a unique constraint of your choosing.
   ///
   /// ```swift
@@ -89,7 +115,7 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   /// derived expression — a cast, an aggregate — is not a target PostgREST can take, and neither
   /// is a column belonging to some other relation. Both are rejected at the call site.
   ///
-  /// To merge on the primary key, use ``upsert(_:)``, which derives the target instead.
+  /// To merge on the primary key, use ``upsert(_:)-(R.Draft)``, which derives the target instead.
   ///
   /// - Parameters:
   ///   - values: The row to upsert, in the relation's ``PostgrestWritableRelation/Draft`` shape.
@@ -114,6 +140,49 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
     return PostgrestTypedMutation(
       builder: try builder.upsert(
         values,
+        onConflict: names.joined(separator: ","),
+        returning: .minimal
+      )
+    )
+  }
+
+  /// Upserts a collection of rows in a single request, merging on a unique constraint of your
+  /// choosing.
+  ///
+  /// ```swift
+  /// try await client.from(User.self)
+  ///   .upsert(imported.map { User.Draft(email: $0.email, name: $0.name) }, onConflict: \.email)
+  ///   .execute()
+  /// ```
+  ///
+  /// The target applies to every row in the batch, and carries the same rules as
+  /// ``upsert(_:onConflict:_:)-(R.Draft,_,_)``: each key path must name a stored column of this
+  /// relation. As with the bulk insert, the rows may encode different columns and an empty collection
+  /// writes nothing rather than throwing.
+  ///
+  /// - Parameters:
+  ///   - values: The rows to upsert, in the relation's ``PostgrestWritableRelation/Draft`` shape.
+  ///   - column: The first column of the unique constraint to merge on.
+  ///   - additional: The remaining columns, for a constraint spanning more than one.
+  /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func upsert<
+    FirstValue,
+    FirstNullability: PostgrestNullability,
+    each RestValue,
+    each RestNullability: PostgrestNullability
+  >(
+    _ values: some Collection<R.Draft>,
+    onConflict column: KeyPath<R.Columns, PostgrestStoredColumn<R, FirstValue, FirstNullability>>,
+    _ additional: repeat KeyPath<
+      R.Columns, PostgrestStoredColumn<R, each RestValue, each RestNullability>
+    >
+  ) throws -> PostgrestTypedMutation<R> {
+    var names = [R.columns[keyPath: column].postgrestExpression]
+    repeat names.append(R.columns[keyPath: each additional].postgrestExpression)
+    return PostgrestTypedMutation(
+      builder: try builder.upsert(
+        Array(values),
         onConflict: names.joined(separator: ","),
         returning: .minimal
       )
@@ -184,9 +253,9 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation & PostgrestKey
   /// overload exists only where the relation declares a key. On a keyless relation the database has
   /// nothing to merge on, so an upsert with no target is not a merge at all — it inserts another row
   /// every call. Requiring the conformance makes that a compile error instead; use
-  /// ``upsert(_:onConflict:_:)`` there and name a unique constraint the relation does have.
+  /// ``upsert(_:onConflict:_:)-(R.Draft,_,_)`` there and name a unique constraint the relation does have.
   ///
-  /// The same ``PostgrestWritableRelation/Draft`` serves this and ``insert(_:)``: it is a row the
+  /// The same ``PostgrestWritableRelation/Draft`` serves this and ``insert(_:)-(R.Draft)``: it is a row the
   /// database has not stored yet, whether this call ends up inserting it or merging it into an
   /// existing one.
   ///
@@ -201,6 +270,35 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation & PostgrestKey
     PostgrestTypedMutation(
       builder: try builder.upsert(
         values,
+        onConflict: R.primaryKeyColumns.joined(separator: ","),
+        returning: .minimal
+      )
+    )
+  }
+
+  /// Upserts a collection of rows in a single request, merging on the relation's primary key.
+  ///
+  /// ```swift
+  /// try await client.from(Todo.self)
+  ///   .upsert(rows.map { Todo.Draft(id: $0.id, task: $0.task) })
+  ///   .execute()
+  /// ```
+  ///
+  /// The target comes from ``PostgrestKeyedRelation/primaryKeyColumns``, exactly as in
+  /// ``upsert(_:)-(R.Draft)``, and applies to every row in the batch. As with the bulk insert, the
+  /// rows may encode different columns and an empty collection writes nothing rather than throwing.
+  ///
+  /// > Note: The target only takes effect for a row that carries the key columns in its body. A
+  /// > row that omits a database-generated key is inserted, so a batch can mix the two.
+  ///
+  /// - Parameter values: The rows to upsert, in the relation's
+  ///   ``PostgrestWritableRelation/Draft`` shape.
+  /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
+  /// - Throws: An encoding error if `values` cannot be serialized.
+  public func upsert(_ values: some Collection<R.Draft>) throws -> PostgrestTypedMutation<R> {
+    PostgrestTypedMutation(
+      builder: try builder.upsert(
+        Array(values),
         onConflict: R.primaryKeyColumns.joined(separator: ","),
         returning: .minimal
       )

--- a/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedMutationTests.swift
@@ -12,7 +12,7 @@ import Testing
 
 @Suite
 struct PostgrestTypedMutationTests {
-  struct Todo: PostgrestWritableRelation {
+  struct Todo: PostgrestWritableRelation, PostgrestKeyedRelation {
     static let relationName = "todos"
     static let schema = "public"
     static let selectString = "*"
@@ -39,10 +39,18 @@ struct PostgrestTypedMutationTests {
     }
 
     static let columns = Columns()
+    static let primaryKeyColumns = ["id"]
 
     struct Draft: Encodable, Sendable {
       var task: String
       var isDone: Bool?
+
+      /// Mirrors the relation's own mapping, so a batch's `columns` parameter is asserted in the
+      /// database's spelling rather than in Swift's.
+      enum CodingKeys: String, CodingKey {
+        case task
+        case isDone = "is_done"
+      }
     }
   }
 
@@ -129,5 +137,114 @@ struct PostgrestTypedMutationTests {
     let rows = try await capture.client.from(Todo.self)
       .insert(Todo.Draft(task: "buy milk", isDone: nil)).returning().execute().value
     #expect(rows.first?.task == "buy milk")
+  }
+
+  @Test
+  func singleRowInsertSendsAnObjectAndNoColumnsParameter() async throws {
+    // The `columns` parameter exists to reconcile rows that encode differently. One row cannot
+    // disagree with itself, so the single-row path must stay as it was.
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .insert(Todo.Draft(task: "buy milk", isDone: nil)).execute()
+    #expect(capture.bodyString?.hasPrefix("{") == true)
+    #expect(capture.query?.contains("columns") != true)
+  }
+
+  @Test
+  func bulkInsertSendsEveryRowInOneRequest() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .insert([Todo.Draft(task: "a", isDone: false), Todo.Draft(task: "b", isDone: false)])
+      .execute()
+    #expect(capture.httpMethod == "POST")
+    #expect(capture.bodyString?.contains("\"task\":\"a\"") == true)
+    #expect(capture.bodyString?.contains("\"task\":\"b\"") == true)
+    #expect(capture.bodyString?.hasPrefix("[") == true)
+  }
+
+  @Test
+  func bulkInsertNamesTheUnionOfColumnsAcrossRaggedRows() async throws {
+    // A draft omits a nil optional rather than sending `null`, so these two rows encode different
+    // key sets. Without the union, PostgREST reads the column list off the first row and drops
+    // `is_done` from the second — the whole reason the parameter is sent.
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .insert([Todo.Draft(task: "a", isDone: nil), Todo.Draft(task: "b", isDone: true)])
+      .execute()
+    #expect(capture.query?.contains(#"columns="is_done","task""#) == true)
+  }
+
+  @Test
+  func bulkInsertOfAnEmptyCollectionWritesNothingRatherThanFailing() async throws {
+    // Decided behavior: an empty batch is a request that writes nothing, not an error. The
+    // `columns` parameter has to be left off — `columns=` names one column called "", which
+    // PostgREST rejects, and a no-op that 400s is not a no-op.
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).insert([Todo.Draft]()).execute()
+    #expect(capture.bodyString == "[]")
+    #expect(capture.query?.contains("columns") != true)
+  }
+
+  @Test
+  func bulkInsertTakesAnyCollection() async throws {
+    // `some Collection` rather than `[Draft]`, so a slice reaches the wire without the caller
+    // rebuilding an array.
+    let rows = [Todo.Draft(task: "a"), Todo.Draft(task: "b"), Todo.Draft(task: "c")]
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).insert(rows[1...]).execute()
+    #expect(capture.bodyString?.contains("\"task\":\"a\"") == false)
+    #expect(capture.bodyString?.contains("\"task\":\"c\"") == true)
+  }
+
+  @Test
+  func bulkInsertCanReturnTheRows() async throws {
+    let capture = QueryCapture(
+      body: #"[{"id":1,"task":"a","is_done":false},{"id":2,"task":"b","is_done":false}]"#
+    )
+    let rows = try await capture.client.from(Todo.self)
+      .insert([Todo.Draft(task: "a"), Todo.Draft(task: "b")]).returning().execute().value
+    #expect(rows.map(\.task) == ["a", "b"])
+  }
+
+  @Test
+  func bulkUpsertDerivesTheConflictTargetFromThePrimaryKey() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .upsert([Todo.Draft(task: "a"), Todo.Draft(task: "b")]).execute()
+    #expect(capture.query?.contains("on_conflict=id") == true)
+    #expect(capture.bodyString?.hasPrefix("[") == true)
+  }
+
+  @Test
+  func bulkUpsertTakesAnExplicitConflictTarget() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .upsert([Todo.Draft(task: "a"), Todo.Draft(task: "b")], onConflict: \.task).execute()
+    #expect(capture.query?.contains("on_conflict=task") == true)
+  }
+
+  @Test
+  func bulkUpsertTakesAConflictTargetSpanningSeveralColumns() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .upsert([Todo.Draft(task: "a")], onConflict: \.id, \.task).execute()
+    #expect(capture.query?.contains("on_conflict=id,task") == true)
+  }
+
+  @Test
+  func bulkUpsertNamesTheUnionOfColumnsAcrossRaggedRows() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .upsert([Todo.Draft(task: "a", isDone: nil), Todo.Draft(task: "b", isDone: true)])
+      .execute()
+    #expect(capture.query?.contains(#"columns="is_done","task""#) == true)
+  }
+
+  @Test
+  func bulkUpsertOfAnEmptyCollectionWritesNothingRatherThanFailing() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).upsert([Todo.Draft]()).execute()
+    #expect(capture.bodyString == "[]")
+    #expect(capture.query?.contains("columns") != true)
   }
 }

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -202,6 +202,7 @@ uniquing
 unsubscription
 untracks
 upserted
+upserts
 URLAPI
 uuid
 UUID


### PR DESCRIPTION
Add overloads for taking a collection of items when inserting/updating/upserting items.

Fixes SDK-1625
