### PR TITLE
fix(auth): preserve status context for non-JSON 5xx errors

### DIFF
--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -1,6 +1,10 @@
 import Foundation
 import HTTPTypes
 
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
 extension HTTPClient {
   init(configuration: AuthClient.Configuration) {
     var interceptors: [any HTTPClientInterceptor] = [
@@ -84,8 +88,23 @@ struct APIClient: Sendable {
         decoder: configuration.resolvedDecoder
       )
     else {
+      // `HTTPURLResponse` does not expose the reason phrase, so Foundation's
+      // status description is the closest analog. The status code is always
+      // included because the description is localized on Darwin and differs
+      // from the Linux one; the empty check is defensive only.
+      let statusDescription = HTTPURLResponse.localizedString(
+        forStatusCode: response.statusCode
+      )
+      let statusMessage = "HTTP \(response.statusCode)"
+      let message =
+        if 500..<600 ~= response.statusCode {
+          statusDescription.isEmpty ? statusMessage : "\(statusMessage): \(statusDescription)"
+        } else {
+          "Unexpected error"
+        }
+
       return .api(
-        message: "Unexpected error",
+        message: message,
         errorCode: .unexpectedFailure,
         underlyingData: response.data,
         underlyingResponse: response.underlyingResponse

--- a/Tests/AuthTests/APIClientTests.swift
+++ b/Tests/AuthTests/APIClientTests.swift
@@ -1,0 +1,110 @@
+//
+//  APIClientTests.swift
+//  Supabase
+//
+//  Created by Muhammadjon Marufov on 02/09/26.
+//
+
+import Foundation
+import Helpers
+import TestHelpers
+import Testing
+
+@testable import Auth
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+@Suite
+struct APIClientTests {
+  private let authClient = AuthClient(
+    configuration: AuthClient.Configuration(
+      url: URL(string: "https://project.supabase.co")!,
+      localStorage: InMemoryLocalStorage()
+    )
+  )
+
+  private var apiClient: APIClient {
+    APIClient(clientID: authClient.clientID)
+  }
+
+  @Test
+  func nonJSONServerErrorUsesStatusCodeAndDescription() async {
+    let data = Data("<html><body>proxy failure</body></html>".utf8)
+    let response = makeResponse(data: data, statusCode: 500)
+
+    let error = await apiClient.handleError(response: response)
+
+    guard
+      case .api(
+        let message,
+        let errorCode,
+        let underlyingData,
+        let underlyingResponse
+      ) = error
+    else {
+      Issue.record("Expected an API error, got \(error)")
+      return
+    }
+
+    #expect(message == "HTTP 500: \(HTTPURLResponse.localizedString(forStatusCode: 500))")
+    #expect(errorCode == .unexpectedFailure)
+    #expect(underlyingData == data)
+    #expect(underlyingResponse === response.underlyingResponse)
+  }
+
+  @Test
+  func nonJSONServerErrorWithEmptyBodyPreservesStatusCode() async {
+    let response = makeResponse(data: Data(), statusCode: 503)
+
+    let error = await apiClient.handleError(response: response)
+
+    #expect(error.message == "HTTP 503: \(HTTPURLResponse.localizedString(forStatusCode: 503))")
+  }
+
+  @Test
+  func jsonErrorKeepsServerMessage() async {
+    let response = makeResponse(
+      data: Data(#"{"message":"Error sending confirmation email"}"#.utf8),
+      statusCode: 500
+    )
+
+    let error = await apiClient.handleError(response: response)
+
+    #expect(error.message == "Error sending confirmation email")
+  }
+
+  @Test
+  func nonJSONServerErrorUpperBoundaryPreservesStatusCode() async {
+    let response = makeResponse(data: Data(), statusCode: 599)
+
+    let error = await apiClient.handleError(response: response)
+
+    #expect(error.message == "HTTP 599: \(HTTPURLResponse.localizedString(forStatusCode: 599))")
+  }
+
+  @Test(arguments: [400, 499, 600])
+  func nonJSONErrorOutsideServerRangeKeepsExistingFallback(statusCode: Int) async {
+    let response = makeResponse(
+      data: Data("<html><body>bad request</body></html>".utf8),
+      statusCode: statusCode
+    )
+
+    let error = await apiClient.handleError(response: response)
+
+    #expect(error.message == "Unexpected error")
+  }
+
+  private func makeResponse(data: Data, statusCode: Int) -> HTTPResponse {
+    HTTPResponse(
+      data: data,
+      response: HTTPURLResponse(
+        url: URL(string: "https://project.supabase.co/auth/v1/token")!,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+      )!
+    )
+  }
+}

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -97,10 +97,12 @@ LinkedIn
 lnbm
 magiclink
 magnifyingglass
+Marufov
 metamask
 metas
 Metas
 mmsdk
+Muhammadjon
 myapp
 newbucket
 newkey


### PR DESCRIPTION
## Summary

- preserve useful HTTP status context when an Auth error body is not valid JSON
- fall back to `HTTP <status>: <status description>` for 5xx responses, e.g. `HTTP 503: service unavailable`
- retain existing structured JSON error behavior, and the existing `Unexpected error` message for undecodable non-5xx responses

## Why

Non-JSON proxy/server failures (an HTML error page from a load balancer, an empty body) currently collapse to `Unexpected error`, hiding the only actionable context available to callers. This is the Swift side of the supabase-js change in supabase/supabase-js#2587; the Dart (supabase/supabase-flutter#1653) and Kotlin (supabase-community/supabase-kt#1379) SDKs already landed equivalents.

Fixes #1171.

## Design notes

- `HTTPURLResponse` does not expose the reason phrase on any platform, so the closest analog is `HTTPURLResponse.localizedString(forStatusCode:)`, which `RealtimeChannelV2` already uses for the same purpose.
- That description is localized on Darwin (`internal server error`) and is capitalized English on Linux (`Internal Server Error`), so the status code is always included to keep a deterministic core in the message. Happy to switch to the bare description if you prefer strict parity with the JS shape.
- The description is never empty in the 5xx range on either platform; the empty check is defensive only.
- Scoped to 5xx to match the issue title and the Dart fix. Undecodable 4xx bodies keep the existing `Unexpected error` message.
- No public API changes. `errorCode`, `underlyingData`, and `underlyingResponse` are unchanged.

## Tests

New `Tests/AuthTests/APIClientTests.swift`:

- `nonJSONServerErrorUsesStatusCodeAndDescription`: HTML 500 body yields `HTTP 500: <description>` and preserves error code, data, and underlying response
- `nonJSONServerErrorWithEmptyBodyPreservesStatusCode`: empty 503 body yields `HTTP 503: <description>`
- `nonJSONServerErrorUpperBoundaryPreservesStatusCode`: 599 boundary
- `jsonErrorKeepsServerMessage`: JSON 500 body still returns the server message
- `nonJSONErrorOutsideServerRangeKeepsExistingFallback` (400, 499, 600): unchanged `Unexpected error`

`Marufov` and `Muhammadjon` were added to `dictionary.txt` for the test file header, following the existing convention for author names.

## Verification

- `swift test --filter APIClientTests` on unpatched `main` (test file copied in): 3 of 5 fail with `Unexpected error`
- `swift test --filter APIClientTests` on this branch: 5 of 5 pass
- `swift test --filter AuthTests --skip IntegrationTests`: 315 tests in 25 suites pass
- `./scripts/format.sh` equivalent on changed files: no diff; `swift-format lint --strict`: clean
- `./scripts/spell-check.sh`: 0 issues
