### PR TITLE
feat(postgrest): let a typed upsert ignore duplicates instead of merging them

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedMutation.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedMutation.swift
@@ -5,6 +5,38 @@
 //  Created by Guilherme Souza on 21/08/26.
 //
 
+/// What an upsert does with a row that conflicts on its target.
+///
+/// Pass a value to the `resolution` parameter of a typed `upsert`. The default,
+/// ``mergeDuplicates``, is the upsert everyone means by the word; ``ignoreDuplicates`` is a
+/// different operation, and worth reaching for deliberately.
+public struct PostgrestConflictResolution: RawRepresentable, Hashable, Sendable,
+  ExpressibleByStringLiteral
+{
+  public let rawValue: String
+
+  /// Creates a ``PostgrestConflictResolution`` from a raw string value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a ``PostgrestConflictResolution`` from a string literal.
+  public init(stringLiteral value: String) {
+    self.init(rawValue: value)
+  }
+
+  /// Updates the existing row with the supplied values — `ON CONFLICT DO UPDATE`.
+  ///
+  /// The default, and what "upsert" normally means.
+  public static let mergeDuplicates: PostgrestConflictResolution = "merge-duplicates"
+
+  /// Leaves the existing row exactly as it is — `ON CONFLICT DO NOTHING`.
+  ///
+  /// Insert-if-absent. Use this for seeding reference data, backfilling, or any at-least-once job
+  /// where overwriting a row someone has since edited would be data loss.
+  public static let ignoreDuplicates: PostgrestConflictResolution = "ignore-duplicates"
+}
+
 /// A write request against a writable relation.
 ///
 /// Obtain one from `insert`, `upsert`, `update` or `delete` on a ``PostgrestTypedSource``. Those
@@ -133,12 +165,14 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   /// derived expression — a cast, an aggregate — is not a target PostgREST can take, and neither
   /// is a column belonging to some other relation. Both are rejected at the call site.
   ///
-  /// To merge on the primary key, use ``upsert(_:)-(R.Draft)``, which derives the target instead.
+  /// To merge on the primary key, use ``upsert(_:resolution:)-(R.Draft,_)``, which derives the target instead.
   ///
   /// - Parameters:
   ///   - values: The row to upsert, in the relation's ``PostgrestWritableRelation/Draft`` shape.
   ///   - column: The first column of the unique constraint to merge on.
   ///   - additional: The remaining columns, for a constraint spanning more than one.
+  ///   - resolution: What to do with a conflicting row. Defaults to
+  ///     ``PostgrestConflictResolution/mergeDuplicates``.
   /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
   /// - Throws: An encoding error if `values` cannot be serialized.
   public func upsert<
@@ -151,7 +185,8 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
     onConflict column: KeyPath<R.Columns, PostgrestStoredColumn<R, FirstValue, FirstNullability>>,
     _ additional: repeat KeyPath<
       R.Columns, PostgrestStoredColumn<R, each RestValue, each RestNullability>
-    >
+    >,
+    resolution: PostgrestConflictResolution = .mergeDuplicates
   ) throws -> PostgrestTypedMutation<R> {
     var names = [R.columns[keyPath: column].postgrestExpression]
     repeat names.append(R.columns[keyPath: each additional].postgrestExpression)
@@ -161,6 +196,7 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
         onConflict: names.joined(separator: ","),
         returning: .minimal
       )
+      .mergingPreferHeader("resolution=\(resolution.rawValue)")
     )
   }
 
@@ -174,7 +210,7 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   /// ```
   ///
   /// The target applies to every row in the batch, and carries the same rules as
-  /// ``upsert(_:onConflict:_:)-(R.Draft,_,_)``: each key path must name a stored column of this
+  /// ``upsert(_:onConflict:_:resolution:)-(R.Draft,_,_,_)``: each key path must name a stored column of this
   /// relation. As with the bulk insert, the rows may encode different columns and an empty collection
   /// writes nothing rather than throwing.
   ///
@@ -182,6 +218,8 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
   ///   - values: The rows to upsert, in the relation's ``PostgrestWritableRelation/Draft`` shape.
   ///   - column: The first column of the unique constraint to merge on.
   ///   - additional: The remaining columns, for a constraint spanning more than one.
+  ///   - resolution: What to do with a conflicting row. Defaults to
+  ///     ``PostgrestConflictResolution/mergeDuplicates``, and applies to every row in the batch.
   /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
   /// - Throws: An encoding error if `values` cannot be serialized.
   public func upsert<
@@ -194,7 +232,8 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
     onConflict column: KeyPath<R.Columns, PostgrestStoredColumn<R, FirstValue, FirstNullability>>,
     _ additional: repeat KeyPath<
       R.Columns, PostgrestStoredColumn<R, each RestValue, each RestNullability>
