### PR TITLE
feat(auth): verify ES256 JWTs locally in getClaims

### DIFF
--- a/Sources/Auth/Internal/JWK+EC.swift
+++ b/Sources/Auth/Internal/JWK+EC.swift
@@ -1,0 +1,20 @@
+import Crypto
+import Foundation
+
+extension JWK {
+  var p256PublicKey: P256.Signing.PublicKey? {
+    guard kty == "EC",
+      crv == "P-256",
+      let x,
+      let xData = Base64URL.decode(x),
+      let y,
+      let yData = Base64URL.decode(y),
+      xData.count == 32,
+      yData.count == 32
+    else {
+      return nil
+    }
+
+    return try? P256.Signing.PublicKey(x963Representation: Data([0x04]) + xData + yData)
+  }
+}

--- a/Sources/Auth/Internal/JWTAlgorithm.swift
+++ b/Sources/Auth/Internal/JWTAlgorithm.swift
@@ -5,10 +5,12 @@
 //  Created by Claude on 06/10/25.
 //
 
+import Crypto
 import Foundation
 
 enum JWTAlgorithm: String {
   case rs256 = "RS256"
+  case es256 = "ES256"
 
   func verify(
     jwt: DecodedJWT,
@@ -29,6 +31,14 @@ enum JWTAlgorithm: String {
       #else
         return false
       #endif
+    case .es256:
+      guard
+        let publicKey = jwk.p256PublicKey,
+        let signature = try? P256.Signing.ECDSASignature(rawRepresentation: jwt.signature)
+      else {
+        return false
+      }
+      return publicKey.isValidSignature(signature, for: message)
     }
   }
 }

--- a/Tests/AuthTests/AuthClientTests.swift
+++ b/Tests/AuthTests/AuthClientTests.swift
@@ -3149,24 +3149,47 @@ extension AuthMockerTests {
     }
 
     @Test
