### PR TITLE
feat(postgrest): add range to the typed query

### DIFF
--- a/Sources/PostgREST/Query/PostgrestTypedQuery+Where.swift
+++ b/Sources/PostgREST/Query/PostgrestTypedQuery+Where.swift
@@ -110,4 +110,16 @@ extension PostgrestTypedQuery where Phase: PostgrestTransformablePhase {
   public func limit(_ count: Int) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> {
     PostgrestTypedQuery<R, Output, PostgrestTransformPhase>(builder: builder.limit(count))
   }
+
+  /// Returns only the rows within the zero-based, inclusive index range.
+  ///
+  /// `range(10...19)` is the second page of ten. Like `limit(_:)` this moves the request into
+  /// ``PostgrestTransformPhase``.
+  public func range(
+    _ bounds: ClosedRange<Int>
+  ) -> PostgrestTypedQuery<R, Output, PostgrestTransformPhase> {
+    PostgrestTypedQuery<R, Output, PostgrestTransformPhase>(
+      builder: builder.range(from: bounds.lowerBound, to: bounds.upperBound)
+    )
+  }
 }

--- a/Tests/PostgRESTTests/PostgrestTypedQueryWhereTests.swift
+++ b/Tests/PostgRESTTests/PostgrestTypedQueryWhereTests.swift
@@ -186,4 +186,35 @@ struct PostgrestTypedQueryWhereTests {
     #expect(capture.query?.contains("id=gt.5") == true)
     #expect(capture.query?.contains("is_done") == false)
   }
+
+  @Test
+  func rangeSendsOffsetAndLimit() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().range(10...19).execute()
+    #expect(capture.query?.contains("offset=10") == true)
+    #expect(capture.query?.contains("limit=10") == true)
+  }
+
+  @Test
+  func rangeFromZeroSendsAZeroOffset() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self).select().range(0...0).execute()
+    #expect(capture.query?.contains("offset=0") == true)
+    #expect(capture.query?.contains("limit=1") == true)
+  }
+
+  @Test
+  func rangeChainsAfterWhereAndOrder() async throws {
+    let capture = QueryCapture()
+    _ = try await capture.client.from(Todo.self)
+      .select()
+      .where { $0.isDone.eq(false) }
+      .order { $0.id.asc() }
+      .range(20...29)
+      .execute()
+    #expect(capture.query?.contains("is_done=eq.false") == true)
+    #expect(capture.query?.contains("order=id.asc") == true)
+    #expect(capture.query?.contains("offset=20") == true)
+    #expect(capture.query?.contains("limit=10") == true)
+  }
 }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -971,6 +971,7 @@ features:
     status: implemented
     symbols:
       - PostgrestRequestBuilder.range
+      - PostgrestTypedQuery.range
   database.using_modifiers.single_row:
     status: implemented
     symbols:


### PR DESCRIPTION
### Problem

The typed query has `limit(_:)` but no way to set an offset, so it cannot fetch anything past the first page. `execute(count:)` is documented as what a paginated view needs, yet page two is unreachable without dropping to the string builder. The v3 design lists `range(_:)` next to `limit(_:)` on the typed query, and the string builder already has `range(from:to:referencedTable:)`.

### Fix

Add `range(_:)` to `PostgrestTypedQuery`, taking a `ClosedRange<Int>` of zero-based inclusive row indexes and delegating to the existing builder method, so the wire encoding (`offset` plus `limit`, with `limit = count`) is shared with the string builder rather than duplicated. Like `limit(_:)` it moves the request into the transform phase.

```swift
try await client.from(Todo.self)
  .select()
  .where { $0.isDone.eq(false) }
  .order { $0.id.asc() }
  .range(20...29)
  .execute()
```

sends `offset=20&limit=10`.

`ClosedRange` follows the spec's single-argument spelling and rules out an empty or inverted range at the type level, which the two-integer form cannot. If you would prefer `range(from:to:)` for symmetry with the string builder, that is a one-line change and I am happy to switch. Embedded-relation pagination (`referencedTable`) is left out on purpose; per-embed `order` and `limit` are not on the typed surface yet either, so they can land together.

### Tests

Three tests in `PostgrestTypedQueryWhereTests`:

- `range(10...19)` sends `offset=10` and `limit=10`
- `range(0...0)` sends `offset=0` and `limit=1`, the single-row edge
- `range` chained after `where` and `order` keeps both and adds the offset and limit

Full `PostgRESTTests` and `PostgrestMacrosTests` suites pass.

Additive public API: `PostgrestTypedQuery.range(_:)`, registered under `database.using_modifiers.range` in `sdk-compliance.yaml`. DocC on the new symbol builds without warnings.