-    >
+    >,
+    resolution: PostgrestConflictResolution = .mergeDuplicates
   ) throws -> PostgrestTypedMutation<R> {
     var names = [R.columns[keyPath: column].postgrestExpression]
     repeat names.append(R.columns[keyPath: each additional].postgrestExpression)
@@ -204,6 +243,7 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation {
         onConflict: names.joined(separator: ","),
         returning: .minimal
       )
+      .mergingPreferHeader("resolution=\(resolution.rawValue)")
     )
   }
 
@@ -271,7 +311,7 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation & PostgrestKey
   /// overload exists only where the relation declares a key. On a keyless relation the database has
   /// nothing to merge on, so an upsert with no target is not a merge at all — it inserts another row
   /// every call. Requiring the conformance makes that a compile error instead; use
-  /// ``upsert(_:onConflict:_:)-(R.Draft,_,_)`` there and name a unique constraint the relation does have.
+  /// ``upsert(_:onConflict:_:resolution:)-(R.Draft,_,_,_)`` there and name a unique constraint the relation does have.
   ///
   /// The same ``PostgrestWritableRelation/Draft`` serves this and ``insert(_:)-(R.Draft)``: it is a row the
   /// database has not stored yet, whether this call ends up inserting it or merging it into an
@@ -280,17 +320,23 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation & PostgrestKey
   /// > Note: The target only takes effect if the columns it names are in the body. A key the
   /// > database generates is optional in `Draft`, so omitting it still inserts.
   ///
-  /// - Parameter values: The row to upsert, in the relation's ``PostgrestWritableRelation/Draft``
-  ///   shape.
+  /// - Parameters:
+  ///   - values: The row to upsert, in the relation's ``PostgrestWritableRelation/Draft`` shape.
+  ///   - resolution: What to do with a conflicting row. Defaults to
+  ///     ``PostgrestConflictResolution/mergeDuplicates``.
   /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
   /// - Throws: An encoding error if `values` cannot be serialized.