-    func getClaims_withProvidedJWKS_shouldStillFallbackForES256() async throws {
-      // ES256 is not yet supported client-side, so it will fallback to server even with JWKS
-      let jwt =
-        "eyJhbGciOiJFUzI1NiIsImtpZCI6InRlc3Qta2lkIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1NDMyMS9hdXRoL3YxIiwiYXVkIjoiYXV0aGVudGljYXRlZCIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlIjoiYXV0aGVudGljYXRlZCJ9.dummysignature"
+    func getClaims_withES256JWTAndJWKS_shouldVerifyLocally() async throws {
+      let signer = ES256TestSigner()
+      let jwt = try signer.sign(
+        header: #"{"alg":"ES256","kid":"es256-test-kid","typ":"JWT"}"#,
+        payload:
+          #"{"sub":"1234567890","iss":"http://localhost:54321/auth/v1","aud":"authenticated","exp":9999999999,"iat":1516239022,"role":"authenticated"}"#
+      )
 
-      // JWK is Codable, no custom init needed
-      let jwkDict: [String: Any] = [
-        "kty": "EC",
-        "kid": "test-kid",
-        "alg": "ES256",
-        "crv": "P-256",
-        "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
-        "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
-      ]
+      Mock(
+        url: clientURL.appendingPathComponent("user"),
+        ignoreQuery: true,
+        contentType: .json,
+        statusCode: 401,
+        data: [.get: Data()]
+      ).register()
 
-      let jwkData = try JSONSerialization.data(withJSONObject: jwkDict)
-      let jwk = try AuthClient.Configuration.jsonDecoder.decode(JWK.self, from: jwkData)
-      let jwks = JWKS(keys: [jwk])
+      let sut = makeSUT()
+
+      let result = try await sut.getClaims(
+        jwt: jwt,
+        options: GetClaimsOptions(jwks: JWKS(keys: [signer.jwk]))
+      )
+
+      #expect(result.claims.sub == "1234567890")
+      #expect(result.claims.role == "authenticated")
+      #expect(result.header.alg == "ES256")
+      #expect(result.header.kid == "es256-test-kid")
+    }
+
+    @Test
+    func getClaims_withTamperedES256JWT_shouldThrowWithoutFallback() async throws {
+      let signer = ES256TestSigner()
+      let jwt = try signer.sign(
+        header: #"{"alg":"ES256","kid":"es256-test-kid","typ":"JWT"}"#,
+        payload: #"{"sub":"1234567890","exp":9999999999,"role":"authenticated"}"#
+      )
+      let parts = jwt.split(separator: ".")
+      let tamperedPayload = Base64URL.encode(
+        Data(#"{"sub":"1234567890","exp":9999999999,"role":"service_role"}"#.utf8)
+      )
+      let tamperedJWT = "\(parts[0]).\(tamperedPayload).\(parts[2])"
 
       let user = User(fromMockNamed: "user")
 
@@ -3180,10 +3203,12 @@ extension AuthMockerTests {
 
       let sut = makeSUT()
 
-      let result = try await sut.getClaims(jwt: jwt, options: GetClaimsOptions(jwks: jwks))
-
-      #expect(result.claims.sub == "1234567890")
-      #expect(result.claims.role == "authenticated")
+      await #expect(throws: AuthError.jwtVerificationFailed(message: "Invalid JWT signature")) {
+        _ = try await sut.getClaims(
+          jwt: tamperedJWT,
+          options: GetClaimsOptions(jwks: JWKS(keys: [signer.jwk]))
+        )
+      }
     }
 
     @Test

--- a/Tests/AuthTests/JWTAlgorithmES256Tests.swift
+++ b/Tests/AuthTests/JWTAlgorithmES256Tests.swift
@@ -1,0 +1,151 @@
+import Crypto
+import Foundation
+import Testing
+
+@testable import Auth
+@testable import Helpers
+
+struct ES256TestSigner {
+  let privateKey = P256.Signing.PrivateKey()
+
+  var jwk: JWK {
+    let coordinates = privateKey.publicKey.x963Representation.dropFirst()
+    return JWK(
+      kty: "EC",
+      keyOps: ["verify"],
+      alg: "ES256",
+      kid: "es256-test-kid",
+      n: nil,
+      e: nil,
+      crv: "P-256",
+      x: Base64URL.encode(coordinates.prefix(32)),
+      y: Base64URL.encode(coordinates.suffix(32)),
+      k: nil
+    )
+  }
+
+  func sign(header: String, payload: String) throws -> String {
+    let headerB64 = Base64URL.encode(Data(header.utf8))
+    let payloadB64 = Base64URL.encode(Data(payload.utf8))
+    let signature = try privateKey.signature(for: Data("\(headerB64).\(payloadB64)".utf8))
+    return "\(headerB64).\(payloadB64).\(Base64URL.encode(signature.rawRepresentation))"
+  }
+}
+
+@Suite
+struct JWTAlgorithmES256Tests {
+  private let header = #"{"alg":"ES256","kid":"es256-test-kid","typ":"JWT"}"#
+  private let payload = #"{"sub":"1234567890","role":"authenticated"}"#
+
+  @Test
+  func p256PublicKeyFromJWK() {
+    let signer = ES256TestSigner()
+
+    let publicKey = signer.jwk.p256PublicKey
+
+    #expect(publicKey?.rawRepresentation == signer.privateKey.publicKey.rawRepresentation)
+  }
+
+  @Test
+  func p256PublicKeyRejectsNonECKey() {
+    let jwk = JWK(
+      kty: "RSA",
+      keyOps: nil,
+      alg: "ES256",
+      kid: "kid",
+      n: "AQAB",
+      e: "AQAB",
+      crv: "P-256",
+      x: "AQAB",
+      y: "AQAB",
+      k: nil
+    )
+
+    #expect(jwk.p256PublicKey == nil)
+  }
+
+  @Test
+  func p256PublicKeyRejectsOtherCurves() {
+    let signer = ES256TestSigner()
+    let base = signer.jwk
+    let jwk = JWK(
+      kty: base.kty,
+      keyOps: base.keyOps,
+      alg: "ES384",
+      kid: base.kid,
+      n: nil,
+      e: nil,
+      crv: "P-384",
+      x: base.x,
+      y: base.y,
+      k: nil
+    )
+
+    #expect(jwk.p256PublicKey == nil)
+  }
+
+  @Test
+  func p256PublicKeyRejectsMalformedCoordinates() {
+    let jwk = JWK(
+      kty: "EC",
+      keyOps: nil,
+      alg: "ES256",
+      kid: "kid",
+      n: nil,
+      e: nil,
+      crv: "P-256",
+      x: "AAAA",
+      y: "!!!invalid-base64!!!",
+      k: nil
+    )
+
+    #expect(jwk.p256PublicKey == nil)
+  }
+
+  @Test
+  func es256VerifiesValidSignature() throws {
+    let signer = ES256TestSigner()
+    let jwt = try signer.sign(header: header, payload: payload)
+    let decoded = try #require(JWT.decode(jwt))
+
+    #expect(JWTAlgorithm.es256.verify(jwt: decoded, jwk: signer.jwk))
+  }
+
+  @Test
+  func es256RejectsTamperedPayload() throws {
+    let signer = ES256TestSigner()
+    let jwt = try signer.sign(header: header, payload: payload)
+    let parts = jwt.split(separator: ".")
+    let tamperedPayload = Base64URL.encode(Data(#"{"sub":"attacker","role":"service_role"}"#.utf8))
+    let decoded = try #require(JWT.decode("\(parts[0]).\(tamperedPayload).\(parts[2])"))
+
+    #expect(!JWTAlgorithm.es256.verify(jwt: decoded, jwk: signer.jwk))
+  }
+
+  @Test
+  func es256RejectsSignatureFromAnotherKey() throws {
+    let signer = ES256TestSigner()
+    let otherSigner = ES256TestSigner()
+    let jwt = try signer.sign(header: header, payload: payload)
+    let decoded = try #require(JWT.decode(jwt))
+
+    #expect(!JWTAlgorithm.es256.verify(jwt: decoded, jwk: otherSigner.jwk))
+  }
+
+  @Test
+  func es256RejectsMalformedSignature() throws {
+    let signer = ES256TestSigner()
+    let jwt = try signer.sign(header: header, payload: payload)
+    let parts = jwt.split(separator: ".")
+    let decoded = try #require(
+      JWT.decode("\(parts[0]).\(parts[1]).\(Base64URL.encode(Data([0x00, 0x01, 0x02, 0x03])))")
+    )
+
+    #expect(!JWTAlgorithm.es256.verify(jwt: decoded, jwk: signer.jwk))
+  }
+
+  @Test
+  func es256AlgorithmType() {
+    #expect(JWTAlgorithm(rawValue: "ES256") == .es256)
+  }
+}

--- a/Tests/AuthTests/JWTAlgorithmES256Tests.swift
+++ b/Tests/AuthTests/JWTAlgorithmES256Tests.swift
@@ -85,7 +85,27 @@ struct JWTAlgorithmES256Tests {
   }
 
   @Test
-  func p256PublicKeyRejectsMalformedCoordinates() {
+  func p256PublicKeyRejectsWrongLengthCoordinates() {
+    let signer = ES256TestSigner()
+    let base = signer.jwk
+    let jwk = JWK(
+      kty: base.kty,
+      keyOps: base.keyOps,
+      alg: base.alg,
+      kid: base.kid,
+      n: nil,
+      e: nil,
+      crv: base.crv,
+      x: base.x,
+      y: Base64URL.encode(Data(repeating: 0x01, count: 31)),
+      k: nil
+    )
+
+    #expect(jwk.p256PublicKey == nil)
+  }
+
+  @Test
+  func p256PublicKeyRejectsOffCurvePoint() {
     let jwk = JWK(
       kty: "EC",
       keyOps: nil,
@@ -94,8 +114,8 @@ struct JWTAlgorithmES256Tests {
       n: nil,
       e: nil,
       crv: "P-256",
-      x: "AAAA",
-      y: "!!!invalid-base64!!!",
+      x: Base64URL.encode(Data(repeating: 0x00, count: 32)),
+      y: Base64URL.encode(Data(repeating: 0x00, count: 32)),
       k: nil
     )
 

--- a/Tests/IntegrationTests/AuthClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/AuthClientIntegrationTests.swift
@@ -10,6 +10,7 @@ import Crypto
 import CryptoSwift
 import CustomDump
 import Foundation
+import Helpers
 import InlineSnapshotTesting
 import P256K
 import TestHelpers
@@ -513,6 +514,81 @@ struct AuthClientIntegrationTests {
     let adminClient = Self.makeClient(serviceRole: true)
     try await adminClient.admin.signOut(jwt: accessToken)
     withExtendedLifetime(adminClient) {}
+  }
+
+  /// Pins the shape of the live JWKS that `getClaims` local verification depends on.
+  ///
+  /// A stock local project has no `auth.signing_keys_path`, so the CLI falls back to its
+  /// built-in ES256 key. `getClaims` picks its verifier from the JWK's `alg` field, not from
+  /// the JWT header, so an ES256 key served without `alg` would silently fall back to
+  /// `GET /user` even though the SDK can verify it.
+  @Test
+  func wellKnownJWKSServesES256Key() async throws {
+    let url = URL(string: "\(DotEnv.SUPABASE_URL)/auth/v1/.well-known/jwks.json")!
+    let (data, _) = try await URLSession.shared.data(from: url)
+    let jwks = try AuthClient.Configuration.jsonDecoder.decode(JWKS.self, from: data)
+
+    let jwk = try #require(jwks.keys.first { $0.alg == "ES256" })
+    expectNoDifference(jwk.kty, "EC")
+    expectNoDifference(jwk.crv, "P-256")
+    #expect(jwk.kid != nil)
+
+    // The coordinates must be 32 raw bytes each, or `JWK.p256PublicKey` returns nil.
+    expectNoDifference(Base64URL.decode(try #require(jwk.x))?.count, 32)
+    expectNoDifference(Base64URL.decode(try #require(jwk.y))?.count, 32)
+
+    // The `alg` the server sends must map to a verifier the SDK actually implements.
+    expectNoDifference(JWTAlgorithm(rawValue: try #require(jwk.alg)), .es256)
+    #expect(jwk.p256PublicKey != nil)
+  }
+
+  /// A live access token is ES256, and `getClaims` returns its claims.
+  @Test
+  func getClaimsWithLiveES256Session() async throws {
+    let email = mockEmail()
+    let session = try #require(
+      try await authClient.signUp(email: email, password: mockPassword()).session
+    )
+
+    let decoded = try #require(JWT.decode(session.accessToken))
+    expectNoDifference(decoded.header["alg"] as? String, "ES256")
+    // Local verification needs a `kid` to look the key up; without one it falls back.
+    #expect(decoded.header["kid"] as? String != nil)
+    // The JWS signature is raw r||s, which is what `ECDSASignature(rawRepresentation:)` takes.
+    expectNoDifference(decoded.signature.count, 64)
+
+    let result = try await authClient.getClaims()
+
+    expectNoDifference(result.header.alg, "ES256")
+    expectNoDifference(result.claims.sub, session.user.id.uuidString.lowercased())
+    expectNoDifference(result.claims.email, email)
+    expectNoDifference(result.claims.role, "authenticated")
+  }
+
+  /// Proves the verification is local, not a `GET /user` round trip.
+  ///
+  /// `jwtVerificationFailed("Invalid JWT signature")` is only reachable from the local
+  /// verification branch. Were the ES256 token still falling back to the server, a tampered
+  /// token would surface a GoTrue API error instead.
+  @Test
+  func getClaimsRejectsTamperedLiveES256Token() async throws {
+    let session = try #require(
+      try await authClient.signUp(email: mockEmail(), password: mockPassword()).session
+    )
+
+    let parts = session.accessToken.split(separator: ".")
+    var payload = try #require(
+      JWT.decodePayload(session.accessToken)
+    )
+    payload["role"] = "service_role"
+    let tamperedPayload = Base64URL.encode(
+      try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+    )
+    let tamperedJWT = "\(parts[0]).\(tamperedPayload).\(parts[2])"
+
+    await #expect(throws: AuthError.jwtVerificationFailed(message: "Invalid JWT signature")) {
+      _ = try await authClient.getClaims(jwt: tamperedJWT)
+    }
   }
 
   @discardableResult


### PR DESCRIPTION
### Problem

`getClaims` can only verify RS256 signatures on device. `JWTAlgorithm` has a single case, so for a project signed with an ES256 key the `JWTAlgorithm(rawValue:)` lookup returns nil and every call falls back to `GET /user`, even when the JWKS is cached or passed in through `GetClaimsOptions.jwks`. The existing test `getClaims_withProvidedJWKS_shouldStillFallbackForES256` pinned that behaviour with the note "ES256 is not yet supported client-side". That covers more than new hosted projects: a stock local project has no signing key configured, so the CLI falls back to its built-in ES256 key and every local dev setup signs ES256 today. auth-js verifies both RS256 and ES256 locally, so Swift callers on ES256 projects pay a network round trip per call that JavaScript callers do not.

### Fix

Add an `es256` case to `JWTAlgorithm` and a `JWK.p256PublicKey` helper that builds a `P256.Signing.PublicKey` from the JWK's `x` and `y` coordinates. Verification uses swift-crypto, which `Auth` already depends on for PKCE, so it works on Linux as well as Apple platforms. The JWS signature is the raw `r || s` form, which `ECDSASignature(rawRepresentation:)` accepts directly.

Anything that is not a well formed P-256 key (wrong `kty`, wrong `crv`, a coordinate that is not 32 bytes, or a point that is not on the curve) yields no key, and any signature that is not 64 bytes is rejected, so `verify` returns false rather than trapping. `Base64URL.decode` ignores unknown characters rather than failing, so the length check and the on-curve check in `P256.Signing.PublicKey(x963Representation:)` are what guard the key builder. A token whose signature does not verify now throws `jwtVerificationFailed("Invalid JWT signature")` exactly like the RS256 path instead of being forwarded to the server.

Before:

```swift
enum JWTAlgorithm: String {
  case rs256 = "RS256"
}
```

After:

```swift
enum JWTAlgorithm: String {
  case rs256 = "RS256"
  case es256 = "ES256"
}
```

### Tests

`JWTAlgorithmES256Tests` (new file, 10 tests) signs tokens with a throwaway P-256 key generated in the test, so there is no fixture material and no network:

- public key built from JWK matches the signing key
- non-EC key, non P-256 curve, a 31-byte coordinate, and an off-curve point all yield no key
- valid signature verifies
- tampered payload, signature from another key, and a 4 byte signature all fail

`AuthClientTests`:

- `getClaims_withES256JWTAndJWKS_shouldVerifyLocally` registers `/user` as a 401 so any fallback would fail the test, then asserts the claims and header come back from local verification
- `getClaims_withTamperedES256JWT_shouldThrowWithoutFallback` registers `/user` as a 200 so a fallback would succeed, then asserts `jwtVerificationFailed` is thrown

Both new client tests fail on main (the first hits the 401, the second returns claims) and pass with the fix. The old `shouldStillFallbackForES256` test is replaced by these two. The existing no-kid ES256 test still falls back to the server and is unchanged. Full `AuthTests` suite: 320 tests pass.

No public API change. Not verified on Linux locally, but the new code only uses swift-crypto and Foundation.

