### PR TITLE
feat(postgrest): add defaultToNull to insert and upsert

### DIFF
--- a/Sources/PostgREST/Legacy/PostgrestClient.swift
+++ b/Sources/PostgREST/Legacy/PostgrestClient.swift
@@ -119,9 +119,9 @@ public struct PostgrestClient: Sendable {
     /// The `JSONEncoder` used to serialize request bodies.
     ///
     /// Defaults to ``jsonEncoder``, which is pre-configured with Supabase-compatible settings.
-    /// Individual calls to ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``,
+    /// Individual calls to ``PostgrestRequestBuilder/insert(_:returning:count:defaultToNull:encoder:)``,
     /// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``, and
-    /// ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:encoder:)``
+    /// ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:defaultToNull:encoder:)``
     /// can override this per call.
     public let encoder: JSONEncoder
 
@@ -249,9 +249,9 @@ public struct PostgrestClient: Sendable {
   /// Returns a query builder targeting the specified table or view.
   ///
   /// Call ``PostgrestRequestBuilder/select(_:head:count:)`` on the returned builder to begin a
-  /// `SELECT`, or use ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``,
+  /// `SELECT`, or use ``PostgrestRequestBuilder/insert(_:returning:count:defaultToNull:encoder:)``,
   /// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``,
-  /// ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:encoder:)``, or
+  /// ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:defaultToNull:encoder:)``, or
   /// ``PostgrestRequestBuilder/delete(returning:count:)`` for write operations.
   ///
   /// - Parameter table: The name of the table or view to query.

--- a/Sources/PostgREST/Legacy/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/Legacy/PostgrestQueryBuilder.swift
@@ -89,6 +89,10 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   ///   - values: An `Encodable` value representing a single row or an array of rows to insert.
   ///   - returning: Controls which rows PostgREST returns. Defaults to `nil` (server decides).
   ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
+  ///   - defaultToNull: Controls what happens to a column that some rows in a bulk payload name and
+  ///     others leave out. `true` (the default) inserts `null` for the rows that omit it; `false`
+  ///     sends `Prefer: missing=default` so the column's `DEFAULT` applies instead. `upsert` takes
+  ///     the same option.
   ///   - encoder: The `JSONEncoder` used to serialize `values`. Overrides
   ///     ``PostgrestClient/Configuration/encoder`` when non-`nil`.
   /// - Returns: A ``PostgrestFilterBuilder`` for applying additional constraints or executing the request.
@@ -97,6 +101,7 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
     _ values: some Encodable,
     returning: PostgrestReturningOptions? = nil,
     count: CountOption? = nil,
+    defaultToNull: Bool = true,
     encoder: JSONEncoder? = nil
   ) throws -> PostgrestFilterBuilder {
     let body = try (encoder ?? configuration.encoder).encode(values)
@@ -110,6 +115,9 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
     request.body = body
     if let count {
       prefersHeaders.append("count=\(count.rawValue)")
+    }
+    if !defaultToNull {
+      prefersHeaders.append("missing=default")
     }
     if let prefer = request.headers[.prefer] {
       prefersHeaders.insert(prefer, at: 0)
@@ -151,6 +159,11 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
   ///   - count: The row-count algorithm to use, or `nil` to skip counting. See ``CountOption``.
   ///   - ignoreDuplicates: When `true`, conflicting rows are silently ignored. When `false` (the
   ///     default), conflicting rows are merged with the supplied values.
+  ///   - defaultToNull: Controls what happens to a column that some rows in a bulk payload name and
+  ///     others leave out. `true` (the default) inserts `null` for the rows that omit it; `false`
+  ///     sends `Prefer: missing=default` so the column's `DEFAULT` applies instead. This also
+  ///     decides what a row omitting the conflict target merges against: under `false` the target
+  ///     resolves to the database-generated value, which is what the conflict is detected on.
   ///   - encoder: The `JSONEncoder` used to serialize `values`. Overrides
   ///     ``PostgrestClient/Configuration/encoder`` when non-`nil`.
   /// - Returns: A ``PostgrestFilterBuilder`` for applying additional constraints or executing the request.
@@ -161,6 +174,7 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
     returning: PostgrestReturningOptions = .representation,
     count: CountOption? = nil,
     ignoreDuplicates: Bool = false,
+    defaultToNull: Bool = true,
     encoder: JSONEncoder? = nil
   ) throws -> PostgrestFilterBuilder {
     let body = try (encoder ?? configuration.encoder).encode(values)
@@ -177,6 +191,9 @@ extension PostgrestRequestBuilder where Phase == PostgrestQueryPhase {
     request.body = body
     if let count {
       prefersHeaders.append("count=\(count.rawValue)")
+    }
+    if !defaultToNull {
+      prefersHeaders.append("missing=default")
     }
     if let prefer = request.headers[.prefer] {
       prefersHeaders.insert(prefer, at: 0)

--- a/Sources/PostgREST/Legacy/PostgrestRequestBuilder.swift
+++ b/Sources/PostgREST/Legacy/PostgrestRequestBuilder.swift
@@ -159,7 +159,7 @@ public struct PostgrestRequestBuilder<Phase>: Sendable {
 ///
 /// ### Inserting Rows
 ///
-/// - ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``
+/// - ``PostgrestRequestBuilder/insert(_:returning:count:defaultToNull:encoder:)``
 ///
 /// ### Updating Rows
 ///
@@ -167,7 +167,7 @@ public struct PostgrestRequestBuilder<Phase>: Sendable {
 ///
 /// ### Upsert Rows
 ///
-/// - ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:encoder:)``
+/// - ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:defaultToNull:encoder:)``
 ///
 /// ### Deleting Rows
 ///
@@ -180,7 +180,7 @@ public typealias PostgrestQueryBuilder = PostgrestRequestBuilder<PostgrestQueryP
 /// This is ``PostgrestRequestBuilder`` specialized to ``PostgrestFilterPhase``.
 ///
 /// Obtain one from ``PostgrestRequestBuilder/select(_:head:count:)``,
-/// ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``,
+/// ``PostgrestRequestBuilder/insert(_:returning:count:defaultToNull:encoder:)``,
 /// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``, or another write method on
 /// ``PostgrestQueryBuilder``, or from ``PostgrestClient/rpc(_:params:head:get:count:)``. Chain one
 /// or more filter methods, then call

--- a/Sources/PostgREST/Legacy/Types.swift
+++ b/Sources/PostgREST/Legacy/Types.swift
@@ -136,8 +136,8 @@ public struct CountOption: RawRepresentable, Hashable, Sendable, ExpressibleBySt
 
 /// Controls which rows PostgREST returns after a write operation.
 ///
-/// Pass a ``PostgrestReturningOptions`` value to ``PostgrestRequestBuilder/insert(_:returning:count:encoder:)``,
-/// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``, ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:encoder:)``,
+/// Pass a ``PostgrestReturningOptions`` value to ``PostgrestRequestBuilder/insert(_:returning:count:defaultToNull:encoder:)``,
+/// ``PostgrestRequestBuilder/update(_:returning:count:encoder:)``, ``PostgrestRequestBuilder/upsert(_:onConflict:returning:count:ignoreDuplicates:defaultToNull:encoder:)``,
 /// or ``PostgrestRequestBuilder/delete(returning:count:)`` to specify what the server sends back.
 ///
 /// See the [PostgREST documentation](https://postgrest.org/en/v9.0/api.html?highlight=PREFER#insertions-updates)

--- a/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
@@ -407,11 +407,6 @@ extension PostgrestMockerTests {
         .execute()
     }
 
-    // SDK-1613. `defaultToNull: false` sends `Prefer: missing=default`, so a column some rows in a
-    // bulk payload omit takes its database `DEFAULT` instead of being overwritten with `null`.
-    // The header is sent regardless of whether the payload is a single row or an array, matching
-    // supabase-js — there the `Array.isArray` check gates only the `columns` parameter.
-
     @Test
     func insertDefaultToNullFalseSendsMissingDefault() async throws {
       Mock(

--- a/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
+++ b/Tests/PostgRESTTests/PostgrestQueryBuilderTests.swift
@@ -407,6 +407,163 @@ extension PostgrestMockerTests {
         .execute()
     }
 
+    // SDK-1613. `defaultToNull: false` sends `Prefer: missing=default`, so a column some rows in a
+    // bulk payload omit takes its database `DEFAULT` instead of being overwritten with `null`.
+    // The header is sent regardless of whether the payload is a single row or an array, matching
+    // supabase-js — there the `Array.isArray` check gates only the `columns` parameter.
+
+    @Test
+    func insertDefaultToNullFalseSendsMissingDefault() async throws {
+      Mock(
+        url: url.appendingPathComponent("users"),
+        ignoreQuery: true,
+        statusCode: 201,
+        data: [
+          .post: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Accept: application/json" \
+        	--header "Content-Length: 27" \
+        	--header "Content-Type: application/json" \
+        	--header "Prefer: return=minimal,missing=default" \
+        	--header "X-Client-Info: postgrest-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"id\":1,\"username\":\"admin\"}" \
+        	"http://localhost:54321/rest/v1/users"
+        """#
+      }
+      .register()
+
+      try await sut
+        .from("users")
+        .insert(User(id: 1, username: "admin"), returning: .minimal, defaultToNull: false)
+        .execute()
+    }
+
+    @Test
+    func insertDefaultToNullFalseComposesWithReturningAndCount() async throws {
+      Mock(
+        url: url.appendingPathComponent("users"),
+        ignoreQuery: true,
+        statusCode: 201,
+        data: [
+          .post: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Accept: application/json" \
+        	--header "Content-Length: 60" \
+        	--header "Content-Type: application/json" \
+        	--header "Prefer: return=minimal,count=estimated,missing=default" \
+        	--header "X-Client-Info: postgrest-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "[{\"id\":1,\"username\":\"admin\"},{\"id\":2,\"username\":\"supabase\"}]" \
+        	"http://localhost:54321/rest/v1/users?columns=%22id%22,%22username%22"
+        """#
+      }
+      .register()
+
+      try await sut
+        .from("users")
+        .insert(
+          [
+            User(id: 1, username: "admin"),
+            User(id: 2, username: "supabase"),
+          ],
+          returning: .minimal,
+          count: .estimated,
+          defaultToNull: false
+        )
+        .execute()
+    }
+
+    @Test
+    func upsertDefaultToNullFalseKeepsEveryOtherPreference() async throws {
+      // The whole point of the option is that it is one more entry in a header that already carries
+      // `resolution=`, `return=`, `count=` and whatever the caller set. Dropping any of them turns
+      // the request into a different operation — see SDK-1626.
+      Mock(
+        url: url.appendingPathComponent("users"),
+        ignoreQuery: true,
+        statusCode: 201,
+        data: [
+          .post: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Accept: application/json" \
+        	--header "Content-Length: 60" \
+        	--header "Content-Type: application/json" \
+        	--header "Prefer: existing=value,resolution=merge-duplicates,return=minimal,count=estimated,missing=default" \
+        	--header "X-Client-Info: postgrest-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "[{\"id\":1,\"username\":\"admin\"},{\"id\":2,\"username\":\"supabase\"}]" \
+        	"http://localhost:54321/rest/v1/users?columns=%22id%22,%22username%22&on_conflict=username"
+        """#
+      }
+      .register()
+
+      try await sut(withPreferHeader: "existing=value")
+        .from("users")
+        .upsert(
+          [
+            User(id: 1, username: "admin"),
+            User(id: 2, username: "supabase"),
+          ],
+          onConflict: "username",
+          returning: .minimal,
+          count: .estimated,
+          defaultToNull: false
+        )
+        .execute()
+    }
+
+    @Test
+    func upsertDefaultToNullFalseComposesWithIgnoreDuplicates() async throws {
+      Mock(
+        url: url.appendingPathComponent("users"),
+        ignoreQuery: true,
+        statusCode: 201,
+        data: [
+          .post: Data()
+        ]
+      )
+      .snapshotRequest {
+        #"""
+        curl \
+        	--request POST \
+        	--header "Accept: application/json" \
+        	--header "Content-Length: 27" \
+        	--header "Content-Type: application/json" \
+        	--header "Prefer: resolution=ignore-duplicates,return=representation,missing=default" \
+        	--header "X-Client-Info: postgrest-swift/0.0.0" \
+        	--header "apikey: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" \
+        	--data "{\"id\":1,\"username\":\"admin\"}" \
+        	"http://localhost:54321/rest/v1/users"
+        """#
+      }
+      .register()
+
+      try await sut
+        .from("users")
+        .upsert(
+          User(id: 1, username: "admin"),
+          ignoreDuplicates: true,
+          defaultToNull: false
+        )
+        .execute()
+    }
+
     @Test
     func delete() async throws {
       Mock(


### PR DESCRIPTION
## Why

A bulk payload sends the union of every row's keys as the `columns` parameter, so a column that only *some* rows carry is written as `null` for the rows that omit it — overwriting its database `DEFAULT`. PostgREST's `Prefer: missing=default` asks for the default instead, and Swift had no first-class way to send it. supabase-js exposes this as `defaultToNull`.

`defaultToNull: Bool = true` on the legacy `insert` and `upsert`; `false` appends `missing=default` to `Prefer`.

> [!IMPORTANT]
> **Draft** — blocked on the spec PR that documents this capability: supabase/sdk#130 (awaiting CODEOWNERS). Opening as a draft so CI can answer the ABI question below while that review happens.

## The ABI question this PR exists to answer

[SDK-1613](https://linear.app/supabase/issue/SDK-1613/postgrest-no-defaulttonull-prefer-missingdefault-on-insert-and-upsert) flags that adding even a *defaulted* parameter to a public function can be reported as an `API breakage:` because the mangled name changes — and this is a **shipped** surface (the legacy builder, present in v2.55.1), so it matters.

I could not answer it locally. `scripts/check-for-breaking-api-changes.sh` reports `❌ Breaking API changes detected` on a tree **byte-identical to the baseline** — all 8 modules fail to load with a `libsecp256k1` module redefinition, so every baseline has zero symbols and the non-zero exit is a false positive (`rm -rf .build` first does not help). The gate is green in CI, so it is a local-environment problem, not a broken gate.

**So `api-stability.yml` on this PR is the verdict.** If it flags the parameter, the fix is to swap it for a new overload rather than carry a `!` and a `V3_MIGRATION.md` entry for a purely additive option — say the word and I will reshape it.

## Two deviations from the issue, both deliberate

**1. The header is not gated on the payload shape.** The issue suggested gating it on the existing `[[String: Any]]` array check "for exact parity". `postgrest-js` does the opposite — `if (!defaultToNull) headers.append('Prefer', 'missing=default')` runs unconditionally, and `Array.isArray` gates only the `columns` parameter. Gating would therefore *break* parity, so the header is sent for a single row too. Harmless there: with no `columns` parameter, omitted columns already take their default.

**2. Scope is insert + upsert only.** PostgREST applies `missing` to `PATCH` as well, but supabase-js exposes `defaultToNull` only on these two, so `update` is untouched.

## Unplanned fallout worth a reviewer's eye

Adding the parameter renames both methods in DocC, which broke **nine pre-existing symbol links** across `PostgrestRequestBuilder.swift`, `PostgrestClient.swift` and `Types.swift` — `./scripts/test-docs.sh` failed until each gained `defaultToNull:`. That is most of the non-test diff and the reason it touches four source files instead of one.

I also dropped a cross-link I had added from `insert` to `upsert`: I wrote it against the `PostgrestQueryBuilder` typealias path, which DocC does not resolve (the type is `PostgrestRequestBuilder`). Replaced with a prose mention — a hardcoded symbol path that must be re-edited on every signature change is not worth the link.

## Test plan

New tests in `PostgrestQueryBuilderTests`, each asserting the **exact full** `Prefer` header via the existing curl inline snapshots (a `contains` check cannot catch a *missing* preference):

| Test | `Prefer` |
|---|---|
| `insertDefaultToNullFalseSendsMissingDefault` | `return=minimal,missing=default` |
| `insertDefaultToNullFalseComposesWithReturningAndCount` | `return=minimal,count=estimated,missing=default` |
| `upsertDefaultToNullFalseKeepsEveryOtherPreference` | `existing=value,resolution=merge-duplicates,return=minimal,count=estimated,missing=default` |
| `upsertDefaultToNullFalseComposesWithIgnoreDuplicates` | `resolution=ignore-duplicates,return=representation,missing=default` |

The third is the one that matters most: it proves the new preference composes with a caller-supplied value, `resolution=`, `return=` and `count=` without dropping any — the failure mode that made #1308 (SDK-1626) a silent data bug.

"Option off" is covered by the pre-existing `insert` / `upsert` / `upsertIgnoreDuplicates` snapshots, which still assert their exact `Prefer` values with no `missing=`. That they pass **unchanged** is also the evidence for "existing call sites unchanged".

- [x] `swift test` — 1441 tests in 148 suites passed (12 known issues)
- [x] `./scripts/format.sh`, `./scripts/spell-check.sh`, `./scripts/test-docs.sh` all clean
- [ ] `api-stability.yml` — the open question; see above
- [x] `sdk-compliance.yaml` unchanged — it lists symbols without parameter labels (`PostgrestRequestBuilder.insert`), and no new symbol lands

Fixes SDK-1613