### PR TITLE
feat(postgrest): add @Relationship and embeds in selections

### DIFF
--- a/Sources/PostgrestMacros/Macros.swift
+++ b/Sources/PostgrestMacros/Macros.swift
@@ -111,6 +111,43 @@ public macro Default() =
     module: "PostgrestMacrosPlugin", type: "MarkerMacro"
   )
 
+/// Declares a property as an embedded relation, identified by its foreign key column.
+///
+/// ```swift
+/// @SelectionOf(Todo.self)
+/// struct TodoWithComments {
+///   var id: UUID
+///   var task: String
+///   @Relationship(\Comment.todoID) var comments: [CommentBody]
+/// }
+///
+/// // "id:id,task:task,comments:comments!todo_id(id:id,body:body)"
+/// ```
+///
+/// The foreign key is itself a column, so the key path exists whichever side declares it:
+/// `\Comment.todoID` for the one-to-many above, and `\Message.senderID` for the many-to-one
+/// `@Relationship(\Message.senderID) var sender: UserName?`. Either way it is compiler-checked, and
+/// it needs nothing from the schema generator that a column does not already provide.
+///
+/// Naming it is a correctness feature, not only compile-time sugar. PostgREST answers an ambiguous
+/// embed — two foreign keys joining the same pair of relations — with HTTP 300 `PGRST201`. Because
+/// the key path is required, the generated `select` always carries the `!todo_id` hint, so that
+/// response cannot be produced.
+///
+/// The embed's shape comes from the property's own type, with `Array` and `Optional` layers
+/// removed: `[CommentBody]` and `UserName?` both embed the selection, one as many rows and one as
+/// at most one. That selection names its own relation, which is what the embed is addressed by.
+///
+/// Embeds belong to a selection. Writing this on a ``Table(_:schema:readOnly:)`` property is a
+/// compile error.
+///
+/// - Parameter foreignKey: A key path to the foreign key column, for example `\Comment.todoID`.
+@attached(peer)
+public macro Relationship(_ foreignKey: AnyKeyPath) =
+  #externalMacro(
+    module: "PostgrestMacrosPlugin", type: "MarkerMacro"
+  )
+
 /// Declares a named subset of a relation's columns.
 ///
 /// ```swift
@@ -126,6 +163,9 @@ public macro Default() =
 /// Property names follow the same snake_case conversion as ``Table(_:schema:readOnly:)``, and
 /// ``Column(_:)`` overrides one. The expansion emits references to the relation's own columns, so a
 /// property that names no column on it fails to compile.
+///
+/// A property that holds another selection rather than a column is an embed, declared with
+/// ``Relationship(_:)``.
 ///
 /// The annotated type must be declared at file scope. The macro attaches an extension, and Swift
 /// does not allow an extension of a type nested inside another type.

--- a/Sources/PostgrestMacrosPlugin/MarkerMacros.swift
+++ b/Sources/PostgrestMacrosPlugin/MarkerMacros.swift
@@ -8,7 +8,13 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-/// The marker attributes carry no expansion of their own — `@Table` reads them off the properties.
+/// The marker attributes carry no expansion of their own — the enclosing macro reads them off the
+/// properties: `@Table` reads `@Column`, `@PrimaryKey` and `@Default`, and `@SelectionOf` reads
+/// `@Column` and `@Relationship`.
+///
+/// The declarations still matter. `@Relationship(\Comment.todoID)` is type-checked as a written
+/// expression, so a key path naming no such column is an error at the attribute, before anything
+/// this plugin emits is compiled.
 public struct MarkerMacro: PeerMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
