### PR TITLE
fix(postgrest): keep resolution=merge-duplicates when returning() follows upsert

### DIFF
--- a/Sources/PostgREST/Legacy/PostgrestRequestBuilder.swift
+++ b/Sources/PostgREST/Legacy/PostgrestRequestBuilder.swift
@@ -349,6 +349,15 @@ extension PostgrestRequestBuilder where Phase: PostgrestExecutablePhase {
     return copy
   }
 
+  /// Adds or replaces one preference in the `Prefer` header, leaving any other preference already
+  /// there untouched — unlike ``setHeader(name:value:)-(String,_)``, which replaces the header
+  /// wholesale.
+  func mergingPreferHeader(_ value: String) -> Self {
+    var copy = self
+    copy.request.headers.appendOrUpdate(.prefer, value: value)
+    return copy
+  }
+
   /// Controls whether automatic retries are enabled for this specific request.
   ///
   /// When enabled, GET and HEAD requests that receive an HTTP 503 or 520 response, or encounter

--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -31,18 +31,15 @@ public struct PostgrestTypedMutation<R: PostgrestWritableRelation>: PostgrestFil
 
   /// Requests the affected rows back, decoded as `[R]`.
   ///
-  /// This replaces the `Prefer` header rather than appending to it. The write methods set
-  /// `return=minimal` so a plain ``execute()`` does not transfer rows, and appending would leave
-  /// `Prefer: return=minimal,return=representation`, which is contradictory.
+  /// This replaces only the `return=` preference in the `Prefer` header, so it composes with
+  /// whatever else a write method already set there — `upsert` puts `resolution=` in the same
+  /// header, and losing it there would silently turn the upsert into a plain insert.
   /// `return=representation` alone returns every column, so no `select` parameter is needed.
-  ///
-  /// > Note: Because this replaces the whole header, do not combine it with any other `Prefer`
-  /// > preference on a mutation. Slice 0 sets none.
   ///
   /// - Returns: A ``PostgrestTypedQuery`` decoding into `[R]`.
   public func returning() -> PostgrestTypedQuery<R, [R], PostgrestFilterPhase> {
     PostgrestTypedQuery(
-      builder: builder.setHeader(name: "Prefer", value: "return=representation")
+      builder: builder.mergingPreferHeader("return=representation")
     )
   }
 

--- a/Tests/PostgrestMacrosTests/RequestCapture.swift
+++ b/Tests/PostgrestMacrosTests/RequestCapture.swift
@@ -48,6 +48,9 @@ struct RequestCapture {
   /// The path of the captured request's URL, which ends in the relation name.
   var path: String? { captured.value?.url?.path }
 
+  /// The captured request's `Prefer` header, for asserting the full value rather than a substring.
+  var prefer: String? { captured.value?.value(forHTTPHeaderField: "Prefer") }
+
   /// The captured request body decoded as UTF-8.
   var bodyString: String? {
     captured.value?.httpBody.map { String(decoding: $0, as: UTF8.self) }

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -267,6 +267,44 @@ struct TableIntegrationTests {
   }
 
   @Test
+  func aTypedUpsertReturningKeepsTheConflictResolutionPreference() async throws {
+    // SDK-1626. `returning()` used to replace the whole `Prefer` header, so it silently dropped
+    // the `resolution=merge-duplicates` that `upsert()` had already set — turning the upsert into
+    // a plain insert the moment a caller asked for the row back.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .upsert(Todo.Draft(id: 1, task: "buy milk"))
+      .returning()
+      .execute()
+
+    #expect(capture.prefer == "resolution=merge-duplicates,return=representation")
+  }
+
+  @Test
+  func aTypedUpsertExecuteAloneKeepsAMinimalReturnPreference() async throws {
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .upsert(Todo.Draft(id: 1, task: "buy milk"))
+      .execute()
+
+    #expect(capture.prefer == "resolution=merge-duplicates,return=minimal")
+  }
+
+  @Test
+  func aTypedInsertReturningSendsExactlyOneReturnPreference() async throws {
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .insert(Todo.Draft(task: "buy milk"))
+      .returning()
+      .execute()
+
+    #expect(capture.prefer == "return=representation")
+  }
+
+  @Test
   func aTypedUpsertDerivesTheConflictTargetFromTheKey() async throws {
     // PostgREST resolves an absent `on_conflict` against the primary key already, so this is the
     // same request either way. Naming it is what makes the request say what it merges on, and it


### PR DESCRIPTION
## Summary

`PostgrestTypedMutation.returning()` replaced the whole `Prefer` header instead of merging into it, so `upsert(...).returning()` silently dropped the `resolution=merge-duplicates` preference `upsert()` had already set — turning the upsert into a plain insert. A conflicting row then came back as a `409` instead of the merged row, on the exact call shape that looks correct at the call site.

Added `PostgrestRequestBuilder.mergingPreferHeader(_:)`, using the existing `HTTPFields.appendOrUpdate` helper to replace only the matching `key=` entry in the comma-separated `Prefer` header (the same mechanism `execute(options:)` already uses for `count=`). `returning()` now calls that instead of `setHeader`.

## Test plan

- [x] Added tests asserting the full `Prefer` header value (not a substring) for `upsert().returning()`, `upsert().execute()`, and `insert().returning()`.
- [x] `swift test`: 1433 tests passed, 148 suites, 12 known (pre-existing) issues.
- [x] `./scripts/format.sh`, `./scripts/spell-check.sh`, `./scripts/test-docs.sh`: clean.

Fixes SDK-1626