### PR TITLE
fix(postgrest): honor the relation schema in typed queries

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedSource.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedSource.swift
@@ -13,11 +13,6 @@ extension PostgrestClient {
   /// let todos = try await client.from(Todo.self).select().execute().value
   /// ```
   ///
-  /// The request targets the schema the relation declares through
-  /// ``PostgrestRelation/schema``, unless this client was already scoped with ``schema(_:)``, in
-  /// which case the client's schema wins. A relation in `public` on an unscoped client sends no
-  /// profile header, which is PostgREST's default.
-  ///
   /// - Parameter relation: The relation type to query.
   /// - Returns: A ``PostgrestTypedSource`` for that relation.
   public func from<R: PostgrestRelation>(_ relation: R.Type) -> PostgrestTypedSource<R> {

--- a/Sources/PostgREST/Query/PostgrestTypedSource.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedSource.swift
@@ -13,10 +13,20 @@ extension PostgrestClient {
   /// let todos = try await client.from(Todo.self).select().execute().value
   /// ```
   ///
+  /// The request targets the schema the relation declares through
+  /// ``PostgrestRelation/schema``, unless this client was already scoped with ``schema(_:)``, in
+  /// which case the client's schema wins. A relation in `public` on an unscoped client sends no
+  /// profile header, which is PostgREST's default.
+  ///
   /// - Parameter relation: The relation type to query.
   /// - Returns: A ``PostgrestTypedSource`` for that relation.
   public func from<R: PostgrestRelation>(_ relation: R.Type) -> PostgrestTypedSource<R> {
-    PostgrestTypedSource(builder: from(R.relationName))
+    PostgrestTypedSource(builder: scoped(to: relation).from(R.relationName))
+  }
+
+  private func scoped<R: PostgrestRelation>(to relation: R.Type) -> PostgrestClient {
+    guard configuration.schema == nil, R.schema != "public" else { return self }
+    return schema(R.schema)
   }
 }
 

--- a/Tests/PostgRESTTests/PostgrestTypedSourceTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedSourceTests.swift
@@ -28,6 +28,26 @@ struct PostgrestTypedSourceTests {
     static let columns = Columns()
   }
 
+  struct Secret: PostgrestWritableRelation {
+    static let relationName = "secrets"
+    static let schema = "private"
+    static let selectString = "*"
+
+    var id: Int
+    var value: String
+
+    struct Columns: Sendable {
+      let id = PostgrestColumn<Secret, Int>("id")
+      let value = PostgrestColumn<Secret, String>("value")
+    }
+
+    static let columns = Columns()
+
+    struct Draft: Encodable, Sendable {
+      var value: String
+    }
+  }
+
   @Test
   func fromUsesTheRelationName() async throws {
     let capture = QueryCapture()
@@ -42,5 +62,37 @@ struct PostgrestTypedSourceTests {
     let todos = try await capture.client.from(Todo.self).select().execute().value
     #expect(todos.count == 1)
     #expect(todos.first?.task == "buy milk")
+  }
+
+  @Test
+  func fromSendsTheRelationSchemaOnReads() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Secret.self).select().execute()
+    #expect(capture.path?.hasSuffix("/secrets") == true)
+    #expect(capture.header("Accept-Profile") == "private")
+    #expect(capture.header("Content-Profile") == nil)
+  }
+
+  @Test
+  func fromSendsTheRelationSchemaOnWrites() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Secret.self).insert(Secret.Draft(value: "shh")).execute()
+    #expect(capture.header("Content-Profile") == "private")
+    #expect(capture.header("Accept-Profile") == nil)
+  }
+
+  @Test
+  func clientSchemaWinsOverTheRelationSchema() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.schema("tenant_a").from(Secret.self).select().execute()
+    #expect(capture.header("Accept-Profile") == "tenant_a")
+  }
+
+  @Test
+  func publicRelationOnUnscopedClientSendsNoProfile() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().execute()
+    #expect(capture.header("Accept-Profile") == nil)
+    #expect(capture.header("Content-Profile") == nil)
   }
 }


### PR DESCRIPTION
### Problem

`@Table` accepts a `schema:` argument and the macro emits it as `static let schema`, but nothing reads it. `PostgrestClient.from(_ relation:)` builds the request from `R.relationName` only, so a relation declared as `@Table("secrets", schema: "private")` is queried in `public`. There is no compiler or runtime signal; the request simply goes to the wrong schema, and the only test touching the value asserts `Todo.schema == "public"` without issuing a request.

Every typed entry point routes through this one call, so reads, inserts, updates, upserts and deletes were all affected.

### Fix

`from(_:)` now scopes the client to the relation's declared schema before building the request, which sends `Accept-Profile` on reads and `Content-Profile` on writes through the existing header logic.

Two rules keep this from surprising anyone:

- A client already scoped with `schema(_:)` keeps that schema. The migration guide documents `client.schema("public").from(Todo.self)` as the typed spelling, and per-tenant schemas rely on the call site winning over a type-level default.
- A relation that declares `public` on an unscoped client sends no profile header, which is what happens today. The macro defaults `schema` to `"public"`, so without this rule every existing typed request would gain a header it never had.

Before:

```swift
public func from<R: PostgrestRelation>(_ relation: R.Type) -> PostgrestTypedSource<R> {
  PostgrestTypedSource(builder: from(R.relationName))
}
```

After:

```swift
public func from<R: PostgrestRelation>(_ relation: R.Type) -> PostgrestTypedSource<R> {
  PostgrestTypedSource(builder: scoped(to: relation).from(R.relationName))
}

private func scoped<R: PostgrestRelation>(to relation: R.Type) -> PostgrestClient {
  guard configuration.schema == nil, R.schema != "public" else { return self }
  return schema(R.schema)
}
```

If you would rather the relation always win, or always send the header even for `public`, both are one-line changes and I am happy to switch.

### Tests

Four new tests in `PostgrestTypedSourceTests`, using a hand-written `Secret` relation in schema `private`:

- a read sends `Accept-Profile: private` and no `Content-Profile`
- an insert sends `Content-Profile: private` and no `Accept-Profile`
- `client.schema("tenant_a").from(Secret.self)` sends `Accept-Profile: tenant_a`
- the existing `public` relation on an unscoped client sends neither header

The two `Secret` tests fail on main (no profile header is sent) and pass with the fix. Full `PostgRESTTests` and `PostgrestMacrosTests` suites pass.

No public API change.