+++ b/Sources/PostgrestMacrosPlugin/SelectionOfMacro.swift
@@ -43,6 +43,9 @@ public struct SelectionOfMacro: ExtensionMacro {
     if declaration.postgrestDiagnoseUnannotatedProperties(macro: "@SelectionOf", in: context) {
       return []
     }
+    if declaration.postgrestDiagnoseRelationships(in: context) {
+      return []
+    }
     let access = declaration.postgrestAccessLevel
     let properties = declaration.postgrestStoredProperties()
 
@@ -86,6 +89,9 @@ public struct SelectionOfMacro: ExtensionMacro {
   /// generated coding keys need no knowledge of the relation's column names — which a macro could
   /// not give them anyway, since a `CodingKey` raw value has to be a literal. When the two names
   /// agree the alias is a no-op, so it is emitted unconditionally rather than guessed at.
+  ///
+  /// A `@Relationship` property renders an embed instead of a column, and every part of it is read
+  /// off a type rather than spelled here — see ``embed(_:)``.
   static func selectString(
     access: String, relation: String, properties: [StoredProperty]
   ) -> String {
@@ -95,12 +101,34 @@ public struct SelectionOfMacro: ExtensionMacro {
 
     var lines = ["  \(access)static let selectString = ["]
     for property in properties {
-      lines.append(
-        "    \"\(property.columnName):\\(\(relation).columns.\(property.name).postgrestExpression)\","
-      )
+      let value =
+        property.foreignKey.map { embed(property, foreignKey: $0) }
+        ?? "\\(\(relation).columns.\(property.name).postgrestExpression)"
+      lines.append("    \"\(property.columnName):\(value)\",")
     }
     lines.append("  ].joined(separator: \",\")")
     return lines.joined(separator: "\n")
+  }
+
+  /// The right-hand side of one embed entry, `comments!todo_id(id:id,body:body)`.
+  ///
+  /// Three interpolations, none of them a literal the macro could write:
+  ///
+  /// - The embedded relation is `Selection.Source.relationName`, taken from the property's own
+  ///   type. That is what lets one attribute serve both directions: `\Comment.todoID` is rooted on
+  ///   the *target* for a one-to-many and on the *source* for a many-to-one, so the key path does
+  ///   not name the embed, and the property does.
+  /// - The `!todo_id` hint is the foreign key's column, read from its relation's namespace so a
+  ///   `@Column` override on it applies. Omitting the hint is what makes PostgREST answer an
+  ///   ambiguous embed with HTTP 300 `PGRST201`; emitting it always means this expansion cannot
+  ///   produce that response.
+  /// - The parenthesised list is the embedded selection's own `selectString`, so an embed nests to
+  ///   any depth with no further work here.
+  static func embed(_ property: StoredProperty, foreignKey: String) -> String {
+    let selection = property.embeddedSelection
+    return "\\(\(selection).Source.relationName)"
+      + "!\\(\(foreignKey).postgrestExpression)"
+      + "(\\(\(selection).selectString))"
   }
 
   /// The cross-type check.
@@ -114,13 +142,20 @@ public struct SelectionOfMacro: ExtensionMacro {
   /// every property's column, it carries the same proof, and this array is redundant. It is kept
   /// because it says out loud what the check is for; the diagnostic a reader gets from a bad
   /// property name is the same either way.
+  ///
+  /// An embed contributes its foreign key rather than a column of this relation. It has no column
+  /// here by construction — `Todo.columns.comments` does not exist — and the foreign key is the
+  /// part that can be wrong, since the compiler already checks the key path at the attribute but
+  /// nothing yet says the column it names belongs to a relation this expansion can reach.
   static func columnCheck(relation: String, properties: [StoredProperty]) -> String {
     var lines = [
-      "  /// Fails to compile if a property does not name a column on \(relation).",
+      "  /// Fails to compile if a property does not name a column on \(relation), or an embed's",
+      "  /// foreign key does not name one on its own relation.",
       "  private static let _columnCheck: [String] = [",
     ]
     for property in properties {
-      lines.append("    \(relation).columns.\(property.name).postgrestExpression,")
+      let reference = property.foreignKey ?? "\(relation).columns.\(property.name)"
+      lines.append("    \(reference).postgrestExpression,")
     }
     lines.append("  ]")
     return lines.joined(separator: "\n")

--- a/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/Diagnostics.swift
@@ -26,14 +26,34 @@ extension MacroExpansionContext {
   }
 }
 
+/// The `@Relationship` foreign key rendered as a namespace reference, `Comment.columns.todoID`,
+/// or `nil` if the argument is not a single-component key path with a written root.
+///
+/// The root is what makes the reference resolvable from the expansion, and it is why the key path
+/// has to be written in full: `\.todoID` infers its root from context the macro cannot see.
+///
+/// One component, because a foreign key is one column. A longer path would name something inside a
+/// column's value, which is not a relationship.
+func postgrestForeignKeyReference(_ attribute: AttributeSyntax) -> String? {
+  guard
+    let keyPath = attribute.arguments?.as(LabeledExprListSyntax.self)?.first?
+      .expression.as(KeyPathExprSyntax.self),
+    let root = keyPath.root?.trimmedDescription,
+    keyPath.components.count == 1,
+    let property = keyPath.components.first?.component.as(KeyPathPropertyComponentSyntax.self)
+  else { return nil }
+  return "\(root).columns.\(property.declName.baseName.trimmedDescription)"
+}
+
 extension DeclGroupSyntax {
   /// The first `@Relationship` attribute on a stored property, if any.
   ///
-  /// Embeds belong to a selection, never to a relation, so `@Table` rejects one.
+  /// Embeds belong to a selection, never to a relation, so `@Table` rejects one. A relation carries
+  /// columns; the property naming the other side of a join is declared by the selection that wants
+  /// it embedded.
   ///
-  /// Forward-looking: `@Relationship` itself lands in stage 3, so today a user who writes it gets
-  /// "unknown attribute" from the compiler first. Matching on the attribute *name* puts the guard
-  /// in place for the day the macro exists.
+  /// Matching on the attribute *name* rather than resolving the macro is what keeps this working
+  /// from `@Table`, which never expands `@Relationship` itself.
   func postgrestRelationshipAttribute() -> AttributeSyntax? {
     for member in memberBlock.members {
       guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
@@ -91,6 +111,36 @@ extension DeclGroupSyntax {
           column is dropped
           """,
           at: binding.pattern
+        )
+        reported = true
+      }
+    }
+    return reported
+  }
+}
+
+extension DeclGroupSyntax {
+  /// Reports every `@Relationship` whose argument is not a usable foreign key key path.
+  ///
+  /// Left alone, the property falls through to the plain-column path and the reader gets
+  /// "value of type 'Todo.Columns' has no member 'comments'" on a line they did not write — the
+  /// column the embed deliberately does not have.
+  ///
+  /// Returns `true` if anything was reported.
+  func postgrestDiagnoseRelationships(in context: some MacroExpansionContext) -> Bool {
+    var reported = false
+    for member in memberBlock.members {
+      guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+      for attribute in variable.attributes.compactMap({ $0.as(AttributeSyntax.self) })
+      where attribute.attributeName.trimmedDescription == "Relationship"
+        && postgrestForeignKeyReference(attribute) == nil
+      {
+        context.error(
+          """
+          @Relationship requires a key path to one foreign key column, written with its root, \
+          as in '@Relationship(\\Comment.todoID)'
+          """,
+          at: attribute
         )
         reported = true
       }

--- a/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
+++ b/Sources/PostgrestMacrosPlugin/Support/StoredProperty.swift
@@ -16,7 +16,14 @@ struct StoredProperty {
   var hasDefault: Bool
   var explicitColumn: String?
 
+  /// The `@Relationship` foreign key, rendered as a reference into the owning relation's column
+  /// namespace — `Comment.columns.todoID` — or `nil` for a plain column.
+  var foreignKey: String?
+
   /// The database column name: an explicit `@Column`, otherwise the snake_case form.
+  ///
+  /// For an embed this is the PostgREST alias rather than a column: the response comes back keyed
+  /// by it, and `CodingKeys` decodes it, exactly as for a column.
   var columnName: String { explicitColumn ?? camelToSnakeCase(name) }
 
   /// The property's type made optional, or left alone if it already is.
@@ -24,6 +31,14 @@ struct StoredProperty {
 
   /// The property's type with every layer of `Optional` removed, or left alone if it has none.
   var unwrappedType: String { postgrestUnwrapOptionalType(type) ?? type }
+
+  /// The selection an embed decodes into: the property's type with every `Array` and `Optional`
+  /// layer removed, so `[CommentBody]` and `UserName?` both give the selection itself.
+  ///
+  /// Only meaningful for a property carrying ``foreignKey``. To-many and to-one differ in the
+  /// Swift type and in nothing PostgREST is told — the embed renders the same either way, and the
+  /// server decides how many rows come back.
+  var embeddedSelection: String { postgrestUnwrapElementType(type) ?? type }
 }
 
 /// A written type with every layer of `Optional` stripped, or `nil` if it is not spelled as one.
@@ -51,6 +66,27 @@ func postgrestUnwrapOptionalType(_ type: String) -> String? {
     return nil
   }
   return postgrestUnwrapOptionalType(inner) ?? inner
+}
+
+/// A written type with every `Optional` and `Array` layer stripped, or `nil` if it has neither.
+///
+/// An embed is written `[CommentBody]` for a to-many and `UserName?` for a nullable to-one, and
+/// both name the same thing to PostgREST — the selection that goes inside the parentheses. Both
+/// array spellings count, since a generated schema emits `[X]` and hand-written code may say
+/// `Array<X>`.
+func postgrestUnwrapElementType(_ type: String) -> String? {
+  if let inner = postgrestUnwrapOptionalType(type) {
+    return postgrestUnwrapElementType(inner) ?? inner
+  }
+  let inner: String
+  if type.hasPrefix("["), type.hasSuffix("]") {
+    inner = String(type.dropFirst().dropLast())
+  } else if type.hasPrefix("Array<"), type.hasSuffix(">") {
+    inner = String(type.dropFirst("Array<".count).dropLast())
+  } else {
+    return nil
+  }
+  return postgrestUnwrapElementType(inner) ?? inner
 }
 
 /// Whether a written type is spelled as an `Optional`.
@@ -105,6 +141,8 @@ extension DeclGroupSyntax {
         .expression.as(StringLiteralExprSyntax.self)?
         .representedLiteralValue
 
+      let foreignKey = attribute("Relationship").flatMap(postgrestForeignKeyReference)
+
       let bindings = Array(variable.bindings)
       return bindings.indices.compactMap { index -> StoredProperty? in
         let binding = bindings[index]
@@ -121,7 +159,8 @@ extension DeclGroupSyntax {
           isOptional: postgrestIsOptionalType(typeText),
           isPrimaryKey: attribute("PrimaryKey") != nil,
           hasDefault: attribute("Default") != nil,
-          explicitColumn: column
+          explicitColumn: column,
+          foreignKey: foreignKey
         )
       }
     }

--- a/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
+++ b/Tests/PostgrestMacrosTests/DiagnosticsTests.swift
@@ -35,8 +35,9 @@ struct DiagnosticsTests {
 
   @Test
   func tableRejectsARelationshipProperty() {
-    // Forward-looking. `@Relationship` lands in stage 3, so today the compiler rejects the unknown
-    // attribute first; `assertMacro` has no such check, which is what lets this be tested now.
+    // `@Relationship` exists now, so this is what a user actually sees: the attribute resolves,
+    // and `@Table` rejects it before the compiler has anything to say. Embeds belong to a
+    // selection, so the fix is to move the property to a `@SelectionOf` type.
     assertMacro {
       """
       @Table("todos")
@@ -53,6 +54,33 @@ struct DiagnosticsTests {
         @Relationship(\Comment.todoID) var comments: [Comment]
         ┬─────────────────────────────
         ╰─ 🛑 @Relationship belongs on a @SelectionOf type, not on @Table
+      }
+      """#
+    }
+  }
+
+  @Test
+  func selectionOfRejectsARelationshipWithNoRoot() {
+    // `\.todoID` infers its root from context a macro cannot see, so the expansion would have
+    // nothing to name the foreign key's relation by. Left unreported, the property falls through
+    // to the plain-column path and the reader gets "no member 'comments'" on a line they did not
+    // write.
+    assertMacro {
+      #"""
+      @SelectionOf(Todo.self)
+      struct TodoWithComments {
+        var id: Int
+        @Relationship(\.todoID) var comments: [CommentBody]
+      }
+      """#
+    } diagnostics: {
+      #"""
+      @SelectionOf(Todo.self)
+      struct TodoWithComments {
+        var id: Int
+        @Relationship(\.todoID) var comments: [CommentBody]
+        ┬──────────────────────
+        ╰─ 🛑 @Relationship requires a key path to one foreign key column, written with its root, as in '@Relationship(\Comment.todoID)'
       }
       """#
     }

--- a/Tests/PostgrestMacrosTests/RelationshipIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/RelationshipIntegrationTests.swift
@@ -1,0 +1,91 @@
+//
+//  RelationshipIntegrationTests.swift
+//  Supabase
+//
+//  Created by Guilherme Souza on 31/08/26.
+//
+
+import Foundation
+import PostgrestMacros
+import Testing
+
+// File scope, for the same reason as `SelectionIntegrationTests`: both macros attach extensions.
+
+@Table("todos")
+struct RelationshipTodo {
+  @PrimaryKey var id: Int
+  var task: String
+}
+
+@Table("comments")
+struct RelationshipComment {
+  @PrimaryKey var id: Int
+  var todoID: Int
+  var body: String
+  @Column("written_by") var authorID: Int
+}
+
+@Table("users")
+struct RelationshipUser {
+  @PrimaryKey var id: Int
+  var name: String
+}
+
+@SelectionOf(RelationshipComment.self)
+struct RelationshipCommentBody {
+  var id: Int
+  var body: String
+}
+
+@SelectionOf(RelationshipUser.self)
+struct RelationshipUserName {
+  var name: String
+}
+
+@SelectionOf(RelationshipTodo.self)
+struct RelationshipTodoWithComments {
+  var id: Int
+  var task: String
+  @Relationship(\RelationshipComment.todoID) var comments: [RelationshipCommentBody]
+}
+
+/// The many-to-one direction: the foreign key sits on *this* selection's own relation, and the
+/// embed is a single row rather than an array.
+@SelectionOf(RelationshipComment.self)
+struct RelationshipCommentWithAuthor {
+  var body: String
+  @Relationship(\RelationshipComment.authorID) var author: RelationshipUserName?
+}
+
+@Suite
+struct RelationshipIntegrationTests {
+  @Test
+  func selectStringCarriesTheEmbedAndItsForeignKeyHint() {
+    // `comments:` is the alias the response comes back under, `comments` the embedded relation,
+    // `!todo_id` the disambiguating hint, and the parentheses the embed's own select list.
+    #expect(
+      RelationshipTodoWithComments.selectString
+        == "id:id,task:task,comments:comments!todo_id(id:id,body:body)"
+    )
+  }
+
+  @Test
+  func aManyToOneEmbedReadsTheForeignKeyOffItsOwnRelation() {
+    // Two things at once. The key path is rooted on the selection's own relation rather than on
+    // the target, so the target comes from the property's type — `users`, which appears nowhere in
+    // the attribute. And the hint is read off that relation's namespace, so the `@Column`
+    // override applies: `written_by`, not the `author_id` a local snake-casing would produce.
+    #expect(
+      RelationshipCommentWithAuthor.selectString == "body:body,author:users!written_by(name:name)"
+    )
+  }
+
+  @Test
+  func anEmbedDecodesUnderItsAlias() throws {
+    let json = #"{"id":1,"task":"ship","comments":[{"id":7,"body":"nice"}]}"#
+    let row = try JSONDecoder().decode(
+      RelationshipTodoWithComments.self, from: Data(json.utf8)
+    )
+    #expect(row.comments.map(\.id) == [7])
+  }
+}

--- a/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
+++ b/Tests/PostgrestMacrosTests/SelectionOfMacroTests.swift
@@ -44,7 +44,8 @@ struct SelectionOfMacroTests {
           case dueDate = "due_at"
         }
 
-        /// Fails to compile if a property does not name a column on Todo.
+        /// Fails to compile if a property does not name a column on Todo, or an embed's
+        /// foreign key does not name one on its own relation.
         private static let _columnCheck: [String] = [
           Todo.columns.id.postgrestExpression,
           Todo.columns.dueDate.postgrestExpression,
@@ -66,7 +67,7 @@ struct SelectionOfMacroTests {
       }
       """
     } expansion: {
-      """
+      #"""
       struct TodoSummary {
         var id: Int
         var isDone: Bool
@@ -76,8 +77,8 @@ struct SelectionOfMacroTests {
         typealias Source = Todo
 
         static let selectString = [
-          "id:\\(Todo.columns.id.postgrestExpression)",
-          "is_done:\\(Todo.columns.isDone.postgrestExpression)",
+          "id:\(Todo.columns.id.postgrestExpression)",
+          "is_done:\(Todo.columns.isDone.postgrestExpression)",
         ].joined(separator: ",")
 
         enum CodingKeys: String, CodingKey {
@@ -85,13 +86,107 @@ struct SelectionOfMacroTests {
           case isDone = "is_done"
         }
 
-        /// Fails to compile if a property does not name a column on Todo.
+        /// Fails to compile if a property does not name a column on Todo, or an embed's
+        /// foreign key does not name one on its own relation.
         private static let _columnCheck: [String] = [
           Todo.columns.id.postgrestExpression,
           Todo.columns.isDone.postgrestExpression,
         ]
       }
-      """
+      """#
+    }
+  }
+
+  /// The embed the whole attribute exists for. Every part of the rendered form is an
+  /// interpolation: the embedded relation and its select list come from the property's type, and
+  /// the `!todo_id` hint from the foreign key's own relation.
+  @Test
+  func expandsAToManyEmbed() {
+    assertMacro {
+      #"""
+      @SelectionOf(Todo.self)
+      struct TodoWithComments {
+        var id: Int
+        var task: String
+        @Relationship(\Comment.todoID) var comments: [CommentBody]
+      }
+      """#
+    } expansion: {
+      #"""
+      struct TodoWithComments {
+        var id: Int
+        var task: String
+        @Relationship(\Comment.todoID) var comments: [CommentBody]
+      }
+
+      extension TodoWithComments {
+        typealias Source = Todo
+
+        static let selectString = [
+          "id:\(Todo.columns.id.postgrestExpression)",
+          "task:\(Todo.columns.task.postgrestExpression)",
+          "comments:\(CommentBody.Source.relationName)!\(Comment.columns.todoID.postgrestExpression)(\(CommentBody.selectString))",
+        ].joined(separator: ",")
+
+        enum CodingKeys: String, CodingKey {
+          case id = "id"
+          case task = "task"
+          case comments = "comments"
+        }
+
+        /// Fails to compile if a property does not name a column on Todo, or an embed's
+        /// foreign key does not name one on its own relation.
+        private static let _columnCheck: [String] = [
+          Todo.columns.id.postgrestExpression,
+          Todo.columns.task.postgrestExpression,
+          Comment.columns.todoID.postgrestExpression,
+        ]
+      }
+      """#
+    }
+  }
+
+  /// The other direction. `\Comment.authorID` is rooted on the selection's *own* relation rather
+  /// than on the target, and the expansion is the same shape — which is the point: the key path
+  /// names the foreign key, and the property names the embed.
+  @Test
+  func expandsAToOneEmbed() {
+    assertMacro {
+      #"""
+      @SelectionOf(Comment.self)
+      struct CommentWithAuthor {
+        var body: String
+        @Relationship(\Comment.authorID) var author: UserName?
+      }
+      """#
+    } expansion: {
+      #"""
+      struct CommentWithAuthor {
+        var body: String
+        @Relationship(\Comment.authorID) var author: UserName?
+      }
+
+      extension CommentWithAuthor {
+        typealias Source = Comment
+
+        static let selectString = [
+          "body:\(Comment.columns.body.postgrestExpression)",
+          "author:\(UserName.Source.relationName)!\(Comment.columns.authorID.postgrestExpression)(\(UserName.selectString))",
+        ].joined(separator: ",")
+
+        enum CodingKeys: String, CodingKey {
+          case body = "body"
+          case author = "author"
+        }
+
+        /// Fails to compile if a property does not name a column on Comment, or an embed's
+        /// foreign key does not name one on its own relation.
+        private static let _columnCheck: [String] = [
+          Comment.columns.body.postgrestExpression,
+          Comment.columns.authorID.postgrestExpression,
+        ]
+      }
+      """#
     }
   }
 
@@ -121,7 +216,8 @@ struct SelectionOfMacroTests {
           case isDone = "is_done"
         }
 
-        /// Fails to compile if a property does not name a column on Todo.
+        /// Fails to compile if a property does not name a column on Todo, or an embed's
+        /// foreign key does not name one on its own relation.
         private static let _columnCheck: [String] = [
           Todo.columns.isDone.postgrestExpression,
         ]

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -195,6 +195,7 @@ supporting_symbols:
   - Column
   - PrimaryKey
   - Default
+  - Relationship
 
 features:
 


### PR DESCRIPTION
A `@SelectionOf` type can now declare an embedded relation, identified by its foreign key column:

```swift
@SelectionOf(Todo.self)
struct TodoWithComments {
  var id: UUID
  var task: String
  @Relationship(\Comment.todoID) var comments: [CommentBody]
}

// "id:id,task:task,comments:comments!todo_id(id:id,body:body)"
```

Fixes SDK-1574