-  public func upsert(_ values: R.Draft) throws -> PostgrestTypedMutation<R> {
+  public func upsert(
+    _ values: R.Draft,
+    resolution: PostgrestConflictResolution = .mergeDuplicates
+  ) throws -> PostgrestTypedMutation<R> {
     PostgrestTypedMutation(
       builder: try builder.upsert(
         values,
         onConflict: R.primaryKeyColumns.joined(separator: ","),
         returning: .minimal
       )
+      .mergingPreferHeader("resolution=\(resolution.rawValue)")
     )
   }
 
@@ -303,23 +349,29 @@ extension PostgrestTypedSource where R: PostgrestWritableRelation & PostgrestKey
   /// ```
   ///
   /// The target comes from ``PostgrestKeyedRelation/primaryKeyColumns``, exactly as in
-  /// ``upsert(_:)-(R.Draft)``, and applies to every row in the batch. As with the bulk insert, the
+  /// ``upsert(_:resolution:)-(R.Draft,_)``, and applies to every row in the batch. As with the bulk insert, the
   /// rows may encode different columns and an empty collection writes nothing rather than throwing.
   ///
   /// > Note: The target only takes effect for a row that carries the key columns in its body. A
   /// > row that omits a database-generated key is inserted, so a batch can mix the two.
   ///
-  /// - Parameter values: The rows to upsert, in the relation's
-  ///   ``PostgrestWritableRelation/Draft`` shape.
+  /// - Parameters:
+  ///   - values: The rows to upsert, in the relation's ``PostgrestWritableRelation/Draft`` shape.
+  ///   - resolution: What to do with a conflicting row. Defaults to
+  ///     ``PostgrestConflictResolution/mergeDuplicates``, and applies to every row in the batch.
   /// - Returns: A ``PostgrestTypedMutation`` to execute, or to request rows back from.
   /// - Throws: An encoding error if `values` cannot be serialized.
-  public func upsert(_ values: some Collection<R.Draft>) throws -> PostgrestTypedMutation<R> {
+  public func upsert(
+    _ values: some Collection<R.Draft>,
+    resolution: PostgrestConflictResolution = .mergeDuplicates
+  ) throws -> PostgrestTypedMutation<R> {
     PostgrestTypedMutation(
       builder: try builder.upsert(
         Array(values),
         onConflict: R.primaryKeyColumns.joined(separator: ","),
         returning: .minimal
       )
+      .mergingPreferHeader("resolution=\(resolution.rawValue)")
     )
   }
 }

--- a/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
+++ b/Tests/PostgrestMacrosTests/TableIntegrationTests.swift
@@ -305,6 +305,76 @@ struct TableIntegrationTests {
   }
 
   @Test
+  func aTypedUpsertCanIgnoreDuplicatesInsteadOfMergingThem() async throws {
+    // SDK-1627. `resolution=ignore-duplicates` is `ON CONFLICT DO NOTHING` — insert if absent,
+    // leave an existing row exactly as it is. A distinct operation, not a tuning knob.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .upsert(Todo.Draft(id: 1, task: "buy milk"), resolution: .ignoreDuplicates)
+      .execute()
+
+    #expect(capture.prefer == "resolution=ignore-duplicates,return=minimal")
+    #expect(capture.query?.contains("on_conflict=id") == true)
+  }
+
+  @Test
+  func anIgnoreDuplicatesResolutionSurvivesReturning() async throws {
+    // The pairing that SDK-1626 broke for `merge`: whichever resolution the caller picked has to
+    // still be on the header once they ask for the row back.
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(Todo.self)
+      .upsert(Todo.Draft(id: 1, task: "buy milk"), resolution: .ignoreDuplicates)
+      .returning()
+      .execute()
+
+    #expect(capture.prefer == "resolution=ignore-duplicates,return=representation")
+  }
+
+  @Test
+  func anExplicitConflictTargetTakesAResolution() async throws {
+    let capture = RequestCapture()
+    _ = try await capture.client
+      .from(IntegrationNote.self)
+      .upsert(
+        IntegrationNote.Draft(body: "remember the milk", tag: "home"),
+        onConflict: \.tag,
+        resolution: .ignoreDuplicates
+      )
+      .execute()
+
+    #expect(capture.prefer == "resolution=ignore-duplicates,return=minimal")
+    #expect(capture.query?.contains("on_conflict=tag") == true)
+  }
+
+  @Test
+  func aBulkUpsertTakesAResolutionOnEitherConflictTarget() async throws {
+    let derived = RequestCapture()
+    _ = try await derived.client
+      .from(Todo.self)
+      .upsert(
+        [Todo.Draft(id: 1, task: "buy milk"), Todo.Draft(id: 2, task: "buy bread")],
+        resolution: .ignoreDuplicates
+      )
+      .execute()
+
+    #expect(derived.prefer == "resolution=ignore-duplicates,return=minimal")
+
+    let explicit = RequestCapture()
+    _ = try await explicit.client
+      .from(IntegrationNote.self)
+      .upsert(
+        [IntegrationNote.Draft(body: "remember the milk", tag: "home")],
+        onConflict: \.tag,
+        resolution: .ignoreDuplicates
+      )
+      .execute()
+
+    #expect(explicit.prefer == "resolution=ignore-duplicates,return=minimal")
+  }
+
+  @Test
   func aTypedUpsertDerivesTheConflictTargetFromTheKey() async throws {
     // PostgREST resolves an absent `on_conflict` against the primary key already, so this is the
     // same request either way. Naming it is what makes the request say what it merges on, and it

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -707,6 +707,12 @@ features:
     symbols:
       - PostgrestRequestBuilder.upsert
       - PostgrestTypedSource.upsert
+    supporting_symbols:
+      - PostgrestConflictResolution
+      - PostgrestConflictResolution.init
+      - PostgrestConflictResolution.rawValue
+      - PostgrestConflictResolution.mergeDuplicates
+      - PostgrestConflictResolution.ignoreDuplicates
   database.mutate.delete:
     status: implemented
     symbols:


### PR DESCRIPTION
> [!NOTE]
> Stacked on #1308 — base is `claude/postgrest-v3-priority-891b48`, not `main`. Review that one first; this diff shows only the SDK-1627 commit.

## Summary

The legacy builder lets a caller choose what happens on conflict (`ignoreDuplicates:`); the typed one always merged. `resolution=ignore-duplicates` is Postgres's `ON CONFLICT DO NOTHING` — insert-if-absent, leave an existing row alone — which is a distinct operation, not a tuning knob. Reaching it previously meant dropping to the legacy builder and losing the typed layer entirely.

Adds `PostgrestConflictResolution`, a `RawRepresentable` struct per `AGENTS.md` (the value crosses the wire), with `.mergeDuplicates` (default) and `.ignoreDuplicates`. It lands as a defaulted parameter on the four existing typed `upsert` overloads — single/bulk × derived/explicit conflict target — so there are **no new signatures** and **no call-site changes**.

## Notes for reviewers

Two alternatives were considered and rejected (discussion on SDK-1627):

- `insertIfAbsent(_:)` as a separate method — four new signatures and a second name to document, for something PostgREST models as one header preference.
- `ignoreDuplicates: Bool` mirroring supabase-js — a boolean that inverts the verb; `upsert(row, ignoreDuplicates: true)` reads as an upsert that never updates.

The resolution is applied with `mergingPreferHeader` (added in #1308), replacing only the `resolution=` entry the legacy builder already wrote. That means the legacy `upsert` signature needed no change, and an unrecognized raw value round-trips to the wire rather than being coerced through a `Bool` — which is the point of the `RawRepresentable`-struct rule.

## Test plan

- [x] Four tests asserting the full `Prefer` header: ignore-duplicates on the derived target, surviving `returning()`, on an explicit target, and on both bulk overloads.
- [x] `swift test`: 1437 tests passed, 148 suites, 12 known (pre-existing) issues.
- [x] `./scripts/format.sh`, `./scripts/spell-check.sh`, `./scripts/test-docs.sh`: clean.
- [x] `sdk-compliance.yaml` updated with the new supporting symbols under `database.mutate.upsert`.

Fixes SDK-1627